### PR TITLE
fix: error when saving model with image feature

### DIFF
--- a/ludwig/encoders/image_encoders.py
+++ b/ludwig/encoders/image_encoders.py
@@ -113,7 +113,9 @@ class Stacked2DCNN(ImageEncoder):
             default_pool_strides=pool_strides,
         )
 
-        logger.debug('  FCStacl')
+        self.flatten = Flatten()
+
+        logger.debug('  FCStack')
         self.fc_stack = FCStack(
             layers=fc_layers,
             num_layers=num_fc_layers,
@@ -143,7 +145,7 @@ class Stacked2DCNN(ImageEncoder):
             inputs,
             training,
         )
-        hidden = tf.reshape(hidden, [hidden.shape[0], -1])
+        hidden = self.flatten(hidden, training=training)
 
         # ================ Fully Connected ================
         outputs = self.fc_stack(hidden)


### PR DESCRIPTION
# Code Pull Requests

Fix Issue #1070 and #1118 with reported error `TypeError: Failed to convert object of type <class 'list'> to Tensor. Contents: [None, -1]. Consider casting elements to a supported type.`

Ran additional test to ensure restored model weights matched original trained model weights.