### PR TITLE
Rename "Trasformer" to "Transformer"; Python 3 syntax updates

### DIFF
--- a/ludwig/cli.py
+++ b/ludwig/cli.py
@@ -22,7 +22,7 @@ import ludwig.contrib
 ludwig.contrib.contrib_import()
 
 
-class CLI(object):
+class CLI:
     """CLI describes a command line interface for interacting with Ludwig, there
     are several different functions that can be performed. These functions are:
     - experiment - run an experiment using ludwig

--- a/ludwig/datasets/amazon_review_polarity/__init__.py
+++ b/ludwig/datasets/amazon_review_polarity/__init__.py
@@ -40,7 +40,7 @@ class AmazonPolarity(TarDownloadMixin, MultifileJoinProcessMixin,
         super().__init__(dataset_name="amazon_review_polarity", cache_dir=cache_dir)
 
     def process_downloaded_dataset(self):
-        super(AmazonPolarity, self).process_downloaded_dataset(header=None)
+        super().process_downloaded_dataset(header=None)
         processed_df = pd.read_csv(os.path.join(self.processed_dataset_path,
                                                 self.csv_filename))
         processed_df.columns = ['label', 'review_tile', 'review_text', 'split']

--- a/ludwig/datasets/amazon_reviews/__init__.py
+++ b/ludwig/datasets/amazon_reviews/__init__.py
@@ -40,7 +40,7 @@ class AmazonReviews(TarDownloadMixin, MultifileJoinProcessMixin,
         super().__init__(dataset_name="amazon_reviews", cache_dir=cache_dir)
 
     def process_downloaded_dataset(self):
-        super(AmazonReviews, self).process_downloaded_dataset(header=None)
+        super().process_downloaded_dataset(header=None)
         processed_df = pd.read_csv(os.path.join(self.processed_dataset_path,
                                                 self.csv_filename))
         processed_df.columns = ['label', 'review_tile', 'review_text', 'split']

--- a/ludwig/datasets/dbpedia/__init__.py
+++ b/ludwig/datasets/dbpedia/__init__.py
@@ -38,7 +38,7 @@ class DBPedia(TarDownloadMixin, MultifileJoinProcessMixin,
         super().__init__(dataset_name="dbpedia", cache_dir=cache_dir)
 
     def process_downloaded_dataset(self):
-        super(DBPedia, self).process_downloaded_dataset(header=None)
+        super().process_downloaded_dataset(header=None)
         processed_df = pd.read_csv(os.path.join(self.processed_dataset_path,
                                                 self.csv_filename))
         processed_df.columns = ['label', 'title', 'content', 'split']

--- a/ludwig/datasets/ethos_binary/__init__.py
+++ b/ludwig/datasets/ethos_binary/__init__.py
@@ -36,7 +36,7 @@ class EthosBinary(UncompressedFileDownloadMixin, IdentityProcessMixin,
         super().__init__(dataset_name="ethos_binary", cache_dir=cache_dir)
 
     def process_downloaded_dataset(self):
-        super(EthosBinary, self).process_downloaded_dataset()
+        super().process_downloaded_dataset()
         # replace ; sperator to ,
         processed_df = pd.read_csv(os.path.join(self.processed_dataset_path,
                                                 self.csv_filename), sep=";")

--- a/ludwig/datasets/goemotions/__init__.py
+++ b/ludwig/datasets/goemotions/__init__.py
@@ -43,7 +43,7 @@ class GoEmotions(UncompressedFileDownloadMixin, MultifileJoinProcessMixin,
         return file_df
 
     def process_downloaded_dataset(self):
-        super(GoEmotions, self).process_downloaded_dataset()
+        super().process_downloaded_dataset()
         # format emotion ids to be a set of emotion ids vs. string
         processed_df = pd.read_csv(os.path.join(self.processed_dataset_path,
                                                 self.csv_filename))

--- a/ludwig/datasets/sst2/sst_utils.py
+++ b/ludwig/datasets/sst2/sst_utils.py
@@ -173,7 +173,7 @@ class SST(ABC, ZipDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin,
                 index=False
             )
 
-        super(SST, self).process_downloaded_dataset()
+        super().process_downloaded_dataset()
 
 
 def format_text(text: str):

--- a/ludwig/datasets/yahoo_answers/__init__.py
+++ b/ludwig/datasets/yahoo_answers/__init__.py
@@ -40,7 +40,7 @@ class YahooAnswers(TarDownloadMixin, MultifileJoinProcessMixin,
         super().__init__(dataset_name="yahoo_answers", cache_dir=cache_dir)
 
     def process_downloaded_dataset(self):
-        super(YahooAnswers, self).process_downloaded_dataset(header=None)
+        super().process_downloaded_dataset(header=None)
         processed_df = pd.read_csv(os.path.join(self.processed_dataset_path,
                                                 self.csv_filename))
         processed_df.columns = ['label', 'question_title', 'question', 'best_answer', 'split']

--- a/ludwig/datasets/yelp_review_polarity/__init__.py
+++ b/ludwig/datasets/yelp_review_polarity/__init__.py
@@ -39,7 +39,7 @@ class YelpPolarity(TarDownloadMixin, MultifileJoinProcessMixin,
         super().__init__(dataset_name="yelp_polarity", cache_dir=cache_dir)
 
     def process_downloaded_dataset(self):
-        super(YelpPolarity, self).process_downloaded_dataset(header=None)
+        super().process_downloaded_dataset(header=None)
         processed_df = pd.read_csv(os.path.join(self.processed_dataset_path,
                                                 self.csv_filename))
         processed_df.columns = ['label', 'text', 'split']

--- a/ludwig/datasets/yelp_reviews/__init__.py
+++ b/ludwig/datasets/yelp_reviews/__init__.py
@@ -39,7 +39,7 @@ class YelpReviews(TarDownloadMixin, MultifileJoinProcessMixin,
         super().__init__(dataset_name="yelp_reviews", cache_dir=cache_dir)
 
     def process_downloaded_dataset(self):
-        super(YelpReviews, self).process_downloaded_dataset(header=None)
+        super().process_downloaded_dataset(header=None)
         processed_df = pd.read_csv(os.path.join(self.processed_dataset_path,
                                                 self.csv_filename))
         processed_df.columns = ['label', 'text', 'split']

--- a/ludwig/decoders/sequence_decoders.py
+++ b/ludwig/decoders/sequence_decoders.py
@@ -78,7 +78,7 @@ class SequenceGeneratorDecoder(SequenceDecoder):
             reduce_input='sum',
             **kwargs
     ):
-        super(SequenceGeneratorDecoder, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         self.cell_type = cell_type
@@ -720,7 +720,7 @@ class SequenceTaggerDecoder(SequenceDecoder):
             is_timeseries=False,
             **kwargs
     ):
-        super(SequenceTaggerDecoder, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         self.attention = attention

--- a/ludwig/encoders/bag_encoders.py
+++ b/ludwig/encoders/bag_encoders.py
@@ -62,7 +62,7 @@ class BagEmbedWeightedEncoder(BagEncoder):
             dropout=0.0,
             **kwargs
     ):
-        super(BagEmbedWeightedEncoder, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         logger.debug('  EmbedWeighted')

--- a/ludwig/encoders/binary_encoders.py
+++ b/ludwig/encoders/binary_encoders.py
@@ -45,7 +45,7 @@ class BinaryPassthroughEncoder(BinaryEncoder):
             self,
             **kwargs
     ):
-        super(BinaryPassthroughEncoder, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
     def call(self, inputs, training=None, mask=None):

--- a/ludwig/encoders/category_encoders.py
+++ b/ludwig/encoders/category_encoders.py
@@ -51,7 +51,7 @@ class CategoricalEmbedEncoder(CategoricalEncoder):
             embedding_regularizer=None,
             **kwargs
     ):
-        super(CategoricalEmbedEncoder, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         logger.debug('  Embed')
@@ -95,7 +95,7 @@ class CategoricalSparseEncoder(CategoricalEncoder):
             embedding_regularizer=None,
             **kwargs
     ):
-        super(CategoricalSparseEncoder, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         logger.debug('  Embed')

--- a/ludwig/encoders/date_encoders.py
+++ b/ludwig/encoders/date_encoders.py
@@ -109,7 +109,7 @@ class DateEmbed(DateEncoder):
             :type dropout: float
 
         """
-        super(DateEmbed, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         logger.debug('  year FCStack')
@@ -379,7 +379,7 @@ class DateWave(DateEncoder):
                    returning the encoder output.
             :type dropout: float
         """
-        super(DateWave, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         logger.debug('  year FCStack')

--- a/ludwig/encoders/generic_encoders.py
+++ b/ludwig/encoders/generic_encoders.py
@@ -29,7 +29,7 @@ class PassthroughEncoder(Layer):
             self,
             **kwargs
     ):
-        super(PassthroughEncoder, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
     def call(self, inputs, training=None, mask=None):
@@ -61,7 +61,7 @@ class DenseEncoder(Layer):
             dropout=0,
             **kwargs
     ):
-        super(DenseEncoder, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         logger.debug('  FCStack')

--- a/ludwig/encoders/h3_encoders.py
+++ b/ludwig/encoders/h3_encoders.py
@@ -102,7 +102,7 @@ class H3Embed(H3Encoder):
                    is greater than 0).
             :type regularize: Boolean
         """
-        super(H3Embed, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         self.embedding_size = embedding_size
@@ -333,7 +333,7 @@ class H3WeightedSum(H3Encoder):
                    is greater than 0).
             :type regularize: Boolean
         """
-        super(H3WeightedSum, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         self.should_softmax = should_softmax
@@ -540,7 +540,7 @@ class H3RNN(H3Encoder):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(H3RNN, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         self.embedding_size = embedding_size

--- a/ludwig/encoders/image_encoders.py
+++ b/ludwig/encoders/image_encoders.py
@@ -83,7 +83,7 @@ class Stacked2DCNN(ImageEncoder):
             fc_dropout=0,
             **kwargs
     ):
-        super(Stacked2DCNN, self).__init__()
+        super().__init__()
 
         logger.debug(' {}'.format(self.name))
 
@@ -183,7 +183,7 @@ class ResNetEncoder(ImageEncoder):
             dropout=0,
             **kwargs
     ):
-        super(ResNetEncoder, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         if resnet_size < 50:

--- a/ludwig/encoders/sequence_encoders.py
+++ b/ludwig/encoders/sequence_encoders.py
@@ -22,7 +22,7 @@ from tensorflow.keras.layers import Dense
 
 from ludwig.encoders.base import Encoder
 from ludwig.utils.registry import Registry, register, register_default
-from ludwig.modules.attention_modules import TrasformerStack
+from ludwig.modules.attention_modules import TransformerStack
 from ludwig.modules.convolutional_modules import Conv1DStack, \
     ParallelConv1DStack, ParallelConv1D
 from ludwig.modules.embedding_modules import EmbedSequence, \
@@ -2042,7 +2042,7 @@ class StackedTransformer(SequenceEncoder):
             self.should_project = True
 
         logger.debug('  TransformerStack')
-        self.transformer_stack = TrasformerStack(
+        self.transformer_stack = TransformerStack(
             hidden_size=hidden_size,
             num_heads=num_heads,
             fc_size=transformer_fc_size,

--- a/ludwig/encoders/sequence_encoders.py
+++ b/ludwig/encoders/sequence_encoders.py
@@ -61,7 +61,7 @@ class SequencePassthroughEncoder(SequenceEncoder):
                    and returns the full tensor).
             :type reduce_output: str
         """
-        super(SequencePassthroughEncoder, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         self.reduce_output = reduce_output
@@ -189,7 +189,7 @@ class SequenceEmbedEncoder(SequenceEncoder):
             :type dropout: Tensor
 
         """
-        super(SequenceEmbedEncoder, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         self.reduce_output = reduce_output
@@ -401,7 +401,7 @@ class ParallelCNN(SequenceEncoder):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(ParallelCNN, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         if conv_layers is not None and num_conv_layers is None:
@@ -723,7 +723,7 @@ class StackedCNN(SequenceEncoder):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedCNN, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         if conv_layers is not None and num_conv_layers is None:
@@ -1083,7 +1083,7 @@ class StackedParallelCNN(SequenceEncoder):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedParallelCNN, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         if stacked_layers is not None and num_stacked_layers is None:
@@ -1412,7 +1412,7 @@ class StackedRNN(SequenceEncoder):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedRNN, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         self.reduce_output = reduce_output
@@ -1676,7 +1676,7 @@ class StackedCNNRNN(SequenceEncoder):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedCNNRNN, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         if conv_layers is not None and num_conv_layers is None:
@@ -2005,7 +2005,7 @@ class StackedTransformer(SequenceEncoder):
                    (which does not reduce and returns the full tensor).
             :type reduce_output: str
         """
-        super(StackedTransformer, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         self.reduce_output = reduce_output

--- a/ludwig/encoders/set_encoders.py
+++ b/ludwig/encoders/set_encoders.py
@@ -63,7 +63,7 @@ class SetSparseEncoder(SetEncoder):
             reduce_output='sum',
             **kwargs
     ):
-        super(SetSparseEncoder, self).__init__()
+        super().__init__()
         logger.debug(' {}'.format(self.name))
 
         logger.debug('  EmbedSparse')

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -56,7 +56,7 @@ class BERTEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(BERTEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFBertModel
         except ModuleNotFoundError:
@@ -112,7 +112,7 @@ class GPTEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(GPTEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFOpenAIGPTModel
         except ModuleNotFoundError:
@@ -163,7 +163,7 @@ class GPT2Encoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(GPT2Encoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFGPT2Model
         except ModuleNotFoundError:
@@ -213,7 +213,7 @@ class TransformerXLEncoder(TextEncoder):
             trainable=True,
             **kwargs
     ):
-        super(TransformerXLEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFTransfoXLModel
         except ModuleNotFoundError:
@@ -261,7 +261,7 @@ class XLNetEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(XLNetEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFXLNetModel
         except ModuleNotFoundError:
@@ -312,7 +312,7 @@ class XLMEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(XLMEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFXLMModel
         except ModuleNotFoundError:
@@ -363,7 +363,7 @@ class RoBERTaEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(RoBERTaEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFRobertaModel
         except ModuleNotFoundError:
@@ -418,7 +418,7 @@ class DistilBERTEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(DistilBERTEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFDistilBertModel
         except ModuleNotFoundError:
@@ -468,7 +468,7 @@ class CTRLEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(CTRLEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFCTRLModel
         except ModuleNotFoundError:
@@ -519,7 +519,7 @@ class CamemBERTEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(CamemBERTEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFCamembertModel
         except ModuleNotFoundError:
@@ -574,7 +574,7 @@ class ALBERTEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(ALBERTEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFAlbertModel
         except ModuleNotFoundError:
@@ -629,7 +629,7 @@ class T5Encoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(T5Encoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFT5Model
         except ModuleNotFoundError:
@@ -680,7 +680,7 @@ class MT5Encoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(MT5Encoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFMT5Model
         except ModuleNotFoundError:
@@ -732,7 +732,7 @@ class XLMRoBERTaEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(XLMRoBERTaEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFXLMRobertaModel
         except ModuleNotFoundError:
@@ -787,7 +787,7 @@ class FlauBERTEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(FlauBERTEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFFlaubertModel
         except ModuleNotFoundError:
@@ -838,7 +838,7 @@ class ELECTRAEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(ELECTRAEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFElectraModel
         except ModuleNotFoundError:
@@ -889,7 +889,7 @@ class LongformerEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(LongformerEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFLongformerModel
         except ModuleNotFoundError:
@@ -940,7 +940,7 @@ class AutoTransformerEncoder(TextEncoder):
             num_tokens=None,
             **kwargs
     ):
-        super(AutoTransformerEncoder, self).__init__()
+        super().__init__()
         try:
             from transformers import TFAutoModel
         except ModuleNotFoundError:

--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -41,7 +41,7 @@ from ludwig.utils.misc_utils import set_default_values
 logger = logging.getLogger(__name__)
 
 
-class AudioFeatureMixin(object):
+class AudioFeatureMixin:
     type = AUDIO
 
     preprocessing_defaults = {

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -30,7 +30,7 @@ from ludwig.utils.strings_utils import create_vocabulary, UNKNOWN_SYMBOL
 logger = logging.getLogger(__name__)
 
 
-class BagFeatureMixin(object):
+class BagFeatureMixin:
     type = BAG
 
     preprocessing_defaults = {

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -29,7 +29,7 @@ from ludwig.utils.tf_utils import sequence_length_3D
 logger = logging.getLogger(__name__)
 
 
-class BaseFeature(object):
+class BaseFeature:
     """Base class for all features.
 
     Note that this class is not-cooperative (does not forward kwargs), so when constructing

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -40,7 +40,7 @@ from ludwig.utils import strings_utils
 logger = logging.getLogger(__name__)
 
 
-class BinaryFeatureMixin(object):
+class BinaryFeatureMixin:
     type = BINARY
     preprocessing_defaults = {
         'missing_value_strategy': FILL_WITH_CONST,

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -41,7 +41,7 @@ from ludwig.utils.strings_utils import create_vocabulary
 logger = logging.getLogger(__name__)
 
 
-class CategoryFeatureMixin(object):
+class CategoryFeatureMixin:
     type = CATEGORY
     preprocessing_defaults = {
         'most_common': 10000,

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 DATE_VECTOR_LENGTH = 9
 
 
-class DateFeatureMixin(object):
+class DateFeatureMixin:
     type = DATE
     preprocessing_defaults = {
         'missing_value_strategy': FILL_WITH_CONST,

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -32,7 +32,7 @@ H3_VECTOR_LENGTH = MAX_H3_RESOLUTION + 4
 H3_PADDING_VALUE = 7
 
 
-class H3FeatureMixin(object):
+class H3FeatureMixin:
     type = H3
     preprocessing_defaults = {
         'missing_value_strategy': FILL_WITH_CONST,

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -36,7 +36,7 @@ from ludwig.utils.misc_utils import set_default_value
 logger = logging.getLogger(__name__)
 
 
-class ImageFeatureMixin(object):
+class ImageFeatureMixin:
     type = IMAGE
     preprocessing_defaults = {
         'missing_value_strategy': BACKFILL,

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -39,7 +39,7 @@ from ludwig.utils.misc_utils import get_from_registry
 logger = logging.getLogger(__name__)
 
 
-class NumericalFeatureMixin(object):
+class NumericalFeatureMixin:
     type = NUMERICAL
     preprocessing_defaults = {
         'missing_value_strategy': FILL_WITH_CONST,

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -43,7 +43,7 @@ from ludwig.utils.strings_utils import create_vocabulary
 logger = logging.getLogger(__name__)
 
 
-class SequenceFeatureMixin(object):
+class SequenceFeatureMixin:
     type = SEQUENCE
 
     preprocessing_defaults = {

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -35,7 +35,7 @@ from ludwig.utils.strings_utils import create_vocabulary, UNKNOWN_SYMBOL
 logger = logging.getLogger(__name__)
 
 
-class SetFeatureMixin(object):
+class SetFeatureMixin:
     type = SET
     preprocessing_defaults = {
         'tokenizer': 'space',

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -37,7 +37,7 @@ from ludwig.utils.strings_utils import create_vocabulary
 logger = logging.getLogger(__name__)
 
 
-class TextFeatureMixin(object):
+class TextFeatureMixin:
     type = TEXT
 
     preprocessing_defaults = {

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -39,7 +39,7 @@ from ludwig.utils.misc_utils import set_default_value
 logger = logging.getLogger(__name__)
 
 
-class VectorFeatureMixin(object):
+class VectorFeatureMixin:
     type = VECTOR
     preprocessing_defaults = {
         'missing_value_strategy': FILL_WITH_CONST,

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -118,7 +118,7 @@ class TransformerBlock(Layer):
         return self.layernorm2(ln1_output + fc_output)
 
 
-class TrasformerStack(Layer):
+class TransformerStack(Layer):
     def __init__(
             self,
             hidden_size=256,
@@ -128,7 +128,7 @@ class TrasformerStack(Layer):
             dropout=0.1,
             **kwargs
     ):
-        super(TrasformerStack, self).__init__()
+        super(TransformerStack, self).__init__()
         self.supports_masking = True
 
         self.layers = []

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -39,7 +39,7 @@ class FeedForwardAttentionReducer(Layer):
 
 class MultiHeadSelfAttention(Layer):
     def __init__(self, hidden_size, num_heads=8):
-        super(MultiHeadSelfAttention, self).__init__()
+        super().__init__()
         self.embedding_size = hidden_size
         self.num_heads = num_heads
         if hidden_size % num_heads != 0:
@@ -99,7 +99,7 @@ class MultiHeadSelfAttention(Layer):
 
 class TransformerBlock(Layer):
     def __init__(self, hidden_size, num_heads, fc_size, dropout=0.1):
-        super(TransformerBlock, self).__init__()
+        super().__init__()
         self.self_attention = MultiHeadSelfAttention(hidden_size, num_heads)
         self.dropout1 = Dropout(dropout)
         self.layernorm1 = LayerNormalization(epsilon=1e-6)
@@ -128,7 +128,7 @@ class TransformerStack(Layer):
             dropout=0.1,
             **kwargs
     ):
-        super(TransformerStack, self).__init__()
+        super().__init__()
         self.supports_masking = True
 
         self.layers = []

--- a/ludwig/modules/convolutional_modules.py
+++ b/ludwig/modules/convolutional_modules.py
@@ -53,7 +53,7 @@ class Conv1DLayer(Layer):
             pool_strides=None,
             pool_padding='valid',
     ):
-        super(Conv1DLayer, self).__init__()
+        super().__init__()
 
         self.layers = []
 
@@ -134,7 +134,7 @@ class Conv1DStack(Layer):
             default_pool_padding='same',
             **kwargs
     ):
-        super(Conv1DStack, self).__init__()
+        super().__init__()
 
         if layers is None:
             if num_layers is None:
@@ -280,7 +280,7 @@ class ParallelConv1D(Layer):
             default_pool_padding='valid',
             **kwargs
     ):
-        super(ParallelConv1D, self).__init__()
+        super().__init__()
 
         if layers is None:
             self.layers = [
@@ -416,7 +416,7 @@ class ParallelConv1DStack(Layer):
             default_pool_padding='valid',
             **kwargs
     ):
-        super(ParallelConv1DStack, self).__init__()
+        super().__init__()
 
         if stacked_layers is None:
             self.stacked_parallel_layers = [
@@ -545,7 +545,7 @@ class Conv2DLayer(Layer):
             pool_strides=None,
             pool_padding='valid',
     ):
-        super(Conv2DLayer, self).__init__()
+        super().__init__()
 
         self.layers = []
 
@@ -625,7 +625,7 @@ class Conv2DStack(Layer):
             default_pool_strides=None,
             default_pool_padding='valid',
     ):
-        super(Conv2DStack, self).__init__()
+        super().__init__()
 
         if layers is None:
             if num_layers is None:
@@ -736,7 +736,7 @@ class Conv2DLayerFixedPadding(Layer):
             strides=1,
             weights_regularizer=None
     ):
-        super(Conv2DLayerFixedPadding, self).__init__()
+        super().__init__()
 
         self.layers = []
 
@@ -778,7 +778,7 @@ class ResNetBlock(Layer):
             batch_norm_epsilon=0.001,
             projection_shortcut=None
     ):
-        super(ResNetBlock, self).__init__()
+        super().__init__()
 
         self.projection_shortcut = projection_shortcut
 
@@ -852,7 +852,7 @@ class ResNetBottleneckBlock(Layer):
             batch_norm_epsilon=0.001,
             projection_shortcut=None
     ):
-        super(ResNetBottleneckBlock, self).__init__()
+        super().__init__()
 
         self.projection_shortcut = projection_shortcut
 
@@ -949,7 +949,7 @@ class ResNetBlockLayer(Layer):
             batch_norm_momentum=0.9,
             batch_norm_epsilon=0.001
     ):
-        super(ResNetBlockLayer, self).__init__()
+        super().__init__()
         # Bottleneck blocks end with 4x the number of filters as they start with
         num_filters_out = num_filters * 4 if is_bottleneck else num_filters
 
@@ -1037,7 +1037,7 @@ class ResNet2(Layer):
          Raises:
            ValueError: if invalid version is selected.
         """
-        super(ResNet2, self).__init__()
+        super().__init__()
         self.resnet_size = resnet_size
 
         block_class = ResNetBlock

--- a/ludwig/modules/embedding_modules.py
+++ b/ludwig/modules/embedding_modules.py
@@ -145,7 +145,7 @@ class Embed(Layer):
             embedding_initializer=None,
             embedding_regularizer=None
     ):
-        super(Embed, self).__init__()
+        super().__init__()
         self.supports_masking = True
 
         self.embeddings, self.embedding_size = embedding_matrix_on_device(
@@ -194,7 +194,7 @@ class EmbedWeighted(Layer):
             embedding_initializer=None,
             embedding_regularizer=None
     ):
-        super(EmbedWeighted, self).__init__()
+        super().__init__()
 
         self.embeddings, self.embedding_size = embedding_matrix_on_device(
             vocab,
@@ -256,7 +256,7 @@ class EmbedSparse(Layer):
             embedding_regularizer=None,
             reduce_output='sum'
     ):
-        super(EmbedSparse, self).__init__()
+        super().__init__()
 
         self.embeddings, self.embedding_size = embedding_matrix_on_device(
             vocab,
@@ -319,7 +319,7 @@ class EmbedSequence(Layer):
             embedding_initializer=None,
             embedding_regularizer=None
     ):
-        super(EmbedSequence, self).__init__()
+        super().__init__()
         self.supports_masking = True
 
         self.embeddings, self.embedding_size = embedding_matrix_on_device(
@@ -375,7 +375,7 @@ class TokenAndPositionEmbedding(Layer):
                  embedding_initializer=None,
                  embedding_regularizer=None
                  ):
-        super(TokenAndPositionEmbedding, self).__init__()
+        super().__init__()
         self.token_embed = EmbedSequence(
             vocab=vocab,
             embedding_size=embedding_size,

--- a/ludwig/modules/fully_connected_modules.py
+++ b/ludwig/modules/fully_connected_modules.py
@@ -39,7 +39,7 @@ class FCLayer(Layer):
             activation='relu',
             dropout=0,
     ):
-        super(FCLayer, self).__init__()
+        super().__init__()
 
         self.layers = []
 
@@ -100,7 +100,7 @@ class FCStack(Layer):
             default_dropout=0,
             **kwargs
     ):
-        super(FCStack, self).__init__()
+        super().__init__()
 
         if layers is None:
             self.layers = []
@@ -162,7 +162,7 @@ class FCStack(Layer):
             self,
             input_shape,
     ):
-        super(FCStack, self).build(input_shape)
+        super().build(input_shape)
 
     def call(self, inputs, training=None, mask=None):
         hidden = inputs

--- a/ludwig/modules/loss_modules.py
+++ b/ludwig/modules/loss_modules.py
@@ -25,7 +25,7 @@ from ludwig.utils.tf_utils import sequence_length_2D
 
 class MSELoss(MeanSquaredError):
     def __init__(self, **kwargs):
-        super(MSELoss, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def __call__(self, y_true, y_pred, sample_weight=None):
         logits = y_pred[LOGITS]
@@ -35,7 +35,7 @@ class MSELoss(MeanSquaredError):
 
 class MAELoss(MeanAbsoluteError):
     def __init__(self, **kwargs):
-        super(MAELoss, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def __call__(self, y_true, y_pred, sample_weight=None):
         logits = y_pred[LOGITS]
@@ -50,7 +50,7 @@ class BWCEWLoss(tf.keras.losses.Loss):
             robust_lambda=0,
             confidence_penalty=0
     ):
-        super(BWCEWLoss, self).__init__()
+        super().__init__()
 
         self.positive_class_weight = positive_class_weight
         self.robust_lambda = robust_lambda
@@ -91,7 +91,7 @@ class SoftmaxCrossEntropyLoss(tf.keras.losses.Loss):
             feature_loss=None,
             name=None
     ):
-        super(SoftmaxCrossEntropyLoss, self).__init__(name=name)
+        super().__init__(name=name)
         self.num_classes = num_classes
         self.feature_loss = feature_loss
 
@@ -118,7 +118,7 @@ class SampledSoftmaxCrossEntropyLoss(tf.keras.losses.Loss):
             feature_loss=None,
             name=None
     ):
-        super(SampledSoftmaxCrossEntropyLoss, self).__init__(name=name)
+        super().__init__(name=name)
 
         self.decoder_obj = decoder_obj
         self.num_classes = num_classes
@@ -146,7 +146,7 @@ class SigmoidCrossEntropyLoss(tf.keras.losses.Loss):
             feature_loss=None,
             name=None
     ):
-        super(SigmoidCrossEntropyLoss, self).__init__(name=name)
+        super().__init__(name=name)
         self.feature_loss = feature_loss
 
     def call(self, y, y_pred):
@@ -160,7 +160,7 @@ class SigmoidCrossEntropyLoss(tf.keras.losses.Loss):
 
 class SequenceLoss(tf.keras.losses.Loss):
     def __init__(self, name=None, from_logits=True, **kwargs):
-        super(SequenceLoss, self).__init__(name=name)
+        super().__init__(name=name)
         self.loss_function = tf.keras.losses.SparseCategoricalCrossentropy(
             from_logits=from_logits,
             reduction='none'

--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -38,7 +38,7 @@ min_metrics = {EDIT_DISTANCE, MEAN_SQUARED_ERROR, MEAN_ABSOLUTE_ERROR, LOSS,
 
 class R2Score(tf.keras.metrics.Metric):
     def __init__(self, name='r2_score'):
-        super(R2Score, self).__init__(name=name)
+        super().__init__(name=name)
         self.sum_y = self.add_weight(
             'sum_y', initializer='zeros',
             dtype=tf.float32
@@ -89,7 +89,7 @@ class R2Score(tf.keras.metrics.Metric):
 
 class ErrorScore(tf.keras.metrics.Metric):
     def __init__(self, name='error_score'):
-        super(ErrorScore, self).__init__(name=name)
+        super().__init__(name=name)
         self.sum_error = self.add_weight(
             'sum_error', initializer='zeros',
             dtype=tf.float32
@@ -121,7 +121,7 @@ class BWCEWLMetric(tf.keras.metrics.Metric):
             confidence_penalty=0,
             name='binary_cross_entropy_weighted_loss_metric'
     ):
-        super(BWCEWLMetric, self).__init__(name=name)
+        super().__init__(name=name)
 
         self.bwcew_loss_function = BWCEWLoss(
             positive_class_weight=positive_class_weight,
@@ -154,7 +154,7 @@ class SoftmaxCrossEntropyMetric(tf.keras.metrics.Mean):
             feature_loss=None,
             name='softmax_cross_entropy_metric'
     ):
-        super(SoftmaxCrossEntropyMetric, self).__init__(name=name)
+        super().__init__(name=name)
 
         self.softmax_cross_entropy_function = SoftmaxCrossEntropyLoss(
             num_classes=num_classes,
@@ -171,7 +171,7 @@ class SigmoidCrossEntropyMetric(tf.keras.metrics.Mean):
             feature_loss=None,
             name='sigmoid_cross_entropy_metric'
     ):
-        super(SigmoidCrossEntropyMetric, self).__init__(name=name)
+        super().__init__(name=name)
         self.sigmoid_cross_entropy_function = SigmoidCrossEntropyLoss(
             feature_loss
         )
@@ -182,7 +182,7 @@ class SigmoidCrossEntropyMetric(tf.keras.metrics.Mean):
 
 class SequenceLossMetric(tf.keras.metrics.Mean):
     def __init__(self, name=None):
-        super(SequenceLossMetric, self).__init__(name=name)
+        super().__init__(name=name)
 
         self.loss_function = SequenceLoss(from_logits=False)
 
@@ -197,7 +197,7 @@ class SequenceLastAccuracyMetric(tf.keras.metrics.Accuracy):
     """
 
     def __init__(self, name=None):
-        super(SequenceLastAccuracyMetric, self).__init__(name=name)
+        super().__init__(name=name)
 
     def update_state(self, y_true, y_pred, sample_weight=None):
         y_true = tf.cast(y_true, dtype=tf.int64)
@@ -218,7 +218,7 @@ class SequenceLastAccuracyMetric(tf.keras.metrics.Accuracy):
 
 class PerplexityMetric(tf.keras.metrics.Mean):
     def __init__(self, name=None):
-        super(PerplexityMetric, self).__init__(name=name)
+        super().__init__(name=name)
         self.loss_function = SequenceLoss(from_logits=False)
 
     def update_state(self, y_true, y_pred, sample_weight=None):
@@ -232,7 +232,7 @@ class PerplexityMetric(tf.keras.metrics.Mean):
 
 class EditDistanceMetric(tf.keras.metrics.Mean):
     def __init__(self, name=None):
-        super(EditDistanceMetric, self).__init__(name=name)
+        super().__init__(name=name)
 
     def update_state(self, y_true, y_pred):
         # y_true: shape [batch_size, sequence_size]
@@ -253,7 +253,7 @@ class EditDistanceMetric(tf.keras.metrics.Mean):
 
 class TokenAccuracyMetric(tf.keras.metrics.Mean):
     def __init__(self, name=None):
-        super(TokenAccuracyMetric, self).__init__(name=name)
+        super().__init__(name=name)
 
     def update_state(self, y_true, y_pred):
         # y_true: shape [batch_size, sequence_size]
@@ -273,7 +273,7 @@ class TokenAccuracyMetric(tf.keras.metrics.Mean):
 
 class SequenceAccuracyMetric(tf.keras.metrics.Mean):
     def __init__(self, name=None):
-        super(SequenceAccuracyMetric, self).__init__(name=name)
+        super().__init__(name=name)
 
     def update_state(self, y_true, y_pred):
         # y_true: shape [batch_size, sequence_size]
@@ -292,7 +292,7 @@ class SequenceAccuracyMetric(tf.keras.metrics.Mean):
 
 class CategoryAccuracy(tf.keras.metrics.Accuracy):
     def __init__(self, name=None):
-        super(CategoryAccuracy, self).__init__(name=name)
+        super().__init__(name=name)
 
     def update_state(self, y_true, y_pred, sample_weight=None):
         # make sure y_true is tf.int64
@@ -305,7 +305,7 @@ class CategoryAccuracy(tf.keras.metrics.Accuracy):
 
 class HitsAtKMetric(tf.keras.metrics.SparseTopKCategoricalAccuracy):
     def __init__(self, k=3, name=None):
-        super(HitsAtKMetric, self).__init__(k=k, name=name)
+        super().__init__(k=k, name=name)
 
     def update_state(self, y_true, y_pred, sample_weight=None):
         super().update_state(
@@ -317,7 +317,7 @@ class HitsAtKMetric(tf.keras.metrics.SparseTopKCategoricalAccuracy):
 
 class MAEMetric(MeanAbsoluteErrorMetric):
     def __init__(self, **kwargs):
-        super(MAEMetric, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def update_state(self, y_true, y_pred, sample_weight=None):
         super().update_state(
@@ -327,7 +327,7 @@ class MAEMetric(MeanAbsoluteErrorMetric):
 
 class MSEMetric(MeanSquaredErrorMetric):
     def __init__(self, **kwargs):
-        super(MSEMetric, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def update_state(self, y_true, y_pred, sample_weight=None):
         super().update_state(
@@ -337,7 +337,7 @@ class MSEMetric(MeanSquaredErrorMetric):
 
 class JaccardMetric(tf.keras.metrics.Metric):
     def __init__(self, name=None):
-        super(JaccardMetric, self).__init__(name=name)
+        super().__init__(name=name)
         self.jaccard_total = self.add_weight(
             'jaccard_numerator', initializer='zeros', dtype=tf.float32
         )

--- a/ludwig/modules/normalization_modules.py
+++ b/ludwig/modules/normalization_modules.py
@@ -7,7 +7,7 @@ class GhostBatchNormalization(tf.keras.Model):
             self, virtual_divider: int = 1, momentum: float = 0.9,
             epsilon: float = 1e-5
     ):
-        super(GhostBatchNormalization, self).__init__()
+        super().__init__()
         self.virtual_divider = virtual_divider
         self.bn = BatchNormInferenceWeighting(momentum=momentum)
 
@@ -34,7 +34,7 @@ class GhostBatchNormalization(tf.keras.Model):
 # adapted and modified from https://github.com/ostamand/tensorflow-tabnet/blob/master/tabnet/models/gbn.py
 class BatchNormInferenceWeighting(tf.keras.layers.Layer):
     def __init__(self, momentum: float = 0.9, epsilon: float = None):
-        super(BatchNormInferenceWeighting, self).__init__()
+        super().__init__()
         self.momentum = momentum
         self.epsilon = tf.keras.backend.epsilon() if epsilon is None else epsilon
 

--- a/ludwig/modules/optimization_modules.py
+++ b/ludwig/modules/optimization_modules.py
@@ -51,7 +51,7 @@ def clip_optimizer(optimizer, clipglobalnorm, clipnorm, clipvalue,
             self.clipnorm = clipnorm
             self.clipvalue = clipvalue
             self.horovod = horovod
-            super().__init__(**kwargs)
+            super(self.__class__, self).__init__(**kwargs)
 
         def minimize_with_tape(self, tape, loss, variables):
             if self.horovod:

--- a/ludwig/modules/optimization_modules.py
+++ b/ludwig/modules/optimization_modules.py
@@ -51,7 +51,7 @@ def clip_optimizer(optimizer, clipglobalnorm, clipnorm, clipvalue,
             self.clipnorm = clipnorm
             self.clipvalue = clipvalue
             self.horovod = horovod
-            super(self.__class__, self).__init__(**kwargs)
+            super().__init__(**kwargs)
 
         def minimize_with_tape(self, tape, loss, variables):
             if self.horovod:

--- a/ludwig/modules/recurrent_modules.py
+++ b/ludwig/modules/recurrent_modules.py
@@ -54,7 +54,7 @@ class RecurrentStack(Layer):
             recurrent_dropout=0.0,
             **kwargs
     ):
-        super(RecurrentStack, self).__init__()
+        super().__init__()
         self.supports_masking = True
 
         rnn_layer_class = get_from_registry(cell_type, rnn_layers_registry)

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -37,7 +37,7 @@ class TabNet(tf.keras.Model):
             bn_momentum (float, optional): Batch normalization, momentum. Defaults to 0.7.
             bn_virtual_divider (int, optional): Batch normalization. Full batch will be divided by this.
         """
-        super(TabNet, self).__init__()
+        super().__init__()
         self.num_features = num_features
         self.size = size
         self.output_size = output_size
@@ -148,7 +148,7 @@ class FeatureBlock(tf.keras.Model):
             shared_fc_layer: tf.keras.layers.Layer = None,
             epsilon: float = 1e-5,
     ):
-        super(FeatureBlock, self).__init__()
+        super().__init__()
         self.apply_glu = apply_glu
         self.size = size
         units = size * 2 if apply_glu else size
@@ -178,7 +178,7 @@ class AttentiveTransformer(tf.keras.Model):
             bn_momentum: float = 0.9,
             bn_virtual_divider: int = 32,
     ):
-        super(AttentiveTransformer, self).__init__()
+        super().__init__()
         self.feature_block = FeatureBlock(
             size,
             bn_momentum=bn_momentum,
@@ -203,7 +203,7 @@ class FeatureTransformer(tf.keras.Model):
             bn_momentum: float = 0.9,
             bn_virtual_divider: int = 1,
     ):
-        super(FeatureTransformer, self).__init__()
+        super().__init__()
         self.num_total_blocks = num_total_blocks
         self.num_shared_blocks = num_shared_blocks
 

--- a/ludwig/utils/time_utils.py
+++ b/ludwig/utils/time_utils.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 logger = logging.getLogger(__name__)
 
 
-class WithTimer(object):
+class WithTimer:
     def __init__(self, title='', quiet=False):
         self.title = title
         self.quiet = quiet
@@ -47,7 +47,7 @@ class WithTimer(object):
                                                                elapsed_wp[1]))
 
 
-class Timer(object):
+class Timer:
     def __init__(self):
         self.reset()
 


### PR DESCRIPTION
Rename `ludwig.modules.attention_modules.TrasformerStack` to `ludwig.modules.attention_modules.TransformerStack`. Use Python 3 syntax for defining classes and calling parent class methods.