### PR TITLE
Added MLflow experiment tracking support

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -184,6 +184,7 @@ class LudwigModel:
             self.config_fp = None
 
         # merge config with defaults
+        self.base_config = copy.deepcopy(config_dict)
         self.config = merge_with_defaults(config_dict)
         validate_config(self.config)
 
@@ -438,6 +439,7 @@ class LudwigModel:
 
             for callback in self.callbacks:
                 callback.on_train_init(
+                    base_config=self.base_config,
                     experiment_directory=output_directory,
                     experiment_name=experiment_name,
                     model_name=model_name,

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -471,9 +471,9 @@ class LudwigModel:
             ) as trainer:
                 for callback in self.callbacks:
                     callback.on_train_start(
-                        self.model,
-                        self.config,
-                        self.config_fp,
+                        model=self.model,
+                        config=self.config,
+                        config_fp=self.config_fp,
                     )
 
                 # train model

--- a/ludwig/callbacks.py
+++ b/ludwig/callbacks.py
@@ -22,6 +22,9 @@ class Callback(ABC):
     def on_cmdline(self, cmd, *args):
         pass
 
+    def on_hyperopt_init(self, experiment_name):
+        pass
+
     def on_train_init(
         self,
         experiment_directory,

--- a/ludwig/callbacks.py
+++ b/ludwig/callbacks.py
@@ -25,6 +25,9 @@ class Callback(ABC):
     def on_hyperopt_init(self, experiment_name):
         pass
 
+    def on_hyperopt_trial_start(self, parameters):
+        pass
+
     def on_train_init(
         self,
         base_config,

--- a/ludwig/callbacks.py
+++ b/ludwig/callbacks.py
@@ -27,6 +27,7 @@ class Callback(ABC):
 
     def on_train_init(
         self,
+        base_config,
         experiment_directory,
         experiment_name,
         model_name,

--- a/ludwig/callbacks.py
+++ b/ludwig/callbacks.py
@@ -73,6 +73,10 @@ class Callback(ABC):
     def on_visualize_figure(self, fig):
         pass
 
+    def prepare_ray_tune(self, train_fn, tune_config):
+        """Configures Ray Tune to properly use this callback in each trial."""
+        return train_fn, tune_config
+
     @staticmethod
     def preload():
         pass

--- a/ludwig/contribs/__init__.py
+++ b/ludwig/contribs/__init__.py
@@ -37,10 +37,12 @@ method with `pass`, or just don't implement the method.
 
 # Contributors, import your class here:
 from .comet import CometCallback
+from .mlflow import MlflowCallback
 from .wandb import WandbCallback
 
 contrib_registry = {
     # Contributors, add your class here:
     'comet': CometCallback,
     'wandb': WandbCallback,
+    'mlflow': MlflowCallback,
 }

--- a/ludwig/contribs/comet.py
+++ b/ludwig/contribs/comet.py
@@ -87,30 +87,8 @@ class CometCallback(Callback):
         """
         logger.info("comet.on_epoch_end() called......")
         if self.cometml_experiment:
-            for item_name in ["batch_size", "epoch", "steps",
-                              "last_improvement_epoch",
-                              "learning_rate", "best_valid_metric",
-                              "num_reductions_lr",
-                              "num_increases_bs", "train_metrics",
-                              "vali_metrics",
-                              "test_metrics"]:
-                try:
-                    item = getattr(progress_tracker, item_name)
-                    if isinstance(item, dict):
-                        for key in item:
-                            if isinstance(item[key], dict):
-                                for key2 in item[key]:
-                                    self.cometml_experiment.log_metric(
-                                        item_name + "." + key + "." + key2,
-                                        item[key][key2][-1])
-                            else:
-                                self.cometml_experiment.log_metric(
-                                    item_name + "." + key, item[key][-1])
-                    elif item is not None:
-                        self.cometml_experiment.log_metric(item_name, item)
-                except Exception:
-                    logger.info("comet.on_epoch_end() skip logging '%s'",
-                                item_name)
+            for key, value in progress_tracker.log_metrics.items():
+                self.cometml_experiment.log_metric(key, value)
 
     def on_visualize_figure(self, fig):
         logger.info("comet.on_visualize_figure() called......")

--- a/ludwig/contribs/comet.py
+++ b/ludwig/contribs/comet.py
@@ -33,8 +33,15 @@ class CometCallback(Callback):
     def __init__(self):
         self.cometml_experiment = None
 
-    def on_train_init(self, experiment_directory, experiment_name, model_name,
-                   resume, output_directory):
+    def on_train_init(
+            self,
+            base_config,
+            experiment_directory,
+            experiment_name,
+            model_name,
+            output_directory,
+            resume,
+    ):
         if self.cometml_experiment:
             # Comet ML already initialized
             return

--- a/ludwig/contribs/comet.py
+++ b/ludwig/contribs/comet.py
@@ -61,7 +61,7 @@ class CometCallback(Callback):
         config = comet_ml.get_config()
         self._save_config(config, directory=experiment_directory)
 
-    def on_train_start(self, model, config, config_path,
+    def on_train_start(self, model, config, config_fp,
                        *args, **kwargs):
         logger.info("comet.on_train_start() called......")
         if self.cometml_experiment:
@@ -72,8 +72,8 @@ class CometCallback(Callback):
             #         str(model._graph.as_graph_def()))
 
             if config:
-                if config_path:
-                    base_name = os.path.basename(config_path)
+                if config_fp:
+                    base_name = os.path.basename(config_fp)
                 else:
                     base_name = "config.yaml"
                 if "." in base_name:

--- a/ludwig/contribs/mlflow.py
+++ b/ludwig/contribs/mlflow.py
@@ -12,17 +12,24 @@ except Exception as e:
 logger = logging.getLogger(__name__)
 
 
+def _get_or_create_experiment_id(experiment_name):
+    experiment = mlflow.get_experiment_by_name(experiment_name)
+    if experiment is not None:
+        return experiment.experiment_id
+    return mlflow.create_experiment(name=experiment_name)
+
+
 class MlflowCallback(Callback):
     def __init__(self):
         self.experiment_id = None
 
     def on_hyperopt_init(self, experiment_name):
-        self.experiment_id = mlflow.create_experiment(experiment_name)
+        self.experiment_id = _get_or_create_experiment_id(experiment_name)
 
     def on_train_init(self, experiment_name, **kwargs):
         if self.experiment_id is not None:
             return
-        self.experiment_id = mlflow.create_experiment(experiment_name)
+        self.experiment_id = _get_or_create_experiment_id(experiment_name)
 
     def on_train_start(self, config, **kwargs):
         config_flattened = json_normalize(config)

--- a/ludwig/contribs/mlflow.py
+++ b/ludwig/contribs/mlflow.py
@@ -1,6 +1,7 @@
 import logging
 
 from ludwig.callbacks import Callback
+from ludwig.utils.data_utils import json_normalize
 from ludwig.utils.exceptions import ExceptionVariable
 
 try:
@@ -15,31 +16,17 @@ class MlflowCallback(Callback):
     def __init__(self):
         self.experiment_id = None
 
+    def on_hyperopt_init(self, experiment_name):
+        self.experiment_id = mlflow.create_experiment(experiment_name)
+
     def on_train_init(self, experiment_name, **kwargs):
-        if self.experiment_id:
+        if self.experiment_id is not None:
             return
         self.experiment_id = mlflow.create_experiment(experiment_name)
 
-    def on_batch_start(self, trainer, progress_tracker, save_path):
-        pass
-
-    def on_batch_end(self, trainer, progress_tracker, save_path):
-        pass
-
-    def on_epoch_start(self, trainer, progress_tracker, save_path):
-        pass
+    def on_train_start(self, config, **kwargs):
+        config_flattened = json_normalize(config)
+        mlflow.log_params(config_flattened)
 
     def on_epoch_end(self, trainer, progress_tracker, save_path):
-        pass
-
-    def on_validation_start(self, trainer, progress_tracker, save_path):
-        pass
-
-    def on_validation_end(self, trainer, progress_tracker, save_path):
-        pass
-
-    def on_test_start(self, trainer, progress_tracker, save_path):
-        pass
-
-    def on_test_end(self, trainer, progress_tracker, save_path):
-        pass
+        mlflow.log_metrics(progress_tracker.log_metrics)

--- a/ludwig/contribs/mlflow.py
+++ b/ludwig/contribs/mlflow.py
@@ -2,12 +2,9 @@ import logging
 
 from ludwig.callbacks import Callback
 from ludwig.utils.data_utils import json_normalize
-from ludwig.utils.exceptions import ExceptionVariable
+from ludwig.utils.package_utils import LazyLoader
 
-try:
-    import mlflow
-except Exception as e:
-    mlflow = ExceptionVariable(e)
+mlflow = LazyLoader('mlflow', globals(), 'mlflow')
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/contribs/mlflow.py
+++ b/ludwig/contribs/mlflow.py
@@ -18,9 +18,12 @@ def _get_or_create_experiment_id(experiment_name):
 
 
 class MlflowCallback(Callback):
-    def __init__(self):
+    def __init__(self, tracking_uri=None):
         self.experiment_id = None
         self.run = None
+        self.tracking_uri = tracking_uri
+        if tracking_uri:
+            mlflow.set_tracking_uri(tracking_uri)
 
     def on_hyperopt_init(self, experiment_name):
         self.experiment_id = _get_or_create_experiment_id(experiment_name)
@@ -84,3 +87,8 @@ class MlflowCallback(Callback):
         flat_params = flatten_dict(params)
         for chunk in chunk_dict(flat_params, chunk_size=100):
             mlflow.log_params(chunk)
+
+    def __setstate__(self, d):
+        self.__dict__ = d
+        if self.tracking_uri:
+            mlflow.set_tracking_uri(self.tracking_uri)

--- a/ludwig/contribs/mlflow.py
+++ b/ludwig/contribs/mlflow.py
@@ -37,3 +37,13 @@ class MlflowCallback(Callback):
 
     def on_epoch_end(self, trainer, progress_tracker, save_path):
         mlflow.log_metrics(progress_tracker.log_metrics)
+
+    def prepare_ray_tune(self, train_fn, tune_config):
+        from ray.tune.integration.mlflow import mlflow_mixin
+        return mlflow_mixin(train_fn), {
+            **tune_config,
+            'mlflow': {
+                'experiment_id': self.experiment_id,
+                'tracking_uri': mlflow.get_tracking_uri(),
+            }
+        }

--- a/ludwig/contribs/mlflow.py
+++ b/ludwig/contribs/mlflow.py
@@ -1,0 +1,45 @@
+import logging
+
+from ludwig.callbacks import Callback
+from ludwig.utils.exceptions import ExceptionVariable
+
+try:
+    import mlflow
+except Exception as e:
+    mlflow = ExceptionVariable(e)
+
+logger = logging.getLogger(__name__)
+
+
+class MlflowCallback(Callback):
+    def __init__(self):
+        self.experiment_id = None
+
+    def on_train_init(self, experiment_name, **kwargs):
+        if self.experiment_id:
+            return
+        self.experiment_id = mlflow.create_experiment(experiment_name)
+
+    def on_batch_start(self, trainer, progress_tracker, save_path):
+        pass
+
+    def on_batch_end(self, trainer, progress_tracker, save_path):
+        pass
+
+    def on_epoch_start(self, trainer, progress_tracker, save_path):
+        pass
+
+    def on_epoch_end(self, trainer, progress_tracker, save_path):
+        pass
+
+    def on_validation_start(self, trainer, progress_tracker, save_path):
+        pass
+
+    def on_validation_end(self, trainer, progress_tracker, save_path):
+        pass
+
+    def on_test_start(self, trainer, progress_tracker, save_path):
+        pass
+
+    def on_test_end(self, trainer, progress_tracker, save_path):
+        pass

--- a/ludwig/contribs/mlflow.py
+++ b/ludwig/contribs/mlflow.py
@@ -1,7 +1,7 @@
 import logging
 
 from ludwig.callbacks import Callback
-from ludwig.utils.data_utils import chunk_dict, flatten_dict
+from ludwig.utils.data_utils import chunk_dict, flatten_dict, to_json_dict
 from ludwig.utils.package_utils import LazyLoader
 
 mlflow = LazyLoader('mlflow', globals(), 'mlflow')
@@ -32,9 +32,15 @@ class MlflowCallback(Callback):
         config_flattened = flatten_dict(config)
         for chunk in chunk_dict(config_flattened, chunk_size=100):
             mlflow.log_params(chunk)
+        mlflow.log_dict(to_json_dict(config), 'config.yaml')
 
     def on_epoch_end(self, trainer, progress_tracker, save_path):
         mlflow.log_metrics(progress_tracker.log_metrics)
+
+    def on_visualize_figure(self, fig):
+        # TODO: need to also include a filename for this figure
+        # mlflow.log_figure(fig)
+        pass
 
     def prepare_ray_tune(self, train_fn, tune_config):
         from ray.tune.integration.mlflow import mlflow_mixin

--- a/ludwig/contribs/mlflow.py
+++ b/ludwig/contribs/mlflow.py
@@ -1,7 +1,7 @@
 import logging
 
 from ludwig.callbacks import Callback
-from ludwig.utils.data_utils import json_normalize
+from ludwig.utils.data_utils import chunk_dict, flatten_dict
 from ludwig.utils.package_utils import LazyLoader
 
 mlflow = LazyLoader('mlflow', globals(), 'mlflow')
@@ -29,8 +29,9 @@ class MlflowCallback(Callback):
         self.experiment_id = _get_or_create_experiment_id(experiment_name)
 
     def on_train_start(self, config, **kwargs):
-        config_flattened = json_normalize(config)
-        mlflow.log_params(config_flattened)
+        config_flattened = flatten_dict(config)
+        for chunk in chunk_dict(config_flattened, chunk_size=100):
+            mlflow.log_params(chunk)
 
     def on_epoch_end(self, trainer, progress_tracker, save_path):
         mlflow.log_metrics(progress_tracker.log_metrics)

--- a/ludwig/contribs/wandb.py
+++ b/ludwig/contribs/wandb.py
@@ -27,8 +27,15 @@ logger = logging.getLogger(__name__)
 class WandbCallback(Callback):
     """Class that defines the methods necessary to hook into process."""
 
-    def on_train_init(self, experiment_directory, experiment_name, model_name,
-                      resume, output_directory):
+    def on_train_init(
+            self,
+            base_config,
+            experiment_directory,
+            experiment_name,
+            model_name,
+            output_directory,
+            resume,
+    ):
         logger.info("wandb.on_train_init() called...")
         wandb.init(project=os.getenv("WANDB_PROJECT", experiment_name),
                    name=model_name, sync_tensorboard=True,

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -666,6 +666,7 @@ class FiberExecutor(HyperoptExecutor):
                     {
                         'config': substitute_parameters(
                             copy.deepcopy(config), parameters),
+                        'parameters': parameters,
                         'experiment_name': f'{experiment_name}_{trials + i}',
                         **experiment_kwargs
                     }
@@ -789,6 +790,7 @@ class RayTuneExecutor(HyperoptExecutor):
         train_stats, eval_stats = run_experiment(
             **hyperopt_dict,
             model_resume_path=checkpoint_dir,
+            parameters=config,
         )
 
         metric_score = self.get_metric_score(train_stats, eval_stats)
@@ -1003,6 +1005,7 @@ def substitute_parameters(config, parameters):
 
 def run_experiment(
         config,
+        parameters=None,
         dataset=None,
         training_set=None,
         validation_set=None,
@@ -1033,6 +1036,10 @@ def run_experiment(
         debug=False,
         **kwargs
 ):
+    if callbacks:
+        for callback in callbacks:
+            callback.on_hyperopt_trial_start(parameters)
+
     # Collect training and validation losses and metrics
     # & append it to `results`
     model = LudwigModel(

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -905,7 +905,7 @@ class RayTuneExecutor(HyperoptExecutor):
             return self._run_experiment(config, checkpoint_dir, hyperopt_dict, self.decode_ctx)
 
         tune_config = {}
-        for callback in callbacks:
+        for callback in callbacks or []:
             run_experiment_trial, tune_config = callback.prepare_ray_tune(
                 run_experiment_trial,
                 tune_config,
@@ -1036,9 +1036,8 @@ def run_experiment(
         debug=False,
         **kwargs
 ):
-    if callbacks:
-        for callback in callbacks:
-            callback.on_hyperopt_trial_start(parameters)
+    for callback in callbacks or []:
+        callback.on_hyperopt_trial_start(parameters)
 
     # Collect training and validation losses and metrics
     # & append it to `results`

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -272,6 +272,10 @@ def hyperopt(
         executor[TYPE]
     )(hyperopt_sampler, output_feature, metric, split, **executor)
 
+    if callbacks:
+        for callback in callbacks:
+            callback.on_hyperopt_init(experiment_name)
+
     hyperopt_results = hyperopt_executor.execute(
         config,
         dataset=dataset,

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -1344,3 +1344,36 @@ class ProgressTracker:
     def load(filepath):
         loaded = load_json(filepath)
         return ProgressTracker(**loaded)
+
+    @property
+    def log_metrics(self):
+        log_metrics = {}
+        for item_name in [
+            "batch_size",
+            "epoch",
+            "steps",
+            "last_improvement_epoch",
+            "learning_rate",
+            "best_valid_metric",
+            "num_reductions_lr",
+            "num_increases_bs",
+            "train_metrics",
+            "vali_metrics",
+            "test_metrics"
+        ]:
+            try:
+                item = getattr(self, item_name)
+                if isinstance(item, dict):
+                    for key in item:
+                        if isinstance(item[key], dict):
+                            for key2 in item[key]:
+                                log_metrics[
+                                    item_name + "." + key + "." + key2
+                                ] = item[key][key2][-1]
+                        else:
+                            log_metrics[item_name + "." + key] = item[key][-1]
+                elif item is not None:
+                    log_metrics[item_name] = item
+            except Exception:
+                logger.info(f"skip logging '{item_name}'")
+        return log_metrics

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -212,6 +212,12 @@ def save_json(data_fp, data, sort_keys=True, indent=4):
                   indent=indent)
 
 
+def json_normalize(d):
+    """Converts nested dictionary into flat dictionary."""
+    df = pd.json_normalize(d, sep='.')
+    return df.to_dict(orient='records')[0]
+
+
 def flatten_df(df, backend):
     # Workaround for: https://issues.apache.org/jira/browse/ARROW-5645
     column_shapes = {}

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -213,6 +213,13 @@ def save_json(data_fp, data, sort_keys=True, indent=4):
                   indent=indent)
 
 
+def to_json_dict(d):
+    """Converts Python dict to pure JSON ready format."""
+    return json.loads(
+        json.dumps(d, cls=NumpyEncoder)
+    )
+
+
 def chunk_dict(data, chunk_size=100):
     """Split large dictionary into chunks.
 

--- a/tests/integration_tests/scripts/run_train_comet.py
+++ b/tests/integration_tests/scripts/run_train_comet.py
@@ -7,6 +7,9 @@
 # This test runs in an isolated environment to ensure TensorFlow imports are not leaked
 # from previous tests.
 
+# Comet must be imported before the libraries to wraps
+import comet_ml
+
 import argparse
 import os
 import shutil
@@ -16,11 +19,8 @@ from unittest.mock import patch, Mock
 # Bad key will ensure Comet is initialized, but nothing is uploaded externally.
 os.environ['COMET_API_KEY'] = 'key'
 
-# Use contrib module before other imports to avoid importing TensorFlow before comet.
-from ludwig.contribs.comet import CometCallback, comet_ml
-comet_ml.__version__
-
 from ludwig.api import LudwigModel
+from ludwig.contribs.comet import CometCallback
 
 PATH_HERE = os.path.abspath(os.path.dirname(__file__))
 PATH_ROOT = os.path.join(PATH_HERE, '..', '..', '..')

--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -140,7 +140,7 @@ def run_hyperopt_executor(
     hyperopt_config = config["hyperopt"]
 
     if validate_output_feature:
-        hyperopt_config['output_feature'] = output_features[0]['name']
+        hyperopt_config['output_feature'] = config['output_features'][0]['name']
     if validation_metric:
         hyperopt_config['validation_metric'] = validation_metric
 
@@ -165,8 +165,6 @@ def run_hyperopt_executor(
     hyperopt_executor.execute(
         config,
         dataset=rel_path,
-        experiment_name=experiment_name,
-        callbacks=callbacks
     )
 
 

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -1,0 +1,80 @@
+import os
+import shutil
+
+import mlflow
+import yaml
+from mlflow.tracking import MlflowClient
+
+from ludwig.api import LudwigModel
+from ludwig.contribs import MlflowCallback
+from tests.integration_tests.utils import sequence_feature, category_feature, generate_data
+
+
+def test_mlflow_callback(tmpdir):
+    epochs = 2
+    batch_size = 8
+    num_examples = 32
+
+    input_features = [sequence_feature(reduce_output='sum')]
+    output_features = [category_feature(vocab_size=2, reduce_input='sum')]
+
+    config = {
+        'input_features': input_features,
+        'output_features': output_features,
+        'combiner': {'type': 'concat', 'fc_size': 14},
+        'training': {'epochs': epochs, 'batch_size': batch_size},
+    }
+
+    data_csv = generate_data(input_features, output_features,
+                             os.path.join(tmpdir, 'train.csv'),
+                             num_examples=num_examples)
+    val_csv = shutil.copyfile(data_csv,
+                              os.path.join(tmpdir, 'validation.csv'))
+    test_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, 'test.csv'))
+
+    mlflow_uri = f'file://{tmpdir}/mlruns'
+    mlflow.set_tracking_uri(mlflow_uri)
+    client = MlflowClient(tracking_uri=mlflow_uri)
+
+    exp_name = 'mlflow_test'
+    callback = MlflowCallback()
+
+    model = LudwigModel(config, callbacks=[callback])
+    model.train(training_set=data_csv,
+                validation_set=val_csv,
+                test_set=test_csv,
+                experiment_name=exp_name)
+
+    # Check mlflow artifacts
+    assert callback.experiment_id is not None
+    assert callback.run is not None
+
+    experiment = mlflow.get_experiment_by_name(exp_name)
+    assert experiment.experiment_id == callback.experiment_id
+
+    df = mlflow.search_runs([experiment.experiment_id])
+    assert len(df) == 1
+
+    run_id = df.run_id[0]
+    assert run_id == callback.run.info.run_id
+
+    artifacts = [f.path for f in MlflowClient().list_artifacts(callback.run.info.run_id, "")]
+    local_dir = f'{tmpdir}/local_artifacts'
+    os.makedirs(local_dir)
+
+    assert 'config.yaml' in artifacts
+    local_config_path = client.download_artifacts(
+        callback.run.info.run_id, "config.yaml", local_dir
+    )
+
+    with open(local_config_path, 'r') as f:
+        config_artifact = yaml.safe_load(f)
+    assert config_artifact == config
+
+    assert 'model' in artifacts
+    local_model_path = client.download_artifacts(
+        callback.run.info.run_id, "model", local_dir
+    )
+
+    loaded_model = LudwigModel.load(local_model_path)
+    assert loaded_model.training_set_metadata == model.training_set_metadata

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -58,7 +58,7 @@ def test_mlflow_callback(tmpdir):
     run_id = df.run_id[0]
     assert run_id == callback.run.info.run_id
 
-    artifacts = [f.path for f in MlflowClient().list_artifacts(callback.run.info.run_id, "")]
+    artifacts = [f.path for f in client.list_artifacts(callback.run.info.run_id, "")]
     local_dir = f'{tmpdir}/local_artifacts'
     os.makedirs(local_dir)
 


### PR DESCRIPTION
This PR adds support for [MLflow](https://mlflow.org/) as a contrib package used to log experiment results during training and hyperopt.

MLflow can be enabled programmatically via callback:

```
model = LudwigModel(..., callbacks=[MlflowCallback()])
```

Or on the command line:

```
ludwig train ... --mlflow
```

When logging experiment results, Ludwig's `experiment_name` will serve as the `Experiment` used to organize results in MLflow. When using hyperopt features such as Ray Tune, every trial will be recorded as a separate run within the experiment.

Hyperopt and training parameters are logged as params, and all progress metrics are reported as metrics per epoch.

Additionally, the user's config file, `description.json`, `training_progress.json`, and `model` folder are all uploaded as artifacts.