### PR TITLE
Fix TensorFlow CUDA version mismatch in Ray GPU image

### DIFF
--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -9,7 +9,8 @@
 #   model serving
 #
 
-FROM rayproject/ray:nightly-gpu
+# Pin to 1.5.1 to ensure CUDA 11.2 following: https://github.com/ray-project/ray/pull/17806
+FROM rayproject/ray:1.5.1-gpu
 
 RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y \
     build-essential \
@@ -21,6 +22,9 @@ RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install
     tzdata \
     rsync \
     vim
+
+# Upgrade to the latest ray
+RUN pip install --upgrade ray
 
 WORKDIR /ludwig
 

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM rayproject/ray:nightly
+FROM rayproject/ray:latest
 
 RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y \
     build-essential \


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/17806 reverted CUDA from 11.2 to 11.0. Because TensorFlow 2.5 and 2.6 are built with 11.2 support, this broke GPU acceleration for Ludwig Ray GPU images.

cc @anneholler 