### PR TITLE
Allow hyperopt parallel workers to create subprocess for image pre-processing

### DIFF
--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -70,7 +70,7 @@ HYPEROPT_CONFIG = {
 }
 
 SAMPLERS = [
-    # {"type": "grid"},
+    {"type": "grid"},
     {"type": "random", "num_samples": 5},
     {"type": "pysot", "num_samples": 5},
 ]

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -71,14 +71,14 @@ HYPEROPT_CONFIG = {
 }
 
 SAMPLERS = [
-    {"type": "grid"},
-    {"type": "random", "num_samples": 5},
-    {"type": "pysot", "num_samples": 5},
+    # {"type": "grid"},
+    {"type": "random", "num_samples": 15},  # 5
+    # {"type": "pysot", "num_samples": 2},  #5
 ]
 
 EXECUTORS = [
     {"type": "serial"},
-    {"type": "parallel", "num_workers": 4},
+    {"type": "parallel", "num_workers": 2},  # 4
     {"type": "fiber", "num_workers": 4},
 ]
 

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -54,25 +54,23 @@ HYPEROPT_CONFIG = {
             'values': [
                 [{'fc_size': 512}, {'fc_size': 256}],
                 [{'fc_size': 512}],
-                # [{'fc_size': 256}]  # todo: undo comment when working
+                [{'fc_size': 256}]
             ]
         },
-
-        # todo: undo comments when working
-        # "utterance.cell_type": {
-        #     "type": "category",
-        #     "values": ["rnn", "gru"]
-        # },
-        # "utterance.bidirectional": {
-        #     "type": "category",
-        #     "values": [True, False]
-        # }
+        "utterance.cell_type": {
+            "type": "category",
+            "values": ["rnn", "gru"]
+        },
+        "utterance.bidirectional": {
+            "type": "category",
+            "values": [True, False]
+        }
     },
     "goal": "minimize"
 }
 
 SAMPLERS = [
-    {"type": "grid"},
+    # {"type": "grid"},
     {"type": "random", "num_samples": 5},
     {"type": "pysot", "num_samples": 5},
 ]

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -72,14 +72,14 @@ HYPEROPT_CONFIG = {
 
 SAMPLERS = [
     # {"type": "grid"},
-    {"type": "random", "num_samples": 15},  # 5
+    {"type": "random", "num_samples": 5},
     # {"type": "pysot", "num_samples": 2},  #5
 ]
 
 EXECUTORS = [
     {"type": "serial"},
     {"type": "parallel", "num_workers": 2},  # 4
-    {"type": "fiber", "num_workers": 4},
+    # {"type": "fiber", "num_workers": 4},
 ]
 
 

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -49,37 +49,38 @@ HYPEROPT_CONFIG = {
             "space": "linear",
             "steps": 3,
         },
-       "combiner.fc_layers" : {
+        "combiner.fc_layers": {
             'type': 'category',
             'values': [
                 [{'fc_size': 512}, {'fc_size': 256}],
                 [{'fc_size': 512}],
-                [{'fc_size': 256}]
+                # [{'fc_size': 256}]  # todo: undo comment when working
             ]
         },
-        
-        "utterance.cell_type": {
-            "type": "category",
-            "values": ["rnn", "gru"]
-        },
-        "utterance.bidirectional": {
-            "type": "category",
-            "values": [True, False]
-        }
+
+        # todo: undo comments when working
+        # "utterance.cell_type": {
+        #     "type": "category",
+        #     "values": ["rnn", "gru"]
+        # },
+        # "utterance.bidirectional": {
+        #     "type": "category",
+        #     "values": [True, False]
+        # }
     },
     "goal": "minimize"
 }
 
 SAMPLERS = [
-    # {"type": "grid"},
+    {"type": "grid"},
     {"type": "random", "num_samples": 5},
-    # {"type": "pysot", "num_samples": 2},  #5
+    {"type": "pysot", "num_samples": 5},
 ]
 
 EXECUTORS = [
     {"type": "serial"},
-    {"type": "parallel", "num_workers": 2},  # 4
-    # {"type": "fiber", "num_workers": 4},
+    {"type": "parallel", "num_workers": 4},
+    {"type": "fiber", "num_workers": 4},
 ]
 
 


### PR DESCRIPTION
# Code Pull Requests

Fix Issue #965.  `AssertionError: daemonic processes are not allowed to have children` is raised when hyperopt parallel workers have an image input feature in the training data.  image preprocessing will have each parallel worker create subprocesses to prepare images for training.

This PR modifies how hyerpopt starts it parallel workers to allow them to create subprocesses themselves.  With this PR in place the above `AssertionError` no longer occurs.

However, when running unit test `test_hyperopt.py` the unit test hangs in this situation: `test_hyperopt.py::test_hyperopt_executor`  The unit test hangs under this condition:
* `serial` unit test runs to completion
* `parallel` unit test hangs on the first test case.

If the `serial` unit test is run **after** the `parallel` unit test, **no hang occur**.  Also **no hang occurs on the main branch**.  

Although the PR addresses the original issue #965 the method by which this is accomplished appear to have some unintended side-effects.  

Submitting PR to allow a broader review of the changes to help identify the root cause for the hang.

