### PR TITLE
Include automl default yaml files in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.txt
 recursive-include ludwig/datasets *.yaml
+recursive-include ludwig/automl/defaults *.yaml


### PR DESCRIPTION
AutoML yaml files were not getting packaged into Python wheels when running `pip install`.