### PR TITLE
Feature Proposal: Allow numpy array to be accepted as vector feature

### DIFF
--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -77,7 +77,7 @@ class VectorFeatureMixin(object):
         try:
             print('feature: ', feature)
             print('input_df: ', input_df)
-            if isinstance(input_df[feature[COLUMN]][0], np.ndarray) and input_df[feature[COLUMN]][0].dtype == np.float32:
+            if isinstance(input_df[feature[COLUMN]].iloc[0], np.ndarray) and input_df[feature[COLUMN]].iloc[0].dtype == np.float32:
                 proc_df[feature[PROC_COLUMN]] = input_df[feature[COLUMN]]
             else: 
                 proc_df[feature[PROC_COLUMN]] = backend.df_engine.map_objects(

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -75,10 +75,15 @@ class VectorFeatureMixin(object):
 
         # Convert the string of features into a numpy array
         try:
-            proc_df[feature[PROC_COLUMN]] = backend.df_engine.map_objects(
-                input_df[feature[COLUMN]],
-                lambda x: np.array(x.split(), dtype=np.float32)
-            )
+            print('feature: ', feature)
+            print('input_df: ', input_df)
+            if isinstance(input_df[feature[COLUMN]][0], np.ndarray) and input_df[feature[COLUMN]][0].dtype == np.float32:
+                proc_df[feature[PROC_COLUMN]] = input_df[feature[COLUMN]]
+            else: 
+                proc_df[feature[PROC_COLUMN]] = backend.df_engine.map_objects(
+                    input_df[feature[COLUMN]],
+                    lambda x: np.array(x.split(), dtype=np.float32)
+                )
         except ValueError:
             logger.error(
                 'Unable to read the vector data. Make sure that all the vectors'

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -68,7 +68,8 @@ class VectorFeatureMixin(object):
     ):
         """
                 Expects all the vectors to be of the same size. The vectors need to be
-                whitespace delimited strings. Missing values are not handled.
+                whitespace delimited strings or a numpy array of type float32. 
+                Missing values are not handled.
                 """
         if len(input_df) == 0:
             raise ValueError("There are no vectors in the dataset provided")
@@ -77,7 +78,10 @@ class VectorFeatureMixin(object):
         try:
             print('feature: ', feature)
             print('input_df: ', input_df)
-            if isinstance(input_df[feature[COLUMN]].iloc[0], np.ndarray) and input_df[feature[COLUMN]].iloc[0].dtype == np.float32:
+            if (
+                isinstance(input_df[feature[COLUMN]].iloc[0], np.ndarray) and
+                input_df[feature[COLUMN]].iloc[0].dtype == np.float32
+            ):
                 proc_df[feature[PROC_COLUMN]] = input_df[feature[COLUMN]]
             else: 
                 proc_df[feature[PROC_COLUMN]] = backend.df_engine.map_objects(


### PR DESCRIPTION
Currently, the only accepted format for vector features is [whitespace separated numerical values. Example: "1.0 0.0 1.04 10.49"](https://ludwig-ai.github.io/ludwig-docs/user_guide/#vector-feature-preprocessing)

This string of numbers is then converted into a `np.ndarray` of type `np.float32` in [vector_feature.py around line 76](https://github.com/ludwig-ai/ludwig/blob/master/ludwig/features/vector_feature.py#L76)

This PR just adds a simple check before the conversion to see if the input feature is already a `np.ndarray` of type `np.float32` 
If so, then it just skips the conversion.

A potential alternative would be to just allow `np.ndarray` vectors of any type and just cast them to `np.float32`  


