### PR TITLE
[feat] verify correctness of RayTune hyperparameter search space format

### DIFF
--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -8,7 +8,6 @@ import signal
 import shutil
 from abc import ABC, abstractmethod
 from typing import Union
-import pdb
 
 from ray.tune.session import get_trial_dir, get_trial_id
 

--- a/ludwig/hyperopt/utils.py
+++ b/ludwig/hyperopt/utils.py
@@ -10,6 +10,22 @@ from ludwig.utils.print_utils import print_boxed
 logger = logging.getLogger(__name__)
 
 
+ray_hparamspace_type_map = {
+    "uniform": "float",
+    "quniform": "float",
+    "loguniform": "float",
+    "qloguniform": "float",
+    "randn": "float",
+    "qrandn": "float",
+    "qlograndint": "int",
+    "lograndint": "int",
+    "qrandint": "int",
+    "randint": "int",
+    "grid": "category",
+    "choice": "category"
+}
+
+
 def print_hyperopt_results(hyperopt_results: HyperoptResults):
     print_boxed('HYPEROPT RESULTS', print_fun=logger.info)
     for trial_results in hyperopt_results.ordered_trials:

--- a/ludwig/hyperopt/utils.py
+++ b/ludwig/hyperopt/utils.py
@@ -22,7 +22,8 @@ ray_hparamspace_type_map = {
     "qrandint": "int",
     "randint": "int",
     "grid": "category",
-    "choice": "category"
+    "choice": "category",
+    "grid_search" : "category",
 }
 
 

--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -51,7 +51,7 @@ HYPEROPT_CONFIG = {
             "upper": 6
         },
         "utterance.cell_type": {
-            "space": "grid",
+            "space": "grid_search",
             "values": ["rnn", "gru"]
         },
         "utterance.bidirectional": {

--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -51,7 +51,7 @@ HYPEROPT_CONFIG = {
             "upper": 6
         },
         "utterance.cell_type": {
-            "space": "grid_search",
+            "space": "grid",
             "values": ["rnn", "gru"]
         },
         "utterance.bidirectional": {


### PR DESCRIPTION
This PR add additional logic in the `execute` function of the `RayTuneExecutor` class that ensures that the provided parameter search space ranges contain a `type` description.

