### PR TITLE
fix: allow pd.Series as predictions_per_model in compare_classifiers_predictions

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -744,7 +744,7 @@ class LudwigModel:
             collect_predictions: bool = False,
             collect_overall_stats: bool = False,
             output_directory: str = 'results',
-            return_type: Union[str, dict, pd.DataFrame] = pd.DataFrame,
+            return_type: Union[dict, pd.DataFrame] = pd.DataFrame,
             debug: bool = False,
             **kwargs
     ) -> Tuple[dict, Union[dict, pd.DataFrame], str]:
@@ -785,8 +785,8 @@ class LudwigModel:
         :param output_directory: (str, default: `'results'`) the directory that
             will contain the training statistics, TensorBoard logs, the saved
             model and the training progress files.
-        :param return_type: (Union[str, dict, pandas.DataFrame], default: pandas.DataFrame) indicates
-            the format to of the returned predictions.
+        :param return_type: (Union[dict, pandas.DataFrame], default: pandas.DataFrame) indicates
+            the format of the returned predictions.
         :param debug: (bool, default: `False`) If `True` turns on `tfdbg`
                 with `inf_or_nan` checks.
 

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -2043,7 +2043,7 @@ def compare_classifiers_predictions(
 
     # Inputs
 
-    :param predictions_per_model: (Union[List[list, pd.Series]]) list containing
+    :param predictions_per_model: (List[Union[list, pd.Series]]) list containing
         the model predictions for the specified output_feature_name.
     :param ground_truth: (Union[pd.Series, np.ndarray]) ground truth values
     :param metadata: (dict) feature metadata dictionary

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -2076,8 +2076,15 @@ def compare_classifiers_predictions(
         model_names_list[1] if model_names is not None and len(model_names) > 1
         else 'c2')
 
-    pred_c1 = np.array(predictions_per_model[0], dtype=int)
-    pred_c2 = np.array(predictions_per_model[1], dtype=int)
+    if isinstance(predictions_per_model[0], pd.Series):
+        pred_c1 = np.array(predictions_per_model[0], dtype=int) 
+    else:
+        pred_c1 = predictions_per_model[0]
+
+    if isinstance(predictions_per_model[1], pd.Series):
+        pred_c2 = np.array(predictions_per_model[1], dtype=int)
+    else:
+        pred_c2 = predictions_per_model[1]
 
     if labels_limit > 0:
         ground_truth[ground_truth > labels_limit] = labels_limit

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -2029,7 +2029,7 @@ def compare_classifiers_multiclass_multimetric(
 
 
 def compare_classifiers_predictions(
-        predictions_per_model: Union[List[list, pd.Series]],
+        predictions_per_model: List[Union[list, pd.Series]],
         ground_truth: Union[pd.Series, np.ndarray],
         metadata: dict,
         output_feature_name: str,

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -2029,7 +2029,7 @@ def compare_classifiers_multiclass_multimetric(
 
 
 def compare_classifiers_predictions(
-        predictions_per_model: List[list],
+        predictions_per_model: Union[List[list, pd.Series]],
         ground_truth: Union[pd.Series, np.ndarray],
         metadata: dict,
         output_feature_name: str,
@@ -2043,8 +2043,8 @@ def compare_classifiers_predictions(
 
     # Inputs
 
-    :param predictions_per_model: (List[list]) list containing the model
-        predictions for the specified output_feature_name.
+    :param predictions_per_model: (Union[List[list, pd.Series]]) list containing
+        the model predictions for the specified output_feature_name.
     :param ground_truth: (Union[pd.Series, np.ndarray]) ground truth values
     :param metadata: (dict) feature metadata dictionary
     :param output_feature_name: (str) output feature name
@@ -2076,8 +2076,8 @@ def compare_classifiers_predictions(
         model_names_list[1] if model_names is not None and len(model_names) > 1
         else 'c2')
 
-    pred_c1 = predictions_per_model[0]
-    pred_c2 = predictions_per_model[1]
+    pred_c1 = np.array(predictions_per_model[0], dtype=int)
+    pred_c2 = np.array(predictions_per_model[1], dtype=int)
 
     if labels_limit > 0:
         ground_truth[ground_truth > labels_limit] = labels_limit


### PR DESCRIPTION
Current behaviour - 

While passing an argument of type pd.Series  to `compare_classifiers_predictions` which is a default output type for `evaluate` results in a `TypeError: '>' not supported between instances of 'str' and 'int'`. This leads to type casting into `np.ndarray` of  `dtype=int` before passing as an argument to `compare_classifiers_predictions`.
```
compare_classifiers_predictions([np.array(predictions_parallel_cnn['label_predictions'], dtype=int), 
                                np.array(predictions_bi_lstm['label_predictions'], dtype=int)],
                                 ...
                                 ...
                                )

```

This PR allows pd.Series to be passed as an argument to `compare_classifiers_predictions` by adding this conversion. 

After this PR:
```
compare_classifiers_predictions([predictions_parallel_cnn['label_predictions'], 
                                predictions_bi_lstm['label_predictions']],
                                 ...
                                 ...
                                )

```