### PR TITLE
feature: restrict docker built GA to only ludwig-ai account

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   docker:
+    if: ${{ github.repository_owner == 'ludwig-ai' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Code Pull Requests

Update GA for docker build to run only in the `ludwig-ai` account.  Currently these builds run in any account that forked the `ludwig` repo.

