### PR TITLE
Additional Kaggle Tabular Datasets

### DIFF
--- a/ludwig/datasets/ieee_fraud/__init__.py
+++ b/ludwig/datasets/ieee_fraud/__init__.py
@@ -62,15 +62,11 @@ class IEEEFraud(CSVLoadMixin, MultifileJoinProcessMixin, KaggleDownloadMixin, Ba
                 test_dfs[split_name] = file_df
 
         # Merge on TransactionID
-        train = pd.merge(
+        final_train = pd.merge(
             train_dfs['train_transaction'], train_dfs['train_identity'], on='TransactionID', how='left')
-        """test = pd.merge(
-            test_dfs['test_transaction'], test_dfs['test_identity'], on='TransactionID', how='left')"""
-        #train['split'], test['split'] = 0, 2
 
-        #concat_df = pd.concat([train, test], ignore_index=True)
-        concat_df = train
         os.makedirs(self.processed_dataset_path, exist_ok=True)
-        concat_df.to_csv(
+        # Only save train split as test split has no ground truth labels
+        final_train.to_csv(
             os.path.join(self.processed_dataset_path, self.csv_filename),
             index=False)

--- a/ludwig/datasets/ieee_fraud/__init__.py
+++ b/ludwig/datasets/ieee_fraud/__init__.py
@@ -1,0 +1,76 @@
+#! /usr/bin/env python
+# coding=utf-8
+# Copyright (c) 2021 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import os
+import pandas as pd
+from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
+from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
+from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+
+
+def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
+    dataset = IEEEFraud(
+        cache_dir=cache_dir,
+        kaggle_username=kaggle_username,
+        kaggle_key=kaggle_key
+    )
+    return dataset.load(split=split)
+
+
+class IEEEFraud(CSVLoadMixin, MultifileJoinProcessMixin, KaggleDownloadMixin, BaseDataset):
+    """The IEEE-CIS Fraud Detection Dataset
+    https://www.kaggle.com/c/ieee-fraud-detection/overview
+    """
+
+    def __init__(self,
+                 cache_dir=DEFAULT_CACHE_LOCATION,
+                 kaggle_username=None,
+                 kaggle_key=None):
+        self.kaggle_username = kaggle_username
+        self.kaggle_key = kaggle_key
+        self.is_kaggle_competition = True
+        super().__init__(dataset_name='ieee_fraud', cache_dir=cache_dir)
+
+    def process_downloaded_dataset(self):
+        downloaded_files = self.download_filenames
+        filetype = self.download_file_type
+
+        train_files = ['train_identity.csv', 'train_transaction.csv']
+        test_files = ['test_identity.csv', 'test_transaction.csv']
+
+        train_dfs, test_dfs = {}, {}
+
+        for split_name, filename in downloaded_files.items():
+            file_df = self.read_file(filetype, filename, header=0)
+            if filename in train_files:
+                train_dfs[split_name] = file_df
+            elif filename in test_files:
+                test_dfs[split_name] = file_df
+
+        # Merge on TransactionID
+        train = pd.merge(
+            train_dfs['train_transaction'], train_dfs['train_identity'], on='TransactionID', how='left')
+        test = pd.merge(
+            test_dfs['test_transaction'], test_dfs['test_identity'], on='TransactionID', how='left')
+        train['split'] = 0
+        test['split'] = 2
+
+        concat_df = pd.concat([train, test], ignore_index=True)
+        os.makedirs(self.processed_dataset_path, exist_ok=True)
+        concat_df.to_csv(
+            os.path.join(self.processed_dataset_path, self.csv_filename),
+            index=False)

--- a/ludwig/datasets/ieee_fraud/__init__.py
+++ b/ludwig/datasets/ieee_fraud/__init__.py
@@ -64,12 +64,12 @@ class IEEEFraud(CSVLoadMixin, MultifileJoinProcessMixin, KaggleDownloadMixin, Ba
         # Merge on TransactionID
         train = pd.merge(
             train_dfs['train_transaction'], train_dfs['train_identity'], on='TransactionID', how='left')
-        test = pd.merge(
-            test_dfs['test_transaction'], test_dfs['test_identity'], on='TransactionID', how='left')
-        train['split'] = 0
-        test['split'] = 2
+        """test = pd.merge(
+            test_dfs['test_transaction'], test_dfs['test_identity'], on='TransactionID', how='left')"""
+        #train['split'], test['split'] = 0, 2
 
-        concat_df = pd.concat([train, test], ignore_index=True)
+        #concat_df = pd.concat([train, test], ignore_index=True)
+        concat_df = train
         os.makedirs(self.processed_dataset_path, exist_ok=True)
         concat_df.to_csv(
             os.path.join(self.processed_dataset_path, self.csv_filename),

--- a/ludwig/datasets/ieee_fraud/config.yaml
+++ b/ludwig/datasets/ieee_fraud/config.yaml
@@ -1,0 +1,10 @@
+version: 1.0
+competition: ieee-fraud-detection
+archive_filename: ieee-fraud-detection.zip
+split_filenames:
+  train_identity: train_identity.csv
+  train_transaction: train_transaction.csv
+  test_identity: test_identity.csv
+  test_transaction: test_transaction.csv
+csv_filename: ieee-fraud.csv
+download_file_type: csv

--- a/ludwig/datasets/ieee_fraud/config.yaml
+++ b/ludwig/datasets/ieee_fraud/config.yaml
@@ -6,5 +6,5 @@ split_filenames:
   train_transaction: train_transaction.csv
   test_identity: test_identity.csv
   test_transaction: test_transaction.csv
-csv_filename: ieee-fraud.csv
+csv_filename: ieee_fraud.csv
 download_file_type: csv

--- a/ludwig/datasets/otto_group_product/__init__.py
+++ b/ludwig/datasets/otto_group_product/__init__.py
@@ -1,0 +1,46 @@
+#! /usr/bin/env python
+# coding=utf-8
+# Copyright (c) 2021 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import os
+import pandas as pd
+from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
+from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
+from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.mixins.process import IdentityProcessMixin
+
+
+def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
+    dataset = OttoGroupProduct(
+        cache_dir=cache_dir,
+        kaggle_username=kaggle_username,
+        kaggle_key=kaggle_key
+    )
+    return dataset.load(split=split)
+
+
+class OttoGroupProduct(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
+    """The Otto Group Product Classification Challenge
+    https://www.kaggle.com/c/otto-group-product-classification-challenge/overview
+    """
+
+    def __init__(self,
+                 cache_dir=DEFAULT_CACHE_LOCATION,
+                 kaggle_username=None,
+                 kaggle_key=None):
+        self.kaggle_username = kaggle_username
+        self.kaggle_key = kaggle_key
+        self.is_kaggle_competition = True
+        super().__init__(dataset_name='otto_group_product', cache_dir=cache_dir)

--- a/ludwig/datasets/otto_group_product/config.yaml
+++ b/ludwig/datasets/otto_group_product/config.yaml
@@ -1,0 +1,7 @@
+version: 1.0
+competition: otto-group-product-classification-challenge
+archive_filename: otto-group-product-classification-challenge.zip
+split_filenames:
+  train_file: train.csv
+csv_filename: train.csv
+download_file_type: csv

--- a/ludwig/datasets/santander_customer_transaction/__init__.py
+++ b/ludwig/datasets/santander_customer_transaction/__init__.py
@@ -1,0 +1,47 @@
+#! /usr/bin/env python
+# coding=utf-8
+# Copyright (c) 2021 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import os
+import pandas as pd
+from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
+from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
+from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.mixins.process import IdentityProcessMixin
+
+
+def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
+    dataset = SantanderCustomerTransaction(
+        cache_dir=cache_dir,
+        kaggle_username=kaggle_username,
+        kaggle_key=kaggle_key
+    )
+    return dataset.load(split=split)
+
+
+class SantanderCustomerTransaction(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
+    """Santander Customer Transaction Prediction
+
+    https://www.kaggle.com/c/santander-customer-transaction-prediction/overview
+    """
+
+    def __init__(self,
+                 cache_dir=DEFAULT_CACHE_LOCATION,
+                 kaggle_username=None,
+                 kaggle_key=None):
+        self.kaggle_username = kaggle_username
+        self.kaggle_key = kaggle_key
+        self.is_kaggle_competition = True
+        super().__init__(dataset_name='santander_customer_transaction', cache_dir=cache_dir)

--- a/ludwig/datasets/santander_customer_transaction/config.yaml
+++ b/ludwig/datasets/santander_customer_transaction/config.yaml
@@ -1,0 +1,7 @@
+version: 1.0
+competition: santander-customer-transaction-prediction
+archive_filename: santander-customer-transaction-prediction.zip
+split_filenames:
+  train_file: train.csv
+csv_filename: train.csv
+download_file_type: csv

--- a/ludwig/datasets/walmart_recruiting/__init__.py
+++ b/ludwig/datasets/walmart_recruiting/__init__.py
@@ -1,0 +1,46 @@
+#! /usr/bin/env python
+# coding=utf-8
+# Copyright (c) 2021 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import os
+import pandas as pd
+from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
+from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
+from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+
+
+def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
+    dataset = WalmartRecruiting(
+        cache_dir=cache_dir,
+        kaggle_username=kaggle_username,
+        kaggle_key=kaggle_key
+    )
+    return dataset.load(split=split)
+
+
+class WalmartRecruiting(CSVLoadMixin, MultifileJoinProcessMixin, KaggleDownloadMixin, BaseDataset):
+    """The Walmart Recruiting: Trip Type Classification
+    https://www.kaggle.com/c/walmart-recruiting-trip-type-classification
+    """
+
+    def __init__(self,
+                 cache_dir=DEFAULT_CACHE_LOCATION,
+                 kaggle_username=None,
+                 kaggle_key=None):
+        self.kaggle_username = kaggle_username
+        self.kaggle_key = kaggle_key
+        self.is_kaggle_competition = True
+        super().__init__(dataset_name='walmart_recruiting', cache_dir=cache_dir)

--- a/ludwig/datasets/walmart_recruiting/__init__.py
+++ b/ludwig/datasets/walmart_recruiting/__init__.py
@@ -47,34 +47,3 @@ class WalmartRecruiting(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin,
         self.kaggle_key = kaggle_key
         self.is_kaggle_competition = True
         super().__init__(dataset_name='walmart_recruiting', cache_dir=cache_dir)
-
-    def download_raw_dataset(self):
-        """
-        Download the raw dataset and extract the contents of the zip file and
-        store that in the cache location.  If the user has not specified creds in the
-        kaggle.json file we lookup the passed in username and the api key and
-        perform authentication.
-        """
-        with self.update_env(KAGGLE_USERNAME=self.kaggle_username, KAGGLE_KEY=self.kaggle_key):
-            # Call authenticate explicitly to pick up new credentials if necessary
-            api = create_kaggle_client()
-            api.authenticate()
-        os.makedirs(self.raw_temp_path, exist_ok=True)
-
-        if self.is_kaggle_competition:
-            download_func = api.competition_download_files
-        else:
-            download_func = api.dataset_download_files
-        # Download all files for a competition/dataset
-        download_func(self.competition_name, path=self.raw_temp_path)
-
-        archive_zip = os.path.join(self.raw_temp_path, self.archive_filename)
-        print(archive_zip)
-        # test.csv.zip is an encrypted zip file that requires a password
-        # Avoid unzipping that file
-        with ZipFile(archive_zip, 'r') as z:
-            file_names = z.namelist()
-            for fname in file_names:
-                if fname != "test.csv.zip":
-                    z.extract(fname, self.raw_temp_path)
-        os.rename(self.raw_temp_path, self.raw_dataset_path)

--- a/ludwig/datasets/walmart_recruiting/config.yaml
+++ b/ludwig/datasets/walmart_recruiting/config.yaml
@@ -3,6 +3,5 @@ competition: walmart-recruiting-trip-type-classification
 archive_filename: walmart-recruiting-trip-type-classification.zip
 split_filenames:
   train_file: train.csv.zip
-  #test_file: test.csv.zip
-csv_filename: walmart_recruiting.csv
+csv_filename: train.csv.zip
 download_file_type: csv

--- a/ludwig/datasets/walmart_recruiting/config.yaml
+++ b/ludwig/datasets/walmart_recruiting/config.yaml
@@ -1,0 +1,8 @@
+version: 1.0
+competition: walmart-recruiting-trip-type-classification
+archive_filename: walmart-recruiting-trip-type-classification.zip
+split_filenames:
+  train_file: train.csv.zip
+  #test_file: test.csv.zip
+csv_filename: walmart_recruiting.csv
+download_file_type: csv


### PR DESCRIPTION
This PR adds four additional Kaggle Tabular Datasets to the `ludwig.datasets` module.

The four datasets included in this PR are:
1. [IEEE-CIS Fraud Detection](https://www.kaggle.com/c/ieee-fraud-detection)
2. [Santander Customer Transaction Prediction](https://www.kaggle.com/c/santander-customer-satisfaction)
3. [Walmart Recruiting: Trip Type Classification](https://www.kaggle.com/c/walmart-recruiting-trip-type-classification)
4. [Otto Group Product Classification Challenge](https://www.kaggle.com/c/otto-group-product-classification-challenge)
