### PR TITLE
FIX: Issue 1104 - Add lengths tensor to encoder output for text feature

### DIFF
--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -252,11 +252,12 @@ class TextInputFeature(TextFeatureMixin, SequenceInputFeature):
             inputs_mask = tf.not_equal(inputs, self.pad_idx)
         else:
             inputs_mask = None
-
+        lengths = tf.reduce_sum(tf.cast(inputs_mask, dtype=tf.int32), axis=1)
         encoder_output = self.encoder_obj(
             inputs_exp, training=training, mask=inputs_mask
         )
 
+        encoder_output[LENGTHS] = lengths
         return encoder_output
 
     @classmethod

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -572,7 +572,7 @@ def test_sequence_tagger(
         sequence_feature(
             max_len=10,
             encoder='rnn',
-            cell_type='lstm',
+            cell_type=enc_cell_type,
             reduce_output=None
         )
     ]
@@ -588,8 +588,31 @@ def test_sequence_tagger(
     # Generate test data
     rel_path = generate_data(input_features, output_features, csv_filename)
 
-    # setup encoder specification
-    input_features[0]['cell_type'] = enc_cell_type
+    # run the experiment
+    run_experiment(input_features, output_features, dataset=rel_path)
+
+
+def test_sequence_tagger_text(
+        csv_filename
+):
+    # Define input and output features
+    input_features = [
+        text_feature(
+            max_len=10,
+            encoder='rnn',
+            reduce_output=None
+        )
+    ]
+    output_features = [
+        sequence_feature(
+            max_len=10,
+            decoder='tagger',
+            reduce_input=None
+        )
+    ]
+
+    # Generate test data
+    rel_path = generate_data(input_features, output_features, csv_filename)
 
     # run the experiment
     run_experiment(input_features, output_features, dataset=rel_path)


### PR DESCRIPTION
# Code Pull Requests

Fix Issue #1104.

Changes:
* Added `lengths` tensor to encoder output generated by the `TextInputFeature`
* Added unit test to account for the situation encountered by the #1104.