### PR TITLE
Added additional backend configuration options

### DIFF
--- a/ludwig/backend/__init__.py
+++ b/ludwig/backend/__init__.py
@@ -57,17 +57,20 @@ backend_registry = {
 }
 
 
-def create_backend(name, **kwargs):
-    if isinstance(name, Backend):
-        return name
+def create_backend(type, **kwargs):
+    if isinstance(type, Backend):
+        return type
 
-    if name is None and has_horovodrun():
-        name = HOROVOD
+    if type is None and has_horovodrun():
+        type = HOROVOD
 
-    return backend_registry[name](**kwargs)
+    return backend_registry[type](**kwargs)
 
 
-def initialize_backend(name, **kwargs):
-    backend = create_backend(name, **kwargs)
+def initialize_backend(backend):
+    if isinstance(backend, dict):
+        backend = create_backend(**backend)
+    else:
+        backend = create_backend(backend)
     backend.initialize()
     return backend

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -27,8 +27,8 @@ from ludwig.utils.tf_utils import initialize_tensorflow
 
 
 class Backend(ABC):
-    def __init__(self, cache_dir=None, data_format=None):
-        self._dataset_manager = create_dataset_manager(self, data_format)
+    def __init__(self, cache_dir=None, cache_format=None):
+        self._dataset_manager = create_dataset_manager(self, cache_format)
         self._cache_manager = CacheManager(self._dataset_manager, cache_dir)
 
     @property

--- a/ludwig/backend/dask.py
+++ b/ludwig/backend/dask.py
@@ -81,13 +81,13 @@ class DaskPredictor(BasePredictor):
 
 
 class DaskBackend(LocalTrainingMixin, Backend):
-    def __init__(self, data_format=PARQUET, engine=None, **kwargs):
-        super().__init__(data_format=data_format, **kwargs)
+    def __init__(self, cache_format=PARQUET, engine=None, **kwargs):
+        super().__init__(cache_format=cache_format, **kwargs)
         engine = engine or {}
         self._df_engine = DaskEngine(**engine)
-        if data_format != PARQUET:
+        if cache_format != PARQUET:
             raise ValueError(
-                f'Data format {data_format} is not supported when using the Dask backend. '
+                f'Data format {cache_format} is not supported when using the Dask backend. '
                 f'Try setting to `parquet`.'
             )
 

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -95,7 +95,8 @@ def _get_df_engine(engine_config):
 class RayRemoteModel:
     def __init__(self, model):
         buf = save_weights_to_buffer(model)
-        self.cls, self.args, state = list(model.__reduce__())
+        self.cls = type(model)
+        self.args = model.get_args()
         self.state = ray.put(buf)
 
     def load(self):

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -212,14 +212,14 @@ class RayPredictor(BasePredictor):
 
 
 class RayBackend(RemoteTrainingMixin, Backend):
-    def __init__(self, horovod_kwargs=None, data_format=PARQUET, engine=None, **kwargs):
-        super().__init__(data_format=data_format, **kwargs)
+    def __init__(self, horovod_kwargs=None, cache_format=PARQUET, engine=None, **kwargs):
+        super().__init__(cache_format=cache_format, **kwargs)
         self._df_engine = _get_df_engine(engine)
         self._horovod_kwargs = horovod_kwargs or {}
         self._tensorflow_kwargs = {}
-        if data_format != PARQUET:
+        if cache_format != PARQUET:
             raise ValueError(
-                f'Data format {data_format} is not supported when using the Ray backend. '
+                f'Data format {cache_format} is not supported when using the Ray backend. '
                 f'Try setting to `parquet`.'
             )
 

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -27,6 +27,7 @@ from ray.util.dask import ray_dask_get
 from ludwig.backend.base import Backend, RemoteTrainingMixin
 from ludwig.constants import NAME, PARQUET
 from ludwig.data.dataframe.dask import DaskEngine
+from ludwig.data.dataframe.pandas import PandasEngine
 from ludwig.data.dataset.partitioned import PartitionedDataset
 from ludwig.models.predictor import BasePredictor, Predictor, get_output_columns
 from ludwig.models.trainer import BaseTrainer, RemoteTrainer
@@ -72,6 +73,23 @@ def get_horovod_kwargs():
         num_hosts=len(best_resources),
         use_gpu=use_gpu
     )
+
+
+_engine_registry = {
+    'dask': DaskEngine,
+    'pandas': PandasEngine,
+}
+
+
+def _get_df_engine(engine_config):
+    if engine_config is None:
+        return DaskEngine()
+
+    engine_config = engine_config.copy()
+
+    dtype = engine_config.pop('type', 'dask')
+    engine_cls = _engine_registry.get(dtype)
+    return engine_cls(**engine_config)
 
 
 class RayRemoteModel:
@@ -193,9 +211,9 @@ class RayPredictor(BasePredictor):
 
 
 class RayBackend(RemoteTrainingMixin, Backend):
-    def __init__(self, horovod_kwargs=None, data_format=PARQUET, **kwargs):
+    def __init__(self, horovod_kwargs=None, data_format=PARQUET, engine=None, **kwargs):
         super().__init__(data_format=data_format, **kwargs)
-        self._df_engine = DaskEngine()
+        self._df_engine = _get_df_engine(engine)
         self._horovod_kwargs = horovod_kwargs or {}
         self._tensorflow_kwargs = {}
         if data_format != PARQUET:

--- a/ludwig/contribs/mlflow.py
+++ b/ludwig/contribs/mlflow.py
@@ -141,7 +141,7 @@ def export_model(model_path, output_path, registered_model_name=None):
             # No run specified, so in order to register the model in mlflow, we need
             # to create a new run and upload the model as an artifact first
             output_path = output_path or 'model'
-            with mlflow.start_run(f'upload_{registered_model_name}'):
+            with mlflow.start_run():
                 mlflow.pyfunc.log_model(
                     artifact_path=output_path,
                     registered_model_name=registered_model_name,

--- a/ludwig/data/dataframe/base.py
+++ b/ludwig/data/dataframe/base.py
@@ -69,3 +69,7 @@ class DataFrameEngine(ABC):
     @abstractmethod
     def partitioned(self):
         raise NotImplementedError()
+
+    @abstractmethod
+    def set_parallelism(self, parallelism):
+        raise NotImplementedError()

--- a/ludwig/data/dataframe/dask.py
+++ b/ludwig/data/dataframe/dask.py
@@ -39,7 +39,7 @@ def set_scheduler(scheduler):
 
 
 class DaskEngine(DataFrameEngine):
-    def __init__(self, parallelism=None, persist=False):
+    def __init__(self, parallelism=None, persist=False, **kwargs):
         self._parallelism = parallelism or multiprocessing.cpu_count()
         self._persist = persist
 

--- a/ludwig/data/dataframe/pandas.py
+++ b/ludwig/data/dataframe/pandas.py
@@ -22,6 +22,9 @@ from ludwig.data.dataframe.base import DataFrameEngine
 
 
 class PandasEngine(DataFrameEngine):
+    def __init__(self, **kwargs):
+        super().__init__()
+
     def empty_df_like(self, df):
         return pd.DataFrame(index=df.index)
 
@@ -60,6 +63,9 @@ class PandasEngine(DataFrameEngine):
     @property
     def partitioned(self):
         return False
+
+    def set_parallelism(self, parallelism):
+        pass
 
 
 PANDAS = PandasEngine()

--- a/ludwig/data/dataset/__init__.py
+++ b/ludwig/data/dataset/__init__.py
@@ -25,5 +25,5 @@ dataset_registry = {
 }
 
 
-def create_dataset_manager(backend, data_format, **kwargs):
-    return dataset_registry.get(data_format)(backend)
+def create_dataset_manager(backend, cache_format, **kwargs):
+    return dataset_registry.get(cache_format)(backend)

--- a/ludwig/data/dataset/base.py
+++ b/ludwig/data/dataset/base.py
@@ -28,6 +28,7 @@ class Dataset(ABC):
     @abstractmethod
     def initialize_batcher(self, batch_size=128,
                            should_shuffle=True,
+                           shuffle_buffer_size=None,
                            seed=0,
                            ignore_last=False,
                            horovod=None):

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -68,6 +68,7 @@ class PandasDataset(Dataset):
     @contextlib.contextmanager
     def initialize_batcher(self, batch_size=128,
                            should_shuffle=True,
+                           shuffle_buffer_size=None,
                            seed=0,
                            ignore_last=False,
                            horovod=None):

--- a/ludwig/data/dataset/parquet.py
+++ b/ludwig/data/dataset/parquet.py
@@ -63,6 +63,7 @@ class ParquetDataset(Dataset):
     def initialize_batcher(self,
                            batch_size=128,
                            should_shuffle=True,
+                           shuffle_buffer_size=None,
                            seed=0,
                            ignore_last=False,
                            horovod=None):
@@ -81,7 +82,7 @@ class ParquetDataset(Dataset):
             dataset = dataset.unbatch()
             if should_shuffle:
                 rows_per_piece = max([piece.get_metadata().num_rows for piece in reader.dataset.pieces])
-                buffer_size = min(rows_per_piece, local_samples)
+                buffer_size = shuffle_buffer_size or min(rows_per_piece, local_samples)
                 dataset = dataset.shuffle(buffer_size)
             dataset = dataset.batch(batch_size)
 

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -193,6 +193,8 @@ def experiment_cli(
         filepath string to where results are stored.
 
     """
+    if isinstance(config, str):
+        config = load_yaml(config)
     backend = initialize_backend(backend or config.get('backend'))
 
     if model_load_path:

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -193,7 +193,7 @@ def experiment_cli(
         filepath string to where results are stored.
 
     """
-    backend = initialize_backend(backend)
+    backend = initialize_backend(backend or config.get('backend'))
 
     if model_load_path:
         model = LudwigModel.load(

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -21,7 +21,6 @@ import sys
 from typing import List, Union
 
 import pandas as pd
-import yaml
 
 from ludwig.api import LudwigModel, kfold_cross_validate
 from ludwig.backend import ALL_BACKENDS, Backend, initialize_backend
@@ -29,7 +28,7 @@ from ludwig.callbacks import Callback
 from ludwig.constants import FULL, TEST, TRAINING, VALIDATION
 from ludwig.contrib import add_contrib_callback_args
 from ludwig.globals import LUDWIG_VERSION
-from ludwig.utils.data_utils import save_json, load_yaml
+from ludwig.utils.data_utils import save_json, load_yaml, load_config_from_str
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.print_utils import logging_level_registry, print_ludwig
 
@@ -410,7 +409,7 @@ def cli(sys_argv):
     config.add_argument(
         '-c',
         '--config',
-        type=yaml.safe_load,
+        type=load_config_from_str,
         help='JSON or YAML serialized string of the model configuration'
     )
     config.add_argument(

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -561,7 +561,7 @@ def cli(sys_argv):
     global logger
     logger = logging.getLogger('ludwig.experiment')
 
-    args.backend = initialize_backend(args.backend)
+    args.backend = initialize_backend(args.backend or args.config.get('backend'))
     if args.backend.is_coordinator():
         print_ludwig('Experiment', LUDWIG_VERSION)
 

--- a/ludwig/features/feature_utils.py
+++ b/ludwig/features/feature_utils.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import re
+
 import numpy as np
 
 from ludwig.constants import SEQUENCE, PREPROCESSING, NAME
@@ -48,6 +50,11 @@ def set_str_to_idx(set_string, feature_dict, tokenizer_name):
     return np.array(out, dtype=np.int32)
 
 
+def sanitize(name):
+    """Replaces invalid id characters."""
+    return re.sub('\W|^(?=\d)', '_', name)
+
+
 def compute_feature_hash(feature: dict) -> str:
     preproc_hash = hash_dict(feature.get(PREPROCESSING, {}))
-    return feature[NAME] + "_" + preproc_hash.decode('ascii')
+    return sanitize(feature[NAME]) + "_" + preproc_hash.decode('ascii')

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -791,7 +791,6 @@ class RayTuneExecutor(HyperoptExecutor):
             **hyperopt_dict,
             model_resume_path=checkpoint_dir,
             parameters=config,
-            backend='local',
         )
 
         metric_score = self.get_metric_score(train_stats, eval_stats)

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -791,6 +791,7 @@ class RayTuneExecutor(HyperoptExecutor):
             **hyperopt_dict,
             model_resume_path=checkpoint_dir,
             parameters=config,
+            backend='local',
         )
 
         metric_score = self.get_metric_score(train_stats, eval_stats)

--- a/ludwig/hyperopt_cli.py
+++ b/ludwig/hyperopt_cli.py
@@ -26,16 +26,15 @@ from ludwig.callbacks import Callback
 from ludwig.contrib import add_contrib_callback_args
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.hyperopt.run import hyperopt
+from ludwig.utils.data_utils import load_yaml
 from ludwig.utils.defaults import default_random_seed
-from ludwig.utils.misc_utils import check_which_config
 from ludwig.utils.print_utils import logging_level_registry, print_ludwig
 
 logger = logging.getLogger(__name__)
 
 
 def hyperopt_cli(
-        config: dict,
-        config_file: str = None,
+        config: Union[str, dict],
         dataset: str = None,
         training_set: str = None,
         validation_set: str = None,
@@ -71,10 +70,8 @@ def hyperopt_cli(
 
     # Inputs
 
-    :param config: (dict) config which defines the different
-        parameters of the model, features, preprocessing and training.
-    :param config_file: (str, default: `None`) the filepath string
-        that specifies the config.  It is a yaml file.
+    :param config: (Union[str, dict]) in-memory representation of
+            config or string path to a YAML config file.
     :param dataset: (Union[str, dict, pandas.DataFrame], default: `None`)
         source containing the entire dataset to be used for training.
         If it has a split column, it will be used for splitting (0 for train,
@@ -165,9 +162,6 @@ def hyperopt_cli(
     # Return
     :return" (`None`)
     """
-    config = check_which_config(config,
-                                config_file)
-
     return hyperopt(
         config=config,
         dataset=dataset,
@@ -283,13 +277,17 @@ def cli(sys_argv):
     # ----------------
     config = parser.add_mutually_exclusive_group(required=True)
     config.add_argument(
-        "-c", "--config", type=yaml.safe_load,
-        help="config"
+        '-c',
+        '--config',
+        type=yaml.safe_load,
+        help='JSON or YAML serialized string of the model configuration'
     )
     config.add_argument(
-        "-cf",
-        "--config_file",
-        help="YAML file describing the model. Ignores --model_hyperparameters",
+        '-cf',
+        '--config_file',
+        dest='config',
+        type=load_yaml,
+        help='Path to the YAML file containing the model configuration'
     )
 
     parser.add_argument(

--- a/ludwig/hyperopt_cli.py
+++ b/ludwig/hyperopt_cli.py
@@ -405,7 +405,7 @@ def cli(sys_argv):
     global logger
     logger = logging.getLogger('ludwig.hyperopt')
 
-    args.backend = initialize_backend(args.backend)
+    args.backend = initialize_backend(args.backend or args.config.get('backend'))
     if args.backend.is_coordinator():
         print_ludwig("Hyperopt", LUDWIG_VERSION)
 

--- a/ludwig/hyperopt_cli.py
+++ b/ludwig/hyperopt_cli.py
@@ -19,14 +19,12 @@ import logging
 import sys
 from typing import List, Union
 
-import yaml
-
 from ludwig.backend import ALL_BACKENDS, Backend, initialize_backend
 from ludwig.callbacks import Callback
 from ludwig.contrib import add_contrib_callback_args
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.hyperopt.run import hyperopt
-from ludwig.utils.data_utils import load_yaml
+from ludwig.utils.data_utils import load_yaml, load_config_from_str
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.print_utils import logging_level_registry, print_ludwig
 
@@ -279,7 +277,7 @@ def cli(sys_argv):
     config.add_argument(
         '-c',
         '--config',
-        type=yaml.safe_load,
+        type=load_config_from_str,
         help='JSON or YAML serialized string of the model configuration'
     )
     config.add_argument(

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -278,9 +278,16 @@ class ECD(tf.keras.Model):
 
         return weights
 
+    def get_args(self):
+        return self._input_features_df, self._combiner_def, self._output_features_df, self._random_seed
+
+    def __setstate__(self, newstate):
+        self.set_weights(newstate['weights'])
+
     def __reduce__(self):
-        args = (self._input_features_df, self._combiner_def, self._output_features_df, self._random_seed)
-        return ECD, args, {}
+        args = self.get_args()
+        state = {'weights': self.get_weights()}
+        return ECD, args, state
 
 
 def build_inputs(

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -278,13 +278,9 @@ class ECD(tf.keras.Model):
 
         return weights
 
-    def __setstate__(self, newstate):
-        self.set_weights(newstate['weights'])
-
     def __reduce__(self):
         args = (self._input_features_df, self._combiner_def, self._output_features_df, self._random_seed)
-        state = {'weights': self.get_weights()}
-        return ECD, args, state
+        return ECD, args, {}
 
 
 def build_inputs(

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -113,6 +113,7 @@ class Trainer(BaseTrainer):
             staircase=False,
             batch_size=128,
             eval_batch_size=0,
+            shuffle_buffer_size=None,
             bucketing_field=None,
             validation_field='combined',
             validation_metric='loss',
@@ -159,8 +160,10 @@ class Trainer(BaseTrainer):
         :type learning_rate: Integer
         :param batch_size: Size of batch to pass to the model for training.
         :type batch_size: Integer
-        :param batch_size: Size of batch to pass to the model for evaluation.
-        :type batch_size: Integer
+        :param eval_batch_size: Size of batch to pass to the model for evaluation.
+        :type eval_batch_size: Integer
+        :param shuffle_buffer_size: Size of buffer in number of examples to read for shuffling.
+        :type shuffle_buffer_size: Integer
         :param bucketing_field: when batching, buckets datapoints based the
                length of a field together. Bucketing on text length speeds up
                training of RNNs consistently, 30% in some cases
@@ -238,6 +241,7 @@ class Trainer(BaseTrainer):
         self.staircase = staircase
         self.batch_size = batch_size
         self.eval_batch_size = batch_size if eval_batch_size < 1 else eval_batch_size
+        self.shuffle_buffer_size = shuffle_buffer_size
         self.bucketing_field = bucketing_field
         self._validation_field = validation_field
         self._validation_metric = validation_metric
@@ -509,8 +513,9 @@ class Trainer(BaseTrainer):
         set_random_seed(self.random_seed)
         with training_set.initialize_batcher(
             batch_size=self.batch_size,
+            shuffle_buffer_size=self.shuffle_buffer_size,
             seed=self.random_seed,
-            horovod=self.horovod
+            horovod=self.horovod,
         ) as batcher:
 
             # ================ Training Loop ================

--- a/ludwig/preprocess.py
+++ b/ludwig/preprocess.py
@@ -27,8 +27,8 @@ from ludwig.backend import ALL_BACKENDS, Backend, initialize_backend
 from ludwig.callbacks import Callback
 from ludwig.contrib import add_contrib_callback_args
 from ludwig.globals import LUDWIG_VERSION
+from ludwig.utils.data_utils import load_yaml
 from ludwig.utils.defaults import default_random_seed
-from ludwig.utils.misc_utils import check_which_config
 from ludwig.utils.print_utils import logging_level_registry
 from ludwig.utils.print_utils import print_ludwig
 
@@ -36,8 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 def preprocess_cli(
-        preprocessing_config: dict = None,
-        preprocessing_config_file: str = None,
+        preprocessing_config: Union[str, dict] = None,
         dataset: Union[str, dict, pd.DataFrame] = None,
         training_set: Union[str, dict, pd.DataFrame] = None,
         validation_set: Union[str, dict, pd.DataFrame] = None,
@@ -55,10 +54,8 @@ def preprocess_cli(
     internals. Requires most of the parameters that are taken into the model.
     Builds a full ludwig model and performs the training.
 
-    :param config: (dict) config which defines the different
-        parameters of the model, features, preprocessing and training.
-    :param config_file: (str, default: `None`) the filepath string
-        that specifies the config.  It is a yaml file.
+    :param preprocessing_config: (Union[str, dict]) in-memory representation of
+            config or string path to a YAML config file.
     :param dataset: (Union[str, dict, pandas.DataFrame], default: `None`)
         source containing the entire dataset to be used for training.
         If it has a split column, it will be used for splitting (0 for train,
@@ -148,11 +145,6 @@ def preprocess_cli(
 
     :return: (`None`)
     """
-    preprocessing_config = check_which_config(
-        preprocessing_config,
-        preprocessing_config_file
-    )
-
     model = LudwigModel(
         config=preprocessing_config,
         logging_level=logging_level,
@@ -228,6 +220,8 @@ def cli(sys_argv):
     preprocessing_def.add_argument(
         '-pcf',
         '--preprocessing_config_file',
+        dest='preprocessing_config',
+        type=load_yaml,
         help='YAML file describing the preprocessing. '
              'Ignores --preprocessing_config.'
              'Uses the same format of config, '

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -413,7 +413,7 @@ def cli(sys_argv):
     global logger
     logger = logging.getLogger('ludwig.train')
 
-    args.backend = initialize_backend(args.backend)
+    args.backend = initialize_backend(args.backend or args.config.get('backend'))
     if args.backend.is_coordinator():
         print_ludwig('Train', LUDWIG_VERSION)
 

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -20,14 +20,13 @@ import sys
 from typing import List, Union
 
 import pandas as pd
-import yaml
 
 from ludwig.api import LudwigModel
 from ludwig.backend import ALL_BACKENDS, Backend, initialize_backend
 from ludwig.callbacks import Callback
 from ludwig.contrib import add_contrib_callback_args
 from ludwig.globals import LUDWIG_VERSION
-from ludwig.utils.data_utils import load_yaml
+from ludwig.utils.data_utils import load_yaml, load_config_from_str
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.print_utils import logging_level_registry, print_ludwig
 
@@ -277,7 +276,7 @@ def cli(sys_argv):
     config.add_argument(
         '-c',
         '--config',
-        type=yaml.safe_load,
+        type=load_config_from_str,
         help='JSON or YAML serialized string of the model configuration'
     )
     config.add_argument(

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -27,16 +27,15 @@ from ludwig.backend import ALL_BACKENDS, Backend, initialize_backend
 from ludwig.callbacks import Callback
 from ludwig.contrib import add_contrib_callback_args
 from ludwig.globals import LUDWIG_VERSION
+from ludwig.utils.data_utils import load_yaml
 from ludwig.utils.defaults import default_random_seed
-from ludwig.utils.misc_utils import check_which_config
 from ludwig.utils.print_utils import logging_level_registry, print_ludwig
 
 logger = logging.getLogger(__name__)
 
 
 def train_cli(
-        config: dict = None,
-        config_file: str = None,
+        config: Union[str, dict] = None,
         dataset: Union[str, dict, pd.DataFrame] = None,
         training_set: Union[str, dict, pd.DataFrame] = None,
         validation_set: Union[str, dict, pd.DataFrame] = None,
@@ -68,10 +67,8 @@ def train_cli(
     internals. Requires most of the parameters that are taken into the model.
     Builds a full ludwig model and performs the training.
 
-    :param config: (dict) config which defines the different
-        parameters of the model, features, preprocessing and training.
-    :param config_file: (str, default: `None`) the filepath string
-        that specifies the config.  It is a yaml file.
+    :param config: (Union[str, dict]) in-memory representation of
+            config or string path to a YAML config file.
     :param dataset: (Union[str, dict, pandas.DataFrame], default: `None`)
         source containing the entire dataset to be used for training.
         If it has a split column, it will be used for splitting (0 for train,
@@ -161,9 +158,6 @@ def train_cli(
 
     :return: (`None`)
     """
-    config = check_which_config(config,
-                                config_file)
-
     if model_load_path:
         model = LudwigModel.load(
             model_load_path,
@@ -284,12 +278,14 @@ def cli(sys_argv):
         '-c',
         '--config',
         type=yaml.safe_load,
-        help='config'
+        help='JSON or YAML serialized string of the model configuration'
     )
     config.add_argument(
         '-cf',
         '--config_file',
-        help='YAML file describing the model. Ignores --config'
+        dest='config',
+        type=load_yaml,
+        help='Path to the YAML file containing the model configuration'
     )
 
     parser.add_argument(

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -27,6 +27,8 @@ from itertools import islice
 
 import numpy as np
 import pandas as pd
+import yaml
+
 from ludwig.utils.fs_utils import open_file, download_h5, upload_h5
 from pandas.errors import ParserError
 from sklearn.model_selection import KFold
@@ -199,6 +201,11 @@ def save_csv(data_fp, data):
 
 def csv_contains_column(data_fp, column_name):
     return column_name in read_csv(data_fp, nrows=0)  # only loads header
+
+
+def load_yaml(yaml_fp):
+    with open_file(yaml_fp, 'r') as f:
+        return yaml.safe_load(f)
 
 
 def load_json(data_fp):

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -208,6 +208,16 @@ def load_yaml(yaml_fp):
         return yaml.safe_load(f)
 
 
+def load_config_from_str(config):
+    """Load the config as either a serialized string or a path to a YAML file."""
+    config = yaml.safe_load(config)
+    if isinstance(config, str):
+        # Assume the caller provided a path name
+        with open(config, 'r') as f:
+            config = yaml.safe_load(f)
+    return config
+
+
 def load_json(data_fp):
     with open_file(data_fp, 'r') as input_file:
         data = json.load(input_file)

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -95,8 +95,8 @@ def upload_output_directory(url):
 
 @contextlib.contextmanager
 def open_file(url, *args, **kwargs):
-    of = fsspec.open(url, *args, **kwargs)
-    with of as f:
+    fs, path = get_fs_and_path(url)
+    with fs.open(path, *args, **kwargs) as f:
         yield f
 
 

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -215,23 +215,6 @@ def get_file_names(output_directory):
     return description_fn, training_stats_fn, model_dir
 
 
-def check_which_config(config, config_file):
-    # check for config and config_file
-    if config is None and config_file is None:
-        raise ValueError(
-            'Either config of config_file have to be'
-            'not None to initialize a LudwigModel'
-        )
-    if config is not None and config_file is not None:
-        raise ValueError(
-            'Only one between config and '
-            'config_file can be provided'
-        )
-    if not config:
-        config = config_file
-    return config
-
-
 def hash_dict(d: dict, max_length: Union[int, None] = 6) -> bytes:
     s = json.dumps(d, sort_keys=True, ensure_ascii=True)
     h = hashlib.md5(s.encode())

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -144,7 +144,7 @@ def test_experiment_seq_seq_model_def_file(csv_filename, yaml_filename):
 
     rel_path = generate_data(input_features, output_features, csv_filename)
     run_experiment(
-        None, None, dataset=rel_path, config_file=yaml_filename
+        None, None, dataset=rel_path, config=yaml_filename
     )
 
 

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -388,7 +388,8 @@ def test_experiment_image_inputs(image_parms: ImageParms, csv_filename: str):
         input_features,
         output_features,
         dataset=rel_path,
-        skip_save_processed_input=image_parms.skip_save_processed_input
+        skip_save_processed_input=image_parms.skip_save_processed_input,
+        backend=LocalTestBackend()
     )
 
     # Delete the temporary data created

--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -165,6 +165,7 @@ def run_hyperopt_executor(
     hyperopt_executor.execute(
         config,
         dataset=rel_path,
+        backend='local',
     )
 
 

--- a/tests/integration_tests/test_kfold_cv.py
+++ b/tests/integration_tests/test_kfold_cv.py
@@ -150,7 +150,7 @@ def test_kfold_cv_cli(features_to_use: FeaturesToUse):
         # run k-fold cv
         kfold_cross_validate_cli(
             k_fold=num_folds,
-            config_file=config_fp,
+            config=config_fp,
             dataset=training_data_fp,
             output_directory=results_dir,
             logging_level='warn'

--- a/tests/integration_tests/test_remote.py
+++ b/tests/integration_tests/test_remote.py
@@ -10,9 +10,9 @@ from ludwig.backend import initialize_backend
 from tests.integration_tests.utils import sequence_feature, category_feature, generate_data
 
 
-@pytest.mark.parametrize('data_format', ['hdf5', 'parquet'])
+@pytest.mark.parametrize('cache_format', ['hdf5', 'parquet'])
 @pytest.mark.parametrize('fs_protocol', ['file'])
-def test_remote_training_set(tmpdir, fs_protocol, data_format):
+def test_remote_training_set(tmpdir, fs_protocol, cache_format):
     with tempfile.TemporaryDirectory() as outdir:
         output_directory = f'{fs_protocol}://{outdir}'
 
@@ -43,7 +43,7 @@ def test_remote_training_set(tmpdir, fs_protocol, data_format):
 
         backend_config = {
             'type': 'local',
-            'data_format': data_format
+            'cache_format': cache_format
         }
         backend = initialize_backend(backend_config)
 

--- a/tests/integration_tests/test_remote.py
+++ b/tests/integration_tests/test_remote.py
@@ -42,10 +42,10 @@ def test_remote_training_set(tmpdir, fs_protocol, data_format):
         config_path = f'{fs_protocol}://{config_path}'
 
         backend_config = {
-            'name': 'local',
+            'type': 'local',
             'data_format': data_format
         }
-        backend = initialize_backend(**backend_config)
+        backend = initialize_backend(backend_config)
 
         model = LudwigModel(config_path, backend=backend)
         _, _, output_directory = model.train(

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -347,6 +347,7 @@ def run_experiment(
         input_features,
         output_features,
         skip_save_processed_input=True,
+        config=None,
         **kwargs
 ):
     """
@@ -358,7 +359,6 @@ def run_experiment(
     arguments
     :return: None
     """
-    config = None
     if input_features is not None and output_features is not None:
         # This if is necessary so that the caller can call with
         # config_file (and not config)


### PR DESCRIPTION
Including:

- Backend config can be provided in the YAML config file under the `backend` section
- Ray can use the Pandas engine
- `shuffle_buffer_size` can be provided in `training` params

Also fixed column names in the processed data to remove invalid column names and fixed Ray backend in AWS.