### PR TITLE
Added support for cloud object storage (S3, GCS, ADLS, etc.)

### DIFF
--- a/docker/ludwig-gpu/Dockerfile
+++ b/docker/ludwig-gpu/Dockerfile
@@ -12,7 +12,6 @@
 FROM tensorflow/tensorflow:2.4.1-gpu
 
 RUN apt-get -y update && apt-get -y install \
-    build-essential \
     git \
     libsndfile1 \
     cmake \

--- a/docker/ludwig-gpu/Dockerfile
+++ b/docker/ludwig-gpu/Dockerfile
@@ -12,6 +12,7 @@
 FROM tensorflow/tensorflow:2.4.1-gpu
 
 RUN apt-get -y update && apt-get -y install \
+    build-essential \
     git \
     libsndfile1 \
     cmake \

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -12,6 +12,7 @@
 FROM rayproject/ray:nightly
 
 RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y \
+    build-essential \
 	wget \
 	git \
 	curl \

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -14,6 +14,8 @@ FROM rayproject/ray:nightly
 RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y \
 	wget \
 	build-essential \
+	libc6-dev \
+	libc-dev-bin \
 	git \
 	curl \
 	libsndfile1 \

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -13,9 +13,6 @@ FROM rayproject/ray:nightly
 
 RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y \
 	wget \
-	build-essential \
-	libc6-dev \
-	libc-dev-bin \
 	git \
 	curl \
 	libsndfile1 \

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -29,7 +29,7 @@ from pprint import pformat
 from typing import Dict, List, Optional, Tuple, Union
 
 import ludwig.contrib
-from ludwig.utils.fs_utils import prepare_output_directory, open_file, path_exists, makedirs
+from ludwig.utils.fs_utils import upload_output_directory, open_file, path_exists, makedirs
 
 ludwig.contrib.contrib_import()
 import numpy as np
@@ -355,7 +355,7 @@ class LudwigModel:
                 skip_save_processed_input
         )
 
-        with prepare_output_directory(output_directory) as output_directory:
+        with upload_output_directory(output_directory) as output_directory:
             description_fn = training_stats_fn = model_dir = None
             if self.backend.is_coordinator():
                 if should_create_output_directory:

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -29,7 +29,7 @@ from pprint import pformat
 from typing import Dict, List, Optional, Tuple, Union
 
 import ludwig.contrib
-from ludwig.utils.fs_utils import prepare_output_directory
+from ludwig.utils.fs_utils import prepare_output_directory, open_file
 
 ludwig.contrib.contrib_import()
 import numpy as np
@@ -173,7 +173,7 @@ class LudwigModel:
         """
         # check if config is a path or a dict
         if isinstance(config, str):  # assume path
-            with open(config, 'r') as def_file:
+            with open_file(config, 'r') as def_file:
                 config_dict = yaml.safe_load(def_file)
             self.config_fp = config
         else:
@@ -1628,7 +1628,7 @@ def kfold_cross_validate(
 
     # if config is a path, convert to dictionary
     if isinstance(config, str):  # assume path
-        with open(config, 'r') as def_file:
+        with open_file(config, 'r') as def_file:
             config = yaml.safe_load(def_file)
 
     # check for k_fold

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -29,6 +29,7 @@ from pprint import pformat
 from typing import Dict, List, Optional, Tuple, Union
 
 import ludwig.contrib
+from ludwig.utils.fs_utils import prepare_output_directory
 
 ludwig.contrib.contrib_import()
 import numpy as np
@@ -354,189 +355,190 @@ class LudwigModel:
                 skip_save_processed_input
         )
 
-        description_fn = training_stats_fn = model_dir = None
-        if self.backend.is_coordinator():
-            if should_create_output_directory:
-                if not os.path.exists(output_directory):
-                    os.makedirs(output_directory, exist_ok=True)
-            description_fn, training_stats_fn, model_dir = get_file_names(
-                output_directory)
+        with prepare_output_directory(output_directory) as output_directory:
+            description_fn = training_stats_fn = model_dir = None
+            if self.backend.is_coordinator():
+                if should_create_output_directory:
+                    if not os.path.exists(output_directory):
+                        os.makedirs(output_directory, exist_ok=True)
+                description_fn, training_stats_fn, model_dir = get_file_names(
+                    output_directory)
 
-        with self.backend.create_cache_dir():
-            if isinstance(training_set, Dataset) and training_set_metadata is not None:
-                preprocessed_data = (training_set, validation_set, test_set, training_set_metadata)
-            else:
-                # save description
-                if self.backend.is_coordinator():
-                    description = get_experiment_description(
-                        self.config,
+            with self.backend.create_cache_dir():
+                if isinstance(training_set, Dataset) and training_set_metadata is not None:
+                    preprocessed_data = (training_set, validation_set, test_set, training_set_metadata)
+                else:
+                    # save description
+                    if self.backend.is_coordinator():
+                        description = get_experiment_description(
+                            self.config,
+                            dataset=dataset,
+                            training_set=training_set,
+                            validation_set=validation_set,
+                            test_set=test_set,
+                            training_set_metadata=training_set_metadata,
+                            data_format=data_format,
+                            random_seed=random_seed
+                        )
+                        if not skip_save_training_description:
+                            save_json(description_fn, description)
+                        # print description
+                        logger.info('Experiment name: {}'.format(experiment_name))
+                        logger.info('Model name: {}'.format(model_name))
+                        logger.info('Output directory: {}'.format(output_directory))
+                        logger.info('\n')
+                        for key, value in description.items():
+                            logger.info('{}: {}'.format(key, pformat(value, indent=4)))
+                        logger.info('\n')
+
+                    preprocessed_data = self.preprocess(
                         dataset=dataset,
                         training_set=training_set,
                         validation_set=validation_set,
                         test_set=test_set,
                         training_set_metadata=training_set_metadata,
                         data_format=data_format,
-                        random_seed=random_seed
+                        experiment_name=experiment_name,
+                        model_name=model_name,
+                        model_resume_path=model_resume_path,
+                        skip_save_training_description=skip_save_training_description,
+                        skip_save_training_statistics=skip_save_training_statistics,
+                        skip_save_model=skip_save_model,
+                        skip_save_progress=skip_save_progress,
+                        skip_save_log=skip_save_log,
+                        skip_save_processed_input=skip_save_processed_input,
+                        output_directory=output_directory,
+                        random_seed=random_seed,
+                        devbug=debug,
+                        **kwargs,
                     )
-                    if not skip_save_training_description:
-                        save_json(description_fn, description)
-                    # print description
-                    logger.info('Experiment name: {}'.format(experiment_name))
-                    logger.info('Model name: {}'.format(model_name))
-                    logger.info('Output directory: {}'.format(output_directory))
-                    logger.info('\n')
-                    for key, value in description.items():
-                        logger.info('{}: {}'.format(key, pformat(value, indent=4)))
-                    logger.info('\n')
-
-                preprocessed_data = self.preprocess(
-                    dataset=dataset,
-                    training_set=training_set,
-                    validation_set=validation_set,
-                    test_set=test_set,
-                    training_set_metadata=training_set_metadata,
-                    data_format=data_format,
-                    experiment_name=experiment_name,
-                    model_name=model_name,
-                    model_resume_path=model_resume_path,
-                    skip_save_training_description=skip_save_training_description,
-                    skip_save_training_statistics=skip_save_training_statistics,
-                    skip_save_model=skip_save_model,
-                    skip_save_progress=skip_save_progress,
-                    skip_save_log=skip_save_log,
-                    skip_save_processed_input=skip_save_processed_input,
-                    output_directory=output_directory,
-                    random_seed=random_seed,
-                    devbug=debug,
-                    **kwargs,
-                )
-                (training_set,
-                 validation_set,
-                 test_set,
-                 training_set_metadata) = preprocessed_data
-
-            self.training_set_metadata = training_set_metadata
-
-            if self.backend.is_coordinator():
-                logger.info('Training set: {0}'.format(len(training_set)))
-                if validation_set is not None:
-                    logger.info('Validation set: {0}'.format(len(validation_set)))
-                if test_set is not None:
-                    logger.info('Test set: {0}'.format(len(test_set)))
-                if not skip_save_model:
-                    # save train set metadata
-                    os.makedirs(model_dir, exist_ok=True)
-                    save_json(
-                        os.path.join(
-                            model_dir,
-                            TRAIN_SET_METADATA_FILE_NAME
-                        ),
-                        training_set_metadata
-                    )
-
-            contrib_command("train_init", experiment_directory=output_directory,
-                            experiment_name=experiment_name, model_name=model_name,
-                            output_directory=output_directory,
-                            resume=model_resume_path is not None)
-
-            # Build model if not provided
-            # if it was provided it means it was already loaded
-            if not self.model:
-                if self.backend.is_coordinator():
-                    print_boxed('MODEL', print_fun=logger.debug)
-                # update config with metadata properties
-                update_config_with_metadata(
-                    self.config,
-                    training_set_metadata
-                )
-                self.model = LudwigModel.create_model(self.config,
-                                                      random_seed=random_seed)
-
-            # init trainer
-            with self.backend.create_trainer(
-                **self.config[TRAINING],
-                resume=model_resume_path is not None,
-                skip_save_model=skip_save_model,
-                skip_save_progress=skip_save_progress,
-                skip_save_log=skip_save_log,
-                callbacks=callbacks,
-                random_seed=random_seed,
-                debug=debug
-            ) as trainer:
-                contrib_command("train_model", self.model, self.config,
-                                self.config_fp)
-
-                # train model
-                if self.backend.is_coordinator():
-                    print_boxed('TRAINING')
-                    if not skip_save_model:
-                        self.save_config(model_dir)
-
-                train_stats = trainer.train(
-                    self.model,
-                    training_set,
-                    validation_set=validation_set,
-                    test_set=test_set,
-                    save_path=model_dir,
-                )
-
-                self.model, train_trainset_stats, train_valiset_stats, train_testset_stats = train_stats
-                train_stats = {
-                    TRAINING: train_trainset_stats,
-                    VALIDATION: train_valiset_stats,
-                    TEST: train_testset_stats
-                }
-
-                # save training statistics
-                if self.backend.is_coordinator():
-                    if not skip_save_training_statistics:
-                        save_json(training_stats_fn, train_stats)
-
-                # grab the results of the model with highest validation test performance
-                validation_field = trainer.validation_field
-                validation_metric = trainer.validation_metric
-                validation_field_result = train_valiset_stats[validation_field]
-
-                best_function = get_best_function(validation_metric)
-                # results of the model with highest validation test performance
-                if self.backend.is_coordinator() and validation_set is not None:
-                    epoch_best_vali_metric, best_vali_metric = best_function(
-                        enumerate(validation_field_result[validation_metric]),
-                        key=lambda pair: pair[1]
-                    )
-                    logger.info(
-                        'Best validation model epoch: {0}'.format(
-                            epoch_best_vali_metric + 1)
-                    )
-                    logger.info(
-                        'Best validation model {0} on validation set {1}: {2}'.format(
-                            validation_metric, validation_field, best_vali_metric
-                        ))
-                    if test_set is not None:
-                        best_vali_metric_epoch_test_metric = train_testset_stats[
-                            validation_field][validation_metric][
-                            epoch_best_vali_metric]
-
-                        logger.info(
-                            'Best validation model {0} on test set {1}: {2}'.format(
-                                validation_metric,
-                                validation_field,
-                                best_vali_metric_epoch_test_metric
-                            )
-                        )
-                    logger.info(
-                        '\nFinished: {0}_{1}'.format(experiment_name, model_name))
-                    logger.info('Saved to: {0}'.format(output_directory))
-
-                contrib_command("train_save", output_directory)
+                    (training_set,
+                     validation_set,
+                     test_set,
+                     training_set_metadata) = preprocessed_data
 
                 self.training_set_metadata = training_set_metadata
 
-                if not skip_save_model:
-                    # Load the best weights from saved checkpoint
-                    self.load_weights(model_dir)
+                if self.backend.is_coordinator():
+                    logger.info('Training set: {0}'.format(len(training_set)))
+                    if validation_set is not None:
+                        logger.info('Validation set: {0}'.format(len(validation_set)))
+                    if test_set is not None:
+                        logger.info('Test set: {0}'.format(len(test_set)))
+                    if not skip_save_model:
+                        # save train set metadata
+                        os.makedirs(model_dir, exist_ok=True)
+                        save_json(
+                            os.path.join(
+                                model_dir,
+                                TRAIN_SET_METADATA_FILE_NAME
+                            ),
+                            training_set_metadata
+                        )
 
-                return train_stats, preprocessed_data, output_directory
+                contrib_command("train_init", experiment_directory=output_directory,
+                                experiment_name=experiment_name, model_name=model_name,
+                                output_directory=output_directory,
+                                resume=model_resume_path is not None)
+
+                # Build model if not provided
+                # if it was provided it means it was already loaded
+                if not self.model:
+                    if self.backend.is_coordinator():
+                        print_boxed('MODEL', print_fun=logger.debug)
+                    # update config with metadata properties
+                    update_config_with_metadata(
+                        self.config,
+                        training_set_metadata
+                    )
+                    self.model = LudwigModel.create_model(self.config,
+                                                          random_seed=random_seed)
+
+                # init trainer
+                with self.backend.create_trainer(
+                    **self.config[TRAINING],
+                    resume=model_resume_path is not None,
+                    skip_save_model=skip_save_model,
+                    skip_save_progress=skip_save_progress,
+                    skip_save_log=skip_save_log,
+                    callbacks=callbacks,
+                    random_seed=random_seed,
+                    debug=debug
+                ) as trainer:
+                    contrib_command("train_model", self.model, self.config,
+                                    self.config_fp)
+
+                    # train model
+                    if self.backend.is_coordinator():
+                        print_boxed('TRAINING')
+                        if not skip_save_model:
+                            self.save_config(model_dir)
+
+                    train_stats = trainer.train(
+                        self.model,
+                        training_set,
+                        validation_set=validation_set,
+                        test_set=test_set,
+                        save_path=model_dir,
+                    )
+
+                    self.model, train_trainset_stats, train_valiset_stats, train_testset_stats = train_stats
+                    train_stats = {
+                        TRAINING: train_trainset_stats,
+                        VALIDATION: train_valiset_stats,
+                        TEST: train_testset_stats
+                    }
+
+                    # save training statistics
+                    if self.backend.is_coordinator():
+                        if not skip_save_training_statistics:
+                            save_json(training_stats_fn, train_stats)
+
+                    # grab the results of the model with highest validation test performance
+                    validation_field = trainer.validation_field
+                    validation_metric = trainer.validation_metric
+                    validation_field_result = train_valiset_stats[validation_field]
+
+                    best_function = get_best_function(validation_metric)
+                    # results of the model with highest validation test performance
+                    if self.backend.is_coordinator() and validation_set is not None:
+                        epoch_best_vali_metric, best_vali_metric = best_function(
+                            enumerate(validation_field_result[validation_metric]),
+                            key=lambda pair: pair[1]
+                        )
+                        logger.info(
+                            'Best validation model epoch: {0}'.format(
+                                epoch_best_vali_metric + 1)
+                        )
+                        logger.info(
+                            'Best validation model {0} on validation set {1}: {2}'.format(
+                                validation_metric, validation_field, best_vali_metric
+                            ))
+                        if test_set is not None:
+                            best_vali_metric_epoch_test_metric = train_testset_stats[
+                                validation_field][validation_metric][
+                                epoch_best_vali_metric]
+
+                            logger.info(
+                                'Best validation model {0} on test set {1}: {2}'.format(
+                                    validation_metric,
+                                    validation_field,
+                                    best_vali_metric_epoch_test_metric
+                                )
+                            )
+                        logger.info(
+                            '\nFinished: {0}_{1}'.format(experiment_name, model_name))
+                        logger.info('Saved to: {0}'.format(output_directory))
+
+                    contrib_command("train_save", output_directory)
+
+                    self.training_set_metadata = training_set_metadata
+
+                    if not skip_save_model:
+                        # Load the best weights from saved checkpoint
+                        self.load_weights(model_dir)
+
+                    return train_stats, preprocessed_data, output_directory
 
     def train_online(
             self,

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -355,6 +355,7 @@ class LudwigModel:
                 skip_save_processed_input
         )
 
+        output_url = output_directory
         with upload_output_directory(output_directory) as output_directory:
             description_fn = training_stats_fn = model_dir = None
             if self.backend.is_coordinator():
@@ -537,7 +538,7 @@ class LudwigModel:
                         # Load the best weights from saved checkpoint
                         self.load_weights(model_dir)
 
-                    return train_stats, preprocessed_data, output_directory
+                    return train_stats, preprocessed_data, output_url
 
     def train_online(
             self,

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -29,7 +29,7 @@ from pprint import pformat
 from typing import Dict, List, Optional, Tuple, Union
 
 import ludwig.contrib
-from ludwig.utils.fs_utils import prepare_output_directory, open_file
+from ludwig.utils.fs_utils import prepare_output_directory, open_file, path_exists, makedirs
 
 ludwig.contrib.contrib_import()
 import numpy as np
@@ -324,7 +324,7 @@ class LudwigModel:
         """
         # setup directories and file names
         if model_resume_path is not None:
-            if os.path.exists(model_resume_path):
+            if path_exists(model_resume_path):
                 output_directory = model_resume_path
             else:
                 if self.backend.is_coordinator():
@@ -359,8 +359,7 @@ class LudwigModel:
             description_fn = training_stats_fn = model_dir = None
             if self.backend.is_coordinator():
                 if should_create_output_directory:
-                    if not os.path.exists(output_directory):
-                        os.makedirs(output_directory, exist_ok=True)
+                    makedirs(output_directory, exist_ok=True)
                 description_fn, training_stats_fn, model_dir = get_file_names(
                     output_directory)
 
@@ -700,7 +699,7 @@ class LudwigModel:
                         skip_save_unprocessed_output and skip_save_predictions
                 )
                 if should_create_exp_dir:
-                    os.makedirs(output_directory, exist_ok=True)
+                    makedirs(output_directory, exist_ok=True)
 
             logger.debug('Postprocessing')
             postproc_predictions = postprocess(
@@ -844,7 +843,7 @@ class LudwigModel:
                         skip_save_eval_stats
                 )
                 if should_create_exp_dir:
-                    os.makedirs(output_directory, exist_ok=True)
+                    makedirs(output_directory, exist_ok=True)
 
             if collect_predictions:
                 logger.debug('Postprocessing')

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -364,181 +364,180 @@ class LudwigModel:
                 description_fn, training_stats_fn, model_dir = get_file_names(
                     output_directory)
 
-            with self.backend.create_cache_dir():
-                if isinstance(training_set, Dataset) and training_set_metadata is not None:
-                    preprocessed_data = (training_set, validation_set, test_set, training_set_metadata)
-                else:
-                    # save description
-                    if self.backend.is_coordinator():
-                        description = get_experiment_description(
-                            self.config,
-                            dataset=dataset,
-                            training_set=training_set,
-                            validation_set=validation_set,
-                            test_set=test_set,
-                            training_set_metadata=training_set_metadata,
-                            data_format=data_format,
-                            random_seed=random_seed
-                        )
-                        if not skip_save_training_description:
-                            save_json(description_fn, description)
-                        # print description
-                        logger.info('Experiment name: {}'.format(experiment_name))
-                        logger.info('Model name: {}'.format(model_name))
-                        logger.info('Output directory: {}'.format(output_directory))
-                        logger.info('\n')
-                        for key, value in description.items():
-                            logger.info('{}: {}'.format(key, pformat(value, indent=4)))
-                        logger.info('\n')
-
-                    preprocessed_data = self.preprocess(
+            if isinstance(training_set, Dataset) and training_set_metadata is not None:
+                preprocessed_data = (training_set, validation_set, test_set, training_set_metadata)
+            else:
+                # save description
+                if self.backend.is_coordinator():
+                    description = get_experiment_description(
+                        self.config,
                         dataset=dataset,
                         training_set=training_set,
                         validation_set=validation_set,
                         test_set=test_set,
                         training_set_metadata=training_set_metadata,
                         data_format=data_format,
-                        experiment_name=experiment_name,
-                        model_name=model_name,
-                        model_resume_path=model_resume_path,
-                        skip_save_training_description=skip_save_training_description,
-                        skip_save_training_statistics=skip_save_training_statistics,
-                        skip_save_model=skip_save_model,
-                        skip_save_progress=skip_save_progress,
-                        skip_save_log=skip_save_log,
-                        skip_save_processed_input=skip_save_processed_input,
-                        output_directory=output_directory,
-                        random_seed=random_seed,
-                        devbug=debug,
-                        **kwargs,
+                        random_seed=random_seed
                     )
-                    (training_set,
-                     validation_set,
-                     test_set,
-                     training_set_metadata) = preprocessed_data
+                    if not skip_save_training_description:
+                        save_json(description_fn, description)
+                    # print description
+                    logger.info('Experiment name: {}'.format(experiment_name))
+                    logger.info('Model name: {}'.format(model_name))
+                    logger.info('Output directory: {}'.format(output_directory))
+                    logger.info('\n')
+                    for key, value in description.items():
+                        logger.info('{}: {}'.format(key, pformat(value, indent=4)))
+                    logger.info('\n')
 
-                self.training_set_metadata = training_set_metadata
-
-                if self.backend.is_coordinator():
-                    logger.info('Training set: {0}'.format(len(training_set)))
-                    if validation_set is not None:
-                        logger.info('Validation set: {0}'.format(len(validation_set)))
-                    if test_set is not None:
-                        logger.info('Test set: {0}'.format(len(test_set)))
-                    if not skip_save_model:
-                        # save train set metadata
-                        os.makedirs(model_dir, exist_ok=True)
-                        save_json(
-                            os.path.join(
-                                model_dir,
-                                TRAIN_SET_METADATA_FILE_NAME
-                            ),
-                            training_set_metadata
-                        )
-
-                contrib_command("train_init", experiment_directory=output_directory,
-                                experiment_name=experiment_name, model_name=model_name,
-                                output_directory=output_directory,
-                                resume=model_resume_path is not None)
-
-                # Build model if not provided
-                # if it was provided it means it was already loaded
-                if not self.model:
-                    if self.backend.is_coordinator():
-                        print_boxed('MODEL', print_fun=logger.debug)
-                    # update config with metadata properties
-                    update_config_with_metadata(
-                        self.config,
-                        training_set_metadata
-                    )
-                    self.model = LudwigModel.create_model(self.config,
-                                                          random_seed=random_seed)
-
-                # init trainer
-                with self.backend.create_trainer(
-                    **self.config[TRAINING],
-                    resume=model_resume_path is not None,
+                preprocessed_data = self.preprocess(
+                    dataset=dataset,
+                    training_set=training_set,
+                    validation_set=validation_set,
+                    test_set=test_set,
+                    training_set_metadata=training_set_metadata,
+                    data_format=data_format,
+                    experiment_name=experiment_name,
+                    model_name=model_name,
+                    model_resume_path=model_resume_path,
+                    skip_save_training_description=skip_save_training_description,
+                    skip_save_training_statistics=skip_save_training_statistics,
                     skip_save_model=skip_save_model,
                     skip_save_progress=skip_save_progress,
                     skip_save_log=skip_save_log,
-                    callbacks=callbacks,
+                    skip_save_processed_input=skip_save_processed_input,
+                    output_directory=output_directory,
                     random_seed=random_seed,
-                    debug=debug
-                ) as trainer:
-                    contrib_command("train_model", self.model, self.config,
-                                    self.config_fp)
+                    devbug=debug,
+                    **kwargs,
+                )
+                (training_set,
+                 validation_set,
+                 test_set,
+                 training_set_metadata) = preprocessed_data
 
-                    # train model
-                    if self.backend.is_coordinator():
-                        print_boxed('TRAINING')
-                        if not skip_save_model:
-                            self.save_config(model_dir)
+            self.training_set_metadata = training_set_metadata
 
-                    train_stats = trainer.train(
-                        self.model,
-                        training_set,
-                        validation_set=validation_set,
-                        test_set=test_set,
-                        save_path=model_dir,
+            if self.backend.is_coordinator():
+                logger.info('Training set: {0}'.format(len(training_set)))
+                if validation_set is not None:
+                    logger.info('Validation set: {0}'.format(len(validation_set)))
+                if test_set is not None:
+                    logger.info('Test set: {0}'.format(len(test_set)))
+                if not skip_save_model:
+                    # save train set metadata
+                    os.makedirs(model_dir, exist_ok=True)
+                    save_json(
+                        os.path.join(
+                            model_dir,
+                            TRAIN_SET_METADATA_FILE_NAME
+                        ),
+                        training_set_metadata
                     )
 
-                    self.model, train_trainset_stats, train_valiset_stats, train_testset_stats = train_stats
-                    train_stats = {
-                        TRAINING: train_trainset_stats,
-                        VALIDATION: train_valiset_stats,
-                        TEST: train_testset_stats
-                    }
+            contrib_command("train_init", experiment_directory=output_directory,
+                            experiment_name=experiment_name, model_name=model_name,
+                            output_directory=output_directory,
+                            resume=model_resume_path is not None)
 
-                    # save training statistics
-                    if self.backend.is_coordinator():
-                        if not skip_save_training_statistics:
-                            save_json(training_stats_fn, train_stats)
+            # Build model if not provided
+            # if it was provided it means it was already loaded
+            if not self.model:
+                if self.backend.is_coordinator():
+                    print_boxed('MODEL', print_fun=logger.debug)
+                # update config with metadata properties
+                update_config_with_metadata(
+                    self.config,
+                    training_set_metadata
+                )
+                self.model = LudwigModel.create_model(self.config,
+                                                      random_seed=random_seed)
 
-                    # grab the results of the model with highest validation test performance
-                    validation_field = trainer.validation_field
-                    validation_metric = trainer.validation_metric
-                    validation_field_result = train_valiset_stats[validation_field]
+            # init trainer
+            with self.backend.create_trainer(
+                **self.config[TRAINING],
+                resume=model_resume_path is not None,
+                skip_save_model=skip_save_model,
+                skip_save_progress=skip_save_progress,
+                skip_save_log=skip_save_log,
+                callbacks=callbacks,
+                random_seed=random_seed,
+                debug=debug
+            ) as trainer:
+                contrib_command("train_model", self.model, self.config,
+                                self.config_fp)
 
-                    best_function = get_best_function(validation_metric)
-                    # results of the model with highest validation test performance
-                    if self.backend.is_coordinator() and validation_set is not None:
-                        epoch_best_vali_metric, best_vali_metric = best_function(
-                            enumerate(validation_field_result[validation_metric]),
-                            key=lambda pair: pair[1]
-                        )
-                        logger.info(
-                            'Best validation model epoch: {0}'.format(
-                                epoch_best_vali_metric + 1)
-                        )
-                        logger.info(
-                            'Best validation model {0} on validation set {1}: {2}'.format(
-                                validation_metric, validation_field, best_vali_metric
-                            ))
-                        if test_set is not None:
-                            best_vali_metric_epoch_test_metric = train_testset_stats[
-                                validation_field][validation_metric][
-                                epoch_best_vali_metric]
-
-                            logger.info(
-                                'Best validation model {0} on test set {1}: {2}'.format(
-                                    validation_metric,
-                                    validation_field,
-                                    best_vali_metric_epoch_test_metric
-                                )
-                            )
-                        logger.info(
-                            '\nFinished: {0}_{1}'.format(experiment_name, model_name))
-                        logger.info('Saved to: {0}'.format(output_directory))
-
-                    contrib_command("train_save", output_directory)
-
-                    self.training_set_metadata = training_set_metadata
-
+                # train model
+                if self.backend.is_coordinator():
+                    print_boxed('TRAINING')
                     if not skip_save_model:
-                        # Load the best weights from saved checkpoint
-                        self.load_weights(model_dir)
+                        self.save_config(model_dir)
 
-                    return train_stats, preprocessed_data, output_url
+                train_stats = trainer.train(
+                    self.model,
+                    training_set,
+                    validation_set=validation_set,
+                    test_set=test_set,
+                    save_path=model_dir,
+                )
+
+                self.model, train_trainset_stats, train_valiset_stats, train_testset_stats = train_stats
+                train_stats = {
+                    TRAINING: train_trainset_stats,
+                    VALIDATION: train_valiset_stats,
+                    TEST: train_testset_stats
+                }
+
+                # save training statistics
+                if self.backend.is_coordinator():
+                    if not skip_save_training_statistics:
+                        save_json(training_stats_fn, train_stats)
+
+                # grab the results of the model with highest validation test performance
+                validation_field = trainer.validation_field
+                validation_metric = trainer.validation_metric
+                validation_field_result = train_valiset_stats[validation_field]
+
+                best_function = get_best_function(validation_metric)
+                # results of the model with highest validation test performance
+                if self.backend.is_coordinator() and validation_set is not None:
+                    epoch_best_vali_metric, best_vali_metric = best_function(
+                        enumerate(validation_field_result[validation_metric]),
+                        key=lambda pair: pair[1]
+                    )
+                    logger.info(
+                        'Best validation model epoch: {0}'.format(
+                            epoch_best_vali_metric + 1)
+                    )
+                    logger.info(
+                        'Best validation model {0} on validation set {1}: {2}'.format(
+                            validation_metric, validation_field, best_vali_metric
+                        ))
+                    if test_set is not None:
+                        best_vali_metric_epoch_test_metric = train_testset_stats[
+                            validation_field][validation_metric][
+                            epoch_best_vali_metric]
+
+                        logger.info(
+                            'Best validation model {0} on test set {1}: {2}'.format(
+                                validation_metric,
+                                validation_field,
+                                best_vali_metric_epoch_test_metric
+                            )
+                        )
+                    logger.info(
+                        '\nFinished: {0}_{1}'.format(experiment_name, model_name))
+                    logger.info('Saved to: {0}'.format(output_directory))
+
+                contrib_command("train_save", output_directory)
+
+                self.training_set_metadata = training_set_metadata
+
+                if not skip_save_model:
+                    # Load the best weights from saved checkpoint
+                    self.load_weights(model_dir)
+
+                return train_stats, preprocessed_data, output_url
 
     def train_online(
             self,

--- a/ludwig/backend/__init__.py
+++ b/ludwig/backend/__init__.py
@@ -29,23 +29,23 @@ RAY = 'ray'
 ALL_BACKENDS = [LOCAL, DASK, HOROVOD, RAY]
 
 
-def get_local_backend():
-    return LOCAL_BACKEND
+def get_local_backend(**kwargs):
+    return LocalBackend(**kwargs)
 
 
-def create_dask_backend():
+def create_dask_backend(**kwargs):
     from ludwig.backend.dask import DaskBackend
-    return DaskBackend()
+    return DaskBackend(**kwargs)
 
 
-def create_horovod_backend():
+def create_horovod_backend(**kwargs):
     from ludwig.backend.horovod import HorovodBackend
-    return HorovodBackend()
+    return HorovodBackend(**kwargs)
 
 
-def create_ray_backend():
+def create_ray_backend(**kwargs):
     from ludwig.backend.ray import RayBackend
-    return RayBackend()
+    return RayBackend(**kwargs)
 
 
 backend_registry = {
@@ -57,17 +57,17 @@ backend_registry = {
 }
 
 
-def create_backend(backend):
-    if isinstance(backend, Backend):
-        return backend
+def create_backend(name, **kwargs):
+    if isinstance(name, Backend):
+        return name
 
-    if backend is None and has_horovodrun():
-        backend = HOROVOD
+    if name is None and has_horovodrun():
+        name = HOROVOD
 
-    return backend_registry[backend]()
+    return backend_registry[name](**kwargs)
 
 
-def initialize_backend(backend):
-    backend = create_backend(backend)
+def initialize_backend(name, **kwargs):
+    backend = create_backend(name, **kwargs)
     backend.initialize()
     return backend

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -22,6 +22,7 @@ import uuid
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
+from ludwig.constants import HDF5
 from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.models.predictor import Predictor
 from ludwig.models.trainer import Trainer
@@ -149,8 +150,9 @@ class RemoteTrainingMixin:
 
 
 class LocalBackend(LocalPreprocessingMixin, LocalTrainingMixin, Backend):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, intermediate_format=HDF5, **kwargs):
+        super().__init__(**kwargs)
+        self.intermediate_format = intermediate_format
 
     def initialize(self):
         pass

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -25,6 +25,7 @@ from contextlib import contextmanager
 from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.models.predictor import Predictor
 from ludwig.models.trainer import Trainer
+from ludwig.utils.fs_utils import makedirs
 from ludwig.utils.tf_utils import initialize_tensorflow
 
 
@@ -49,7 +50,7 @@ class CacheMixin:
         prev_cache_dir = self._cache_dir
         try:
             if self._cache_dir:
-                os.makedirs(self._cache_dir, exist_ok=True)
+                makedirs(self._cache_dir, exist_ok=True)
                 yield self._cache_dir
             else:
                 with tempfile.TemporaryDirectory() as tmpdir:

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -15,55 +15,29 @@
 # limitations under the License.
 # ==============================================================================
 
-import os
-import tempfile
-import uuid
-
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
-from ludwig.constants import HDF5
+from ludwig.data.cache.manager import CacheManager
 from ludwig.data.dataframe.pandas import PANDAS
+from ludwig.data.dataset import create_dataset_manager
 from ludwig.models.predictor import Predictor
 from ludwig.models.trainer import Trainer
-from ludwig.utils.fs_utils import makedirs
 from ludwig.utils.tf_utils import initialize_tensorflow
 
 
-class CacheMixin:
-    _cache_dir: str
+class Backend(ABC):
+    def __init__(self, cache_dir=None, data_format=None):
+        self._dataset_manager = create_dataset_manager(self, data_format)
+        self._cache_manager = CacheManager(self._dataset_manager, cache_dir)
 
     @property
-    def cache_enabled(self):
-        return self._cache_dir is not None
-
-    def create_cache_entry(self):
-        return os.path.join(self.cache_dir, str(uuid.uuid1()))
+    def cache(self):
+        return self._cache_manager
 
     @property
-    def cache_dir(self):
-        if not self._cache_dir:
-            raise ValueError('Cache directory not available, try calling `with backend.create_cache_dir()`.')
-        return self._cache_dir
-
-    @contextmanager
-    def create_cache_dir(self):
-        prev_cache_dir = self._cache_dir
-        try:
-            if self._cache_dir:
-                makedirs(self._cache_dir, exist_ok=True)
-                yield self._cache_dir
-            else:
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    self._cache_dir = tmpdir
-                    yield tmpdir
-        finally:
-            self._cache_dir = prev_cache_dir
-
-
-class Backend(CacheMixin, ABC):
-    def __init__(self, cache_dir=None):
-        self._cache_dir = cache_dir
+    def dataset_manager(self):
+        return self._dataset_manager
 
     @abstractmethod
     def initialize(self):
@@ -102,11 +76,6 @@ class Backend(CacheMixin, ABC):
 
     @abstractmethod
     def check_lazy_load_supported(self, feature):
-        raise NotImplementedError()
-
-    @property
-    @abstractmethod
-    def dataset_factory(self):
         raise NotImplementedError()
 
 
@@ -155,9 +124,8 @@ class RemoteTrainingMixin:
 
 
 class LocalBackend(LocalPreprocessingMixin, LocalTrainingMixin, Backend):
-    def __init__(self, intermediate_format=HDF5, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.intermediate_format = intermediate_format
 
     def initialize(self):
         pass

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -104,6 +104,11 @@ class Backend(CacheMixin, ABC):
     def check_lazy_load_supported(self, feature):
         raise NotImplementedError()
 
+    @property
+    @abstractmethod
+    def dataset_factory(self):
+        raise NotImplementedError()
+
 
 class LocalPreprocessingMixin:
     @property

--- a/ludwig/backend/dask.py
+++ b/ludwig/backend/dask.py
@@ -21,8 +21,8 @@ from ludwig.data.dataframe.dask import DaskEngine
 
 
 class DaskBackend(LocalTrainingMixin, Backend):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self._df_engine = DaskEngine()
 
     def initialize(self):

--- a/ludwig/backend/dask.py
+++ b/ludwig/backend/dask.py
@@ -21,8 +21,8 @@ from ludwig.data.dataframe.dask import DaskEngine
 
 
 class DaskBackend(LocalTrainingMixin, Backend):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, data_format='parquet', **kwargs):
+        super().__init__(data_format=data_format, **kwargs)
         self._df_engine = DaskEngine()
 
     def initialize(self):

--- a/ludwig/backend/dask.py
+++ b/ludwig/backend/dask.py
@@ -16,14 +16,19 @@
 # ==============================================================================
 
 from ludwig.backend.base import Backend, LocalTrainingMixin
-from ludwig.constants import NAME
+from ludwig.constants import NAME, PARQUET
 from ludwig.data.dataframe.dask import DaskEngine
 
 
 class DaskBackend(LocalTrainingMixin, Backend):
-    def __init__(self, data_format='parquet', **kwargs):
+    def __init__(self, data_format=PARQUET, **kwargs):
         super().__init__(data_format=data_format, **kwargs)
         self._df_engine = DaskEngine()
+        if data_format != PARQUET:
+            raise ValueError(
+                f'Data format {data_format} is not supported when using the Dask backend. '
+                f'Try setting to `parquet`.'
+            )
 
     def initialize(self):
         pass

--- a/ludwig/backend/horovod.py
+++ b/ludwig/backend/horovod.py
@@ -25,8 +25,8 @@ from ludwig.utils.tf_utils import initialize_tensorflow
 
 
 class HorovodBackend(LocalPreprocessingMixin, Backend):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self._horovod = None
 
     def initialize(self):

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -24,7 +24,7 @@ from horovod.ray import RayExecutor
 from ray.util.dask import ray_dask_get
 
 from ludwig.backend.base import Backend, RemoteTrainingMixin
-from ludwig.constants import NAME
+from ludwig.constants import NAME, PARQUET
 from ludwig.data.dataframe.dask import DaskEngine
 from ludwig.models.predictor import BasePredictor, RemotePredictor
 from ludwig.models.trainer import BaseTrainer, RemoteTrainer
@@ -173,11 +173,16 @@ class RayPredictor(BasePredictor):
 
 
 class RayBackend(RemoteTrainingMixin, Backend):
-    def __init__(self, horovod_kwargs=None, data_format='parquet', **kwargs):
+    def __init__(self, horovod_kwargs=None, data_format=PARQUET, **kwargs):
         super().__init__(data_format=data_format, **kwargs)
         self._df_engine = DaskEngine()
         self._horovod_kwargs = horovod_kwargs or {}
         self._tensorflow_kwargs = {}
+        if data_format != PARQUET:
+            raise ValueError(
+                f'Data format {data_format} is not supported when using the Ray backend. '
+                f'Try setting to `parquet`.'
+            )
 
     def initialize(self):
         try:

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -173,8 +173,8 @@ class RayPredictor(BasePredictor):
 
 
 class RayBackend(RemoteTrainingMixin, Backend):
-    def __init__(self, horovod_kwargs=None):
-        super().__init__()
+    def __init__(self, horovod_kwargs=None, data_format='parquet', **kwargs):
+        super().__init__(data_format=data_format, **kwargs)
         self._df_engine = DaskEngine()
         self._horovod_kwargs = horovod_kwargs or {}
         self._tensorflow_kwargs = {}

--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -107,3 +107,6 @@ PROC_COLUMN = 'proc_column'
 
 CHECKSUM = 'checksum'
 
+HDF5 = 'hdf5'
+PARQUET = 'parquet'
+

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -80,7 +80,7 @@ class CacheManager(object):
     def get_cache_key(self, input_fname, config):
         if input_fname is None:
             # TODO(travis): could try hashing the in-memory dataset, but this is tricky for Dask
-            return str(uuid.uuid4())
+            return str(uuid.uuid1())
         return calculate_checksum(input_fname, config)
 
     def get_cache_path(self, input_fname, key, tag=None, ext=None):

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -3,7 +3,7 @@ import os
 import uuid
 from pathlib import Path
 
-from ludwig.constants import CHECKSUM
+from ludwig.constants import CHECKSUM, TRAINING, TEST, VALIDATION
 from ludwig.data.cache.util import calculate_checksum
 from ludwig.utils import data_utils
 from ludwig.utils.fs_utils import path_exists
@@ -26,28 +26,31 @@ class CacheManager(object):
 
         logger.info('Writing preprocessed training set cache')
         training_set = self.save(
-            self.get_cache_path(input_fname, key, 'train'),
+            self.get_cache_path(input_fname, key, TRAINING),
             training_set,
             config,
             training_set_metadata,
+            TRAINING,
         )
 
         if test_set is not None:
             logger.info('Writing preprocessed test set cache')
             test_set = self.save(
-                self.get_cache_path(input_fname, key, 'test'),
+                self.get_cache_path(input_fname, key, TEST),
                 test_set,
                 config,
                 training_set_metadata,
+                TEST,
             )
 
         if validation_set is not None:
             logger.info('Writing preprocessed validation set cache')
             validation_set = self.save(
-                self.get_cache_path(input_fname, key, 'val'),
+                self.get_cache_path(input_fname, key, VALIDATION),
                 validation_set,
                 config,
                 training_set_metadata,
+                VALIDATION,
             )
 
         logger.info('Writing train set metadata')
@@ -69,9 +72,9 @@ class CacheManager(object):
                 training_set_metadata_fp
             )
 
-            dataset_fp = self.get_cache_path(input_fname, key, 'train')
-            test_fp = self.get_cache_path(input_fname, key, 'test')
-            val_fp = self.get_cache_path(input_fname, key, 'val')
+            dataset_fp = self.get_cache_path(input_fname, key, TRAINING)
+            test_fp = self.get_cache_path(input_fname, key, TEST)
+            val_fp = self.get_cache_path(input_fname, key, VALIDATION)
             valid = key == cache_training_set_metadata.get(CHECKSUM) and path_exists(dataset_fp)
             return valid, cache_training_set_metadata, dataset_fp, test_fp, val_fp
 
@@ -98,8 +101,8 @@ class CacheManager(object):
             return '.'
         return self._cache_dir
 
-    def save(self, cache_path, dataset, config, training_set_metadata):
-        return self._dataset_manager.save(cache_path, dataset, config, training_set_metadata)
+    def save(self, cache_path, dataset, config, training_set_metadata, tag):
+        return self._dataset_manager.save(cache_path, dataset, config, training_set_metadata, tag)
 
     def can_cache(self, input_fname, config, skip_save_processed_input):
         return self._dataset_manager.can_cache(input_fname, config, skip_save_processed_input)

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -24,12 +24,6 @@ class CacheManager(object):
         key = self.get_cache_key(input_fname, config)
         training_set, test_set, validation_set, training_set_metadata = processed
 
-        logger.info('Writing train set metadata')
-        data_utils.save_json(
-            self.get_cache_path(input_fname, key, 'meta', 'json'),
-            training_set_metadata
-        )
-
         logger.info('Writing preprocessed training set cache')
         training_set = self.save(
             self.get_cache_path(input_fname, key),
@@ -55,6 +49,12 @@ class CacheManager(object):
                 config,
                 training_set_metadata,
             )
+
+        logger.info('Writing train set metadata')
+        data_utils.save_json(
+            self.get_cache_path(input_fname, key, 'meta', 'json'),
+            training_set_metadata
+        )
 
         return training_set, test_set, validation_set, training_set_metadata
 

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -21,8 +21,11 @@ class CacheManager(object):
         if not self.can_cache(input_fname, config, skip_save_processed_input):
             return processed
 
-        key = self.get_cache_key(input_fname, config)
         training_set, test_set, validation_set, training_set_metadata = processed
+        key = training_set_metadata.get(CHECKSUM)
+        if not key:
+            key = self.get_cache_key(input_fname, config)
+            training_set_metadata[CHECKSUM] = key
 
         logger.info('Writing preprocessed training set cache')
         training_set = self.save(

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -102,7 +102,7 @@ class CacheManager(object):
         return calculate_checksum(input_fname, config)
 
     def get_cache_path(self, input_fname, key, tag, ext=None):
-        stem = key if self._cache_dir is not None else Path(input_fname).stem
+        stem = key if self._cache_dir is not None or input_fname is None else Path(input_fname).stem
         ext = ext or self.data_format
         cache_fname = f'{stem}.{tag}.{ext}'
         return os.path.join(self.get_cache_directory(input_fname), cache_fname)

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -26,7 +26,7 @@ class CacheManager(object):
 
         logger.info('Writing preprocessed training set cache')
         training_set = self.save(
-            self.get_cache_path(input_fname, key),
+            self.get_cache_path(input_fname, key, 'train'),
             training_set,
             config,
             training_set_metadata,
@@ -69,7 +69,7 @@ class CacheManager(object):
                 training_set_metadata_fp
             )
 
-            dataset_fp = self.get_cache_path(input_fname, key)
+            dataset_fp = self.get_cache_path(input_fname, key, 'train')
             test_fp = self.get_cache_path(input_fname, key, 'test')
             val_fp = self.get_cache_path(input_fname, key, 'val')
             valid = key == cache_training_set_metadata.get(CHECKSUM) and path_exists(dataset_fp)

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -101,12 +101,10 @@ class CacheManager(object):
             return str(uuid.uuid1())
         return calculate_checksum(input_fname, config)
 
-    def get_cache_path(self, input_fname, key, tag=None, ext=None):
-        tag = tag or Path(input_fname).stem
+    def get_cache_path(self, input_fname, key, tag, ext=None):
+        stem = key if self._cache_dir is not None else Path(input_fname).stem
         ext = ext or self.data_format
-        cache_fname = f'{key}.{tag}.{ext}'
-        if self._cache_dir is None:
-            cache_fname = f'{tag}.{ext}'
+        cache_fname = f'{stem}.{tag}.{ext}'
         return os.path.join(self.get_cache_directory(input_fname), cache_fname)
 
     def get_cache_directory(self, input_fname):

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -1,0 +1,109 @@
+import logging
+import os
+import uuid
+from pathlib import Path
+
+from ludwig.constants import CHECKSUM
+from ludwig.data.cache.util import calculate_checksum
+from ludwig.utils import data_utils
+from ludwig.utils.fs_utils import path_exists
+
+
+logger = logging.getLogger(__name__)
+
+
+class CacheManager(object):
+    def __init__(self, dataset_manager, cache_dir=None):
+        self._dataset_manager = dataset_manager
+        self._cache_dir = cache_dir
+
+    def put_dataset(self, input_fname, config, processed, skip_save_processed_input):
+        if not self.can_cache(input_fname, config, skip_save_processed_input):
+            return processed
+
+        key = self.get_cache_key(input_fname, config)
+        training_set, test_set, validation_set, training_set_metadata = processed
+
+        logger.info('Writing train set metadata')
+        data_utils.save_json(
+            self.get_cache_path(input_fname, key, 'meta', 'json'),
+            training_set_metadata
+        )
+
+        logger.info('Writing preprocessed training set cache')
+        training_set = self.save(
+            self.get_cache_path(input_fname, key),
+            training_set,
+            config,
+            training_set_metadata,
+        )
+
+        if test_set is not None:
+            logger.info('Writing preprocessed test set cache')
+            test_set = self.save(
+                self.get_cache_path(input_fname, key, 'test'),
+                test_set,
+                config,
+                training_set_metadata,
+            )
+
+        if validation_set is not None:
+            logger.info('Writing preprocessed validation set cache')
+            validation_set = self.save(
+                self.get_cache_path(input_fname, key, 'val'),
+                validation_set,
+                config,
+                training_set_metadata,
+            )
+
+        return training_set, test_set, validation_set, training_set_metadata
+
+    def get_dataset(self, input_fname, config):
+        key = self.get_cache_key(input_fname, config)
+        training_set_metadata_fp = self.get_cache_path(
+            input_fname, key, 'meta', 'json'
+        )
+
+        if path_exists(training_set_metadata_fp):
+            cache_training_set_metadata = data_utils.load_json(
+                training_set_metadata_fp
+            )
+
+            dataset_fp = self.get_cache_path(input_fname, key)
+            test_fp = self.get_cache_path(input_fname, key, 'test')
+            val_fp = self.get_cache_path(input_fname, key, 'val')
+            valid = key == cache_training_set_metadata.get(CHECKSUM) and path_exists(dataset_fp)
+            return valid, cache_training_set_metadata, dataset_fp, test_fp, val_fp
+
+        return None
+
+    def get_cache_key(self, input_fname, config):
+        if input_fname is None:
+            # TODO(travis): could try hashing the in-memory dataset, but this is tricky for Dask
+            return str(uuid.uuid4())
+        return calculate_checksum(input_fname, config)
+
+    def get_cache_path(self, input_fname, key, tag=None, ext=None):
+        tag = tag or Path(input_fname).stem
+        ext = ext or self.data_format
+        cache_fname = f'{key}.{tag}.{ext}'
+        if self._cache_dir is None:
+            cache_fname = f'{tag}.{ext}'
+        return os.path.join(self.get_cache_directory(input_fname), cache_fname)
+
+    def get_cache_directory(self, input_fname):
+        if self._cache_dir is None:
+            if input_fname is not None:
+                return os.path.dirname(input_fname)
+            return '.'
+        return self._cache_dir
+
+    def save(self, cache_path, dataset, config, training_set_metadata):
+        return self._dataset_manager.save(cache_path, dataset, config, training_set_metadata)
+
+    def can_cache(self, input_fname, config, skip_save_processed_input):
+        return self._dataset_manager.can_cache(input_fname, config, skip_save_processed_input)
+
+    @property
+    def data_format(self):
+        return self._dataset_manager.data_format

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -6,8 +6,7 @@ from pathlib import Path
 from ludwig.constants import CHECKSUM, TRAINING, TEST, VALIDATION
 from ludwig.data.cache.util import calculate_checksum
 from ludwig.utils import data_utils
-from ludwig.utils.fs_utils import path_exists
-
+from ludwig.utils.fs_utils import path_exists, delete
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +81,19 @@ class CacheManager(object):
             return valid, cache_training_set_metadata, dataset_fp, test_fp, val_fp
 
         return None
+
+    def delete_dataset(self, input_fname, config):
+        key = self.get_cache_key(input_fname, config)
+        fnames = [
+            self.get_cache_path(input_fname, key, 'meta', 'json'),
+            self.get_cache_path(input_fname, key, TRAINING),
+            self.get_cache_path(input_fname, key, TEST),
+            self.get_cache_path(input_fname, key, VALIDATION),
+        ]
+
+        for fname in fnames:
+            if path_exists(fname):
+                delete(fname)
 
     def get_cache_key(self, input_fname, config):
         if input_fname is None:

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import uuid
 from pathlib import Path
 
@@ -9,6 +10,11 @@ from ludwig.utils import data_utils
 from ludwig.utils.fs_utils import path_exists, delete
 
 logger = logging.getLogger(__name__)
+
+
+def alphanum(v):
+    """Filters a string to only its alphanumeric characters."""
+    return re.sub(r'\W+', '', v)
 
 
 class CacheManager(object):
@@ -102,7 +108,9 @@ class CacheManager(object):
         return calculate_checksum(input_fname, config)
 
     def get_cache_path(self, input_fname, key, tag, ext=None):
-        stem = key if self._cache_dir is not None or input_fname is None else Path(input_fname).stem
+        stem = alphanum(key) \
+            if self._cache_dir is not None or input_fname is None \
+            else Path(input_fname).stem
         ext = ext or self.data_format
         cache_fname = f'{stem}.{tag}.{ext}'
         return os.path.join(self.get_cache_directory(input_fname), cache_fname)

--- a/ludwig/data/cache/util.py
+++ b/ludwig/data/cache/util.py
@@ -1,0 +1,20 @@
+import ludwig
+from ludwig.constants import NAME, TYPE, PREPROCESSING
+from ludwig.utils.fs_utils import get_modified_timestamp
+from ludwig.utils.misc_utils import hash_dict
+
+
+def calculate_checksum(original_dataset, config):
+    info = {}
+    info['ludwig_version'] = ludwig.globals.LUDWIG_VERSION
+    info['dataset_modification_date'] = get_modified_timestamp(original_dataset)
+    info['global_preprocessing'] = config['preprocessing']
+    features = config.get('input_features', []) + \
+               config.get('output_features', []) + \
+               config.get('features', [])
+    info['feature_names'] = [feature[NAME] for feature in features]
+    info['feature_types'] = [feature[TYPE] for feature in features]
+    info['feature_preprocessing'] = [feature.get(PREPROCESSING, {})
+                                     for feature in features]
+    hash = hash_dict(info, max_length=None)
+    return hash.decode('ascii')

--- a/ludwig/data/cache/util.py
+++ b/ludwig/data/cache/util.py
@@ -5,16 +5,17 @@ from ludwig.utils.misc_utils import hash_dict
 
 
 def calculate_checksum(original_dataset, config):
-    info = {}
-    info['ludwig_version'] = ludwig.globals.LUDWIG_VERSION
-    info['dataset_checksum'] = checksum(original_dataset)
-    info['global_preprocessing'] = config['preprocessing']
     features = config.get('input_features', []) + \
                config.get('output_features', []) + \
                config.get('features', [])
-    info['feature_names'] = [feature[NAME] for feature in features]
-    info['feature_types'] = [feature[TYPE] for feature in features]
-    info['feature_preprocessing'] = [feature.get(PREPROCESSING, {})
-                                     for feature in features]
-    hash = hash_dict(info, max_length=None)
-    return hash.decode('ascii')
+    info = {
+        'ludwig_version': ludwig.globals.LUDWIG_VERSION,
+        'dataset_checksum': checksum(original_dataset),
+        'global_preprocessing': config['preprocessing'],
+        'feature_names': [feature[NAME] for feature in features],
+        'feature_types': [feature[TYPE] for feature in features],
+        'feature_preprocessing': [
+            feature.get(PREPROCESSING, {}) for feature in features
+        ],
+    }
+    return hash_dict(info, max_length=None).decode('ascii')

--- a/ludwig/data/cache/util.py
+++ b/ludwig/data/cache/util.py
@@ -1,13 +1,13 @@
 import ludwig
 from ludwig.constants import NAME, TYPE, PREPROCESSING
-from ludwig.utils.fs_utils import get_modified_timestamp
+from ludwig.utils.fs_utils import checksum
 from ludwig.utils.misc_utils import hash_dict
 
 
 def calculate_checksum(original_dataset, config):
     info = {}
     info['ludwig_version'] = ludwig.globals.LUDWIG_VERSION
-    info['dataset_modification_date'] = get_modified_timestamp(original_dataset)
+    info['dataset_checksum'] = checksum(original_dataset)
     info['global_preprocessing'] = config['preprocessing']
     features = config.get('input_features', []) + \
                config.get('output_features', []) + \

--- a/ludwig/data/dataframe/base.py
+++ b/ludwig/data/dataframe/base.py
@@ -47,10 +47,6 @@ class DataFrameEngine(ABC):
     def reduce_objects(self, series, reduce_fn):
         raise NotImplementedError()
 
-    @abstractmethod
-    def create_dataset(self, dataset, tag, config, training_set_metadata):
-        raise NotImplementedError()
-
     @property
     @abstractmethod
     def array_lib(self):

--- a/ludwig/data/dataframe/base.py
+++ b/ludwig/data/dataframe/base.py
@@ -47,6 +47,10 @@ class DataFrameEngine(ABC):
     def reduce_objects(self, series, reduce_fn):
         raise NotImplementedError()
 
+    @abstractmethod
+    def to_parquet(self, df, path):
+        raise NotImplementedError()
+
     @property
     @abstractmethod
     def array_lib(self):
@@ -55,9 +59,4 @@ class DataFrameEngine(ABC):
     @property
     @abstractmethod
     def df_lib(self):
-        raise NotImplementedError()
-
-    @property
-    @abstractmethod
-    def use_hdf5_cache(self):
         raise NotImplementedError()

--- a/ludwig/data/dataframe/dask.py
+++ b/ludwig/data/dataframe/dask.py
@@ -67,38 +67,6 @@ class DaskEngine(DataFrameEngine):
     def reduce_objects(self, series, reduce_fn):
         return series.reduction(reduce_fn, aggregate=reduce_fn, meta=('data', 'object')).compute()[0]
 
-    def create_dataset(self, dataset, tag, config, training_set_metadata):
-        cache_dir = training_set_metadata.get(DATA_PROCESSED_CACHE_DIR)
-        tag = tag.lower()
-        dataset_parquet_fp = os.path.join(cache_dir, f'{tag}.parquet')
-
-        # Workaround for https://issues.apache.org/jira/browse/ARROW-1614
-        # Currently, Arrow does not support storing multi-dimensional arrays / tensors.
-        # When we write a column of tensors to disk, we need to first flatten it into a
-        # 1D array, which we will then reshape back when we read the data at train time.
-        features = get_combined_features(config)
-        for feature in features:
-            name = feature[NAME]
-            proc_column = feature[PROC_COLUMN]
-            reshape = training_set_metadata[name].get('reshape')
-            if reshape is not None:
-                dataset[proc_column] = self.map_objects(dataset[proc_column], lambda x: x.reshape(-1))
-
-        makedirs(dataset_parquet_fp, exist_ok=True)
-        dataset.to_parquet(dataset_parquet_fp,
-                           engine='pyarrow',
-                           write_index=False,
-                           schema='infer')
-
-        dataset_parquet_url = to_url(dataset_parquet_fp)
-        training_set_metadata[DATASET_SPLIT_URL.format(tag)] = dataset_parquet_url
-
-        return ParquetDataset(
-            dataset_parquet_url,
-            features,
-            training_set_metadata
-        )
-
     @property
     def array_lib(self):
         return da

--- a/ludwig/data/dataframe/dask.py
+++ b/ludwig/data/dataframe/dask.py
@@ -26,6 +26,7 @@ from ludwig.constants import NAME, PROC_COLUMN
 from ludwig.data.dataset.parquet import ParquetDataset
 from ludwig.data.dataframe.base import DataFrameEngine
 from ludwig.utils.data_utils import DATA_PROCESSED_CACHE_DIR, DATASET_SPLIT_URL
+from ludwig.utils.fs_utils import makedirs, to_url
 from ludwig.utils.misc_utils import get_combined_features
 
 TMP_COLUMN = '__TMP_COLUMN__'
@@ -83,13 +84,13 @@ class DaskEngine(DataFrameEngine):
             if reshape is not None:
                 dataset[proc_column] = self.map_objects(dataset[proc_column], lambda x: x.reshape(-1))
 
-        os.makedirs(dataset_parquet_fp, exist_ok=True)
+        makedirs(dataset_parquet_fp, exist_ok=True)
         dataset.to_parquet(dataset_parquet_fp,
                            engine='pyarrow',
                            write_index=False,
                            schema='infer')
 
-        dataset_parquet_url = 'file://' + os.path.abspath(dataset_parquet_fp)
+        dataset_parquet_url = to_url(dataset_parquet_fp)
         training_set_metadata[DATASET_SPLIT_URL.format(tag)] = dataset_parquet_url
 
         return ParquetDataset(

--- a/ludwig/data/dataframe/dask.py
+++ b/ludwig/data/dataframe/dask.py
@@ -67,6 +67,14 @@ class DaskEngine(DataFrameEngine):
     def reduce_objects(self, series, reduce_fn):
         return series.reduction(reduce_fn, aggregate=reduce_fn, meta=('data', 'object')).compute()[0]
 
+    def to_parquet(self, df, path):
+        df.to_parquet(
+            path,
+            engine='pyarrow',
+            write_index=False,
+            schema='infer',
+        )
+
     @property
     def array_lib(self):
         return da
@@ -74,10 +82,6 @@ class DaskEngine(DataFrameEngine):
     @property
     def df_lib(self):
         return dd
-
-    @property
-    def use_hdf5_cache(self):
-        return False
 
     @property
     def parallelism(self):

--- a/ludwig/data/dataframe/pandas.py
+++ b/ludwig/data/dataframe/pandas.py
@@ -46,6 +46,9 @@ class PandasEngine(DataFrameEngine):
     def reduce_objects(self, series, reduce_fn):
         return reduce_fn(series)
 
+    def to_parquet(self, df, path):
+        df.to_parquet(path, engine='pyarrow')
+
     @property
     def array_lib(self):
         return np
@@ -53,10 +56,6 @@ class PandasEngine(DataFrameEngine):
     @property
     def df_lib(self):
         return pd
-
-    @property
-    def use_hdf5_cache(self):
-        return True
 
 
 PANDAS = PandasEngine()

--- a/ludwig/data/dataframe/pandas.py
+++ b/ludwig/data/dataframe/pandas.py
@@ -46,13 +46,6 @@ class PandasEngine(DataFrameEngine):
     def reduce_objects(self, series, reduce_fn):
         return reduce_fn(series)
 
-    def create_dataset(self, dataset, tag, config, training_set_metadata):
-        return PandasDataset(
-            dataset,
-            get_proc_features(config),
-            training_set_metadata.get(DATA_TRAIN_HDF5_FP)
-        )
-
     @property
     def array_lib(self):
         return np

--- a/ludwig/data/dataset/__init__.py
+++ b/ludwig/data/dataset/__init__.py
@@ -15,15 +15,15 @@
 # limitations under the License.
 # ==============================================================================
 
-from ludwig.data.dataset.pandas import PandasDataset
-from ludwig.data.dataset.parquet import ParquetDataset
+from ludwig.data.dataset.pandas import PandasDatasetManager
+from ludwig.data.dataset.parquet import ParquetDatasetManager
 
 dataset_registry = {
-    'parquet': ParquetDataset,
-    'hdf5': PandasDataset,
-    None: PandasDataset,
+    'parquet': ParquetDatasetManager,
+    'hdf5': PandasDatasetManager,
+    None: PandasDatasetManager,
 }
 
 
 def create_dataset_manager(backend, data_format, **kwargs):
-    return dataset_registry.get(data_format)(backend, **kwargs)
+    return dataset_registry.get(data_format)(backend)

--- a/ludwig/data/dataset/__init__.py
+++ b/ludwig/data/dataset/__init__.py
@@ -14,3 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+
+from ludwig.data.dataset.pandas import PandasDataset
+from ludwig.data.dataset.parquet import ParquetDataset
+
+dataset_registry = {
+    'parquet': ParquetDataset,
+    'hdf5': PandasDataset,
+    None: PandasDataset,
+}
+
+
+def create_dataset_manager(backend, data_format, **kwargs):
+    return dataset_registry.get(data_format)(backend, **kwargs)

--- a/ludwig/data/dataset/base.py
+++ b/ludwig/data/dataset/base.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 # ==============================================================================
 
+import contextlib
 from abc import ABC, abstractmethod
 
 
@@ -23,6 +24,7 @@ class Dataset(ABC):
     def __len__(self):
         raise NotImplementedError()
 
+    @contextlib.contextmanager
     @abstractmethod
     def initialize_batcher(self, batch_size=128,
                            should_shuffle=True,

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import contextlib
+
 import numpy as np
 
 from ludwig.constants import PREPROCESSING, TRAINING
@@ -63,6 +65,7 @@ class PandasDataset(Dataset):
     def __len__(self):
         return self.size
 
+    @contextlib.contextmanager
     def initialize_batcher(self, batch_size=128,
                            should_shuffle=True,
                            seed=0,
@@ -76,7 +79,7 @@ class PandasDataset(Dataset):
                                       sampler,
                                       batch_size=batch_size,
                                       ignore_last=ignore_last)
-        return batcher
+        yield batcher
 
 
 class PandasDatasetManager(object):

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -16,7 +16,7 @@
 # ==============================================================================
 import numpy as np
 
-from ludwig.constants import PREPROCESSING
+from ludwig.constants import PREPROCESSING, TRAINING
 from ludwig.data.batcher.random_access import RandomAccessBatcher
 from ludwig.data.dataset.base import Dataset
 from ludwig.data.sampler import DistributedSampler
@@ -90,8 +90,10 @@ class PandasDatasetManager(object):
             training_set_metadata.get(DATA_TRAIN_HDF5_FP)
         )
 
-    def save(self, cache_path, dataset, config, training_set_metadata):
+    def save(self, cache_path, dataset, config, training_set_metadata, tag):
         data_utils.save_hdf5(cache_path, dataset)
+        if tag == TRAINING:
+            training_set_metadata[DATA_TRAIN_HDF5_FP] = cache_path
         return dataset
 
     def can_cache(self, input_fname, config, skip_save_processed_input):

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import h5py
 import numpy as np
 
 from ludwig.constants import PREPROCESSING
@@ -22,7 +21,7 @@ from ludwig.data.batcher.random_access import RandomAccessBatcher
 from ludwig.data.dataset.base import Dataset
 from ludwig.data.sampler import DistributedSampler
 from ludwig.utils.data_utils import to_numpy_dataset
-from ludwig.utils.fs_utils import open_h5
+from ludwig.utils.fs_utils import download_h5
 
 
 class PandasDataset(Dataset):
@@ -50,7 +49,7 @@ class PandasDataset(Dataset):
         indices[1, :] = np.arange(len(sub_batch))
         indices = indices[:, np.argsort(indices[0])]
 
-        with open_h5(self.data_hdf5_fp, 'r') as h5_file:
+        with download_h5(self.data_hdf5_fp) as h5_file:
             im_data = h5_file[proc_column + '_data'][indices[0, :], :, :]
         indices[2, :] = np.arange(len(sub_batch))
         indices = indices[:, np.argsort(indices[1])]

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -92,6 +92,7 @@ class PandasDatasetManager(object):
 
     def save(self, cache_path, dataset, config, training_set_metadata):
         data_utils.save_hdf5(cache_path, dataset)
+        return dataset
 
     def can_cache(self, input_fname, config, skip_save_processed_input):
         return input_fname is not None and \

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -22,6 +22,7 @@ from ludwig.data.batcher.random_access import RandomAccessBatcher
 from ludwig.data.dataset.base import Dataset
 from ludwig.data.sampler import DistributedSampler
 from ludwig.utils.data_utils import to_numpy_dataset
+from ludwig.utils.fs_utils import open_h5
 
 
 class PandasDataset(Dataset):
@@ -49,7 +50,7 @@ class PandasDataset(Dataset):
         indices[1, :] = np.arange(len(sub_batch))
         indices = indices[:, np.argsort(indices[0])]
 
-        with h5py.File(self.data_hdf5_fp, 'r') as h5_file:
+        with open_h5(self.data_hdf5_fp, 'r') as h5_file:
             im_data = h5_file[proc_column + '_data'][indices[0, :], :, :]
         indices[2, :] = np.arange(len(sub_batch))
         indices = indices[:, np.argsort(indices[1])]

--- a/ludwig/data/dataset/parquet.py
+++ b/ludwig/data/dataset/parquet.py
@@ -124,7 +124,7 @@ class ParquetDatasetManager(object):
         return dataset_parquet_fp
 
     def can_cache(self, input_fname, config, skip_save_processed_input):
-        return input_fname is not None and self.backend.is_coordinator()
+        return self.backend.is_coordinator()
 
     @property
     def data_format(self):

--- a/ludwig/data/dataset/parquet.py
+++ b/ludwig/data/dataset/parquet.py
@@ -24,12 +24,13 @@ from petastorm.tf_utils import make_petastorm_dataset
 from ludwig.constants import NAME, PROC_COLUMN
 from ludwig.data.batcher.iterable import IterableBatcher
 from ludwig.data.dataset.base import Dataset
+from ludwig.utils.fs_utils import to_url
 from ludwig.utils.misc_utils import get_combined_features
 
 
 class ParquetDataset(Dataset):
     def __init__(self, url, features, training_set_metadata):
-        self.url = url
+        self.url = to_url(url)
         self.features = [feature[PROC_COLUMN] for feature in features]
         self.training_set_metadata = training_set_metadata
 
@@ -119,9 +120,7 @@ class ParquetDatasetManager(object):
                     lambda x: x.reshape(-1)
                 )
 
-        # makedirs(dataset_parquet_fp, exist_ok=True)
-        dataset.to_parquet(dataset_parquet_fp,
-                           engine='pyarrow')
+        self.backend.df_engine.to_parquet(dataset, dataset_parquet_fp)
         return dataset_parquet_fp
 
     def can_cache(self, input_fname, config, skip_save_processed_input):

--- a/ludwig/data/dataset/parquet.py
+++ b/ludwig/data/dataset/parquet.py
@@ -123,8 +123,7 @@ class ParquetDatasetManager(object):
         makedirs(dataset_parquet_fp, exist_ok=True)
         dataset.to_parquet(dataset_parquet_fp,
                            engine='pyarrow',
-                           write_index=False,
-                           schema='infer')
+                           write_index=False)
         return dataset_parquet_fp
 
     def can_cache(self, input_fname, config, skip_save_processed_input):

--- a/ludwig/data/dataset/parquet.py
+++ b/ludwig/data/dataset/parquet.py
@@ -115,7 +115,7 @@ class ParquetDatasetManager(object):
             proc_column = feature[PROC_COLUMN]
             reshape = training_set_metadata[name].get('reshape')
             if reshape is not None:
-                dataset[proc_column] = self.backend.map_objects(
+                dataset[proc_column] = self.backend.df_engine.map_objects(
                     dataset[proc_column],
                     lambda x: x.reshape(-1)
                 )

--- a/ludwig/data/dataset/parquet.py
+++ b/ludwig/data/dataset/parquet.py
@@ -102,7 +102,7 @@ class ParquetDatasetManager(object):
             training_set_metadata
         )
 
-    def save(self, cache_path, dataset, config, training_set_metadata):
+    def save(self, cache_path, dataset, config, training_set_metadata, tag):
         dataset_parquet_fp = cache_path
 
         # Workaround for https://issues.apache.org/jira/browse/ARROW-1614

--- a/ludwig/data/dataset/parquet.py
+++ b/ludwig/data/dataset/parquet.py
@@ -125,13 +125,7 @@ class ParquetDatasetManager(object):
                            engine='pyarrow',
                            write_index=False,
                            schema='infer')
-
-        dataset_parquet_url = to_url(dataset_parquet_fp)
-        return ParquetDataset(
-            dataset_parquet_url,
-            features,
-            training_set_metadata
-        )
+        return dataset_parquet_fp
 
     def can_cache(self, input_fname, config, skip_save_processed_input):
         return input_fname is not None and self.backend.is_coordinator()

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -53,7 +53,7 @@ from ludwig.utils.data_utils import (CACHEABLE_FORMATS, CSV_FORMATS,
 from ludwig.utils.data_utils import save_array, get_split_path
 from ludwig.utils.defaults import (default_preprocessing_parameters,
                                    default_random_seed, merge_with_defaults)
-from ludwig.utils.fs_utils import get_modified_timestamp, delete, path_exists
+from ludwig.utils.fs_utils import delete, path_exists
 from ludwig.utils.misc_utils import (get_from_registry, merge_dict,
                                      resolve_pointers, set_random_seed,
                                      hash_dict, get_proc_features_from_lists)
@@ -1364,7 +1364,6 @@ def preprocess_for_training(
     input_fname = None
     if data_format in CACHEABLE_FORMATS:
         input_fname = dataset or training_set
-        dataset = None
 
         checksum = backend.cache.get_cache_key(input_fname, config)
         cache_results = backend.cache.get_dataset(input_fname, config)
@@ -1379,6 +1378,7 @@ def preprocess_for_training(
                 config['data_hdf5_fp'] = training_set
                 data_format = backend.cache.file_format
                 cached = True
+                dataset = None
             else:
                 logger.info(
                     "Found hdf5 and meta.json with the same filename "

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -520,6 +520,8 @@ class ParquetPreprocessor(DataFormatPreprocessor):
             backend=LOCAL_BACKEND,
             random_seed=default_random_seed
     ):
+        test_set = test_set if path_exists(test_set) else None
+        validation_set = validation_set if path_exists(validation_set) else None
         return training_set, test_set, validation_set, training_set_metadata
 
 

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1515,10 +1515,6 @@ def _preprocess_file_for_training(
             random_seed=random_seed
         )
 
-        if backend.cache_enabled:
-            training_set_metadata[
-                DATA_PROCESSED_CACHE_DIR] = backend.create_cache_entry()
-
         # TODO dask: consolidate hdf5 cache with backend cache
         if backend.is_coordinator() and not skip_save_processed_input:
             # save split values for use by visualization routines
@@ -1573,10 +1569,6 @@ def _preprocess_file_for_training(
             backend=backend,
             random_seed=random_seed
         )
-
-        if backend.cache_enabled:
-            training_set_metadata[
-                DATA_PROCESSED_CACHE_DIR] = backend.create_cache_entry()
 
         training_data, test_data, validation_data = split_dataset_ttv(
             data,
@@ -1673,10 +1665,6 @@ def _preprocess_df_for_training(
         random_seed=random_seed,
         backend=backend
     )
-
-    if backend.cache_enabled:
-        training_set_metadata[
-            DATA_PROCESSED_CACHE_DIR] = backend.create_cache_entry()
 
     training_set, test_set, validation_set = split_dataset_ttv(
         dataset,

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1370,15 +1370,15 @@ def preprocess_for_training(
         checksum = backend.cache.get_cache_key(input_fname, config)
         cache_results = backend.cache.get_dataset(input_fname, config)
         if cache_results is not None:
-            valid, *fnames = cache_results
+            valid, *cache_values = cache_results
             if valid:
                 logger.info(
                     'Found hdf5 and meta.json with the same filename '
                     'of the dataset, using them instead'
                 )
-                training_set_metadata, training_set, test_set, validation_set = cache_results
+                training_set_metadata, training_set, test_set, validation_set = cache_values
                 config['data_hdf5_fp'] = training_set
-                data_format = backend.cache.file_format
+                data_format = backend.cache.data_format
                 cached = True
                 dataset = None
             else:
@@ -1388,9 +1388,7 @@ def preprocess_for_training(
                     "if saving of processed input is not skipped "
                     "they will be overridden"
                 )
-                for fname in fnames:
-                    if path_exists(fname):
-                        delete(fname)
+                backend.cache.delete_dataset(input_fname, config)
 
     if CHECKSUM not in training_set_metadata:
         checksum = checksum or backend.cache.get_cache_key(input_fname, config)

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1422,6 +1422,13 @@ def preprocess_for_training(
             backend=backend,
             random_seed=random_seed
         )
+        training_set, test_set, validation_set, training_set_metadata = processed
+
+        replace_text_feature_level(
+            features,
+            [training_set, validation_set, test_set]
+        )
+        processed = (training_set, test_set, validation_set, training_set_metadata)
 
         # cache the dataset
         processed = backend.cache.put_dataset(
@@ -1431,11 +1438,6 @@ def preprocess_for_training(
 
     if CHECKSUM not in training_set_metadata and checksum is not None:
         training_set_metadata[CHECKSUM] = checksum
-
-    replace_text_feature_level(
-        features,
-        [training_set, validation_set, test_set]
-    )
 
     training_dataset = backend.dataset_manager.create(
         training_set,

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1515,26 +1515,10 @@ def _preprocess_file_for_training(
             random_seed=random_seed
         )
 
-        # TODO dask: consolidate hdf5 cache with backend cache
         if backend.is_coordinator() and not skip_save_processed_input:
             # save split values for use by visualization routines
             split_fp = get_split_path(dataset)
             save_array(split_fp, data[SPLIT])
-
-            # logger.info('Writing preprocessed dataset cache')
-            # data_hdf5_fp = replace_file_extension(dataset, 'hdf5')
-            # data_utils.save_hdf5(data_hdf5_fp, data)
-            #
-            # logger.info('Writing train set metadata')
-            # training_set_metadata[DATA_TRAIN_HDF5_FP] = data_hdf5_fp
-            # training_set_metadata[CHECKSUM] = calculate_checksum(
-            #     dataset,
-            #     {'features': features, PREPROCESSING: preprocessing_params}
-            # )
-            # training_set_metadata_fp = replace_file_extension(dataset,
-            #                                                   'meta.json')
-            # data_utils.save_json(training_set_metadata_fp,
-            #                      training_set_metadata)
 
         # TODO dask: https://docs.dask.org/en/latest/dataframe-api.html#dask.dataframe.DataFrame.random_split
         training_data, test_data, validation_data = split_dataset_ttv(
@@ -1574,51 +1558,6 @@ def _preprocess_file_for_training(
             data,
             SPLIT
         )
-
-        # if backend.is_coordinator() and not skip_save_processed_input and backend.df_engine.use_hdf5_cache:
-        #     logger.info('Writing preprocessed training set cache')
-        #     data_train_hdf5_fp = replace_file_extension(training_set, 'hdf5')
-        #     data_utils.save_hdf5(
-        #         data_train_hdf5_fp,
-        #         training_data,
-        #     )
-        #
-        #     if validation_set is not None:
-        #         logger.info('Writing preprocessed validation set cache')
-        #         data_validation_hdf5_fp = replace_file_extension(
-        #             validation_set,
-        #             'hdf5'
-        #         )
-        #         data_utils.save_hdf5(
-        #             data_validation_hdf5_fp,
-        #             validation_data,
-        #         )
-        #
-        #     if test_set is not None:
-        #         logger.info('Writing preprocessed test set cache')
-        #         data_test_hdf5_fp = replace_file_extension(
-        #             test_set,
-        #             'hdf5'
-        #         )
-        #         data_utils.save_hdf5(
-        #             data_test_hdf5_fp,
-        #             test_data,
-        #         )
-        #
-        #     logger.info('Writing train set metadata')
-        #     training_set_metadata[DATA_TRAIN_HDF5_FP] = data_train_hdf5_fp
-        #     training_set_metadata[CHECKSUM] = calculate_checksum(
-        #         training_set,
-        #         {'features': features, PREPROCESSING: preprocessing_params}
-        #     )
-        #     training_set_metadata_fp = replace_file_extension(
-        #         training_set,
-        #         'meta.json'
-        #     )
-        #     data_utils.save_json(
-        #         training_set_metadata_fp,
-        #         training_set_metadata,
-        #     )
 
     else:
         raise ValueError('either data or data_train have to be not None')

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -53,6 +53,7 @@ from ludwig.utils.data_utils import (CACHEABLE_FORMATS, CSV_FORMATS,
 from ludwig.utils.data_utils import save_array, get_split_path
 from ludwig.utils.defaults import (default_preprocessing_parameters,
                                    default_random_seed, merge_with_defaults)
+from ludwig.utils.fs_utils import get_modified_timestamp
 from ludwig.utils.misc_utils import (get_from_registry, merge_dict,
                                      resolve_pointers, set_random_seed,
                                      hash_dict, get_proc_features_from_lists)
@@ -1803,7 +1804,7 @@ def replace_text_feature_level(features, datasets):
 def calculate_checksum(original_dataset, config):
     info = {}
     info['ludwig_version'] = ludwig.globals.LUDWIG_VERSION
-    info['dataset_modification_date'] = os.path.getmtime(original_dataset)
+    info['dataset_modification_date'] = get_modified_timestamp(original_dataset)
     info['global_preprocessing'] = config['preprocessing']
     features = config.get('input_features', []) + \
                config.get('output_features', []) + \

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1684,7 +1684,7 @@ def preprocess_for_prediction(
     # because the cached data is stored in its split form, and would be
     # expensive to recombine, requiring further caching.
     cached = False
-    training_set, test_set, validation_set = None
+    training_set = test_set = validation_set = None
     if data_format in CACHEABLE_FORMATS and split != FULL:
         cache_results = backend.cache.get_dataset(dataset, config)
         if cache_results is not None:

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -28,6 +28,7 @@ from ludwig.constants import *
 from ludwig.encoders.image_encoders import ENCODER_REGISTRY
 from ludwig.features.base_feature import InputFeature
 from ludwig.utils.data_utils import get_abs_path
+from ludwig.utils.fs_utils import open_h5
 from ludwig.utils.image_utils import greyscale
 from ludwig.utils.image_utils import num_channels_in_image
 from ludwig.utils.image_utils import resize_image
@@ -326,7 +327,7 @@ class ImageFeatureMixin(object):
             if os.path.isfile(data_fp):
                 mode = 'r+'
 
-            with h5py.File(data_fp, mode) as h5_file:
+            with open_h5(data_fp, mode) as h5_file:
                 # todo future add multiprocessing/multithreading
                 image_dataset = h5_file.create_dataset(
                     feature[PROC_COLUMN] + '_data',

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -20,7 +20,6 @@ import sys
 from functools import partial
 from multiprocessing import Pool
 
-import h5py
 import numpy as np
 import tensorflow as tf
 
@@ -28,7 +27,7 @@ from ludwig.constants import *
 from ludwig.encoders.image_encoders import ENCODER_REGISTRY
 from ludwig.features.base_feature import InputFeature
 from ludwig.utils.data_utils import get_abs_path
-from ludwig.utils.fs_utils import open_h5
+from ludwig.utils.fs_utils import upload_h5
 from ludwig.utils.image_utils import greyscale
 from ludwig.utils.image_utils import num_channels_in_image
 from ludwig.utils.image_utils import resize_image
@@ -323,11 +322,7 @@ class ImageFeatureMixin(object):
                               for file_path in input_df[feature[NAME]]]
 
             data_fp = os.path.splitext(input_df.src)[0] + '.hdf5'
-            mode = 'w'
-            if os.path.isfile(data_fp):
-                mode = 'r+'
-
-            with open_h5(data_fp, mode) as h5_file:
+            with upload_h5(data_fp) as h5_file:
                 # todo future add multiprocessing/multithreading
                 image_dataset = h5_file.create_dataset(
                     feature[PROC_COLUMN] + '_data',

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -321,7 +321,9 @@ class ImageFeatureMixin(object):
             all_file_paths = [get_abs_path(src_path, file_path)
                               for file_path in input_df[feature[NAME]]]
 
-            data_fp = os.path.splitext(input_df.src)[0] + '.hdf5'
+            data_fp = backend.cache.get_cache_path(
+                input_df.src, metadata.get(CHECKSUM), TRAINING
+            )
             with upload_h5(data_fp) as h5_file:
                 # todo future add multiprocessing/multithreading
                 image_dataset = h5_file.create_dataset(

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -15,6 +15,7 @@ from ludwig.hyperopt.sampling import get_build_hyperopt_sampler
 from ludwig.hyperopt.utils import update_hyperopt_params_with_defaults, \
     print_hyperopt_results, save_hyperopt_stats
 from ludwig.utils.defaults import default_random_seed, merge_with_defaults
+from ludwig.utils.fs_utils import open_file
 from ludwig.utils.misc_utils import get_from_registry
 
 logger = logging.getLogger(__name__)
@@ -147,7 +148,7 @@ def hyperopt(
 
     # check if config is a path or a dict
     if isinstance(config, str):  # assume path
-        with open(config, 'r') as def_file:
+        with open_file(config, 'r') as def_file:
             config_dict = yaml.safe_load(def_file)
     else:
         config_dict = config

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -15,7 +15,7 @@ from ludwig.hyperopt.sampling import get_build_hyperopt_sampler
 from ludwig.hyperopt.utils import update_hyperopt_params_with_defaults, \
     print_hyperopt_results, save_hyperopt_stats
 from ludwig.utils.defaults import default_random_seed, merge_with_defaults
-from ludwig.utils.fs_utils import open_file
+from ludwig.utils.fs_utils import open_file, makedirs
 from ludwig.utils.misc_utils import get_from_registry
 
 logger = logging.getLogger(__name__)
@@ -301,8 +301,7 @@ def hyperopt(
         print_hyperopt_results(hyperopt_results)
 
         if not skip_save_hyperopt_statistics:
-            if not os.path.exists(output_directory):
-                os.makedirs(output_directory)
+            makedirs(output_directory, exist_ok=True)
 
             hyperopt_stats = {
                 'hyperopt_config': hyperopt_config,

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -87,49 +87,49 @@ class Predictor(BasePredictor):
             dataset,
             dataset_name=None
     ):
-        batcher = dataset.initialize_batcher(
+        with dataset.initialize_batcher(
             self._batch_size,
             should_shuffle=False,
             horovod=self._horovod
-        )
+        ) as batcher:
 
-        progress_bar = None
-        if self.is_coordinator():
-            progress_bar = tqdm(
-                desc='Prediction' if dataset_name is None
-                else 'Prediction {0: <5.5}'.format(dataset_name),
-                total=batcher.steps_per_epoch,
-                file=sys.stdout,
-                disable=is_progressbar_disabled()
-            )
+            progress_bar = None
+            if self.is_coordinator():
+                progress_bar = tqdm(
+                    desc='Prediction' if dataset_name is None
+                    else 'Prediction {0: <5.5}'.format(dataset_name),
+                    total=batcher.steps_per_epoch,
+                    file=sys.stdout,
+                    disable=is_progressbar_disabled()
+                )
 
-        predictions = {}
-        while not batcher.last_batch():
-            batch = batcher.next_batch()
+            predictions = {}
+            while not batcher.last_batch():
+                batch = batcher.next_batch()
 
-            inputs = {
-                i_feat.feature_name: batch[i_feat.proc_column]
-                for i_feat in model.input_features.values()
-            }
+                inputs = {
+                    i_feat.feature_name: batch[i_feat.proc_column]
+                    for i_feat in model.input_features.values()
+                }
 
-            preds = model.predict_step(inputs)
+                preds = model.predict_step(inputs)
 
-            # accumulate predictions from batch for each output feature
-            for of_name, of_preds in preds.items():
-                if of_name not in predictions:
-                    predictions[of_name] = {}
-                for pred_name, pred_values in of_preds.items():
-                    if pred_name not in EXCLUE_PRED_SET:
-                        if pred_name not in predictions[of_name]:
-                            predictions[of_name][pred_name] = [pred_values]
-                        else:
-                            predictions[of_name][pred_name].append(pred_values)
+                # accumulate predictions from batch for each output feature
+                for of_name, of_preds in preds.items():
+                    if of_name not in predictions:
+                        predictions[of_name] = {}
+                    for pred_name, pred_values in of_preds.items():
+                        if pred_name not in EXCLUE_PRED_SET:
+                            if pred_name not in predictions[of_name]:
+                                predictions[of_name][pred_name] = [pred_values]
+                            else:
+                                predictions[of_name][pred_name].append(pred_values)
+
+                if self.is_coordinator():
+                    progress_bar.update(1)
 
             if self.is_coordinator():
-                progress_bar.update(1)
-
-        if self.is_coordinator():
-            progress_bar.close()
+                progress_bar.close()
 
         # consolidate predictions from each batch to a single tensor
         for of_name, of_predictions in predictions.items():
@@ -146,55 +146,55 @@ class Predictor(BasePredictor):
             collect_predictions=False,
             dataset_name=None
     ):
-        batcher = dataset.initialize_batcher(
+        with dataset.initialize_batcher(
             self._batch_size,
             should_shuffle=False,
             horovod=self._horovod
-        )
+        ) as batcher:
 
-        progress_bar = None
-        if self.is_coordinator():
-            progress_bar = tqdm(
-                desc='Evaluation' if dataset_name is None
-                else 'Evaluation {0: <5.5}'.format(dataset_name),
-                total=batcher.steps_per_epoch,
-                file=sys.stdout,
-                disable=is_progressbar_disabled()
-            )
+            progress_bar = None
+            if self.is_coordinator():
+                progress_bar = tqdm(
+                    desc='Evaluation' if dataset_name is None
+                    else 'Evaluation {0: <5.5}'.format(dataset_name),
+                    total=batcher.steps_per_epoch,
+                    file=sys.stdout,
+                    disable=is_progressbar_disabled()
+                )
 
-        predictions = {}
-        while not batcher.last_batch():
-            batch = batcher.next_batch()
+            predictions = {}
+            while not batcher.last_batch():
+                batch = batcher.next_batch()
 
-            inputs = {
-                i_feat.feature_name: batch[i_feat.proc_column]
-                for i_feat in model.input_features.values()
-            }
-            targets = {
-                o_feat.feature_name: batch[o_feat.proc_column]
-                for o_feat in model.output_features.values()
-            }
+                inputs = {
+                    i_feat.feature_name: batch[i_feat.proc_column]
+                    for i_feat in model.input_features.values()
+                }
+                targets = {
+                    o_feat.feature_name: batch[o_feat.proc_column]
+                    for o_feat in model.output_features.values()
+                }
 
-            preds = model.evaluation_step(inputs, targets)
+                preds = model.evaluation_step(inputs, targets)
 
-            # accumulate predictions from batch for each output feature
-            if collect_predictions:
-                for of_name, of_preds in preds.items():
-                    if of_name not in predictions:
-                        predictions[of_name] = {}
-                    for pred_name, pred_values in of_preds.items():
-                        if pred_name not in EXCLUE_PRED_SET and pred_values is not None:
-                            if pred_name not in predictions[of_name]:
-                                predictions[of_name][pred_name] = [pred_values]
-                            else:
-                                predictions[of_name][pred_name].append(
-                                    pred_values)
+                # accumulate predictions from batch for each output feature
+                if collect_predictions:
+                    for of_name, of_preds in preds.items():
+                        if of_name not in predictions:
+                            predictions[of_name] = {}
+                        for pred_name, pred_values in of_preds.items():
+                            if pred_name not in EXCLUE_PRED_SET and pred_values is not None:
+                                if pred_name not in predictions[of_name]:
+                                    predictions[of_name][pred_name] = [pred_values]
+                                else:
+                                    predictions[of_name][pred_name].append(
+                                        pred_values)
+
+                if self.is_coordinator():
+                    progress_bar.update(1)
 
             if self.is_coordinator():
-                progress_bar.update(1)
-
-        if self.is_coordinator():
-            progress_bar.close()
+                progress_bar.close()
 
         # consolidate predictions from each batch to a single tensor
         if collect_predictions:
@@ -233,48 +233,48 @@ class Predictor(BasePredictor):
         activation_model = tf.keras.Model(inputs=keras_model_inputs,
                                           outputs=output_nodes)
 
-        batcher = dataset.initialize_batcher(
+        with dataset.initialize_batcher(
             self._batch_size,
             should_shuffle=False
-        )
+        ) as batcher:
 
-        progress_bar = tqdm(
-            desc='Collecting Tensors',
-            total=batcher.steps_per_epoch,
-            file=sys.stdout,
-            disable=is_progressbar_disabled()
-        )
+            progress_bar = tqdm(
+                desc='Collecting Tensors',
+                total=batcher.steps_per_epoch,
+                file=sys.stdout,
+                disable=is_progressbar_disabled()
+            )
 
-        collected_tensors = []
-        while not batcher.last_batch():
-            batch = batcher.next_batch()
+            collected_tensors = []
+            while not batcher.last_batch():
+                batch = batcher.next_batch()
 
-            inputs = {
-                i_feat.feature_name: batch[i_feat.proc_column]
-                for i_feat in model.input_features.values()
-            }
-            outputs = activation_model(inputs)
+                inputs = {
+                    i_feat.feature_name: batch[i_feat.proc_column]
+                    for i_feat in model.input_features.values()
+                }
+                outputs = activation_model(inputs)
 
-            for layer_name, output in outputs.items():
-                if isinstance(output, tuple):
-                    output = list(output)
+                for layer_name, output in outputs.items():
+                    if isinstance(output, tuple):
+                        output = list(output)
 
-                if isinstance(output, tf.Tensor):
-                    output = [('', output)]
-                elif isinstance(output, dict):
-                    output = [(f'_{key}', tensor)
-                              for key, tensor in output.items()]
-                elif isinstance(output, list):
-                    output = [(f'_{idx}', tensor)
-                              for idx, tensor in enumerate(output)]
+                    if isinstance(output, tf.Tensor):
+                        output = [('', output)]
+                    elif isinstance(output, dict):
+                        output = [(f'_{key}', tensor)
+                                  for key, tensor in output.items()]
+                    elif isinstance(output, list):
+                        output = [(f'_{idx}', tensor)
+                                  for idx, tensor in enumerate(output)]
 
-                for suffix, tensor in output:
-                    full_name = f'{layer_name}{suffix}'
-                    collected_tensors.append((full_name, tensor))
+                    for suffix, tensor in output:
+                        full_name = f'{layer_name}{suffix}'
+                        collected_tensors.append((full_name, tensor))
 
-            progress_bar.update(1)
+                progress_bar.update(1)
 
-        progress_bar.close()
+            progress_bar.close()
 
         return collected_tensors
 

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -508,284 +508,284 @@ class Trainer(BaseTrainer):
             )
 
         set_random_seed(self.random_seed)
-        batcher = training_set.initialize_batcher(
+        with training_set.initialize_batcher(
             batch_size=self.batch_size,
             seed=self.random_seed,
             horovod=self.horovod
-        )
+        ) as batcher:
 
-        # ================ Training Loop ================
-        first_batch = True
-        while progress_tracker.epoch < self.epochs:
-            batcher.set_epoch(progress_tracker.epoch)
+            # ================ Training Loop ================
+            first_batch = True
+            while progress_tracker.epoch < self.epochs:
+                batcher.set_epoch(progress_tracker.epoch)
 
-            # epoch init
-            start_time = time.time()
-            if self.is_coordinator():
-                logger.info(
-                    '\nEpoch {epoch:{digits}d}'.format(
-                        epoch=progress_tracker.epoch + 1,
-                        digits=digits_per_epochs
-                    )
-                )
-
-            # needed because batch size may change
-            batcher.batch_size = progress_tracker.batch_size
-
-            # Reset the metrics at the start of the next epoch
-            model.reset_metrics()
-
-            # ================ Train ================
-            progress_bar = None
-            if self.is_coordinator():
-                progress_bar = tqdm(
-                    desc='Training',
-                    total=batcher.steps_per_epoch,
-                    file=sys.stdout,
-                    disable=is_progressbar_disabled()
-                )
-
-            for callback in self.callbacks:
-                callback.on_epoch_start(self, progress_tracker, save_path)
-
-            # training step loop
-            while not batcher.last_batch():
-                for callback in self.callbacks:
-                    callback.on_batch_start(self, progress_tracker, save_path)
-
-                # Set learning rate for this batch
-                current_learning_rate = progress_tracker.learning_rate
-
-                if self.decay:
-                    current_learning_rate = exponential_decay(
-                        current_learning_rate,
-                        self.decay_rate,
-                        self.decay_steps,
-                        progress_tracker.steps,
-                        self.staircase
-                    )
-
-                if self.horovod:
-                    current_learning_rate = learning_rate_warmup_distributed(
-                        current_learning_rate,
-                        progress_tracker.epoch,
-                        self.learning_rate_warmup_epochs,
-                        self.horovod.size(),
-                        batcher.step,
-                        batcher.steps_per_epoch
-                    ) * self.horovod.size()
-                else:
-                    current_learning_rate = learning_rate_warmup(
-                        current_learning_rate,
-                        progress_tracker.epoch,
-                        self.learning_rate_warmup_epochs,
-                        batcher.step,
-                        batcher.steps_per_epoch
-                    )
-                self.optimizer.set_learning_rate(current_learning_rate)
-
-                # obtain batch
-                batch = batcher.next_batch()
-                inputs = {
-                    i_feat.feature_name: batch[i_feat.proc_column]
-                    for i_feat in model.input_features.values()
-                }
-                targets = {
-                    o_feat.feature_name: batch[o_feat.proc_column]
-                    for o_feat in model.output_features.values()
-                }
-
-                # Reintroduce for tensorboard graph
-                # if first_batch and self.is_coordinator() and not skip_save_log:
-                #    tf.summary.trace_on(graph=True, profiler=True)
-
-                loss, all_losses = model.train_step(
-                    self.optimizer,
-                    inputs,
-                    targets,
-                    self.regularization_lambda
-                )
-
-                # Reintroduce for tensorboard graph
-                # if first_batch and self.is_coordinator() and not skip_save_log:
-                #     with train_summary_writer.as_default():
-                #         tf.summary.trace_export(
-                #             name="Model",
-                #             step=0,
-                #             profiler_outdir=tensorboard_log_dir
-                #         )
-
-                if self.is_coordinator() and not self.skip_save_log:
-                    self.write_step_summary(
-                        train_summary_writer=train_summary_writer,
-                        combined_loss=loss,
-                        all_losses=all_losses,
-                        step=progress_tracker.steps,
-                        learning_rate=current_learning_rate,
-                    )
-
-                if self.horovod and first_batch:
-                    # Horovod: broadcast initial variable states from rank 0 to all other processes.
-                    # This is necessary to ensure consistent initialization of all workers when
-                    # training is started with random weights or restored from a checkpoint.
-                    #
-                    # Note: broadcast should be done after the first gradient step to ensure
-                    # optimizer initialization.
-                    self.horovod.broadcast_variables(model.variables,
-                                                     root_rank=0)
-                    self.horovod.broadcast_variables(
-                        self.optimizer.variables(), root_rank=0)
-
-                progress_tracker.steps += 1
+                # epoch init
+                start_time = time.time()
                 if self.is_coordinator():
-                    progress_bar.update(1)
-                first_batch = False
-
-                for callback in self.callbacks:
-                    callback.on_batch_end(self, progress_tracker, save_path)
-
-            # ================ Post Training Epoch ================
-            if self.is_coordinator():
-                progress_bar.close()
-
-            progress_tracker.epoch += 1
-
-            # ================ Eval ================
-            # init tables
-            tables = OrderedDict()
-            for output_feature_name, output_feature in output_features.items():
-                tables[output_feature_name] = [
-                    [output_feature_name] + metrics_names[output_feature_name]
-                ]
-            tables[COMBINED] = [[COMBINED, LOSS]]
-
-            # eval metrics on train
-            self.evaluation(
-                model,
-                training_set,
-                'train',
-                progress_tracker.train_metrics,
-                tables,
-                self.eval_batch_size,
-            )
-
-            self.write_epoch_summary(
-                summary_writer=train_summary_writer,
-                metrics=progress_tracker.train_metrics,
-                step=progress_tracker.epoch,
-            )
-
-            if validation_set is not None and len(validation_set) > 0:
-                for callback in self.callbacks:
-                    callback.on_validation_start(self, progress_tracker,
-                                                 save_path)
-
-                # eval metrics on validation set
-                self.evaluation(
-                    model,
-                    validation_set,
-                    'vali',
-                    progress_tracker.vali_metrics,
-                    tables,
-                    self.eval_batch_size,
-                )
-
-                self.write_epoch_summary(
-                    summary_writer=validation_summary_writer,
-                    metrics=progress_tracker.vali_metrics,
-                    step=progress_tracker.epoch,
-                )
-
-                for callback in self.callbacks:
-                    callback.on_validation_end(self, progress_tracker,
-                                               save_path)
-
-            if test_set is not None and len(test_set) > 0:
-                for callback in self.callbacks:
-                    callback.on_test_start(self, progress_tracker, save_path)
-
-                # eval metrics on test set
-                self.evaluation(
-                    model,
-                    test_set,
-                    TEST,
-                    progress_tracker.test_metrics,
-                    tables,
-                    self.eval_batch_size,
-                )
-
-                self.write_epoch_summary(
-                    summary_writer=test_summary_writer,
-                    metrics=progress_tracker.test_metrics,
-                    step=progress_tracker.epoch,
-                )
-
-                for callback in self.callbacks:
-                    callback.on_test_end(self, progress_tracker, save_path)
-
-            elapsed_time = (time.time() - start_time) * 1000.0
-
-            if self.is_coordinator():
-                logger.info('Took {time}'.format(
-                    time=time_utils.strdelta(elapsed_time)))
-
-            # metric prints
-            if self.is_coordinator():
-                for output_feature, table in tables.items():
                     logger.info(
-                        tabulate(
-                            table,
-                            headers='firstrow',
-                            tablefmt='fancy_grid',
-                            floatfmt='.4f'
+                        '\nEpoch {epoch:{digits}d}'.format(
+                            epoch=progress_tracker.epoch + 1,
+                            digits=digits_per_epochs
                         )
                     )
 
-            # ================ Validation Logic ================
-            if should_validate:
-                should_break = self.check_progress_on_validation(
+                # needed because batch size may change
+                batcher.batch_size = progress_tracker.batch_size
+
+                # Reset the metrics at the start of the next epoch
+                model.reset_metrics()
+
+                # ================ Train ================
+                progress_bar = None
+                if self.is_coordinator():
+                    progress_bar = tqdm(
+                        desc='Training',
+                        total=batcher.steps_per_epoch,
+                        file=sys.stdout,
+                        disable=is_progressbar_disabled()
+                    )
+
+                for callback in self.callbacks:
+                    callback.on_epoch_start(self, progress_tracker, save_path)
+
+                # training step loop
+                while not batcher.last_batch():
+                    for callback in self.callbacks:
+                        callback.on_batch_start(self, progress_tracker, save_path)
+
+                    # Set learning rate for this batch
+                    current_learning_rate = progress_tracker.learning_rate
+
+                    if self.decay:
+                        current_learning_rate = exponential_decay(
+                            current_learning_rate,
+                            self.decay_rate,
+                            self.decay_steps,
+                            progress_tracker.steps,
+                            self.staircase
+                        )
+
+                    if self.horovod:
+                        current_learning_rate = learning_rate_warmup_distributed(
+                            current_learning_rate,
+                            progress_tracker.epoch,
+                            self.learning_rate_warmup_epochs,
+                            self.horovod.size(),
+                            batcher.step,
+                            batcher.steps_per_epoch
+                        ) * self.horovod.size()
+                    else:
+                        current_learning_rate = learning_rate_warmup(
+                            current_learning_rate,
+                            progress_tracker.epoch,
+                            self.learning_rate_warmup_epochs,
+                            batcher.step,
+                            batcher.steps_per_epoch
+                        )
+                    self.optimizer.set_learning_rate(current_learning_rate)
+
+                    # obtain batch
+                    batch = batcher.next_batch()
+                    inputs = {
+                        i_feat.feature_name: batch[i_feat.proc_column]
+                        for i_feat in model.input_features.values()
+                    }
+                    targets = {
+                        o_feat.feature_name: batch[o_feat.proc_column]
+                        for o_feat in model.output_features.values()
+                    }
+
+                    # Reintroduce for tensorboard graph
+                    # if first_batch and self.is_coordinator() and not skip_save_log:
+                    #    tf.summary.trace_on(graph=True, profiler=True)
+
+                    loss, all_losses = model.train_step(
+                        self.optimizer,
+                        inputs,
+                        targets,
+                        self.regularization_lambda
+                    )
+
+                    # Reintroduce for tensorboard graph
+                    # if first_batch and self.is_coordinator() and not skip_save_log:
+                    #     with train_summary_writer.as_default():
+                    #         tf.summary.trace_export(
+                    #             name="Model",
+                    #             step=0,
+                    #             profiler_outdir=tensorboard_log_dir
+                    #         )
+
+                    if self.is_coordinator() and not self.skip_save_log:
+                        self.write_step_summary(
+                            train_summary_writer=train_summary_writer,
+                            combined_loss=loss,
+                            all_losses=all_losses,
+                            step=progress_tracker.steps,
+                            learning_rate=current_learning_rate,
+                        )
+
+                    if self.horovod and first_batch:
+                        # Horovod: broadcast initial variable states from rank 0 to all other processes.
+                        # This is necessary to ensure consistent initialization of all workers when
+                        # training is started with random weights or restored from a checkpoint.
+                        #
+                        # Note: broadcast should be done after the first gradient step to ensure
+                        # optimizer initialization.
+                        self.horovod.broadcast_variables(model.variables,
+                                                         root_rank=0)
+                        self.horovod.broadcast_variables(
+                            self.optimizer.variables(), root_rank=0)
+
+                    progress_tracker.steps += 1
+                    if self.is_coordinator():
+                        progress_bar.update(1)
+                    first_batch = False
+
+                    for callback in self.callbacks:
+                        callback.on_batch_end(self, progress_tracker, save_path)
+
+                # ================ Post Training Epoch ================
+                if self.is_coordinator():
+                    progress_bar.close()
+
+                progress_tracker.epoch += 1
+
+                # ================ Eval ================
+                # init tables
+                tables = OrderedDict()
+                for output_feature_name, output_feature in output_features.items():
+                    tables[output_feature_name] = [
+                        [output_feature_name] + metrics_names[output_feature_name]
+                    ]
+                tables[COMBINED] = [[COMBINED, LOSS]]
+
+                # eval metrics on train
+                self.evaluation(
                     model,
-                    progress_tracker,
-                    self.validation_field,
-                    self.validation_metric,
-                    model_weights_path,
-                    model_hyperparameters_path,
-                    self.reduce_learning_rate_on_plateau,
-                    self.reduce_learning_rate_on_plateau_patience,
-                    self.reduce_learning_rate_on_plateau_rate,
-                    self.reduce_learning_rate_eval_metric,
-                    self.reduce_learning_rate_eval_split,
-                    self.increase_batch_size_on_plateau,
-                    self.increase_batch_size_on_plateau_patience,
-                    self.increase_batch_size_on_plateau_rate,
-                    self.increase_batch_size_on_plateau_max,
-                    self.increase_batch_size_eval_metric,
-                    self.increase_batch_size_eval_split,
-                    self.early_stop,
-                    self.skip_save_model,
+                    training_set,
+                    'train',
+                    progress_tracker.train_metrics,
+                    tables,
+                    self.eval_batch_size,
                 )
-                if should_break:
-                    break
-            else:
-                # there's no validation, so we save the model at each iteration
-                if self.is_coordinator() and not self.skip_save_model:
-                    model.save_weights(model_weights_path)
 
-            # ========== Save training progress ==========
-            if self.is_coordinator():
-                if not self.skip_save_progress:
-                    checkpoint_manager.save()
-                    progress_tracker.save(
-                        os.path.join(
-                            save_path,
-                            TRAINING_PROGRESS_TRACKER_FILE_NAME
-                        )
+                self.write_epoch_summary(
+                    summary_writer=train_summary_writer,
+                    metrics=progress_tracker.train_metrics,
+                    step=progress_tracker.epoch,
+                )
+
+                if validation_set is not None and len(validation_set) > 0:
+                    for callback in self.callbacks:
+                        callback.on_validation_start(self, progress_tracker,
+                                                     save_path)
+
+                    # eval metrics on validation set
+                    self.evaluation(
+                        model,
+                        validation_set,
+                        'vali',
+                        progress_tracker.vali_metrics,
+                        tables,
+                        self.eval_batch_size,
                     )
-                contrib_command("train_epoch_end", progress_tracker)
-                logger.info('')
 
-            for callback in self.callbacks:
-                callback.on_epoch_end(self, progress_tracker, save_path)
+                    self.write_epoch_summary(
+                        summary_writer=validation_summary_writer,
+                        metrics=progress_tracker.vali_metrics,
+                        step=progress_tracker.epoch,
+                    )
+
+                    for callback in self.callbacks:
+                        callback.on_validation_end(self, progress_tracker,
+                                                   save_path)
+
+                if test_set is not None and len(test_set) > 0:
+                    for callback in self.callbacks:
+                        callback.on_test_start(self, progress_tracker, save_path)
+
+                    # eval metrics on test set
+                    self.evaluation(
+                        model,
+                        test_set,
+                        TEST,
+                        progress_tracker.test_metrics,
+                        tables,
+                        self.eval_batch_size,
+                    )
+
+                    self.write_epoch_summary(
+                        summary_writer=test_summary_writer,
+                        metrics=progress_tracker.test_metrics,
+                        step=progress_tracker.epoch,
+                    )
+
+                    for callback in self.callbacks:
+                        callback.on_test_end(self, progress_tracker, save_path)
+
+                elapsed_time = (time.time() - start_time) * 1000.0
+
+                if self.is_coordinator():
+                    logger.info('Took {time}'.format(
+                        time=time_utils.strdelta(elapsed_time)))
+
+                # metric prints
+                if self.is_coordinator():
+                    for output_feature, table in tables.items():
+                        logger.info(
+                            tabulate(
+                                table,
+                                headers='firstrow',
+                                tablefmt='fancy_grid',
+                                floatfmt='.4f'
+                            )
+                        )
+
+                # ================ Validation Logic ================
+                if should_validate:
+                    should_break = self.check_progress_on_validation(
+                        model,
+                        progress_tracker,
+                        self.validation_field,
+                        self.validation_metric,
+                        model_weights_path,
+                        model_hyperparameters_path,
+                        self.reduce_learning_rate_on_plateau,
+                        self.reduce_learning_rate_on_plateau_patience,
+                        self.reduce_learning_rate_on_plateau_rate,
+                        self.reduce_learning_rate_eval_metric,
+                        self.reduce_learning_rate_eval_split,
+                        self.increase_batch_size_on_plateau,
+                        self.increase_batch_size_on_plateau_patience,
+                        self.increase_batch_size_on_plateau_rate,
+                        self.increase_batch_size_on_plateau_max,
+                        self.increase_batch_size_eval_metric,
+                        self.increase_batch_size_eval_split,
+                        self.early_stop,
+                        self.skip_save_model,
+                    )
+                    if should_break:
+                        break
+                else:
+                    # there's no validation, so we save the model at each iteration
+                    if self.is_coordinator() and not self.skip_save_model:
+                        model.save_weights(model_weights_path)
+
+                # ========== Save training progress ==========
+                if self.is_coordinator():
+                    if not self.skip_save_progress:
+                        checkpoint_manager.save()
+                        progress_tracker.save(
+                            os.path.join(
+                                save_path,
+                                TRAINING_PROGRESS_TRACKER_FILE_NAME
+                            )
+                        )
+                    contrib_command("train_epoch_end", progress_tracker)
+                    logger.info('')
+
+                for callback in self.callbacks:
+                    callback.on_epoch_end(self, progress_tracker, save_path)
 
         if train_summary_writer is not None:
             train_summary_writer.close()
@@ -806,40 +806,40 @@ class Trainer(BaseTrainer):
             model,
             dataset,
     ):
-        batcher = dataset.initialize_batcher(
+        with dataset.initialize_batcher(
             batch_size=self.batch_size,
             horovod=self.horovod
-        )
+        ) as batcher:
 
-        # training step loop
-        progress_bar = tqdm(
-            desc='Trainining online',
-            total=batcher.steps_per_epoch,
-            file=sys.stdout,
-            disable=is_progressbar_disabled()
-        )
-
-        while not batcher.last_batch():
-            batch = batcher.next_batch()
-            inputs = {
-                i_feat.feature_name: batch[i_feat.proc_column]
-                for i_feat in model.input_features.values()
-            }
-            targets = {
-                o_feat.feature_name: batch[o_feat.proc_column]
-                for o_feat in model.output_features.values()
-            }
-
-            model.train_step(
-                self.optimizer,
-                inputs,
-                targets,
-                self.regularization_lambda
+            # training step loop
+            progress_bar = tqdm(
+                desc='Trainining online',
+                total=batcher.steps_per_epoch,
+                file=sys.stdout,
+                disable=is_progressbar_disabled()
             )
 
-            progress_bar.update(1)
+            while not batcher.last_batch():
+                batch = batcher.next_batch()
+                inputs = {
+                    i_feat.feature_name: batch[i_feat.proc_column]
+                    for i_feat in model.input_features.values()
+                }
+                targets = {
+                    o_feat.feature_name: batch[o_feat.proc_column]
+                    for o_feat in model.output_features.values()
+                }
 
-        progress_bar.close()
+                model.train_step(
+                    self.optimizer,
+                    inputs,
+                    targets,
+                    self.regularization_lambda
+                )
+
+                progress_bar.update(1)
+
+            progress_bar.close()
         return model
 
     @property

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -26,7 +26,7 @@ import re
 
 import numpy as np
 import pandas as pd
-from ludwig.utils.fs_utils import open_h5, open_file
+from ludwig.utils.fs_utils import open_h5, open_file, path_exists
 from pandas.errors import ParserError
 from sklearn.model_selection import KFold
 
@@ -236,9 +236,8 @@ def from_numpy_dataset(dataset):
 
 def save_hdf5(data_fp, data):
     mode = 'w'
-    if os.path.isfile(data_fp):
+    if path_exists(data_fp):
         mode = 'r+'
-    print('SAVE', mode)
 
     numpy_dataset = to_numpy_dataset(data)
     with open_h5(data_fp, mode) as h5_file:

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -400,8 +400,6 @@ def split_dataset_ttv(dataset, split):
 
 def split_dataset(dataset, split, value_to_split=0):
     split_df = dataset[dataset[split] == value_to_split]
-    if len(split_df) == 0:
-        return None
     return split_df.reset_index()
 
 

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -238,6 +238,7 @@ def save_hdf5(data_fp, data):
     mode = 'w'
     if os.path.isfile(data_fp):
         mode = 'r+'
+    print('SAVE', mode)
 
     numpy_dataset = to_numpy_dataset(data)
     with open_h5(data_fp, mode) as h5_file:

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -26,7 +26,7 @@ import re
 
 import numpy as np
 import pandas as pd
-from ludwig.utils.fs_utils import open_h5, open_file, path_exists
+from ludwig.utils.fs_utils import open_file, download_h5, upload_h5
 from pandas.errors import ParserError
 from sklearn.model_selection import KFold
 
@@ -235,19 +235,15 @@ def from_numpy_dataset(dataset):
 
 
 def save_hdf5(data_fp, data):
-    mode = 'w'
-    if path_exists(data_fp):
-        mode = 'r+'
-
     numpy_dataset = to_numpy_dataset(data)
-    with open_h5(data_fp, mode) as h5_file:
+    with upload_h5(data_fp) as h5_file:
         h5_file.create_dataset(HDF5_COLUMNS_KEY, data=np.array(data.columns.values, dtype='S'))
         for column in data.columns:
             h5_file.create_dataset(column, data=numpy_dataset[column])
 
 
 def load_hdf5(data_fp):
-    with open_h5(data_fp, 'r') as hdf5_data:
+    with download_h5(data_fp) as hdf5_data:
         columns = [s.decode('utf-8') for s in hdf5_data[HDF5_COLUMNS_KEY][()].tolist()]
 
         numpy_dataset = {}

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -24,9 +24,9 @@ import pickle
 import random
 import re
 
-import h5py
 import numpy as np
 import pandas as pd
+from ludwig.utils.fs_utils import open_h5, open_file
 from pandas.errors import ParserError
 from sklearn.model_selection import KFold
 
@@ -87,8 +87,7 @@ def get_abs_path(data_csv_path, file_path):
 
 
 def load_csv(data_fp):
-    data = []
-    with open(data_fp, 'rb') as f:
+    with open_file(data_fp, 'rb') as f:
         data = list(csv.reader(f))
     return data
 
@@ -105,7 +104,7 @@ def read_xsv(data_fp, df_lib=PANDAS_DF, separator=',', header=0, nrows=None, ski
     :param skiprows: number of rows to skip from the csv, None means no skips
     :return: Pandas dataframe with the data
     """
-    with open(data_fp, 'r', encoding="utf8") as csvfile:
+    with open_file(data_fp, 'r', encoding="utf8") as csvfile:
         try:
             dialect = csv.Sniffer().sniff(csvfile.read(1024 * 100),
                                           delimiters=[',', '\t', '|'])
@@ -188,7 +187,7 @@ def read_stata(data_fp, df_lib):
 
 
 def save_csv(data_fp, data):
-    with open(data_fp, 'w', encoding='utf-8') as csv_file:
+    with open_file(data_fp, 'w', encoding='utf-8') as csv_file:
         writer = csv.writer(csv_file)
         for row in data:
             if not isinstance(row, collections.Iterable) or isinstance(row,
@@ -202,13 +201,13 @@ def csv_contains_column(data_fp, column_name):
 
 
 def load_json(data_fp):
-    with open(data_fp, 'r') as input_file:
+    with open_file(data_fp, 'r') as input_file:
         data = json.load(input_file)
     return data
 
 
 def save_json(data_fp, data, sort_keys=True, indent=4):
-    with open(data_fp, 'w') as output_file:
+    with open_file(data_fp, 'w') as output_file:
         json.dump(data, output_file, cls=NumpyEncoder, sort_keys=sort_keys,
                   indent=indent)
 
@@ -241,36 +240,36 @@ def save_hdf5(data_fp, data):
         mode = 'r+'
 
     numpy_dataset = to_numpy_dataset(data)
-    with h5py.File(data_fp, mode) as h5_file:
+    with open_h5(data_fp, mode) as h5_file:
         h5_file.create_dataset(HDF5_COLUMNS_KEY, data=np.array(data.columns.values, dtype='S'))
         for column in data.columns:
             h5_file.create_dataset(column, data=numpy_dataset[column])
 
 
 def load_hdf5(data_fp):
-    hdf5_data = h5py.File(data_fp, 'r')
-    columns = [s.decode('utf-8') for s in hdf5_data[HDF5_COLUMNS_KEY][()].tolist()]
+    with open_h5(data_fp, 'r') as hdf5_data:
+        columns = [s.decode('utf-8') for s in hdf5_data[HDF5_COLUMNS_KEY][()].tolist()]
 
-    numpy_dataset = {}
-    for column in columns:
-        numpy_dataset[column] = hdf5_data[column][()]
+        numpy_dataset = {}
+        for column in columns:
+            numpy_dataset[column] = hdf5_data[column][()]
 
     return from_numpy_dataset(numpy_dataset)
 
 
 def load_object(object_fp):
-    with open(object_fp, 'rb') as f:
+    with open_file(object_fp, 'rb') as f:
         return pickle.load(f)
 
 
 def save_object(object_fp, obj):
-    with open(object_fp, 'wb') as f:
+    with open_file(object_fp, 'wb') as f:
         pickle.dump(obj, f)
 
 
 def load_array(data_fp, dtype=float):
     list_num = []
-    with open(data_fp, 'r') as input_file:
+    with open_file(data_fp, 'r') as input_file:
         for x in input_file:
             list_num.append(dtype(x.strip()))
     return np.array(list_num)
@@ -278,14 +277,14 @@ def load_array(data_fp, dtype=float):
 
 def load_matrix(data_fp, dtype=float):
     list_num = []
-    with open(data_fp, 'r') as input_file:
+    with open_file(data_fp, 'r') as input_file:
         for row in input_file:
             list_num.append([dtype(elem) for elem in row.strip().split()])
     return np.squeeze(np.array(list_num))
 
 
 def save_array(data_fp, array):
-    with open(data_fp, 'w') as output_file:
+    with open_file(data_fp, 'w') as output_file:
         for x in np.nditer(array):
             output_file.write(str(x) + '\n')
 
@@ -330,7 +329,7 @@ def load_glove(file_path):
     embedding_size = 0
 
     # collect embeddings size assuming the first line is correct
-    with open(file_path, 'r', encoding='utf-8') as f:
+    with open_file(file_path, 'r', encoding='utf-8') as f:
         found_line = False
         while not found_line:
             line = f.readline()
@@ -339,7 +338,7 @@ def load_glove(file_path):
                 found_line = True
 
     # collect embeddings
-    with open(file_path, 'r', encoding='utf-8') as f:
+    with open_file(file_path, 'r', encoding='utf-8') as f:
         for line_number, line in enumerate(f):
             if line:
                 try:

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -400,6 +400,8 @@ def split_dataset_ttv(dataset, split):
 
 def split_dataset(dataset, split, value_to_split=0):
     split_df = dataset[dataset[split] == value_to_split]
+    if len(split_df) == 0:
+        return None
     return split_df.reset_index()
 
 

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -25,9 +25,11 @@ import h5py
 from fsspec.core import split_protocol
 
 
-def get_fs_mode(mode):
+def get_binary_mode(mode):
     if mode == 'r':
         return 'rb'
+    elif mode == 'r+':
+        return 'rb+'
     elif mode == 'w':
         return 'wb'
     return mode
@@ -97,6 +99,6 @@ def open_file(url, *args, **kwargs):
 
 @contextlib.contextmanager
 def open_h5(url, mode):
-    with open_file(url, get_fs_mode(mode)) as fh:
+    with open_file(url, get_binary_mode(mode)) as fh:
         with h5py.File(fh, mode) as f:
             yield f

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -1,0 +1,60 @@
+#! /usr/bin/env python
+# coding=utf-8
+# Copyright (c) 2021 Linux Foundation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import contextlib
+import tempfile
+
+import fsspec
+from fsspec.core import split_protocol
+
+
+def get_fs_and_path(url):
+    protocol, path = split_protocol(url)
+    fs = fsspec.filesystem(protocol)
+    return fs, path
+
+
+def find_non_existing_dir_by_adding_suffix(directory_name):
+    fs, _ = get_fs_and_path(directory_name)
+    suffix = 0
+    curr_directory_name = directory_name
+    while fs.exists(curr_directory_name):
+        curr_directory_name = directory_name + '_' + str(suffix)
+        suffix += 1
+    return curr_directory_name
+
+
+@contextlib.contextmanager
+def prepare_output_directory(url):
+    if url is None:
+        yield None
+        return
+
+    protocol, _ = split_protocol(url)
+    if protocol is not None:
+        # To avoid extra network load, write all output files locally at runtime,
+        # then upload to the remote fs at the end.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Write to temp directory locally
+            yield tmpdir
+
+            # Upload to remote when finished
+            fs, remote_path = get_fs_and_path(url)
+            fs.put(tmpdir, remote_path, recursive=True)
+    else:
+        # Just use the output directory directly if using a local filesystem
+        yield url

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -25,16 +25,6 @@ import h5py
 from fsspec.core import split_protocol
 
 
-def get_binary_mode(mode):
-    if mode == 'r':
-        return 'rb'
-    elif mode == 'r+':
-        return 'rb+'
-    elif mode == 'w':
-        return 'wb'
-    return mode
-
-
 def get_fs_and_path(url):
     protocol, path = split_protocol(url)
     fs = fsspec.filesystem(protocol)

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -25,6 +25,14 @@ import h5py
 from fsspec.core import split_protocol
 
 
+def get_fs_mode(mode):
+    if mode == 'r':
+        return 'rb'
+    elif mode == 'w':
+        return 'wb'
+    return mode
+
+
 def get_fs_and_path(url):
     protocol, path = split_protocol(url)
     fs = fsspec.filesystem(protocol)
@@ -88,7 +96,7 @@ def open_file(url, *args, **kwargs):
 
 
 @contextlib.contextmanager
-def open_h5(url, *args, **kwargs):
-    with open_file(url, *args, **kwargs) as fh:
-        with h5py.File(fh) as f:
+def open_h5(url, mode):
+    with open_file(url, get_fs_mode(mode)) as fh:
+        with h5py.File(fh, mode) as f:
             yield f

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -19,6 +19,7 @@ import contextlib
 import tempfile
 
 import fsspec
+import h5py
 from fsspec.core import split_protocol
 
 
@@ -58,3 +59,17 @@ def prepare_output_directory(url):
     else:
         # Just use the output directory directly if using a local filesystem
         yield url
+
+
+@contextlib.contextmanager
+def open_file(url, *args, **kwargs):
+    of = fsspec.open(url, *args, **kwargs)
+    with of as f:
+        yield f
+
+
+@contextlib.contextmanager
+def open_h5(url, *args, **kwargs):
+    with open_file(url, *args, **kwargs) as fh:
+        with h5py.File(fh) as f:
+            yield f

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -16,6 +16,8 @@
 # ==============================================================================
 
 import contextlib
+import os
+import pathlib
 import tempfile
 
 import fsspec
@@ -37,6 +39,23 @@ def find_non_existing_dir_by_adding_suffix(directory_name):
         curr_directory_name = directory_name + '_' + str(suffix)
         suffix += 1
     return curr_directory_name
+
+
+def path_exists(url):
+    fs, path = get_fs_and_path(url)
+    return fs.exists(path)
+
+
+def makedirs(url, exist_ok=False):
+    fs, path = get_fs_and_path(url)
+    return fs.makedirs(path, exist_ok=exist_ok)
+
+
+def to_url(path):
+    protocol, _ = split_protocol(path)
+    if protocol is not None:
+        return path
+    return pathlib.Path(os.path.abspath(path)).as_uri()
 
 
 @contextlib.contextmanager

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -84,11 +84,14 @@ def upload_output_directory(url):
         # To avoid extra network load, write all output files locally at runtime,
         # then upload to the remote fs at the end.
         with tempfile.TemporaryDirectory() as tmpdir:
+            fs, remote_path = get_fs_and_path(url)
+            if path_exists(url):
+                fs.get(url, tmpdir + '/', recursive=True)
+
             # Write to temp directory locally
             yield tmpdir
 
             # Upload to remote when finished
-            fs, remote_path = get_fs_and_path(url)
             fs.put(tmpdir, remote_path, recursive=True)
     else:
         # Just use the output directory directly if using a local filesystem

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -61,6 +61,11 @@ def makedirs(url, exist_ok=False):
     return fs.makedirs(path, exist_ok=exist_ok)
 
 
+def delete(url, recursive=False):
+    fs, path = get_fs_and_path(url)
+    return fs.delete(path, recursive=recursive)
+
+
 def get_modified_timestamp(url):
     fs, path = get_fs_and_path(url)
     return fs.modified(path).timestamp()

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -66,9 +66,9 @@ def delete(url, recursive=False):
     return fs.delete(path, recursive=recursive)
 
 
-def get_modified_timestamp(url):
+def checksum(url):
     fs, path = get_fs_and_path(url)
-    return fs.modified(path).timestamp()
+    return fs.checksum(path)
 
 
 def to_url(path):

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -32,6 +32,7 @@ import numpy
 import ludwig.globals
 from ludwig.constants import PROC_COLUMN
 from ludwig.utils.data_utils import figure_data_format
+from ludwig.utils.fs_utils import find_non_existing_dir_by_adding_suffix
 
 
 def get_experiment_description(
@@ -168,15 +169,6 @@ def set_default_values(dictionary, default_value_dictionary):
     # Set multiple default values
     for key, value in default_value_dictionary.items():
         set_default_value(dictionary, key, value)
-
-
-def find_non_existing_dir_by_adding_suffix(directory_name):
-    curr_directory_name = directory_name
-    suffix = 0
-    while os.path.exists(curr_directory_name):
-        curr_directory_name = directory_name + '_' + str(suffix)
-        suffix += 1
-    return curr_directory_name
 
 
 def get_class_attributes(c):

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -23,6 +23,7 @@ from collections import Counter
 import numpy as np
 
 from ludwig.data.dataframe.pandas import PANDAS
+from ludwig.utils.fs_utils import open_file
 from ludwig.utils.math_utils import int_type
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.nlp_utils import load_nlp_pipeline, process_text
@@ -78,7 +79,7 @@ def match_replace(string_to_match, list_regex):
 
 
 def load_vocabulary(vocab_file):
-    with open(vocab_file, 'r', encoding='utf-8') as f:
+    with open_file(vocab_file, 'r', encoding='utf-8') as f:
         vocabulary = []
         for line in f:
             line = line.strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ absl-py
 kaggle
 requests
 tables
+fsspec
 
 # new data format support
 xlwt            # excel

--- a/requirements_dask.txt
+++ b/requirements_dask.txt
@@ -1,3 +1,3 @@
 dask[dataframe]<2021.3.1  # https://github.com/ray-project/ray/issues/14992
-petastorm>=0.9.7
+petastorm>=0.10.0
 pyarrow>=2.0.0

--- a/tests/integration_tests/test_remote.py
+++ b/tests/integration_tests/test_remote.py
@@ -31,6 +31,7 @@ def test_remote_training_set(tmpdir, fs_protocol):
             'input_features': input_features,
             'output_features': output_features,
             'combiner': {'type': 'concat', 'fc_size': 14},
+            'training': {'epochs': 2},
         }
 
         config_path = os.path.join(tmpdir, 'config.yaml')

--- a/tests/integration_tests/test_remote.py
+++ b/tests/integration_tests/test_remote.py
@@ -57,7 +57,7 @@ def test_remote_training_set(tmpdir, fs_protocol, data_format):
         model.predict(dataset=test_csv,
                       output_directory=output_directory)
 
-        # Train again, this time the HDF5 cache will be used
+        # Train again, this time the cache will be used
         # Resume from the remote output directory
         model.train(training_set=data_csv,
                     validation_set=val_csv,

--- a/tests/integration_tests/test_remote.py
+++ b/tests/integration_tests/test_remote.py
@@ -10,7 +10,7 @@ from ludwig.backend import initialize_backend
 from tests.integration_tests.utils import sequence_feature, category_feature, generate_data
 
 
-@pytest.mark.parametrize('data_format', ['hdf5'])
+@pytest.mark.parametrize('data_format', ['hdf5', 'parquet'])
 @pytest.mark.parametrize('fs_protocol', ['file'])
 def test_remote_training_set(tmpdir, fs_protocol, data_format):
     with tempfile.TemporaryDirectory() as outdir:

--- a/tests/integration_tests/test_remote.py
+++ b/tests/integration_tests/test_remote.py
@@ -10,9 +10,9 @@ from ludwig.backend import initialize_backend
 from tests.integration_tests.utils import sequence_feature, category_feature, generate_data
 
 
-@pytest.mark.parametrize('intermediate_format', ['hdf5', 'parquet'])
+@pytest.mark.parametrize('data_format', ['hdf5', 'parquet'])
 @pytest.mark.parametrize('fs_protocol', ['file'])
-def test_remote_training_set(tmpdir, fs_protocol, intermediate_format):
+def test_remote_training_set(tmpdir, fs_protocol, data_format):
     with tempfile.TemporaryDirectory() as outdir:
         output_directory = f'{fs_protocol}://{outdir}'
 
@@ -43,7 +43,7 @@ def test_remote_training_set(tmpdir, fs_protocol, intermediate_format):
 
         backend_config = {
             'name': 'local',
-            'intermediate_format': intermediate_format
+            'data_format': data_format
         }
         backend = initialize_backend(**backend_config)
 

--- a/tests/integration_tests/test_remote.py
+++ b/tests/integration_tests/test_remote.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+
+import pytest
+
+from ludwig.api import LudwigModel
+from tests.integration_tests.utils import sequence_feature, category_feature, generate_data
+
+
+@pytest.mark.parametrize('fs_protocol', ['file'])
+def test_remote_training_set(tmpdir, fs_protocol):
+        input_features = [sequence_feature(reduce_output='sum')]
+        output_features = [category_feature(vocab_size=2, reduce_input='sum')]
+
+        csv_filename = os.path.join(tmpdir, 'training.csv')
+        data_csv = generate_data(input_features, output_features, csv_filename)
+        val_csv = shutil.copyfile(data_csv,
+                                  os.path.join(tmpdir, 'validation.csv'))
+        test_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, 'test.csv'))
+
+        data_csv = f'{fs_protocol}://{os.path.abspath(data_csv)}'
+        val_csv = f'{fs_protocol}://{os.path.abspath(val_csv)}'
+        test_csv = f'{fs_protocol}://{os.path.abspath(test_csv)}'
+
+        config = {
+            'input_features': input_features,
+            'output_features': output_features,
+            'combiner': {'type': 'concat', 'fc_size': 14},
+        }
+        model = LudwigModel(config)
+        model.train(training_set=data_csv,
+                    validation_set=val_csv,
+                    test_set=test_csv)
+        model.predict(dataset=test_csv)
+
+        # Train again, this time the HDF5 cache will be used
+        model.train(training_set=data_csv,
+                    validation_set=val_csv,
+                    test_set=test_csv)

--- a/tests/integration_tests/test_remote.py
+++ b/tests/integration_tests/test_remote.py
@@ -10,7 +10,7 @@ from ludwig.backend import initialize_backend
 from tests.integration_tests.utils import sequence_feature, category_feature, generate_data
 
 
-@pytest.mark.parametrize('data_format', ['hdf5', 'parquet'])
+@pytest.mark.parametrize('data_format', ['hdf5'])
 @pytest.mark.parametrize('fs_protocol', ['file'])
 def test_remote_training_set(tmpdir, fs_protocol, data_format):
     with tempfile.TemporaryDirectory() as outdir:

--- a/tests/integration_tests/test_sequence_features.py
+++ b/tests/integration_tests/test_sequence_features.py
@@ -1,3 +1,4 @@
+import contextlib
 import copy
 from io import StringIO
 
@@ -6,11 +7,9 @@ import pytest
 import tensorflow as tf
 
 from ludwig.api import LudwigModel
-from ludwig.data.dataset_synthesizer import build_synthetic_dataset
 from ludwig.data.preprocessing import preprocess_for_training
 from ludwig.features.feature_registries import update_config_with_metadata
 from ludwig.data.dataset_synthesizer import build_synthetic_dataset
-from tests.integration_tests.utils import sequence_feature
 from tests.integration_tests.utils import ENCODERS
 from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import run_experiment
@@ -64,6 +63,7 @@ def generate_sequence_training_data():
 # setups up minimal number of data structures required to support initialized
 # input and output features.  The function returns initialized LudwigModel
 # and batcher for training dataset
+@contextlib.contextmanager
 def setup_model_scaffolding(
         raw_df,
         input_features,
@@ -88,9 +88,8 @@ def setup_model_scaffolding(
     model.model = model.create_model(model.config)
 
     # setup batcher to go through synthetic data
-    batcher = training_set.initialize_batcher()
-
-    return model, batcher
+    with training_set.initialize_batcher() as batcher:
+        yield model, batcher
 
 
 # test sequence input features
@@ -112,99 +111,99 @@ def test_sequence_encoders(
     input_features[0]['encoder'] = enc_encoder
     input_features[0]['cell_type'] = enc_cell_type
 
-    model, batcher = setup_model_scaffolding(
+    with setup_model_scaffolding(
         raw_df,
         input_features,
         output_features
-    )
+    ) as (model, batcher):
 
-    while not batcher.last_batch():
-        batch = batcher.next_batch()
-        inputs = {
-            i_feat.feature_name: batch[i_feat.proc_column]
-            for i_feat in model.model.input_features.values()
-        }
+        while not batcher.last_batch():
+            batch = batcher.next_batch()
+            inputs = {
+                i_feat.feature_name: batch[i_feat.proc_column]
+                for i_feat in model.model.input_features.values()
+            }
 
-        # retrieve encoder to test
-        encoder = model.model.input_features[input_feature_name].encoder_obj
-        encoder_out = encoder(
-            tf.cast(inputs[input_feature_name], dtype=tf.int32))
+            # retrieve encoder to test
+            encoder = model.model.input_features[input_feature_name].encoder_obj
+            encoder_out = encoder(
+                tf.cast(inputs[input_feature_name], dtype=tf.int32))
 
-        # check encoder output for proper content, type and shape
-        proc_column = model.model.input_features[
-            input_feature_name].proc_column
-        batch_size = batch[proc_column].shape[0]
-        seq_size = input_features[0]['max_len']
+            # check encoder output for proper content, type and shape
+            proc_column = model.model.input_features[
+                input_feature_name].proc_column
+            batch_size = batch[proc_column].shape[0]
+            seq_size = input_features[0]['max_len']
 
-        assert 'encoder_output' in encoder_out
-        assert isinstance(encoder_out['encoder_output'], tf.Tensor)
+            assert 'encoder_output' in encoder_out
+            assert isinstance(encoder_out['encoder_output'], tf.Tensor)
 
-        if enc_encoder == 'parallel_cnn':
-            number_parallel_cnn_layers = \
-                len(model.model.input_features[
-                        input_feature_name].encoder_obj.conv_layers)
-            hidden_size = input_features[0][
-                              'state_size'] * number_parallel_cnn_layers
-            assert encoder_out['encoder_output'].shape.as_list() == \
-                   [batch_size, seq_size, hidden_size]
+            if enc_encoder == 'parallel_cnn':
+                number_parallel_cnn_layers = \
+                    len(model.model.input_features[
+                            input_feature_name].encoder_obj.conv_layers)
+                hidden_size = input_features[0][
+                                  'state_size'] * number_parallel_cnn_layers
+                assert encoder_out['encoder_output'].shape.as_list() == \
+                       [batch_size, seq_size, hidden_size]
 
-        elif enc_encoder == 'stacked_parallel_cnn':
-            number_parallel_cnn_layers = \
-                len(model.model.input_features[input_feature_name] \
-                    .encoder_obj.parallel_conv1d_stack \
-                    .stacked_parallel_layers[0])
-            hidden_size = input_features[0][
-                              'state_size'] * number_parallel_cnn_layers
-            assert encoder_out['encoder_output'].shape.as_list() == \
-                   [batch_size, seq_size, hidden_size]
+            elif enc_encoder == 'stacked_parallel_cnn':
+                number_parallel_cnn_layers = \
+                    len(model.model.input_features[input_feature_name] \
+                        .encoder_obj.parallel_conv1d_stack \
+                        .stacked_parallel_layers[0])
+                hidden_size = input_features[0][
+                                  'state_size'] * number_parallel_cnn_layers
+                assert encoder_out['encoder_output'].shape.as_list() == \
+                       [batch_size, seq_size, hidden_size]
 
-        elif enc_encoder == 'rnn':
-            assert encoder_out['encoder_output'].shape.as_list() == \
-                   [batch_size, seq_size, TEST_HIDDEN_SIZE]
+            elif enc_encoder == 'rnn':
+                assert encoder_out['encoder_output'].shape.as_list() == \
+                       [batch_size, seq_size, TEST_HIDDEN_SIZE]
 
-            assert 'encoder_output_state' in encoder_out
-            if enc_cell_type == 'lstm':
-                assert isinstance(encoder_out['encoder_output_state'], list)
-                assert encoder_out['encoder_output_state'][
-                           0].shape.as_list() == \
-                       [batch_size, TEST_HIDDEN_SIZE]
-                assert encoder_out['encoder_output_state'][
-                           1].shape.as_list() == \
-                       [batch_size, TEST_HIDDEN_SIZE]
+                assert 'encoder_output_state' in encoder_out
+                if enc_cell_type == 'lstm':
+                    assert isinstance(encoder_out['encoder_output_state'], list)
+                    assert encoder_out['encoder_output_state'][
+                               0].shape.as_list() == \
+                           [batch_size, TEST_HIDDEN_SIZE]
+                    assert encoder_out['encoder_output_state'][
+                               1].shape.as_list() == \
+                           [batch_size, TEST_HIDDEN_SIZE]
+                else:
+                    assert isinstance(encoder_out['encoder_output_state'],
+                                      tf.Tensor)
+                    assert encoder_out['encoder_output_state'].shape.as_list() == \
+                           [batch_size, TEST_HIDDEN_SIZE]
+
+            elif enc_encoder == 'cnnrnn':
+                assert encoder_out['encoder_output'].shape.as_list() == \
+                       [batch_size, 1, TEST_HIDDEN_SIZE]
+                assert 'encoder_output_state' in encoder_out
+
+                if enc_cell_type == 'lstm':
+                    assert isinstance(encoder_out['encoder_output_state'], list)
+                    assert encoder_out['encoder_output_state'][0].shape.as_list() \
+                           == [batch_size, TEST_HIDDEN_SIZE]
+                    assert encoder_out['encoder_output_state'][1].shape.as_list() \
+                           == [batch_size, TEST_HIDDEN_SIZE]
+                else:
+                    assert isinstance(encoder_out['encoder_output_state'],
+                                      tf.Tensor)
+                    assert encoder_out['encoder_output_state'].shape.as_list() \
+                           == [batch_size, TEST_HIDDEN_SIZE]
+
+            elif enc_encoder == 'stacked_cnn':
+                assert encoder_out['encoder_output'].shape.as_list() \
+                       == [batch_size, 1, TEST_HIDDEN_SIZE]
+
+            elif enc_encoder == 'transformer' or enc_encoder == 'embed':
+                assert encoder_out['encoder_output'].shape.as_list() \
+                       == [batch_size, seq_size, TEST_HIDDEN_SIZE]
+
             else:
-                assert isinstance(encoder_out['encoder_output_state'],
-                                  tf.Tensor)
-                assert encoder_out['encoder_output_state'].shape.as_list() == \
-                       [batch_size, TEST_HIDDEN_SIZE]
-
-        elif enc_encoder == 'cnnrnn':
-            assert encoder_out['encoder_output'].shape.as_list() == \
-                   [batch_size, 1, TEST_HIDDEN_SIZE]
-            assert 'encoder_output_state' in encoder_out
-
-            if enc_cell_type == 'lstm':
-                assert isinstance(encoder_out['encoder_output_state'], list)
-                assert encoder_out['encoder_output_state'][0].shape.as_list() \
-                       == [batch_size, TEST_HIDDEN_SIZE]
-                assert encoder_out['encoder_output_state'][1].shape.as_list() \
-                       == [batch_size, TEST_HIDDEN_SIZE]
-            else:
-                assert isinstance(encoder_out['encoder_output_state'],
-                                  tf.Tensor)
-                assert encoder_out['encoder_output_state'].shape.as_list() \
-                       == [batch_size, TEST_HIDDEN_SIZE]
-
-        elif enc_encoder == 'stacked_cnn':
-            assert encoder_out['encoder_output'].shape.as_list() \
-                   == [batch_size, 1, TEST_HIDDEN_SIZE]
-
-        elif enc_encoder == 'transformer' or enc_encoder == 'embed':
-            assert encoder_out['encoder_output'].shape.as_list() \
-                   == [batch_size, seq_size, TEST_HIDDEN_SIZE]
-
-        else:
-            raise ValueError('{} is an invalid encoder specification' \
-                             .format(enc_encoder))
+                raise ValueError('{} is an invalid encoder specification' \
+                                 .format(enc_encoder))
 
 
 #
@@ -252,59 +251,59 @@ def test_sequence_decoders(
     output_features[0]['beam_width'] = dec_beam_width
     output_features[0]['num_layers'] = dec_num_layers
 
-    model, _ = setup_model_scaffolding(
+    with setup_model_scaffolding(
         raw_df,
         input_features,
         output_features
-    )
+    ) as (model, _):
 
-    # generate synthetic encoder_output tensors and make it look like
-    # it came out of the combiner
-    encoder_output = tf.random.normal(combiner_output_shapes[0])
-    combiner_outputs = {'hidden': encoder_output}
+        # generate synthetic encoder_output tensors and make it look like
+        # it came out of the combiner
+        encoder_output = tf.random.normal(combiner_output_shapes[0])
+        combiner_outputs = {'hidden': encoder_output}
 
-    if combiner_output_shapes[1] is not None:
-        if len(combiner_output_shapes[1]) > 1:
-            encoder_output_state = [
-                tf.random.normal(combiner_output_shapes[1][0]),
-                tf.random.normal(combiner_output_shapes[1][1])
-            ]
+        if combiner_output_shapes[1] is not None:
+            if len(combiner_output_shapes[1]) > 1:
+                encoder_output_state = [
+                    tf.random.normal(combiner_output_shapes[1][0]),
+                    tf.random.normal(combiner_output_shapes[1][1])
+                ]
+            else:
+                encoder_output_state = \
+                    tf.random.normal(combiner_output_shapes[1][0])
+
+            combiner_outputs['encoder_output_state'] = encoder_output_state
+
+        decoder = model.model.output_features[output_feature_name].decoder_obj
+        decoder_out = decoder(combiner_outputs)
+
+        # gather expected components of the shape
+        batch_size = combiner_outputs['hidden'].shape[0]
+        seq_size = output_features[0]['max_len']
+        num_classes = model.config['output_features'][0]['num_classes']
+
+        # confirm output is what is expected
+        assert len(decoder_out) == 5
+        logits, lengths, preds, last_preds, probs = decoder_out
+
+        # confirm shape and format of deocoder output
+        if dec_beam_width > 1:
+            assert logits is None
         else:
-            encoder_output_state = \
-                tf.random.normal(combiner_output_shapes[1][0])
+            assert isinstance(logits, tf.Tensor)
+            assert logits.shape.as_list() == [batch_size, seq_size, num_classes]
 
-        combiner_outputs['encoder_output_state'] = encoder_output_state
+        assert isinstance(lengths, tf.Tensor)
+        assert lengths.shape.as_list() == [batch_size]
 
-    decoder = model.model.output_features[output_feature_name].decoder_obj
-    decoder_out = decoder(combiner_outputs)
+        assert isinstance(preds, tf.Tensor)
+        assert preds.shape.as_list() == [batch_size, seq_size]
 
-    # gather expected components of the shape
-    batch_size = combiner_outputs['hidden'].shape[0]
-    seq_size = output_features[0]['max_len']
-    num_classes = model.config['output_features'][0]['num_classes']
+        assert isinstance(last_preds, tf.Tensor)
+        assert last_preds.shape.as_list() == [batch_size]
 
-    # confirm output is what is expected
-    assert len(decoder_out) == 5
-    logits, lengths, preds, last_preds, probs = decoder_out
-
-    # confirm shape and format of deocoder output
-    if dec_beam_width > 1:
-        assert logits is None
-    else:
-        assert isinstance(logits, tf.Tensor)
-        assert logits.shape.as_list() == [batch_size, seq_size, num_classes]
-
-    assert isinstance(lengths, tf.Tensor)
-    assert lengths.shape.as_list() == [batch_size]
-
-    assert isinstance(preds, tf.Tensor)
-    assert preds.shape.as_list() == [batch_size, seq_size]
-
-    assert isinstance(last_preds, tf.Tensor)
-    assert last_preds.shape.as_list() == [batch_size]
-
-    assert isinstance(probs, tf.Tensor)
-    assert probs.shape.as_list() == [batch_size, seq_size, num_classes]
+        assert isinstance(probs, tf.Tensor)
+        assert probs.shape.as_list() == [batch_size, seq_size, num_classes]
 
 
 #


### PR DESCRIPTION
Also consolidated HDF5 and Parquet caching into a single abstraction layer as part of the backend called `CacheManager`. Now, local backends can optionally cache in either HDF5 or Parquet, and the new `DatasetManager` abstraction will do the work of creating the appropriate dataset based on the cache format.

Depends on https://github.com/uber/petastorm/pull/665.