### PR TITLE
Fixed flaky image tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ install:
   - HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITHOUT_MPI=1 HOROVOD_WITHOUT_PYTORCH=1 HOROVOD_WITHOUT_MXNET=1 pip install --no-cache-dir '.[test]'
 script:
   - pip list
-  - pytest -v tests
+  - pytest -v --timeout 300 tests

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -670,7 +670,8 @@ class LudwigModel:
             training_set_metadata=self.training_set_metadata,
             data_format=data_format,
             split=split,
-            include_outputs=False
+            include_outputs=False,
+            backend=self.backend,
         )
 
         logger.debug('Predicting')
@@ -795,7 +796,8 @@ class LudwigModel:
             training_set_metadata=self.training_set_metadata,
             data_format=data_format,
             split=split,
-            include_outputs=True
+            include_outputs=True,
+            backend=self.backend,
         )
 
         logger.debug('Predicting')

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-timeout
 six>=1.13.0
 wandb
 comet_ml

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -332,18 +332,21 @@ def test_experiment_image_inputs(image_parms: ImageParms, csv_filename: str):
     shutil.rmtree(image_dest_folder)
 
 
-IMAGE_DATA_FORMATS_TO_TEST = ['csv', 'df', 'dict', 'hdf5']
+IMAGE_DATA_FORMATS_TO_TEST = ['csv', 'df', 'hdf5']
 
 
-@pytest.mark.parametrize('process_in_memory', [True, False])
-@pytest.mark.parametrize('data_format', IMAGE_DATA_FORMATS_TO_TEST)
-def test_experiment_image_dataset(data_format, process_in_memory):
+@pytest.mark.parametrize('test_in_memory', [True, False])
+@pytest.mark.parametrize('test_format', IMAGE_DATA_FORMATS_TO_TEST)
+@pytest.mark.parametrize('train_in_memory', [True, False])
+@pytest.mark.parametrize('train_format', IMAGE_DATA_FORMATS_TO_TEST)
+def test_experiment_image_dataset(
+        train_format, train_in_memory,
+        test_format, test_in_memory
+):
     run_experiment_fn = run_experiment_image_dataset
-    if process_in_memory:
+    if train_in_memory or test_in_memory:
         run_experiment_fn = spawn(run_experiment_fn)
 
-    train_format = test_format = data_format
-    train_in_memory = test_in_memory = process_in_memory
     run_experiment_fn(
         train_format, train_in_memory, test_format, test_in_memory
     )

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -23,7 +23,7 @@ import pytest
 import yaml
 
 from ludwig.api import LudwigModel
-from ludwig.backend import LOCAL_BACKEND
+from ludwig.backend import LOCAL_BACKEND, LocalBackend
 from ludwig.data.concatenate_datasets import concatenate_df
 from ludwig.data.preprocessing import preprocess_for_training
 from ludwig.experiment import experiment_cli
@@ -31,6 +31,7 @@ from ludwig.features.h3_feature import H3InputFeature
 from ludwig.predict import predict_cli
 from ludwig.utils.data_utils import read_csv
 from ludwig.utils.defaults import default_random_seed
+
 from tests.conftest import delete_temporary_data
 from tests.integration_tests.utils import ENCODERS, HF_ENCODERS, \
     HF_ENCODERS_SHORT, slow, create_data_set_to_use
@@ -56,6 +57,12 @@ from tests.integration_tests.utils import vector_feature
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 logging.getLogger("ludwig").setLevel(logging.INFO)
+
+
+class LocalTestBackend(LocalBackend):
+    @property
+    def supports_multiprocessing(self):
+        return False
 
 
 @pytest.mark.parametrize('encoder', ENCODERS)
@@ -343,19 +350,6 @@ def test_experiment_image_dataset(
         train_format, train_in_memory,
         test_format, test_in_memory
 ):
-    run_experiment_fn = run_experiment_image_dataset
-    if train_in_memory or test_in_memory:
-        run_experiment_fn = spawn(run_experiment_fn)
-
-    run_experiment_fn(
-        train_format, train_in_memory, test_format, test_in_memory
-    )
-
-
-def run_experiment_image_dataset(
-        train_format, train_in_memory,
-        test_format, test_in_memory
-):
     # primary focus of this test is to determine if exceptions are
     # raised for different data set formats and in_memory setting
     # Image Inputs
@@ -402,11 +396,13 @@ def run_experiment_image_dataset(
         = train_in_memory
     training_set_metadata = None
 
+    backend = LocalTestBackend()
     if train_format == 'hdf5':
         # hdf5 format
         train_set, _, _, training_set_metadata = preprocess_for_training(
             config,
-            dataset=train_data
+            dataset=train_data,
+            backend=backend,
         )
         train_dataset_to_use = train_set.data_hdf5_fp
     else:
@@ -415,6 +411,7 @@ def run_experiment_image_dataset(
     # define Ludwig model
     model = LudwigModel(
         config=config,
+        backend=backend,
     )
     model.train(
         dataset=train_dataset_to_use,

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -333,11 +333,23 @@ def test_experiment_image_inputs(image_parms: ImageParms, csv_filename: str):
 
 
 IMAGE_DATA_FORMATS_TO_TEST = ['csv', 'df', 'dict', 'hdf5']
-@pytest.mark.parametrize('test_in_memory', [True, False])
-@pytest.mark.parametrize('test_format', IMAGE_DATA_FORMATS_TO_TEST)
-@pytest.mark.parametrize('train_in_memory', [True, False])
-@pytest.mark.parametrize('train_format', IMAGE_DATA_FORMATS_TO_TEST)
-def test_experiment_image_dataset(
+
+
+@pytest.mark.parametrize('process_in_memory', [True, False])
+@pytest.mark.parametrize('data_format', IMAGE_DATA_FORMATS_TO_TEST)
+def test_experiment_image_dataset(data_format, process_in_memory):
+    run_experiment_fn = run_experiment_image_dataset
+    if process_in_memory:
+        run_experiment_fn = spawn(run_experiment_fn)
+
+    train_format = test_format = data_format
+    train_in_memory = test_in_memory = process_in_memory
+    run_experiment_fn(
+        train_format, train_in_memory, test_format, test_in_memory
+    )
+
+
+def run_experiment_image_dataset(
         train_format, train_in_memory,
         test_format, test_in_memory
 ):


### PR DESCRIPTION
Since upgrading `scikit-image`, several experiment tests have started to hang at random times during CI.

This PR disables the `multiprocessing.Pool` execution of the in-memory image tests to (1) prevent hangs due to forking the main process and (2) speed up test execution.  Combined with removing one of the test formats (`dict`), this set of tests now completes in about 30s.