### PR TITLE
Fixing SST-2 subtree logic to match GLUE SST-2

### DIFF
--- a/ludwig/datasets/sst2/__init__.py
+++ b/ludwig/datasets/sst2/__init__.py
@@ -47,11 +47,14 @@ class SST2(SST):
     """
 
     def __init__(self, cache_dir=DEFAULT_CACHE_LOCATION,
-                 include_subtrees=False, convert_parentheses=True):
+                 include_subtrees=False, 
+                 convert_parentheses=True,
+                 remove_duplicates=False):
         super().__init__(dataset_name='sst2', cache_dir=cache_dir,
                          include_subtrees=include_subtrees,
                          discard_neutral=True,
-                         convert_parentheses=convert_parentheses)
+                         convert_parentheses=convert_parentheses,
+                         remove_duplicates=False)
 
     def get_sentiment_label(self, id2sent, phrase_id):
         sentiment = id2sent[phrase_id]

--- a/ludwig/datasets/sst3/__init__.py
+++ b/ludwig/datasets/sst3/__init__.py
@@ -43,10 +43,12 @@ class SST3(SST):
 
     def __init__(self, cache_dir=DEFAULT_CACHE_LOCATION,
                  include_subtrees=False,
-                 convert_parentheses=True):
+                 convert_parentheses=True,
+                 remove_duplicates=False):
         super().__init__(dataset_name='sst3', cache_dir=cache_dir,
                          include_subtrees=include_subtrees,
-                         convert_parentheses=convert_parentheses)
+                         convert_parentheses=convert_parentheses,
+                         remove_duplicates=False)
 
     def get_sentiment_label(self, id2sent, phrase_id):
         sentiment = id2sent[phrase_id]

--- a/ludwig/datasets/sst5/__init__.py
+++ b/ludwig/datasets/sst5/__init__.py
@@ -42,10 +42,13 @@ class SST5(SST):
     """
 
     def __init__(self, cache_dir=DEFAULT_CACHE_LOCATION,
-                 include_subtrees=False, convert_parentheses=True):
+                 include_subtrees=False, 
+                 convert_parentheses=True,
+                 remove_duplicates=False):
         super().__init__(dataset_name='sst5', cache_dir=cache_dir,
                          include_subtrees=include_subtrees,
-                         convert_parentheses=convert_parentheses)
+                         convert_parentheses=convert_parentheses,
+                         remove_duplicates=False)
 
     def get_sentiment_label(self, id2sent, phrase_id):
         sentiment = id2sent[phrase_id]


### PR DESCRIPTION
This PR makes the following changes to the SST datasets:
1. Adds `remove_duplicates` parameter to SST classes: Parameter is necessary to make the SST-2 dataset match the SST-2 GLUE Dataset. `remove_duplicates` was added as a parameter as some SST datasets (i.e. torchtext) do not remove duplicates
2. In the construction of `phrase2id` (lines 78-82), removes the statement which actively replaced -LRB- and -RRB- with parenthesis: this logic was causing some phrases to be wrongfully marked as neutral
