### PR TITLE
Update Readme to activate directly the virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ brew install python3      # on mac
 You may want to use a virtual environment to maintain an isolated [Python environment](https://docs.python-guide.org/dev/virtualenvs/).
 
 ```
-virtualenv -p python3 venv
+virtualenv -p python3 venv && source venv/bin/activate
 ```
 
 In order to install Ludwig just run:


### PR DESCRIPTION
Minor change in order to help the unexperienced reader to correctly activate the virtual environment before installation. In my opinion this minor fix would make the suggestion of using a virtualenv more robust. Many thanks and best regards.
