### PR TITLE
[hyperopt] fixed metric_score to use test split when available

### DIFF
--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -72,18 +72,18 @@ class HyperoptExecutor(ABC):
         return isinstance(stats, float)
 
     def get_metric_score(self, train_stats, eval_stats) -> float:
-        if self._has_eval_metric(eval_stats):
+        if (train_stats is not None and
+                self._has_metric(train_stats, self.split) and
+                self._has_metric(train_stats, TEST)):
+            logger.info("Returning metric score from training (test) statistics")
+            return self.get_metric_score_from_train_stats(train_stats, TEST, TEST)
+        elif self._has_eval_metric(eval_stats):
             logger.info("Returning metric score from eval statistics. "
                         "If skip_save_model is True, eval statistics "
                         "are calculated using the model at the last epoch "
                         "rather than the model at the epoch with "
                         "best validation performance")
             return self.get_metric_score_from_eval_stats(eval_stats)
-        elif (train_stats is not None and
-                self._has_metric(train_stats, self.split) and
-                self._has_metric(train_stats, TEST)):
-            logger.info("Returning metric score from training (test) statistics")
-            return self.get_metric_score_from_train_stats(train_stats, TEST, TEST)
         elif (train_stats is not None and
                 self._has_metric(train_stats, self.split) and
                 self._has_metric(train_stats, VALIDATION)):

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -72,21 +72,26 @@ class HyperoptExecutor(ABC):
         return isinstance(stats, float)
 
     def get_metric_score(self, train_stats, eval_stats) -> float:
-        if (train_stats is not None and
-                self._has_metric(train_stats, self.split) and
-                self._has_metric(train_stats, VALIDATION)):
-            logger.info("Returning metric score from training statistics")
-            return self.get_metric_score_from_train_stats(train_stats)
-        elif self._has_eval_metric(eval_stats):
+        if self._has_eval_metric(eval_stats):
             logger.info("Returning metric score from eval statistics. "
                         "If skip_save_model is True, eval statistics "
                         "are calculated using the model at the last epoch "
                         "rather than the model at the epoch with "
                         "best validation performance")
             return self.get_metric_score_from_eval_stats(eval_stats)
+        elif (train_stats is not None and
+                self._has_metric(train_stats, self.split) and
+                self._has_metric(train_stats, TEST)):
+            logger.info("Returning metric score from training (test) statistics")
+            return self.get_metric_score_from_train_stats(train_stats, TEST, TEST)
+        elif (train_stats is not None and
+                self._has_metric(train_stats, self.split) and
+                self._has_metric(train_stats, VALIDATION)):
+            logger.info("Returning metric score from training (validation) statistics")
+            return self.get_metric_score_from_train_stats(train_stats)
         elif self._has_metric(train_stats, TRAINING):
             logger.info("Returning metric score from training split statistics, "
-                        "as no validation / eval sets were given")
+                        "as no test / validation / eval sets were given")
             return self.get_metric_score_from_train_stats(train_stats, TRAINING, TRAINING)
         else:
             raise RuntimeError(


### PR DESCRIPTION
In the previous version of the code, the priority was:

1. validation from training stats
2. evaluation stats
3. training from training stats

This PR changes the priority to:

1. test from training stats
2. evaluation stats
3. validation from training stats
4. training from training stats