### PR TITLE
Add tabnet modifications to achieve performance reported in the paper

### DIFF
--- a/ludwig/modules/normalization_modules.py
+++ b/ludwig/modules/normalization_modules.py
@@ -13,7 +13,11 @@ class GhostBatchNormalization(tf.keras.Model):
 
     def call(self, x, training: bool = None, alpha: float = 0.0):
         if training:
-            chunks = tf.split(x, self.virtual_divider)
+            num_or_size_splits = self.virtual_divider
+            if x.shape[0] % self.virtual_divider != 0:
+                q, r = divmod(x.shape[0], self.virtual_divider)
+                num_or_size_splits = [q] * self.virtual_divider + [r]
+            chunks = tf.split(x, num_or_size_splits)
             x = [self.bn(x, training=True) for x in chunks]
             return tf.concat(x, 0)
         return self.bn(x, training=False, alpha=alpha)

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -51,7 +51,7 @@ class TabNet(tf.keras.Model):
         )
 
         kargs = {
-            "size": size,
+            "size": size + output_size,
             "num_total_blocks": num_total_blocks,
             "num_shared_blocks": num_shared_blocks,
             "bn_momentum": bn_momentum,
@@ -100,7 +100,7 @@ class TabNet(tf.keras.Model):
             # Attentive Transormer #
             ########################
             mask_values = self.attentive_transforms[step_i](
-                x, prior_scales, training=training, alpha=alpha
+                x[:, self.output_size :], prior_scales, training=training, alpha=alpha
             )
 
             # relaxation factor 1 forces the feature to be only used once
@@ -127,7 +127,7 @@ class TabNet(tf.keras.Model):
                 masked_features, training=training, alpha=alpha
             )
 
-            out = tf.keras.activations.relu(masked_features)
+            out = tf.keras.activations.relu(x[:, : self.output_size])
             out_accumulator += out
 
         final_output = self.final_projection(out_accumulator)


### PR DESCRIPTION
Modifications allow for `output_size` to differ from `size` (the number of input features). They also facilitate training with arbitrary virtual batch divider constants, although some questions remain regarding virtual batch normalization. 

Reproducible test of PR: 

- `config.yaml`: https://gist.github.com/mananshah99/edff141fd291047bf0588688a0a533f4
- covtype dataset: https://www.kaggle.com/uciml/forest-cover-type-dataset

Achieves accuracy of 0.9508, which is within 1.5% of the reported accuracy in the paper. Remaining work needs to be done to identify the remaining discrepancy; the virtual batch size modifications didn't improve overall performance.