### PR TITLE
Added custom encoder / decoder registration decorator

### DIFF
--- a/ludwig/decoders/base.py
+++ b/ludwig/decoders/base.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python
+# coding=utf-8
+# Copyright (c) 2020 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from abc import ABC, abstractmethod
+
+from tensorflow.keras.layers import Layer
+
+from ludwig.utils.registry import DEFAULT_KEYS
+
+
+class Decoder(Layer, ABC):
+    @abstractmethod
+    def call(self, inputs, training=None, mask=None):
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def register(cls, name):
+        raise NotImplementedError
+
+    @classmethod
+    def register_default(cls):
+        for key in DEFAULT_KEYS:
+            cls.register(name=key)

--- a/ludwig/decoders/sequence_decoders.py
+++ b/ludwig/decoders/sequence_decoders.py
@@ -13,21 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from abc import ABC
 import logging
 
 import tensorflow as tf
 import tensorflow_addons as tfa
 from tensorflow.keras.layers import GRUCell, SimpleRNNCell, LSTMCell
-from tensorflow.keras.layers import Layer, Dense, Embedding
+from tensorflow.keras.layers import Dense, Embedding
 from tensorflow.keras.layers import average
 from tensorflow_addons.seq2seq import AttentionWrapper
 from tensorflow_addons.seq2seq import BahdanauAttention
 from tensorflow_addons.seq2seq import LuongAttention
 
 from ludwig.constants import *
+from ludwig.decoders.base import Decoder
 from ludwig.modules.attention_modules import MultiHeadSelfAttention
 from ludwig.modules.reduction_modules import SequenceReducer
 from ludwig.utils.misc_utils import get_from_registry
+from ludwig.utils.registry import Registry, register
 from ludwig.utils.tf_utils import sequence_length_3D, sequence_length_2D
 
 logger = logging.getLogger(__name__)
@@ -41,7 +44,17 @@ rnn_layers_registry = {
 PAD_TOKEN = 0
 
 
-class SequenceGeneratorDecoder(Layer):
+DECODER_REGISTRY = Registry()
+
+
+class SequenceDecoder(Decoder, ABC):
+    @classmethod
+    def register(cls, name):
+        DECODER_REGISTRY[name] = cls
+
+
+@register(name='generator')
+class SequenceGeneratorDecoder(SequenceDecoder):
 
     def __init__(
             self,
@@ -690,7 +703,8 @@ def extract_sequence_probabilities(decoder_output, beam_width, sequence_id=0):
     return probabilities
 
 
-class SequenceTaggerDecoder(Layer):
+@register(name='tagger')
+class SequenceTaggerDecoder(SequenceDecoder):
 
     def __init__(
             self,

--- a/ludwig/encoders/__init__.py
+++ b/ludwig/encoders/__init__.py
@@ -1,1 +1,2 @@
-from ludwig.encoders.base import Encoder, register, register_default
+from ludwig.encoders.base import Encoder
+from ludwig.utils.registry import register, register_default

--- a/ludwig/encoders/__init__.py
+++ b/ludwig/encoders/__init__.py
@@ -1,0 +1,1 @@
+from ludwig.encoders.base import Encoder, register, register_default

--- a/ludwig/encoders/bag_encoders.py
+++ b/ludwig/encoders/bag_encoders.py
@@ -17,7 +17,8 @@
 import logging
 from abc import ABC
 
-from ludwig.encoders.base import Encoder, Registry, register_default
+from ludwig.encoders.base import Encoder
+from ludwig.utils.registry import Registry, register_default
 from ludwig.modules.embedding_modules import EmbedWeighted
 from ludwig.modules.fully_connected_modules import FCStack
 

--- a/ludwig/encoders/bag_encoders.py
+++ b/ludwig/encoders/bag_encoders.py
@@ -15,17 +15,26 @@
 # limitations under the License.
 # ==============================================================================
 import logging
+from abc import ABC
 
-from tensorflow.keras.layers import Layer
-
+from ludwig.encoders.base import Encoder, register_default
 from ludwig.modules.embedding_modules import EmbedWeighted
 from ludwig.modules.fully_connected_modules import FCStack
 
 logger = logging.getLogger(__name__)
 
 
-class BagEmbedWeightedEncoder(Layer):
+ENCODER_REGISTRY = {}
 
+
+class BagEncoder(Encoder, ABC):
+    @classmethod
+    def register(cls, name):
+        ENCODER_REGISTRY[name] = cls
+
+
+@register_default(name='embed')
+class BagEmbedWeightedEncoder(BagEncoder):
     def __init__(
             self,
             vocab,

--- a/ludwig/encoders/bag_encoders.py
+++ b/ludwig/encoders/bag_encoders.py
@@ -17,14 +17,14 @@
 import logging
 from abc import ABC
 
-from ludwig.encoders.base import Encoder, register_default
+from ludwig.encoders.base import Encoder, Registry, register_default
 from ludwig.modules.embedding_modules import EmbedWeighted
 from ludwig.modules.fully_connected_modules import FCStack
 
 logger = logging.getLogger(__name__)
 
 
-ENCODER_REGISTRY = {}
+ENCODER_REGISTRY = Registry()
 
 
 class BagEncoder(Encoder, ABC):

--- a/ludwig/encoders/base.py
+++ b/ludwig/encoders/base.py
@@ -16,11 +16,35 @@
 # ==============================================================================
 
 from abc import ABC, abstractmethod
+from collections import UserDict
 
 from tensorflow.keras.layers import Layer
 
 
 DEFAULT_KEYS = ['None', 'none', 'null', None]
+
+
+class Registry(UserDict):
+    """Registry is like a normal dict, but with optional child dicts.
+
+    When an item is added / removed from the parent, the children will also have
+    that item added or removed.
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.children = []
+        if isinstance(parent, Registry):
+            parent.children.append(self)
+
+    def __setitem__(self, key, value):
+        for child in self.children:
+            child.__setitem__(key, value)
+        super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        for child in self.children:
+            child.__delitem__(key)
+        super().__delitem__(key)
 
 
 def register(name):

--- a/ludwig/encoders/base.py
+++ b/ludwig/encoders/base.py
@@ -16,50 +16,10 @@
 # ==============================================================================
 
 from abc import ABC, abstractmethod
-from collections import UserDict
 
 from tensorflow.keras.layers import Layer
 
-
-DEFAULT_KEYS = ['None', 'none', 'null', None]
-
-
-class Registry(UserDict):
-    """Registry is like a normal dict, but with optional child dicts.
-
-    When an item is added / removed from the parent, the children will also have
-    that item added or removed.
-    """
-    def __init__(self, parent=None):
-        self.children = []
-        if isinstance(parent, Registry):
-            parent.children.append(self)
-        super().__init__(parent)
-
-    def __setitem__(self, key, value):
-        for child in self.children:
-            child.__setitem__(key, value)
-        super().__setitem__(key, value)
-
-    def __delitem__(self, key):
-        for child in self.children:
-            child.__delitem__(key)
-        super().__delitem__(key)
-
-
-def register(name):
-    def wrap(cls):
-        cls.register(name)
-        return cls
-    return wrap
-
-
-def register_default(name):
-    def wrap(cls):
-        cls.register(name)
-        cls.register_default()
-        return cls
-    return wrap
+from ludwig.utils.registry import DEFAULT_KEYS
 
 
 class Encoder(Layer, ABC):

--- a/ludwig/encoders/base.py
+++ b/ludwig/encoders/base.py
@@ -31,10 +31,10 @@ class Registry(UserDict):
     that item added or removed.
     """
     def __init__(self, parent=None):
-        super().__init__(parent)
         self.children = []
         if isinstance(parent, Registry):
             parent.children.append(self)
+        super().__init__(parent)
 
     def __setitem__(self, key, value):
         for child in self.children:

--- a/ludwig/encoders/base.py
+++ b/ludwig/encoders/base.py
@@ -1,0 +1,54 @@
+#! /usr/bin/env python
+# coding=utf-8
+# Copyright (c) 2020 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from abc import ABC, abstractmethod
+
+from tensorflow.keras.layers import Layer
+
+
+DEFAULT_KEYS = ['None', 'none', 'null', None]
+
+
+def register(name):
+    def wrap(cls):
+        cls.register(name)
+        return cls
+    return wrap
+
+
+def register_default(name):
+    def wrap(cls):
+        cls.register(name)
+        cls.register_default()
+        return cls
+    return wrap
+
+
+class Encoder(Layer, ABC):
+    @abstractmethod
+    def call(self, inputs, training=None, mask=None):
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def register(cls, name):
+        raise NotImplementedError
+
+    @classmethod
+    def register_default(cls):
+        for key in DEFAULT_KEYS:
+            cls.register(name=key)

--- a/ludwig/encoders/binary_encoders.py
+++ b/ludwig/encoders/binary_encoders.py
@@ -19,16 +19,16 @@ from abc import ABC
 
 import tensorflow as tf
 
-from ludwig.encoders.base import Encoder, register_default
+from ludwig.encoders.base import Encoder, Registry, register_default
 from ludwig.encoders.generic_encoders import DenseEncoder
 
 
 logger = logging.getLogger(__name__)
 
 
-ENCODER_REGISTRY = {
+ENCODER_REGISTRY = Registry({
     'dense': DenseEncoder
-}
+})
 
 
 class BinaryEncoder(Encoder, ABC):

--- a/ludwig/encoders/binary_encoders.py
+++ b/ludwig/encoders/binary_encoders.py
@@ -19,7 +19,8 @@ from abc import ABC
 
 import tensorflow as tf
 
-from ludwig.encoders.base import Encoder, Registry, register_default
+from ludwig.encoders.base import Encoder
+from ludwig.utils.registry import Registry, register_default
 from ludwig.encoders.generic_encoders import DenseEncoder
 
 

--- a/ludwig/encoders/binary_encoders.py
+++ b/ludwig/encoders/binary_encoders.py
@@ -15,14 +15,30 @@
 # limitations under the License.
 # ==============================================================================
 import logging
+from abc import ABC
 
 import tensorflow as tf
-from tensorflow.keras.layers import Layer
+
+from ludwig.encoders.base import Encoder, register_default
+from ludwig.encoders.generic_encoders import DenseEncoder
+
 
 logger = logging.getLogger(__name__)
 
 
-class BinaryPassthroughEncoder(Layer):
+ENCODER_REGISTRY = {
+    'dense': DenseEncoder
+}
+
+
+class BinaryEncoder(Encoder, ABC):
+    @classmethod
+    def register(cls, name):
+        ENCODER_REGISTRY[name] = cls
+
+
+@register_default(name='passthrough')
+class BinaryPassthroughEncoder(BinaryEncoder):
 
     def __init__(
             self,

--- a/ludwig/encoders/category_encoders.py
+++ b/ludwig/encoders/category_encoders.py
@@ -17,7 +17,8 @@
 import logging
 from abc import ABC
 
-from ludwig.encoders.base import DEFAULT_KEYS, Encoder, Registry, register
+from ludwig.encoders.base import Encoder
+from ludwig.utils.registry import Registry, register, DEFAULT_KEYS
 from ludwig.encoders.generic_encoders import PassthroughEncoder
 from ludwig.modules.embedding_modules import Embed
 

--- a/ludwig/encoders/category_encoders.py
+++ b/ludwig/encoders/category_encoders.py
@@ -15,15 +15,30 @@
 # limitations under the License.
 # ==============================================================================
 import logging
+from abc import ABC
 
 from tensorflow.keras.layers import Layer
 
+from ludwig.encoders.base import DEFAULT_KEYS, Encoder, register
+from ludwig.encoders.generic_encoders import PassthroughEncoder
 from ludwig.modules.embedding_modules import Embed
 
 logger = logging.getLogger(__name__)
 
 
-class CategoricalEmbedEncoder(Layer):
+ENCODER_REGISTRY = {
+    key: PassthroughEncoder for key in DEFAULT_KEYS + ['passthrough']
+}
+
+
+class CategoricalEncoder(Encoder, ABC):
+    @classmethod
+    def register(cls, name):
+        ENCODER_REGISTRY[name] = cls
+
+
+@register(name='dense')
+class CategoricalEmbedEncoder(CategoricalEncoder):
 
     def __init__(
             self,
@@ -66,6 +81,7 @@ class CategoricalEmbedEncoder(Layer):
         return embedded
 
 
+@register(name='sparse')
 class CategoricalSparseEncoder(Layer):
 
     def __init__(

--- a/ludwig/encoders/category_encoders.py
+++ b/ludwig/encoders/category_encoders.py
@@ -17,18 +17,16 @@
 import logging
 from abc import ABC
 
-from tensorflow.keras.layers import Layer
-
-from ludwig.encoders.base import DEFAULT_KEYS, Encoder, register
+from ludwig.encoders.base import DEFAULT_KEYS, Encoder, Registry, register
 from ludwig.encoders.generic_encoders import PassthroughEncoder
 from ludwig.modules.embedding_modules import Embed
 
 logger = logging.getLogger(__name__)
 
 
-ENCODER_REGISTRY = {
+ENCODER_REGISTRY = Registry({
     key: PassthroughEncoder for key in DEFAULT_KEYS + ['passthrough']
-}
+})
 
 
 class CategoricalEncoder(Encoder, ABC):
@@ -82,7 +80,7 @@ class CategoricalEmbedEncoder(CategoricalEncoder):
 
 
 @register(name='sparse')
-class CategoricalSparseEncoder(Layer):
+class CategoricalSparseEncoder(CategoricalEncoder):
 
     def __init__(
             self,

--- a/ludwig/encoders/date_encoders.py
+++ b/ludwig/encoders/date_encoders.py
@@ -20,7 +20,8 @@ from abc import ABC
 
 import tensorflow as tf
 
-from ludwig.encoders.base import Encoder, Registry, register
+from ludwig.encoders.base import Encoder
+from ludwig.utils.registry import Registry, register
 from ludwig.modules.embedding_modules import Embed
 from ludwig.modules.fully_connected_modules import FCStack
 

--- a/ludwig/encoders/date_encoders.py
+++ b/ludwig/encoders/date_encoders.py
@@ -16,17 +16,28 @@
 # ==============================================================================
 import logging
 import math
+from abc import ABC
 
 import tensorflow as tf
-from tensorflow.keras.layers import Layer
 
+from ludwig.encoders.base import Encoder, register
 from ludwig.modules.embedding_modules import Embed
 from ludwig.modules.fully_connected_modules import FCStack
 
 logger = logging.getLogger(__name__)
 
 
-class DateEmbed(Layer):
+ENCODER_REGISTRY = {}
+
+
+class DateEncoder(Encoder, ABC):
+    @classmethod
+    def register(cls, name):
+        ENCODER_REGISTRY[name] = cls
+
+
+@register(name='embed')
+class DateEmbed(DateEncoder):
 
     def __init__(
             self,
@@ -312,7 +323,8 @@ class DateEmbed(Layer):
         return {'encoder_output': hidden}
 
 
-class DateWave(Layer):
+@register(name='wave')
+class DateWave(DateEncoder):
 
     def __init__(
             self,

--- a/ludwig/encoders/date_encoders.py
+++ b/ludwig/encoders/date_encoders.py
@@ -20,14 +20,14 @@ from abc import ABC
 
 import tensorflow as tf
 
-from ludwig.encoders.base import Encoder, register
+from ludwig.encoders.base import Encoder, Registry, register
 from ludwig.modules.embedding_modules import Embed
 from ludwig.modules.fully_connected_modules import FCStack
 
 logger = logging.getLogger(__name__)
 
 
-ENCODER_REGISTRY = {}
+ENCODER_REGISTRY = Registry()
 
 
 class DateEncoder(Encoder, ABC):

--- a/ludwig/encoders/h3_encoders.py
+++ b/ludwig/encoders/h3_encoders.py
@@ -15,10 +15,11 @@
 # limitations under the License.
 # ==============================================================================
 import logging
+from abc import ABC
 
 import tensorflow as tf
-from tensorflow.keras.layers import Layer
 
+from ludwig.encoders.base import Encoder, register
 from ludwig.modules.embedding_modules import Embed
 from ludwig.modules.fully_connected_modules import FCStack
 from ludwig.modules.initializer_modules import get_initializer
@@ -28,7 +29,17 @@ from ludwig.modules.reduction_modules import SequenceReducer
 logger = logging.getLogger(__name__)
 
 
-class H3Embed(Layer):
+ENCODER_REGISTRY = {}
+
+
+class H3Encoder(Encoder, ABC):
+    @classmethod
+    def register(cls, name):
+        ENCODER_REGISTRY[name] = cls
+
+
+@register(name='embed')
+class H3Embed(H3Encoder):
 
     def __init__(
             self,
@@ -258,7 +269,8 @@ class H3Embed(Layer):
         return {'encoder_output': hidden}
 
 
-class H3WeightedSum(Layer):
+@register(name='weighted_sum')
+class H3WeightedSum(H3Encoder):
 
     def __init__(
             self,
@@ -405,7 +417,8 @@ class H3WeightedSum(Layer):
         return {'encoder_output': hidden}
 
 
-class H3RNN(Layer):
+@register(name='rnn')
+class H3RNN(H3Encoder):
 
     def __init__(
             self,

--- a/ludwig/encoders/h3_encoders.py
+++ b/ludwig/encoders/h3_encoders.py
@@ -19,7 +19,7 @@ from abc import ABC
 
 import tensorflow as tf
 
-from ludwig.encoders.base import Encoder, register
+from ludwig.encoders.base import Encoder, Registry, register
 from ludwig.modules.embedding_modules import Embed
 from ludwig.modules.fully_connected_modules import FCStack
 from ludwig.modules.initializer_modules import get_initializer
@@ -29,7 +29,7 @@ from ludwig.modules.reduction_modules import SequenceReducer
 logger = logging.getLogger(__name__)
 
 
-ENCODER_REGISTRY = {}
+ENCODER_REGISTRY = Registry()
 
 
 class H3Encoder(Encoder, ABC):

--- a/ludwig/encoders/h3_encoders.py
+++ b/ludwig/encoders/h3_encoders.py
@@ -19,7 +19,8 @@ from abc import ABC
 
 import tensorflow as tf
 
-from ludwig.encoders.base import Encoder, Registry, register
+from ludwig.encoders.base import Encoder
+from ludwig.utils.registry import Registry, register
 from ludwig.modules.embedding_modules import Embed
 from ludwig.modules.fully_connected_modules import FCStack
 from ludwig.modules.initializer_modules import get_initializer

--- a/ludwig/encoders/image_encoders.py
+++ b/ludwig/encoders/image_encoders.py
@@ -15,11 +15,12 @@
 # limitations under the License.
 # ==============================================================================
 import logging
+from abc import ABC
 
 import tensorflow as tf
 from tensorflow.keras.layers import Flatten
-from tensorflow.keras.layers import Layer
 
+from ludwig.encoders.base import Encoder, register, register_default
 from ludwig.modules.convolutional_modules import Conv2DStack, \
     get_resnet_block_sizes
 from ludwig.modules.convolutional_modules import ResNet2
@@ -28,7 +29,17 @@ from ludwig.modules.fully_connected_modules import FCStack
 logger = logging.getLogger(__name__)
 
 
-class Stacked2DCNN(Layer):
+ENCODER_REGISTRY = {}
+
+
+class ImageEncoder(Encoder, ABC):
+    @classmethod
+    def register(cls, name):
+        ENCODER_REGISTRY[name] = cls
+
+
+@register_default(name='stacked_cnn')
+class Stacked2DCNN(ImageEncoder):
 
     def __init__(
             self,
@@ -139,7 +150,8 @@ class Stacked2DCNN(Layer):
         return {'encoder_output': outputs}
 
 
-class ResNetEncoder(Layer):
+@register(name='resnet')
+class ResNetEncoder(ImageEncoder):
 
     def __init__(
             self,

--- a/ludwig/encoders/image_encoders.py
+++ b/ludwig/encoders/image_encoders.py
@@ -20,7 +20,8 @@ from abc import ABC
 import tensorflow as tf
 from tensorflow.keras.layers import Flatten
 
-from ludwig.encoders.base import Encoder, Registry, register, register_default
+from ludwig.encoders.base import Encoder
+from ludwig.utils.registry import Registry, register, register_default
 from ludwig.modules.convolutional_modules import Conv2DStack, \
     get_resnet_block_sizes
 from ludwig.modules.convolutional_modules import ResNet2

--- a/ludwig/encoders/image_encoders.py
+++ b/ludwig/encoders/image_encoders.py
@@ -20,7 +20,7 @@ from abc import ABC
 import tensorflow as tf
 from tensorflow.keras.layers import Flatten
 
-from ludwig.encoders.base import Encoder, register, register_default
+from ludwig.encoders.base import Encoder, Registry, register, register_default
 from ludwig.modules.convolutional_modules import Conv2DStack, \
     get_resnet_block_sizes
 from ludwig.modules.convolutional_modules import ResNet2
@@ -29,7 +29,7 @@ from ludwig.modules.fully_connected_modules import FCStack
 logger = logging.getLogger(__name__)
 
 
-ENCODER_REGISTRY = {}
+ENCODER_REGISTRY = Registry()
 
 
 class ImageEncoder(Encoder, ABC):

--- a/ludwig/encoders/sequence_encoders.py
+++ b/ludwig/encoders/sequence_encoders.py
@@ -20,7 +20,7 @@ from abc import ABC
 import tensorflow as tf
 from tensorflow.keras.layers import Dense
 
-from ludwig.encoders.base import Encoder, register, register_default
+from ludwig.encoders.base import Encoder, Registry, register, register_default
 from ludwig.modules.attention_modules import TrasformerStack
 from ludwig.modules.convolutional_modules import Conv1DStack, \
     ParallelConv1DStack, ParallelConv1D
@@ -33,7 +33,7 @@ from ludwig.modules.reduction_modules import SequenceReducer
 logger = logging.getLogger(__name__)
 
 
-ENCODER_REGISTRY = {}
+ENCODER_REGISTRY = Registry()
 
 
 class SequenceEncoder(Encoder, ABC):

--- a/ludwig/encoders/sequence_encoders.py
+++ b/ludwig/encoders/sequence_encoders.py
@@ -20,7 +20,8 @@ from abc import ABC
 import tensorflow as tf
 from tensorflow.keras.layers import Dense
 
-from ludwig.encoders.base import Encoder, Registry, register, register_default
+from ludwig.encoders.base import Encoder
+from ludwig.utils.registry import Registry, register, register_default
 from ludwig.modules.attention_modules import TrasformerStack
 from ludwig.modules.convolutional_modules import Conv1DStack, \
     ParallelConv1DStack, ParallelConv1D

--- a/ludwig/encoders/sequence_encoders.py
+++ b/ludwig/encoders/sequence_encoders.py
@@ -15,10 +15,12 @@
 # limitations under the License.
 # ==============================================================================
 import logging
+from abc import ABC
 
 import tensorflow as tf
-from tensorflow.keras.layers import Layer, Dense
+from tensorflow.keras.layers import Dense
 
+from ludwig.encoders.base import Encoder, register, register_default
 from ludwig.modules.attention_modules import TrasformerStack
 from ludwig.modules.convolutional_modules import Conv1DStack, \
     ParallelConv1DStack, ParallelConv1D
@@ -31,7 +33,17 @@ from ludwig.modules.reduction_modules import SequenceReducer
 logger = logging.getLogger(__name__)
 
 
-class SequencePassthroughEncoder(Layer):
+ENCODER_REGISTRY = {}
+
+
+class SequenceEncoder(Encoder, ABC):
+    @classmethod
+    def register(cls, name):
+        ENCODER_REGISTRY[name] = cls
+
+
+@register_default(name='passthrough')
+class SequencePassthroughEncoder(SequenceEncoder):
 
     def __init__(
             self,
@@ -80,7 +92,8 @@ class SequencePassthroughEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class SequenceEmbedEncoder(Layer):
+@register(name='embed')
+class SequenceEmbedEncoder(SequenceEncoder):
 
     def __init__(
             self,
@@ -216,7 +229,8 @@ class SequenceEmbedEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class ParallelCNN(Layer):
+@register(name='parallel_cnn')
+class ParallelCNN(SequenceEncoder):
 
     def __init__(
             self,
@@ -531,7 +545,8 @@ class ParallelCNN(Layer):
         return {'encoder_output': hidden}
 
 
-class StackedCNN(Layer):
+@register(name='stacked_cnn')
+class StackedCNN(SequenceEncoder):
 
     def __init__(
             self,
@@ -888,7 +903,8 @@ class StackedCNN(Layer):
         return {'encoder_output': hidden}
 
 
-class StackedParallelCNN(Layer):
+@register(name='stacked_parallel_cnn')
+class StackedParallelCNN(SequenceEncoder):
 
     def __init__(
             self,
@@ -1230,7 +1246,8 @@ class StackedParallelCNN(Layer):
         return {'encoder_output': hidden}
 
 
-class StackedRNN(Layer):
+@register(name='rnn')
+class StackedRNN(SequenceEncoder):
 
     def __init__(
             self,
@@ -1514,7 +1531,8 @@ class StackedRNN(Layer):
         }
 
 
-class StackedCNNRNN(Layer):
+@register(name='cnnrnn')
+class StackedCNNRNN(SequenceEncoder):
 
     def __init__(
             self,
@@ -1827,7 +1845,8 @@ class StackedCNNRNN(Layer):
         }
 
 
-class StackedTransformer(Layer):
+@register(name='transformer')
+class StackedTransformer(SequenceEncoder):
 
     def __init__(
             self,

--- a/ludwig/encoders/set_encoders.py
+++ b/ludwig/encoders/set_encoders.py
@@ -17,7 +17,8 @@
 import logging
 from abc import ABC
 
-from ludwig.encoders.base import Encoder, Registry, register_default
+from ludwig.encoders.base import Encoder
+from ludwig.utils.registry import Registry, register_default
 from ludwig.modules.embedding_modules import EmbedSparse
 from ludwig.modules.fully_connected_modules import FCStack
 

--- a/ludwig/encoders/set_encoders.py
+++ b/ludwig/encoders/set_encoders.py
@@ -15,16 +15,26 @@
 # limitations under the License.
 # ==============================================================================
 import logging
+from abc import ABC
 
-from tensorflow.keras.layers import Layer
-
+from ludwig.encoders.base import Encoder, register_default
 from ludwig.modules.embedding_modules import EmbedSparse
 from ludwig.modules.fully_connected_modules import FCStack
 
 logger = logging.getLogger(__name__)
 
 
-class SetSparseEncoder(Layer):
+ENCODER_REGISTRY = {}
+
+
+class SetEncoder(Encoder, ABC):
+    @classmethod
+    def register(cls, name):
+        ENCODER_REGISTRY[name] = cls
+
+
+@register_default(name='embed')
+class SetSparseEncoder(SetEncoder):
 
     def __init__(
             self,

--- a/ludwig/encoders/set_encoders.py
+++ b/ludwig/encoders/set_encoders.py
@@ -17,14 +17,14 @@
 import logging
 from abc import ABC
 
-from ludwig.encoders.base import Encoder, register_default
+from ludwig.encoders.base import Encoder, Registry, register_default
 from ludwig.modules.embedding_modules import EmbedSparse
 from ludwig.modules.fully_connected_modules import FCStack
 
 logger = logging.getLogger(__name__)
 
 
-ENCODER_REGISTRY = {}
+ENCODER_REGISTRY = Registry()
 
 
 class SetEncoder(Encoder, ABC):

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -21,16 +21,13 @@ from abc import ABC
 import tensorflow as tf
 
 from ludwig.encoders import sequence_encoders
-from ludwig.encoders.base import Encoder, register
+from ludwig.encoders.base import Encoder, Registry, register
 from ludwig.modules.reduction_modules import SequenceReducer
 
 logger = logging.getLogger(__name__)
 
 
-ENCODER_REGISTRY = {
-    # TODO(travis): this will not work with custom sequence encoders added after this module is imported
-    **sequence_encoders.ENCODER_REGISTRY
-}
+ENCODER_REGISTRY = Registry(sequence_encoders.ENCODER_REGISTRY)
 
 
 class TextEncoder(Encoder, ABC):

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -21,7 +21,8 @@ from abc import ABC
 import tensorflow as tf
 
 from ludwig.encoders import sequence_encoders
-from ludwig.encoders.base import Encoder, Registry, register
+from ludwig.encoders.base import Encoder
+from ludwig.utils.registry import Registry, register
 from ludwig.modules.reduction_modules import SequenceReducer
 
 logger = logging.getLogger(__name__)

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -16,16 +16,31 @@
 # ==============================================================================
 import logging
 import sys
+from abc import ABC
 
 import tensorflow as tf
-from tensorflow.keras.layers import Layer
 
+from ludwig.encoders import sequence_encoders
+from ludwig.encoders.base import Encoder, register
 from ludwig.modules.reduction_modules import SequenceReducer
 
 logger = logging.getLogger(__name__)
 
 
-class BERTEncoder(Layer):
+ENCODER_REGISTRY = {
+    # TODO(travis): this will not work with custom sequence encoders added after this module is imported
+    **sequence_encoders.ENCODER_REGISTRY
+}
+
+
+class TextEncoder(Encoder, ABC):
+    @classmethod
+    def register(cls, name):
+        ENCODER_REGISTRY[name] = cls
+
+
+@register(name='bert')
+class BERTEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -81,7 +96,8 @@ class BERTEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class GPTEncoder(Layer):
+@register(name='gpt')
+class GPTEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -132,7 +148,8 @@ class GPTEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class GPT2Encoder(Layer):
+@register(name='gpt2')
+class GPT2Encoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -183,7 +200,8 @@ class GPT2Encoder(Layer):
         return {'encoder_output': hidden}
 
 
-class TransformerXLEncoder(Layer):
+# @register(name='transformer_xl')
+class TransformerXLEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -229,7 +247,8 @@ class TransformerXLEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class XLNetEncoder(Layer):
+@register(name='xlnet')
+class XLNetEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -280,7 +299,8 @@ class XLNetEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class XLMEncoder(Layer):
+@register(name='xlm')
+class XLMEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -331,7 +351,8 @@ class XLMEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class RoBERTaEncoder(Layer):
+@register(name='roberta')
+class RoBERTaEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -386,7 +407,8 @@ class RoBERTaEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class DistilBERTEncoder(Layer):
+@register(name='distilbert')
+class DistilBERTEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -436,7 +458,8 @@ class DistilBERTEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class CTRLEncoder(Layer):
+@register(name='ctrl')
+class CTRLEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -487,7 +510,8 @@ class CTRLEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class CamemBERTEncoder(Layer):
+@register(name='camembert')
+class CamemBERTEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -542,7 +566,8 @@ class CamemBERTEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class ALBERTEncoder(Layer):
+@register(name='albert')
+class ALBERTEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -597,7 +622,8 @@ class ALBERTEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class T5Encoder(Layer):
+@register(name='t5')
+class T5Encoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -649,7 +675,8 @@ class T5Encoder(Layer):
         return {'encoder_output': hidden}
 
 
-class XLMRoBERTaEncoder(Layer):
+@register(name='xlmroberta')
+class XLMRoBERTaEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -704,7 +731,8 @@ class XLMRoBERTaEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class FlauBERTEncoder(Layer):
+@register(name='flaubert')
+class FlauBERTEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -755,7 +783,8 @@ class FlauBERTEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class ELECTRAEncoder(Layer):
+@register(name='electra')
+class ELECTRAEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -806,7 +835,8 @@ class ELECTRAEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class LongformerEncoder(Layer):
+@register(name='longformer')
+class LongformerEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',
@@ -861,7 +891,8 @@ class LongformerEncoder(Layer):
         return {'encoder_output': hidden}
 
 
-class AutoTransformerEncoder(Layer):
+@register(name='auto_transformer')
+class AutoTransformerEncoder(TextEncoder):
     fixed_preprocessing_parameters = {
         'word_tokenizer': 'hf_tokenizer',
         'pretrained_model_name_or_path': 'feature.pretrained_model_name_or_path',

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -21,7 +21,7 @@ import numpy as np
 import tensorflow as tf
 
 from ludwig.constants import *
-from ludwig.encoders.bag_encoders import BagEmbedWeightedEncoder
+from ludwig.encoders.bag_encoders import ENCODER_REGISTRY
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.feature_utils import set_str_to_idx
 from ludwig.utils.misc_utils import set_default_value
@@ -92,6 +92,7 @@ class BagFeatureMixin(object):
 
 
 class BagInputFeature(BagFeatureMixin, InputFeature):
+    encoder_registry = ENCODER_REGISTRY
     encoder = 'embed'
     vocab = []
 
@@ -129,8 +130,3 @@ class BagInputFeature(BagFeatureMixin, InputFeature):
     @staticmethod
     def populate_defaults(input_feature):
         set_default_value(input_feature, TIED, None)
-
-    encoder_registry = {
-        'embed': BagEmbedWeightedEncoder,
-        None: BagEmbedWeightedEncoder
-    }

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -92,7 +92,6 @@ class BagFeatureMixin(object):
 
 
 class BagInputFeature(BagFeatureMixin, InputFeature):
-    encoder_registry = ENCODER_REGISTRY
     encoder = 'embed'
     vocab = []
 
@@ -130,3 +129,5 @@ class BagInputFeature(BagFeatureMixin, InputFeature):
     @staticmethod
     def populate_defaults(input_feature):
         set_default_value(input_feature, TIED, None)
+
+    encoder_registry = ENCODER_REGISTRY

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -23,8 +23,7 @@ from tensorflow.keras.metrics import Accuracy as BinaryAccuracy
 
 from ludwig.constants import *
 from ludwig.decoders.generic_decoders import Regressor
-from ludwig.encoders.generic_encoders import PassthroughEncoder, \
-    DenseEncoder
+from ludwig.encoders.binary_encoders import ENCODER_REGISTRY
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.base_feature import OutputFeature
 from ludwig.modules.loss_modules import BWCEWLoss
@@ -112,14 +111,7 @@ class BinaryInputFeature(BinaryFeatureMixin, InputFeature):
     def populate_defaults(input_feature):
         set_default_value(input_feature, TIED, None)
 
-    encoder_registry = {
-        'dense': DenseEncoder,
-        'passthrough': PassthroughEncoder,
-        'null': PassthroughEncoder,
-        'none': PassthroughEncoder,
-        'None': PassthroughEncoder,
-        None: PassthroughEncoder
-    }
+    encoder_registry = ENCODER_REGISTRY
 
 
 class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -22,9 +22,7 @@ import tensorflow as tf
 
 from ludwig.constants import *
 from ludwig.decoders.generic_decoders import Classifier
-from ludwig.encoders.category_encoders import CategoricalEmbedEncoder
-from ludwig.encoders.category_encoders import CategoricalSparseEncoder
-from ludwig.encoders.generic_encoders import PassthroughEncoder
+from ludwig.encoders.category_encoders import ENCODER_REGISTRY
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.base_feature import OutputFeature
 from ludwig.modules.loss_modules import SampledSoftmaxCrossEntropyLoss
@@ -139,15 +137,7 @@ class CategoryInputFeature(CategoryFeatureMixin, InputFeature):
     def populate_defaults(input_feature):
         set_default_value(input_feature, TIED, None)
 
-    encoder_registry = {
-        'dense': CategoricalEmbedEncoder,
-        'sparse': CategoricalSparseEncoder,
-        'passthrough': PassthroughEncoder,
-        'null': PassthroughEncoder,
-        'none': PassthroughEncoder,
-        'None': PassthroughEncoder,
-        None: PassthroughEncoder
-    }
+    encoder_registry = ENCODER_REGISTRY
 
 
 class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -23,7 +23,7 @@ import tensorflow as tf
 from dateutil.parser import parse
 
 from ludwig.constants import *
-from ludwig.encoders.date_encoders import DateEmbed, DateWave
+from ludwig.encoders.date_encoders import ENCODER_REGISTRY
 from ludwig.features.base_feature import InputFeature
 from ludwig.utils.misc_utils import set_default_value
 
@@ -151,7 +151,4 @@ class DateInputFeature(DateFeatureMixin, InputFeature):
     def populate_defaults(input_feature):
         set_default_value(input_feature, TIED, None)
 
-    encoder_registry = {
-        'embed': DateEmbed,
-        'wave': DateWave
-    }
+    encoder_registry = ENCODER_REGISTRY

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -20,7 +20,7 @@ import numpy as np
 import tensorflow as tf
 
 from ludwig.constants import *
-from ludwig.encoders.h3_encoders import H3Embed, H3WeightedSum, H3RNN
+from ludwig.encoders.h3_encoders import ENCODER_REGISTRY
 from ludwig.features.base_feature import InputFeature
 from ludwig.utils.h3_util import h3_to_components
 from ludwig.utils.misc_utils import set_default_value
@@ -115,8 +115,4 @@ class H3InputFeature(H3FeatureMixin, InputFeature):
     def populate_defaults(input_feature):
         set_default_value(input_feature, TIED, None)
 
-    encoder_registry = {
-        'embed': H3Embed,
-        'weighted_sum': H3WeightedSum,
-        'rnn': H3RNN
-    }
+    encoder_registry = ENCODER_REGISTRY

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -25,7 +25,7 @@ import numpy as np
 import tensorflow as tf
 
 from ludwig.constants import *
-from ludwig.encoders.image_encoders import Stacked2DCNN, ResNetEncoder
+from ludwig.encoders.image_encoders import ENCODER_REGISTRY
 from ludwig.features.base_feature import InputFeature
 from ludwig.utils.data_utils import get_abs_path
 from ludwig.utils.image_utils import greyscale
@@ -384,11 +384,7 @@ class ImageInputFeature(ImageFeatureMixin, InputFeature):
         set_default_value(input_feature, TIED, None)
         set_default_value(input_feature, PREPROCESSING, {})
 
-    encoder_registry = {
-        'stacked_cnn': Stacked2DCNN,
-        'resnet': ResNetEncoder,
-        None: Stacked2DCNN
-    }
+    encoder_registry = ENCODER_REGISTRY
 
 
 image_scaling_registry = {

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -21,13 +21,7 @@ import numpy as np
 from ludwig.constants import *
 from ludwig.decoders.sequence_decoders import SequenceGeneratorDecoder
 from ludwig.decoders.sequence_decoders import SequenceTaggerDecoder
-from ludwig.encoders.sequence_encoders import ParallelCNN, StackedTransformer
-from ludwig.encoders.sequence_encoders import SequenceEmbedEncoder
-from ludwig.encoders.sequence_encoders import SequencePassthroughEncoder
-from ludwig.encoders.sequence_encoders import StackedCNN
-from ludwig.encoders.sequence_encoders import StackedCNNRNN
-from ludwig.encoders.sequence_encoders import StackedParallelCNN
-from ludwig.encoders.sequence_encoders import StackedRNN
+from ludwig.encoders.sequence_encoders import ENCODER_REGISTRY
 from ludwig.encoders.text_encoders import *
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.base_feature import OutputFeature
@@ -170,20 +164,7 @@ class SequenceInputFeature(SequenceFeatureMixin, InputFeature):
         set_default_value(input_feature, TIED, None)
         set_default_value(input_feature, 'encoder', 'parallel_cnn')
 
-    encoder_registry = {
-        'stacked_cnn': StackedCNN,
-        'parallel_cnn': ParallelCNN,
-        'stacked_parallel_cnn': StackedParallelCNN,
-        'rnn': StackedRNN,
-        'cnnrnn': StackedCNNRNN,
-        'transformer': StackedTransformer,
-        'embed': SequenceEmbedEncoder,
-        'passthrough': SequencePassthroughEncoder,
-        'null': SequencePassthroughEncoder,
-        'none': SequencePassthroughEncoder,
-        'None': SequencePassthroughEncoder,
-        None: SequencePassthroughEncoder
-    }
+    encoder_registry = ENCODER_REGISTRY
 
 
 class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -19,9 +19,8 @@ import os
 import numpy as np
 
 from ludwig.constants import *
-from ludwig.decoders.sequence_decoders import SequenceGeneratorDecoder
-from ludwig.decoders.sequence_decoders import SequenceTaggerDecoder
-from ludwig.encoders.sequence_encoders import ENCODER_REGISTRY
+from ludwig.decoders.sequence_decoders import DECODER_REGISTRY
+from ludwig.encoders.sequence_encoders import ENCODER_REGISTRY as SEQUENCE_ENCODER_REGISTRY
 from ludwig.encoders.text_encoders import *
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.base_feature import OutputFeature
@@ -164,7 +163,7 @@ class SequenceInputFeature(SequenceFeatureMixin, InputFeature):
         set_default_value(input_feature, TIED, None)
         set_default_value(input_feature, 'encoder', 'parallel_cnn')
 
-    encoder_registry = ENCODER_REGISTRY
+    encoder_registry = SEQUENCE_ENCODER_REGISTRY
 
 
 class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):
@@ -504,7 +503,4 @@ class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):
         set_default_value(output_feature, 'reduce_input', SUM)
         set_default_value(output_feature, 'reduce_dependencies', SUM)
 
-    decoder_registry = {
-        'generator': SequenceGeneratorDecoder,
-        'tagger': SequenceTaggerDecoder
-    }
+    decoder_registry = DECODER_REGISTRY

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -22,7 +22,7 @@ import tensorflow as tf
 
 from ludwig.constants import *
 from ludwig.decoders.generic_decoders import Classifier
-from ludwig.encoders.set_encoders import SetSparseEncoder
+from ludwig.encoders.set_encoders import ENCODER_REGISTRY
 from ludwig.features.base_feature import InputFeature
 from ludwig.features.base_feature import OutputFeature
 from ludwig.features.feature_utils import set_str_to_idx
@@ -140,10 +140,7 @@ class SetInputFeature(SetFeatureMixin, InputFeature):
     def populate_defaults(input_feature):
         set_default_value(input_feature, TIED, None)
 
-    encoder_registry = {
-        'embed': SetSparseEncoder,
-        None: SetSparseEncoder
-    }
+    encoder_registry = ENCODER_REGISTRY
 
 
 class SetOutputFeature(SetFeatureMixin, OutputFeature):

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -19,7 +19,7 @@ import os
 import numpy as np
 
 from ludwig.constants import *
-from ludwig.encoders.text_encoders import *
+from ludwig.encoders.text_encoders import ENCODER_REGISTRY
 from ludwig.features.sequence_feature import SequenceInputFeature
 from ludwig.features.sequence_feature import SequenceOutputFeature
 from ludwig.utils.horovod_utils import is_on_master
@@ -294,26 +294,7 @@ class TextInputFeature(TextFeatureMixin, SequenceInputFeature):
                 encoder_class.default_params
             )
 
-    encoder_registry = {
-        'bert': BERTEncoder,
-        'gpt': GPTEncoder,
-        'gpt2': GPT2Encoder,
-        # 'transformer_xl': TransformerXLEncoder,
-        'xlnet': XLNetEncoder,
-        'xlm': XLMEncoder,
-        'roberta': RoBERTaEncoder,
-        'distilbert': DistilBERTEncoder,
-        'ctrl': CTRLEncoder,
-        'camembert': CamemBERTEncoder,
-        'albert': ALBERTEncoder,
-        't5': T5Encoder,
-        'xlmroberta': XLMRoBERTaEncoder,
-        'flaubert': FlauBERTEncoder,
-        'electra': ELECTRAEncoder,
-        'longformer': LongformerEncoder,
-        'auto_transformer': AutoTransformerEncoder,
-        **SequenceInputFeature.encoder_registry
-    }
+    encoder_registry = ENCODER_REGISTRY
 
 
 class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import logging
 import os
 
 import numpy as np

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -18,6 +18,7 @@ import logging
 import os
 
 import numpy as np
+import tensorflow as tf
 
 from ludwig.constants import *
 from ludwig.encoders.text_encoders import ENCODER_REGISTRY

--- a/ludwig/utils/registry.py
+++ b/ludwig/utils/registry.py
@@ -55,7 +55,7 @@ def register(name):
 
 def register_default(name):
     def wrap(cls):
-        ludwig.utils.registry.register(name)
+        cls.register(name)
         cls.register_default()
         return cls
     return wrap

--- a/ludwig/utils/registry.py
+++ b/ludwig/utils/registry.py
@@ -1,0 +1,61 @@
+#! /usr/bin/env python
+# coding=utf-8
+# Copyright (c) 2020 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from collections import UserDict
+
+import ludwig.utils
+
+
+DEFAULT_KEYS = ['None', 'none', 'null', None]
+
+
+class Registry(UserDict):
+    """Registry is like a normal dict, but with optional child dicts.
+
+    When an item is added / removed from the parent, the children will also have
+    that item added or removed.
+    """
+    def __init__(self, parent=None):
+        self.children = []
+        if isinstance(parent, Registry):
+            parent.children.append(self)
+        super().__init__(parent)
+
+    def __setitem__(self, key, value):
+        for child in self.children:
+            child.__setitem__(key, value)
+        super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        for child in self.children:
+            child.__delitem__(key)
+        super().__delitem__(key)
+
+
+def register(name):
+    def wrap(cls):
+        cls.register(name)
+        return cls
+    return wrap
+
+
+def register_default(name):
+    def wrap(cls):
+        ludwig.utils.registry.register(name)
+        cls.register_default()
+        return cls
+    return wrap


### PR DESCRIPTION
The purpose of this PR is to make it easy for users to extend Ludwig by adding custom encoders and decoders:

```
@register(name='my_encoder')
class CustomNumericalEncoder(NumericalEncoder):
    def call(self, inputs, training=None, mask=None):
        ...
```