### PR TITLE
Do not initialize Ray if already initalized

### DIFF
--- a/ludwig/backend/__init__.py
+++ b/ludwig/backend/__init__.py
@@ -38,6 +38,9 @@ def _has_ray():
     if _ray is None:
         return False
 
+    if _ray.is_initialized():
+        return True
+
     try:
         _ray.init('auto', ignore_reinit_error=True)
         return True

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -224,11 +224,12 @@ class RayBackend(RemoteTrainingMixin, Backend):
             )
 
     def initialize(self):
-        try:
-            ray.init('auto', ignore_reinit_error=True)
-        except ConnectionError:
-            logger.info('Initializing new Ray cluster...')
-            ray.init(ignore_reinit_error=True)
+        if not ray.is_initialized():
+            try:
+                ray.init('auto', ignore_reinit_error=True)
+            except ConnectionError:
+                logger.info('Initializing new Ray cluster...')
+                ray.init(ignore_reinit_error=True)
 
         dask.config.set(scheduler=ray_dask_get)
         self._df_engine.set_parallelism(**get_dask_kwargs())

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -730,12 +730,12 @@ class RayTuneExecutor(HyperoptExecutor):
                              )
         HyperoptExecutor.__init__(self, hyperopt_sampler, output_feature,
                                   metric, split)
-        try:
-            ray.init('auto', ignore_reinit_error=True)
-        except ConnectionError:
-            logger.info('Initializing new Ray cluster...')
-            ray.init()
-
+        if not ray.is_initialized():
+            try:
+                ray.init('auto', ignore_reinit_error=True)
+            except ConnectionError:
+                logger.info('Initializing new Ray cluster...')
+                ray.init(ignore_reinit_error=True)
         self.search_space = hyperopt_sampler.search_space
         self.num_samples = hyperopt_sampler.num_samples
         self.goal = hyperopt_sampler.goal


### PR DESCRIPTION
This PR ensures that Ray is not initialized if it's already initialized. The previous way of handling that case by `ignore_reinit_error` causes an exception to be thrown with Ray Client.
