### PR TITLE
Adding register_trainable logic to RayTuneExecutor

### DIFF
--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -15,7 +15,7 @@ from ludwig.modules.metric_modules import get_best_function
 from ludwig.utils.data_utils import NumpyEncoder
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.misc_utils import (get_available_gpu_memory, 
-                                     get_from_registry
+                                     get_from_registry,
                                      hash_dict)
 from ludwig.utils.tf_utils import get_available_gpus_cuda_string
 

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -14,13 +14,16 @@ from ludwig.hyperopt.sampling import HyperoptSampler, RayTuneSampler, logger
 from ludwig.modules.metric_modules import get_best_function
 from ludwig.utils.data_utils import NumpyEncoder
 from ludwig.utils.defaults import default_random_seed
-from ludwig.utils.misc_utils import get_available_gpu_memory, get_from_registry
+from ludwig.utils.misc_utils import (get_available_gpu_memory, 
+                                     get_from_registry
+                                     hash_dict)
 from ludwig.utils.tf_utils import get_available_gpus_cuda_string
 
 try:
     import ray
     from ray import tune
     from ray.tune.utils import wait_for_gpu
+    from ray.tune import register_trainable
 except ImportError:
     ray = None
 
@@ -844,8 +847,13 @@ class RayTuneExecutor(HyperoptExecutor):
         def run_experiment_trial(config, checkpoint_dir=None):
             return self._run_experiment(config, checkpoint_dir, hyperopt_dict, self.decode_ctx)
 
+        register_trainable(
+            f"trainable_func_f{hash_dict(config)}", 
+            run_experiment_trial
+        )
+
         analysis = tune.run(
-            run_experiment_trial,
+            f"trainable_func_f{hash_dict(config)}",
             config=self.search_space,
             scheduler=self.scheduler,
             search_alg=search_alg,


### PR DESCRIPTION
This PR registers the trainable function passed to `tune.run` using the `ray.tune` util function `register_trainable`. This fix is necessary in order ensure that the trainable function is accessible to all Ray processes in a cluster. Moreover, when running several parallel `ludwig.hyperopt` calls on a given ray cluster, it is necessary to have a unique trainable function for each experiment. Doing so prevents the underlying objects of different experiments (i.e. `self.decode_ctx`) from being shared. A unique trainable function name is created by generating a hash of the experiment config.

cc: @tgaddair 