### PR TITLE
Harmonize  return object for categorical, sequence generator and sequence tagger

### DIFF
--- a/ludwig/decoders/sequence_decoders.py
+++ b/ludwig/decoders/sequence_decoders.py
@@ -368,7 +368,10 @@ class SequenceGeneratorDecoder(SequenceDecoder):
         # EXPECTED SIZE OF RETURNED TENSORS
         # logits: shape[batch_size, seq_size, num_classes] used for evaluation
         # projection_input: shape[batch_size, seq_size, state_size] for sampled softmax
-        return logits, outputs.projection_input
+        return {
+            LOGITS: logits,
+            PROJECTION_INPUT: outputs.projection_input
+        }
 
     def decoder_beam_search(
             self,

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -272,25 +272,21 @@ class OutputFeature(BaseFeature, tf.keras.Model, ABC):
         logits = self.logits(logits_input, target=target,
                              training=training)
 
-        # most of the cases the output of self.logits is a tensor
+        # most of the cases the output of self.logits() is a tensor
         # there are three special cases:
-        # categorical feature: logits is a tuple of
-        #   logits, projection_input
-        # sequence feature with Generator Decoder: 'logits' is a tuple of
-        #   logits, projection_input
-        # sequence feature with Tagger Decoder: 'logits' is a dictionary with
-        #   these keys: logits, lengths, projection_input
+        # categorical feature: logits is a dictionary
+        #   with keys: logits, projection_input
+        # sequence feature with Generator Decoder: 'logits' is a dictionary
+        #   with keys: logits, projection_input
+        # sequence feature with Tagger Decoder: 'logits' is a dictionary
+        #   with keys: logits, lengths, projection_input
         #
-        projection_input = None
-        if isinstance(logits, tuple):
-            projection_input = logits[1]
-            logits = logits[0]
-        if not isinstance(logits, dict):
+
+        if isinstance(logits, tf.Tensor):
             logits = {'logits': logits}
-        if projection_input is not None:
-            logits[PROJECTION_INPUT] = projection_input
 
         return {
+            # last_hidden used for dependencies processing
             'last_hidden': hidden,
             **logits
         }

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -171,7 +171,10 @@ class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):
         # EXPECTED SHAPES FOR RETURNED TENSORS
         # logits: shape [batch_size, num_classes]
         # hidden: shape [batch_size, size of final fully connected layer]
-        return self.decoder_obj(hidden), hidden
+        return {
+            LOGITS: self.decoder_obj(hidden),
+            PROJECTION_INPUT: hidden
+        }
 
     def predictions(
             self,


### PR DESCRIPTION
# Code Pull Requests

Convert return object from tuple to dictionary.  This allows simplify handling of returns for categorical, generator and tagger in the base feature module.  