### PR TITLE
Learning rate graph

### DIFF
--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -126,7 +126,7 @@ class Trainer:
             summary_writer,
             metrics,
             step,
-            learning_rate=0
+            learning_rate=None
     ):
         if not summary_writer:
             return
@@ -139,7 +139,7 @@ class Trainer:
                     )
                     metric_val = output_feature[metric][-1]
                     tf.summary.scalar(metric_tag, metric_val, step=step)
-            if learning_rate > 0:
+            if learning_rate:
                 tf.summary.scalar("combined/epoch_learning_rate", learning_rate, step=step)
         summary_writer.flush()
 


### PR DESCRIPTION
This adds a visualization for the learning rate currently used within training.
It is useful to me to plot and compare various learning rate patterns (affected by the initial learning rate, warmup epochs, decay rate, and so on), and to compare model performance over time to optimize for the most efficient learning rate, with different yaml model configurations.

It's a bit rough, but it should pass checks, although it could be improved by integrating the learning rate with the training metrics, and not having an additional parameter with a default value to zero (not to plot it for the validation and test datasets too, since it's epoch-related and not dataset-related).