### PR TITLE
Changed processed format for Higgs dataset to Parquet

### DIFF
--- a/ludwig/datasets/higgs/__init__.py
+++ b/ludwig/datasets/higgs/__init__.py
@@ -20,7 +20,7 @@ import pandas as pd
 
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
-from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.mixins.load import ParquetLoadMixin
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False,
@@ -29,7 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False,
     return dataset.load(split=split)
 
 
-class Higgs(UncompressedFileDownloadMixin, CSVLoadMixin, BaseDataset):
+class Higgs(UncompressedFileDownloadMixin, ParquetLoadMixin, BaseDataset):
     """The Higgs Boson dataset.
 
     This is a classification problem to distinguish between a signal process
@@ -70,6 +70,8 @@ class Higgs(UncompressedFileDownloadMixin, CSVLoadMixin, BaseDataset):
             df['split'] = [0] * 10500000 + [2] * 500000
 
         os.makedirs(self.processed_temp_path, exist_ok=True)
-        df.to_csv(os.path.join(self.processed_temp_path, self.csv_filename),
-                  index=False)
+        df.to_parquet(os.path.join(self.processed_temp_path, self.parquet_filename),
+                      engine='pyarrow',
+                      row_group_size=50000,
+                      index=False)
         os.rename(self.processed_temp_path, self.processed_dataset_path)

--- a/ludwig/datasets/higgs/config.yaml
+++ b/ludwig/datasets/higgs/config.yaml
@@ -1,4 +1,4 @@
 version: 1.0
 download_urls:
   - https://archive.ics.uci.edu/ml/machine-learning-databases/00280/HIGGS.csv.gz
-csv_filename: higgs.csv
+parquet_filename: higgs.parquet

--- a/ludwig/datasets/mixins/load.py
+++ b/ludwig/datasets/mixins/load.py
@@ -23,6 +23,21 @@ import pandas as pd
 from ludwig.constants import SPLIT
 
 
+def _split(data_df, split):
+    if SPLIT in data_df:
+        data_df[SPLIT] = pd.to_numeric(data_df[SPLIT])
+    if split:
+        if SPLIT in data_df:
+            training_set = data_df[data_df[SPLIT] == 0]
+            val_set = data_df[data_df[SPLIT] == 1]
+            test_set = data_df[data_df[SPLIT] == 2]
+            return training_set, test_set, val_set
+        else:
+            raise ValueError("The dataset does not have splits, "
+                             "load with `split=False`")
+    return data_df
+
+
 class CSVLoadMixin:
     """Reads a CSV file into a Pandas DataFrame."""
 
@@ -41,20 +56,34 @@ class CSVLoadMixin:
         dataset_csv = os.path.join(self.processed_dataset_path,
                                    self.csv_filename)
         data_df = pd.read_csv(dataset_csv)
-        if SPLIT in data_df:
-            data_df[SPLIT] = pd.to_numeric(data_df[SPLIT])
-        if split:
-            if SPLIT in data_df:
-                training_set = data_df[data_df[SPLIT] == 0]
-                val_set = data_df[data_df[SPLIT] == 1]
-                test_set = data_df[data_df[SPLIT] == 2]
-                return training_set, test_set, val_set
-            else:
-                raise ValueError("The dataset does not have splits, "
-                                 "load with `split=False`")
-        return data_df
+        return _split(data_df, split)
 
     @property
     def csv_filename(self):
         return self.config["csv_filename"]
+
+
+class ParquetLoadMixin:
+    """Reads a Parquet file into a Pandas DataFrame."""
+
+    config: dict
+    processed_dataset_path: str
+
+    def load_processed_dataset(self, split) -> Union[pd.DataFrame,
+                                                     Tuple[pd.DataFrame,
+                                                           pd.DataFrame,
+                                                           pd.DataFrame]]:
+        """Loads the processed Parquet into a dataframe.
+
+        :param split: Splits along 'split' column if present
+        :returns: A pandas dataframe
+        """
+        dataset_path = os.path.join(self.processed_dataset_path,
+                                    self.parquet_filename)
+        data_df = pd.read_parquet(dataset_path)
+        return _split(data_df, split)
+
+    @property
+    def parquet_filename(self):
+        return self.config["parquet_filename"]
 


### PR DESCRIPTION
Storing this dataset as CSV on disk was taking about 5GB due to all the double-precision float values being represented as strings. By converting to Parquet, we can represent these numbers as doubles on disk, reducing the space requirements to 1GB. This also speeds up the reading/writing substantially, and will make it easier to distribute the data for training.

The caveat is that anyone who previously used this dataset will need to remove the previous processed folder. I did not bump up the version of the dataset here since we have not officially released it.