### PR TITLE
compare_performance documenting example usage

### DIFF
--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1354,11 +1354,11 @@ def compare_performance(
     # Example usage:
     
     ```python
-    model_a = LudwigModel(config,logging_level=logging.INFO)
-    model_a.train(dataset=dataset)
-    a_evaluation_stats, a_preprocessed_data, b_output_directory = model_a.evaluate(dataset=dataset)
-    model_b = LudwigModel.load('path/to/model/',logging_level=logging.INFO)
-    b_evaluation_stats, b_preprocessed_data, b_output_directory = model_b.evaluate(dataset=dataset)
+    model_a = LudwigModel(config)
+    model_a.train(dataset)
+    a_evaluation_stats, _, _ = model_a.evaluate(eval_set)
+    model_b = LudwigModel.load('path/to/model/')
+    b_evaluation_stats, _, _ = model_b.evaluate(eval_set)
     compare_performance([a_evaluation_stats, b_evaluation_stats], model_names=['A', 'B'])
     ```
     """

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1350,6 +1350,16 @@ def compare_performance(
     # Return
 
     :return: (None)
+    
+    # Example usage:
+    
+    ```python
+    model_a = LudwigModel(config,logging_level=logging.INFO)
+    model_b = LudwigModel(config,logging_level=logging.INFO)
+    a_training_stats, a_preprocessed_data, b_output_directory = model_a.train(dataset=dataset)
+    b_evaluation_stats, b_preprocessed_data, b_output_directory = model_b.evaluate(dataset=dataset)
+    compare_performance([a_training_stats, b_evaluation_stats], model_names=['A', 'B'])
+    ```
     """
     ignore_names = ['overall_stats', 'confusion_matrix', 'per_class_stats',
                     'predictions', 'probabilities']

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1355,10 +1355,11 @@ def compare_performance(
     
     ```python
     model_a = LudwigModel(config,logging_level=logging.INFO)
-    model_b = LudwigModel(config,logging_level=logging.INFO)
-    a_training_stats, a_preprocessed_data, b_output_directory = model_a.train(dataset=dataset)
+    model_a.train(dataset=dataset)
+    a_evaluation_stats, a_preprocessed_data, b_output_directory = model_a.evaluate(dataset=dataset)
+    model_b = LudwigModel.load('path/to/model/',logging_level=logging.INFO)
     b_evaluation_stats, b_preprocessed_data, b_output_directory = model_b.evaluate(dataset=dataset)
-    compare_performance([a_training_stats, b_evaluation_stats], model_names=['A', 'B'])
+    compare_performance([a_evaluation_stats, b_evaluation_stats], model_names=['A', 'B'])
     ```
     """
     ignore_names = ['overall_stats', 'confusion_matrix', 'per_class_stats',


### PR DESCRIPTION
Adds documentation of how to use the `compare_performance` visualization with two models.

*TODO: Generate the docs and add them to this PR using `mkdocs/code_docs_autogen.py`*