### PR TITLE
Update Titanic and serve examples so they work with Kaggle based dataset

### DIFF
--- a/examples/serve/README.md
+++ b/examples/serve/README.md
@@ -61,25 +61,24 @@ python client_program.py
 
 Output should look like this
 ``` 
-retrieved 418 records for predictions
-single record for prediciton:
- {'PassengerId': 892, 'Pclass': 3, 'Name': 'Kelly, Mr. James', 'Sex': 'male', 'Age': 34.5, 'SibSp': 0, 'Parch': 0, 'Ticket': '330911', 'Fare': 7.8292, 'Cabin': nan, 'Embarked': 'Q'}
+retrieved 1309 records for predictions
+single record for prediction:
+ {'PassengerId': 1, 'Survived': 0.0, 'Pclass': 3, 'Name': 'Braund, Mr. Owen Harris', 'Sex': 'male', 'Age': 22.0, 'SibSp': 1, 'Parch': 0, 'Ticket': 'A/5 21171', 'Fare': 7.25, 'Cabin': nan, 'Embarked': 'S', 'split': 0}
 
 invoking REST API /predict for single record...
 
 Received 1 predictions
 Sample predictions:
-   Survived_predictions  Survived_probabilities
-0                 False                0.257691
+   Survived_predictions  Survived_probabilities_False  Survived_probabilities_True  Survived_probability
+0                 False                      0.906132                     0.093868              0.906132
 
 invoking REST API /batch_predict for entire dataframe...
 
-Received 418 predictions
+Received 1309 predictions
 Sample predictions:
-   Survived_predictions  Survived_probabilities
-0                 False                0.257691
-1                 False                0.439749
-2                 False                0.439286
-3                 False                0.146570
-4                 False                0.427077
-```
+   Survived_predictions  Survived_probabilities_False  Survived_probabilities_True  Survived_probability
+0                 False                      0.906132                     0.093868              0.906132
+1                  True                      0.165714                     0.834286              0.834286
+2                  True                      0.441169                     0.558831              0.558831
+3                  True                      0.228311                     0.771689              0.771689
+4                 False                      0.878072                     0.121928              0.878072```

--- a/examples/serve/client_program.py
+++ b/examples/serve/client_program.py
@@ -1,6 +1,7 @@
 import sys
 import requests
 import pandas as pd
+from ludwig.datasets import titanic
 
 # Ludwig model server default values
 LUDWIG_HOST = '0.0.0.0'
@@ -10,7 +11,7 @@ LUDWIG_PORT = '8000'
 #
 # retrieve data to make predictions
 #
-test_df = pd.read_csv('../titanic/data/test.csv')
+test_df = titanic.load()
 print('retrieved {:d} records for predictions'.format(test_df.shape[0]))
 
 

--- a/examples/titanic/README.md
+++ b/examples/titanic/README.md
@@ -6,8 +6,7 @@ This API example is based on [Ludwig's Kaggle Titanic example](https://ludwig-ai
 
 Create and download your [Kaggle API Credentials](https://github.com/Kaggle/kaggle-api#api-credentials).
 
-The Titanic dataset is hosted by Kaggle, and as such Ludwig will need to authenticate you through the Kaggle
-API to download the dataset.
+The Titanic dataset is hosted by Kaggle, and as such Ludwig will need to authenticate you through the Kaggle API to download the dataset. You will also need to join [the competition](https://www.kaggle.com/c/titanic) to enable downloading of the data.
 
 ### Examples
 |File|Description|


### PR DESCRIPTION
#1021 added dataset download from Kaggle. This pull request is a follow on so that the `serve` example can work out of the box for users.

There is also an additional documentation commit (f4446d9) that might be useful for users downloading data from Kaggle for the first time.