### PR TITLE
Use config which has been previously validated

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -190,7 +190,7 @@ class LudwigModel:
         self.set_logging_level(logging_level)
 
         # setup Backend
-        self.backend = initialize_backend(backend or config.get('backend'))
+        self.backend = initialize_backend(backend or self.config.get('backend'))
         self.callbacks = callbacks if callbacks is not None else []
 
         # setup TensorFlow


### PR DESCRIPTION
The input param config might be a str or a dict, in case of string the command config.get will generate an error. Using the already validated self.config should avoid a potential error.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
