### PR TITLE
update example-titanic config

### DIFF
--- a/examples/titanic/model2_config.yaml
+++ b/examples/titanic/model2_config.yaml
@@ -15,14 +15,14 @@ input_features:
         name: SibSp
         type: numerical
         preprocessing:
-            missing_value_strategy: fill_with_median
-            normalization: minmax
+            missing_value_strategy: fill_with_mean
+            normalization: zscore
     -
         name: Parch
         type: numerical
         preprocessing:
-            missing_value_strategy: fill_with_median
-            normalization: minmax
+            missing_value_strategy: fill_with_mean
+            normalization: zscore
     -
         name: Fare
         type: numerical


### PR DESCRIPTION
# Update Multi Model Training in titanic example

- `fill_with_median` in preprocessing is no longer supported in latest ludwig, replace it with `fill_with_mean`
- `python multiple_model_training.py` will now run through with the fix
