### PR TITLE
[DO NOT MERGE] Parquet dataset and Iteratable batcher incompatibility workaround

### DIFF
--- a/ludwig/data/dataset/parquet.py
+++ b/ludwig/data/dataset/parquet.py
@@ -28,7 +28,6 @@ class ParquetDataset(Dataset):
     def __init__(self, url, features, training_set_metadata):
         self.url = url
         self.training_set_metadata = training_set_metadata
-
         with make_batch_reader(self.url) as reader:
             self.size = reader.dataset.metadata.num_rows
 
@@ -37,14 +36,23 @@ class ParquetDataset(Dataset):
             for feature in features
             if 'reshape' in training_set_metadata[feature[NAME]]
         }
+        self.features = {
+            feature[PROC_COLUMN]: list((-1, *training_set_metadata[feature[NAME]]))
+            for feature in features
+        }
+
+    # def get(self, feature_name, sample):
+    #     t = getattr(sample, feature_name)
+    #     reshape_dim = self.reshape_features.get(feature_name)
+    #     # reshape_dim = self.features.get(feature_name)
+    #     if reshape_dim is not None:
+    #         # When we read a 1D array from disk, we need to reshape it back to its
+    #         # full dimensions.
+    #         t = tf.reshape(t, reshape_dim)
+    #     return t
 
     def get(self, feature_name, sample):
         t = getattr(sample, feature_name)
-        reshape_dim = self.reshape_features.get(feature_name)
-        if reshape_dim is not None:
-            # When we read a 1D array from disk, we need to reshape it back to its
-            # full dimensions.
-            t = tf.reshape(t, reshape_dim)
         return t
 
     def __len__(self):

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -20,6 +20,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 import pandas as pd
+import dask.dataframe as dd
 
 import ludwig
 from ludwig.backend import LOCAL_BACKEND
@@ -1173,8 +1174,12 @@ def precompute_fill_value(dataset_df, feature, preprocessing_parameters):
                 'Filling missing values with mean is supported '
                 'only for numerical types',
             )
-        return dataset_df[feature[COLUMN]].mean()
-
+        if isinstance(dataset_df, pd.DataFrame):
+            return dataset_df[feature[COLUMN]].mean()
+        elif isinstance(dataset_df, dd.DataFrame):
+            return dataset_df[feature[COLUMN]].mean().compute()
+        else:
+            raise ValueError('Unsupported DataFrame type.')
     # Otherwise, we cannot precompute the fill value for this dataset
     return None
 


### PR DESCRIPTION
# Code Pull Requests
This PR aims to show my workaround on the two issues: #1135 #1134 so one can better understand the two issues. Please do not merge.

A bit explanation about the workaround:
- Due to Issue #1134 -- the `self.features` attribute is missing, I appended a `self.features` so it can work with IteratableBatcher without errors.

- Due to Issue #1135  -- on petfinder dataset, after the dict comprehension we'll get an empty dict which will cause an error when reading data batches. I remove the `if `reshape` in training_set_metadata[feature[NAME]]` and seem to work around the issue.

