### PR TITLE
feat(progress_tracker): save current learning rate

### DIFF
--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -583,6 +583,8 @@ class Trainer:
                         self.optimizer.variables(), root_rank=0)
 
                 progress_tracker.steps += 1
+                progress_tracker.learning_rate = current_learning_rate
+
                 if is_on_master():
                     progress_bar.update(1)
                 first_batch = False

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -583,7 +583,7 @@ class Trainer:
                         self.optimizer.variables(), root_rank=0)
 
                 progress_tracker.steps += 1
-                progress_tracker.learning_rate = current_learning_rate
+                progress_tracker.current_learning_rate = current_learning_rate
 
                 if is_on_master():
                     progress_bar.update(1)


### PR DESCRIPTION
There is no option to track current learning rate. I tried to update `progress_tracker.learning_rate` but it destroyed the training.