### PR TITLE
Modify Kaggle datasets to not process test sets

### DIFF
--- a/ludwig/datasets/bnp_claims_management/__init__.py
+++ b/ludwig/datasets/bnp_claims_management/__init__.py
@@ -19,7 +19,7 @@ import pandas as pd
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
-from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.mixins.process import IdentityProcessMixin
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -31,7 +31,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
-class BNPClaimsManagement(CSVLoadMixin, MultifileJoinProcessMixin, KaggleDownloadMixin, BaseDataset):
+class BNPClaimsManagement(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """The BNP Paribas Cardif Claims Management dataset.
 
     Additional details:

--- a/ludwig/datasets/bnp_claims_management/config.yaml
+++ b/ludwig/datasets/bnp_claims_management/config.yaml
@@ -3,6 +3,6 @@ competition: bnp-paribas-cardif-claims-management
 archive_filename: bnp-paribas-cardif-claims-management.zip
 split_filenames:
   train_file: train.csv.zip
-  test_file: test.csv.zip
+  #test_file: test.csv.zip
 download_file_type: csv
-csv_filename: bnp-paribas-cardif-claims-management.csv
+csv_filename: train.csv.zip

--- a/ludwig/datasets/mercedes_benz_greener/__init__.py
+++ b/ludwig/datasets/mercedes_benz_greener/__init__.py
@@ -19,7 +19,7 @@ import pandas as pd
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
-from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.mixins.process import IdentityProcessMixin
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -31,7 +31,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
-class MercedesBenzGreener(CSVLoadMixin, MultifileJoinProcessMixin, KaggleDownloadMixin, BaseDataset):
+class MercedesBenzGreener(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """The Mercedes-Benz Greener Manufacturing dataset.
 
     Additional details:

--- a/ludwig/datasets/mercedes_benz_greener/config.yaml
+++ b/ludwig/datasets/mercedes_benz_greener/config.yaml
@@ -3,6 +3,6 @@ competition: mercedes-benz-greener-manufacturing
 archive_filename: mercedes-benz-greener-manufacturing.zip
 split_filenames:
   train_file: train.csv.zip
-  test_file: test.csv.zip
+  #test_file: test.csv.zip
 download_file_type: csv
-csv_filename: mercedes-benz-greener-manufacturing.csv
+csv_filename: train.csv.zip

--- a/ludwig/datasets/santander_value_prediction/__init__.py
+++ b/ludwig/datasets/santander_value_prediction/__init__.py
@@ -19,7 +19,7 @@ import pandas as pd
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
-from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.mixins.process import IdentityProcessMixin
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -31,7 +31,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
-class SantanderValuePrediction(CSVLoadMixin, MultifileJoinProcessMixin, KaggleDownloadMixin, BaseDataset):
+class SantanderValuePrediction(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """The Santander Value Prediction Challenge dataset.
 
     Additional details:
@@ -54,7 +54,8 @@ class SantanderValuePrediction(CSVLoadMixin, MultifileJoinProcessMixin, KaggleDo
                                                 self.csv_filename))
         # Ensure feature column names are strings (some are numeric); keep special names as is
         processed_df.columns = ['C' + str(col) for col in processed_df.columns]
-        processed_df.rename(columns={'CID': 'ID', 'Ctarget': 'target', 'Csplit': 'split'}, inplace=True)
+        processed_df.rename(
+            columns={'CID': 'ID', 'Ctarget': 'target', 'Csplit': 'split'}, inplace=True)
         processed_df.to_csv(
             os.path.join(self.processed_dataset_path, self.csv_filename),
             index=False

--- a/ludwig/datasets/santander_value_prediction/config.yaml
+++ b/ludwig/datasets/santander_value_prediction/config.yaml
@@ -3,6 +3,6 @@ competition: santander-value-prediction-challenge
 archive_filename: santander-value-prediction-challenge.zip
 split_filenames:
   train_file: train.csv
-  test_file: test.csv
+  #test_file: test.csv
 download_file_type: csv
-csv_filename: santander-value-prediction-challenge.csv
+csv_filename: train.csv


### PR DESCRIPTION
This PR modifies three kaggle datasets in the datasets module: BNP Claims Management, Mercedez Benz Greener, Santander Value Prediction. 

The modification removes the processing of the test set in the datasets modules as Kaggle test sets do not contain ground truth labels.
