### PR TITLE
Torch output shape support

### DIFF
--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -24,7 +24,7 @@ from typing import List
 
 import torch
 from torch.nn import Module
-from ludwig.utils.torch_utils import LudwigModule
+from ludwig.utils.torch_utils import LudwigComponent
 
 from ludwig.constants import NUMERICAL, BINARY, TYPE, NAME
 from ludwig.encoders.sequence_encoders import ParallelCNN
@@ -43,7 +43,7 @@ from ludwig.utils.tf_utils import sequence_length_3D
 logger = logging.getLogger(__name__)
 
 
-class ConcatCombiner(LudwigModule):
+class ConcatCombiner(LudwigComponent):
     def __init__(
             self,
             input_features=None,
@@ -148,19 +148,20 @@ class ConcatCombiner(LudwigModule):
 
         return return_data
 
-    def get_input_shape(self):
+    @property
+    def input_shape(self) -> torch.Size:
         shapes = [self.input_features[k].get_output_shape() for k in self.input_features] #output shape not input shape
-        return sum(shapes)
+        return torch.Size([sum(shapes)])
 
-    def get_output_shape(self):
+    @property
+    def output_shape(self) -> torch.Size:
         if self.fc_layers is not None:
-            return self.fc_layers[-1]['fc_size']
+            return torch.Size([self.fc_layers[-1]['fc_size']])
         else:
             return self.get_input_shape()
 
 
-
-class SequenceConcatCombiner(LudwigModule):
+class SequenceConcatCombiner(LudwigComponent):
     def __init__(
             self,
             reduce_output=None,
@@ -299,7 +300,7 @@ class SequenceConcatCombiner(LudwigModule):
         return return_data
 
 
-class SequenceCombiner(LudwigModule):
+class SequenceCombiner(LudwigComponent):
     def __init__(
             self,
             reduce_output=None,

--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -24,7 +24,7 @@ from typing import List
 
 import torch
 from torch.nn import Module
-from ludwig.utils.torch_utils import LudwigComponent
+from ludwig.utils.torch_utils import LudwigModule
 
 from ludwig.constants import NUMERICAL, BINARY, TYPE, NAME
 from ludwig.encoders.sequence_encoders import ParallelCNN
@@ -43,7 +43,7 @@ from ludwig.utils.tf_utils import sequence_length_3D
 logger = logging.getLogger(__name__)
 
 
-class ConcatCombiner(LudwigComponent):
+class ConcatCombiner(LudwigModule):
     def __init__(
             self,
             input_features=None,
@@ -161,7 +161,7 @@ class ConcatCombiner(LudwigComponent):
             return self.input_shape
 
 
-class SequenceConcatCombiner(LudwigComponent):
+class SequenceConcatCombiner(LudwigModule):
     def __init__(
             self,
             reduce_output=None,
@@ -300,7 +300,7 @@ class SequenceConcatCombiner(LudwigComponent):
         return return_data
 
 
-class SequenceCombiner(LudwigComponent):
+class SequenceCombiner(LudwigModule):
     def __init__(
             self,
             reduce_output=None,

--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -86,7 +86,7 @@ class ConcatCombiner(LudwigComponent):
         if fc_layers is not None:
             logger.debug('  FCStack')
             self.fc_stack = FCStack(
-                first_layer_input_size=self.get_input_shape(),
+                first_layer_input_size=self.input_shape,
                 layers=fc_layers,
                 num_layers=num_fc_layers,
                 default_fc_size=fc_size,
@@ -150,7 +150,7 @@ class ConcatCombiner(LudwigComponent):
 
     @property
     def input_shape(self) -> torch.Size:
-        shapes = [self.input_features[k].get_output_shape() for k in self.input_features] #output shape not input shape
+        shapes = [self.input_features[k].output_shape for k in self.input_features] #output shape not input shape
         return torch.Size([sum(shapes)])
 
     @property
@@ -158,7 +158,7 @@ class ConcatCombiner(LudwigComponent):
         if self.fc_layers is not None:
             return torch.Size([self.fc_layers[-1]['fc_size']])
         else:
-            return self.get_input_shape()
+            return self.input_shape
 
 
 class SequenceConcatCombiner(LudwigComponent):

--- a/ludwig/encoders/base.py
+++ b/ludwig/encoders/base.py
@@ -17,8 +17,6 @@
 
 from abc import ABC, abstractmethod
 
-# from torch.nn import Module
-
 from ludwig.utils.registry import DEFAULT_KEYS
 from ludwig.utils.torch_utils import LudwigComponent
 
@@ -37,10 +35,6 @@ class Encoder(LudwigComponent, ABC):
     def register_default(cls):
         for key in DEFAULT_KEYS:
             cls.register(name=key)
-
-    # @abstractmethod
-    # def get_output_shape(self, input_shape):
-    #     raise NotImplementedError
 
     @property
     def name(self):

--- a/ludwig/encoders/base.py
+++ b/ludwig/encoders/base.py
@@ -17,12 +17,13 @@
 
 from abc import ABC, abstractmethod
 
-from torch.nn import Module
+# from torch.nn import Module
 
 from ludwig.utils.registry import DEFAULT_KEYS
+from ludwig.utils.torch_utils import LudwigComponent
 
 
-class Encoder(Module, ABC):
+class Encoder(LudwigComponent, ABC):
     @abstractmethod
     def forward(self, inputs, training=None, mask=None):
         raise NotImplementedError
@@ -37,9 +38,9 @@ class Encoder(Module, ABC):
         for key in DEFAULT_KEYS:
             cls.register(name=key)
 
-    @abstractmethod
-    def get_output_shape(self, input_shape):
-        raise NotImplementedError
+    # @abstractmethod
+    # def get_output_shape(self, input_shape):
+    #     raise NotImplementedError
 
     @property
     def name(self):

--- a/ludwig/encoders/base.py
+++ b/ludwig/encoders/base.py
@@ -18,10 +18,10 @@
 from abc import ABC, abstractmethod
 
 from ludwig.utils.registry import DEFAULT_KEYS
-from ludwig.utils.torch_utils import LudwigComponent
+from ludwig.utils.torch_utils import LudwigModule
 
 
-class Encoder(LudwigComponent, ABC):
+class Encoder(LudwigModule, ABC):
     @abstractmethod
     def forward(self, inputs, training=None, mask=None):
         raise NotImplementedError

--- a/ludwig/encoders/category_encoders.py
+++ b/ludwig/encoders/category_encoders.py
@@ -82,9 +82,6 @@ class CategoricalEmbedEncoder(CategoricalEncoder):
         )
         return embedded
 
-    # def get_output_shape(self, input_shape):
-    #     return self.embedding_size
-
     @property
     def output_shape(self) -> torch.Size:
         return torch.Size([self.embedding_size])
@@ -133,9 +130,6 @@ class CategoricalSparseEncoder(CategoricalEncoder):
             inputs, training=training, mask=mask
         )
         return embedded
-
-    # def get_output_shape(self, input_shape):
-    #     return self.embedding_size
 
     @property
     def output_shape(self) -> torch.Size:

--- a/ludwig/encoders/category_encoders.py
+++ b/ludwig/encoders/category_encoders.py
@@ -17,6 +17,8 @@
 import logging
 from abc import ABC
 
+import torch
+
 from ludwig.encoders.base import Encoder
 from ludwig.encoders.generic_encoders import PassthroughEncoder
 from ludwig.modules.embedding_modules import Embed
@@ -80,8 +82,12 @@ class CategoricalEmbedEncoder(CategoricalEncoder):
         )
         return embedded
 
-    def get_output_shape(self, input_shape):
-        return self.embedding_size
+    # def get_output_shape(self, input_shape):
+    #     return self.embedding_size
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size([self.embedding_size])
 
 
 @register(name='sparse')
@@ -128,5 +134,9 @@ class CategoricalSparseEncoder(CategoricalEncoder):
         )
         return embedded
 
-    def get_output_shape(self, input_shape):
-        return self.embedding_size
+    # def get_output_shape(self, input_shape):
+    #     return self.embedding_size
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size([self.embedding_size])

--- a/ludwig/encoders/generic_encoders.py
+++ b/ludwig/encoders/generic_encoders.py
@@ -40,9 +40,6 @@ class PassthroughEncoder(Encoder):
         """
         return {'encoder_output': inputs}
 
-    # def get_output_shape(self, input_shape):
-    #     return input_shape
-
     @property
     def output_shape(self) -> torch.Size:
         return torch.Size(self.input_shape)
@@ -103,9 +100,6 @@ class DenseEncoder(Encoder):
                    Shape: [batch x 1], type tf.float32
         """
         return {'encoder_output': self.fc_stack(inputs)}
-
-    # def get_output_shape(self, input_shape):
-    #     return self.fc_stack.layers[-1]['fc_size']
 
     @property
     def output_shape(self) -> torch.Size:

--- a/ludwig/encoders/generic_encoders.py
+++ b/ludwig/encoders/generic_encoders.py
@@ -16,8 +16,9 @@
 # ==============================================================================
 import logging
 
-from ludwig.encoders import Encoder
+import torch
 
+from ludwig.encoders import Encoder
 from ludwig.modules.fully_connected_modules import FCStack
 
 logger = logging.getLogger(__name__)
@@ -39,8 +40,12 @@ class PassthroughEncoder(Encoder):
         """
         return {'encoder_output': inputs}
 
-    def get_output_shape(self, input_shape):
-        return input_shape
+    # def get_output_shape(self, input_shape):
+    #     return input_shape
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size(self.input_shape)
 
     @classmethod
     def register(cls, name):
@@ -99,8 +104,12 @@ class DenseEncoder(Encoder):
         """
         return {'encoder_output': self.fc_stack(inputs)}
 
-    def get_output_shape(self, input_shape):
-        return self.fc_stack.layers[-1]['fc_size']
+    # def get_output_shape(self, input_shape):
+    #     return self.fc_stack.layers[-1]['fc_size']
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size([self.fc_stack.layers[-1]['fc_size']])
 
     @classmethod
     def register(cls, name):

--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -447,9 +447,6 @@ class AudioInputFeature(AudioFeatureMixin, SequenceInputFeature):
     def get_input_dtype(cls):
         return torch.float32
 
-    # def get_input_shape(self):
-    #     return self.max_sequence_length, self.embedding_size
-
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size([self.max_sequence_length, self.embedding_size])

--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -447,8 +447,12 @@ class AudioInputFeature(AudioFeatureMixin, SequenceInputFeature):
     def get_input_dtype(cls):
         return torch.float32
 
-    def get_input_shape(self):
-        return self.max_sequence_length, self.embedding_size
+    # def get_input_shape(self):
+    #     return self.max_sequence_length, self.embedding_size
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size([self.max_sequence_length, self.embedding_size])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -130,8 +130,12 @@ class BagInputFeature(BagFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return torch.float32
 
-    def get_input_shape(self):
-        return len(self.vocab),
+    # def get_input_shape(self):
+    #     return len(self.vocab),
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size([len(self.vocab)])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -130,9 +130,6 @@ class BagInputFeature(BagFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return torch.float32
 
-    # def get_input_shape(self):
-    #     return len(self.vocab),
-
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size([len(self.vocab)])

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -25,7 +25,7 @@ from ludwig.modules.fully_connected_modules import FCStack
 from ludwig.modules.reduction_modules import SequenceReducer
 from ludwig.utils.misc_utils import merge_dict, get_from_registry
 #from ludwig.utils.tf_utils import sequence_length_3D
-from ludwig.utils.torch_utils import sequence_length_3D, sequence_mask, LudwigModule
+from ludwig.utils.torch_utils import sequence_length_3D, sequence_mask, LudwigComponent
 
 import numpy as np
 
@@ -72,14 +72,14 @@ class BaseFeature:
                     setattr(self, k, feature[k])
 
 
-class InputFeature(BaseFeature, LudwigModule, ABC):
+class InputFeature(BaseFeature, LudwigComponent, ABC):
     """Parent class for all input features."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def create_input(self):
-        return tf.keras.Input(shape=self.get_input_shape(),
+        return tf.keras.Input(shape=self.input_shape,
                               dtype=self.get_input_dtype(),
                               name=self.name + '_input')
 
@@ -89,15 +89,15 @@ class InputFeature(BaseFeature, LudwigModule, ABC):
         """Returns the Tensor data type this input accepts."""
         pass
 
-    @abstractmethod
-    def get_input_shape(self):
-        """Returns a tuple representing the Tensor shape this input accepts."""
-        pass
+    # @abstractmethod
+    # def get_input_shape(self):
+    #     """Returns a tuple representing the Tensor shape this input accepts."""
+    #     pass
 
-    @abstractmethod
-    def get_output_shape(self):
-        """Returns a tuple representing the Tensor shape this input outputs."""
-        pass
+    # @abstractmethod
+    # def get_output_shape(self):
+    #     """Returns a tuple representing the Tensor shape this input outputs."""
+    #     pass
 
     @staticmethod
     @abstractmethod
@@ -125,7 +125,7 @@ class InputFeature(BaseFeature, LudwigModule, ABC):
         )
 
 
-class OutputFeature(BaseFeature, LudwigModule, ABC):
+class OutputFeature(BaseFeature, LudwigComponent, ABC):
     """Parent class for all output features."""
 
     #train_loss_function = None
@@ -190,7 +190,7 @@ class OutputFeature(BaseFeature, LudwigModule, ABC):
                 )
 
     def create_input(self):
-        return tf.keras.Input(shape=self.get_output_shape(),
+        return tf.keras.Input(shape=self.output_shape,
                               dtype=self.get_output_dtype(),
                               name=self.name + '_input')
 
@@ -205,15 +205,15 @@ class OutputFeature(BaseFeature, LudwigModule, ABC):
         """Returns the Tensor data type feature outputs."""
         pass
 
-    @abstractmethod
-    def get_output_shape(self):
-        """Returns a tuple representing the Tensor shape this feature outputs."""
-        pass
+    # @abstractmethod
+    # def get_output_shape(self):
+    #     """Returns a tuple representing the Tensor shape this feature outputs."""
+    #     pass
 
-    @abstractmethod
-    def get_input_shape(self):
-        """Returns a tuple representing the Tensor shape this feature accepts."""
-        pass
+    # @abstractmethod
+    # def get_input_shape(self):
+    #     """Returns a tuple representing the Tensor shape this feature accepts."""
+    #     pass
 
     @property
     @abstractmethod

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -25,7 +25,7 @@ from ludwig.modules.fully_connected_modules import FCStack
 from ludwig.modules.reduction_modules import SequenceReducer
 from ludwig.utils.misc_utils import merge_dict, get_from_registry
 #from ludwig.utils.tf_utils import sequence_length_3D
-from ludwig.utils.torch_utils import sequence_length_3D, sequence_mask, LudwigComponent
+from ludwig.utils.torch_utils import sequence_length_3D, sequence_mask, LudwigModule
 
 import numpy as np
 
@@ -72,7 +72,7 @@ class BaseFeature:
                     setattr(self, k, feature[k])
 
 
-class InputFeature(BaseFeature, LudwigComponent, ABC):
+class InputFeature(BaseFeature, LudwigModule, ABC):
     """Parent class for all input features."""
 
     def __init__(self, *args, **kwargs):
@@ -115,7 +115,7 @@ class InputFeature(BaseFeature, LudwigComponent, ABC):
         )
 
 
-class OutputFeature(BaseFeature, LudwigComponent, ABC):
+class OutputFeature(BaseFeature, LudwigModule, ABC):
     """Parent class for all output features."""
 
     #train_loss_function = None

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -89,16 +89,6 @@ class InputFeature(BaseFeature, LudwigComponent, ABC):
         """Returns the Tensor data type this input accepts."""
         pass
 
-    # @abstractmethod
-    # def get_input_shape(self):
-    #     """Returns a tuple representing the Tensor shape this input accepts."""
-    #     pass
-
-    # @abstractmethod
-    # def get_output_shape(self):
-    #     """Returns a tuple representing the Tensor shape this input outputs."""
-    #     pass
-
     @staticmethod
     @abstractmethod
     def update_config_with_metadata(
@@ -204,16 +194,6 @@ class OutputFeature(BaseFeature, LudwigComponent, ABC):
     def get_output_dtype(cls):
         """Returns the Tensor data type feature outputs."""
         pass
-
-    # @abstractmethod
-    # def get_output_shape(self):
-    #     """Returns a tuple representing the Tensor shape this feature outputs."""
-    #     pass
-
-    # @abstractmethod
-    # def get_input_shape(self):
-    #     """Returns a tuple representing the Tensor shape this feature accepts."""
-    #     pass
 
     @property
     @abstractmethod

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -145,8 +145,8 @@ class BinaryInputFeature(BinaryFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return tf.bool
 
-    def get_input_shape(self):
-        return ()
+    # def get_input_shape(self):
+    #     return ()
 
     @staticmethod
     def update_config_with_metadata(
@@ -232,8 +232,9 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
     def get_output_dtype(cls):
         return tf.bool
 
-    def get_output_shape(self):
-        return ()
+    @property
+    def output_shape(self) -> torch.Size:
+        return super().output_shape
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -145,8 +145,9 @@ class BinaryInputFeature(BinaryFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return tf.bool
 
-    # def get_input_shape(self):
-    #     return ()
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size([1])
 
     @staticmethod
     def update_config_with_metadata(
@@ -234,7 +235,7 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
 
     @property
     def output_shape(self) -> torch.Size:
-        return super().output_shape
+        return torch.Size([1])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -137,11 +137,16 @@ class CategoryInputFeature(CategoryFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return torch.int32
 
-    def get_input_shape(self):
-        return 1
+    # def get_input_shape(self):
+    #     return 1
 
-    def get_output_shape(self):
-        return self.encoder_obj.get_output_shape(self.get_input_shape())
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size([1])
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size(self.encoder_obj.output_shape)
 
     @staticmethod
     def update_config_with_metadata(
@@ -215,15 +220,23 @@ class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):
             PREDICTIONS, PROBABILITIES, LOGITS
         }
 
-    def get_input_shape(self):
-        return self.input_size
+    # def get_input_shape(self):
+    #     return self.input_size
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size(self.input_size)
 
     @classmethod
     def get_output_dtype(cls):
         return torch.int64
 
-    def get_output_shape(self):
-        return 1
+    # def get_output_shape(self):
+    #     return 1
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size([1])
 
     def _setup_loss(self):
         if self.loss[TYPE] == 'softmax_cross_entropy':

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -137,9 +137,6 @@ class CategoryInputFeature(CategoryFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return torch.int32
 
-    # def get_input_shape(self):
-    #     return 1
-
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size([1])
@@ -220,9 +217,6 @@ class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):
             PREDICTIONS, PROBABILITIES, LOGITS
         }
 
-    # def get_input_shape(self):
-    #     return self.input_size
-
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size(self.input_size)
@@ -230,9 +224,6 @@ class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):
     @classmethod
     def get_output_dtype(cls):
         return torch.int64
-
-    # def get_output_shape(self):
-    #     return 1
 
     @property
     def output_shape(self) -> torch.Size:

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -21,6 +21,7 @@ from datetime import datetime
 import numpy as np
 # import tensorflow as tf
 from dateutil.parser import parse
+import torch
 
 from ludwig.constants import *
 from ludwig.encoders.date_encoders import ENCODER_REGISTRY
@@ -148,8 +149,12 @@ class DateInputFeature(DateFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return tf.int16
 
-    def get_input_shape(self):
-        return DATE_VECTOR_LENGTH,
+    # def get_input_shape(self):
+    #     return DATE_VECTOR_LENGTH,
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size([DATE_VECTOR_LENGTH])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -19,9 +19,8 @@ from datetime import date
 from datetime import datetime
 
 import numpy as np
-# import tensorflow as tf
-from dateutil.parser import parse
 import torch
+from dateutil.parser import parse
 
 from ludwig.constants import *
 from ludwig.encoders.date_encoders import ENCODER_REGISTRY
@@ -148,9 +147,6 @@ class DateInputFeature(DateFeatureMixin, InputFeature):
     @classmethod
     def get_input_dtype(cls):
         return tf.int16
-
-    # def get_input_shape(self):
-    #     return DATE_VECTOR_LENGTH,
 
     @property
     def input_shape(self) -> torch.Size:

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -118,12 +118,9 @@ class H3InputFeature(H3FeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return tf.uint8
 
-    # def get_input_shape(self):
-    #     return H3_VECTOR_LENGTH,
-
     @property
     def input_shape(self) -> torch.Size:
-        return torch.Size((H3_VECTOR_LENGTH, ))
+        return torch.Size([H3_VECTOR_LENGTH, ])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -17,6 +17,7 @@
 import logging
 
 import numpy as np
+import torch
 # import tensorflow as tf
 
 from ludwig.constants import *
@@ -117,8 +118,12 @@ class H3InputFeature(H3FeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return tf.uint8
 
-    def get_input_shape(self):
-        return H3_VECTOR_LENGTH,
+    # def get_input_shape(self):
+    #     return H3_VECTOR_LENGTH,
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size((H3_VECTOR_LENGTH, ))
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -120,7 +120,7 @@ class H3InputFeature(H3FeatureMixin, InputFeature):
 
     @property
     def input_shape(self) -> torch.Size:
-        return torch.Size([H3_VECTOR_LENGTH, ])
+        return torch.Size([H3_VECTOR_LENGTH])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -425,9 +425,6 @@ class ImageInputFeature(ImageFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return tf.uint8
 
-    # def get_input_shape(self):
-    #     return self.height, self.width, self.num_channels
-
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size([self.height, self.width, self.num_channels])

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -22,6 +22,7 @@ from multiprocessing import Pool
 from typing import Union
 
 import numpy as np
+import torch
 # import tensorflow as tf
 
 from ludwig.constants import *
@@ -424,8 +425,12 @@ class ImageInputFeature(ImageFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return tf.uint8
 
-    def get_input_shape(self):
-        return self.height, self.width, self.num_channels
+    # def get_input_shape(self):
+    #     return self.height, self.width, self.num_channels
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size([self.height, self.width, self.num_channels])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -199,7 +199,7 @@ class NumericalInputFeature(NumericalFeatureMixin, InputFeature):
         # Required for certain encoders, maybe pass into initialize_encoder
         super().__init__(feature)
         self.overwrite_defaults(feature)
-        feature['input_size'] = self.get_input_shape()
+        feature['input_size'] = self.input_shape
         if encoder_obj:
             self.encoder_obj = encoder_obj
         else:
@@ -222,21 +222,13 @@ class NumericalInputFeature(NumericalFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return torch.float32
 
-    # def get_input_shape(self):
-    #     return 1
-
-    # def get_output_shape(self):
-    #     return self.encoder_obj.get_output_shape(self.get_input_shape())
-
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size([1])
 
     @property
     def output_shape(self) -> torch.Size:
-        return torch.Size(
-            self.encoder_obj.output_shape
-        )
+        return torch.Size(self.encoder_obj.output_shape)
 
     @staticmethod
     def update_config_with_metadata(
@@ -275,7 +267,7 @@ class NumericalOutputFeature(NumericalFeatureMixin, OutputFeature):
     def __init__(self, feature):
         super().__init__(feature)
         self.overwrite_defaults(feature)
-        feature['input_size'] = self.get_input_shape()
+        feature['input_size'] = self.input_shape
         self.decoder_obj = self.initialize_decoder(feature)
         self._setup_loss()
         self._setup_metrics()
@@ -352,9 +344,6 @@ class NumericalOutputFeature(NumericalFeatureMixin, OutputFeature):
     def get_prediction_set(self):
         return {PREDICTIONS, LOGITS}
 
-    # def get_input_shape(self):
-    #     return self.input_size
-
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size(self.input_size)
@@ -362,9 +351,6 @@ class NumericalOutputFeature(NumericalFeatureMixin, OutputFeature):
     @classmethod
     def get_output_dtype(cls):
         return torch.float32
-
-    # def get_output_shape(self):
-    #     return 1
 
     @property
     def output_shape(self) -> torch.Size:

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -222,11 +222,21 @@ class NumericalInputFeature(NumericalFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return torch.float32
 
-    def get_input_shape(self):
-        return 1
+    # def get_input_shape(self):
+    #     return 1
 
-    def get_output_shape(self):
-        return self.encoder_obj.get_output_shape(self.get_input_shape())
+    # def get_output_shape(self):
+    #     return self.encoder_obj.get_output_shape(self.get_input_shape())
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size([1])
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size(
+            self.encoder_obj.output_shape
+        )
 
     @staticmethod
     def update_config_with_metadata(
@@ -342,15 +352,23 @@ class NumericalOutputFeature(NumericalFeatureMixin, OutputFeature):
     def get_prediction_set(self):
         return {PREDICTIONS, LOGITS}
 
-    def get_input_shape(self):
-        return self.input_size
+    # def get_input_shape(self):
+    #     return self.input_size
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size(self.input_size)
 
     @classmethod
     def get_output_dtype(cls):
         return torch.float32
 
-    def get_output_shape(self):
-        return 1
+    # def get_output_shape(self):
+    #     return 1
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size([1])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -172,9 +172,6 @@ class SequenceInputFeature(SequenceFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return tf.int32
 
-    def get_input_shape(self):
-        return None,
-
     @staticmethod
     def update_config_with_metadata(
             input_feature,
@@ -304,7 +301,7 @@ class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):
 
     @property
     def output_shape(self) -> torch.Size:
-        return torch.Size((self.max_sequence_length, ))
+        return torch.Size([self.max_sequence_length, ])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -17,6 +17,7 @@
 import os
 
 import numpy as np
+import torch
 
 from ludwig.constants import *
 from ludwig.decoders.sequence_decoders import DECODER_REGISTRY
@@ -301,8 +302,9 @@ class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):
     def get_output_dtype(cls):
         return tf.int32
 
-    def get_output_shape(self):
-        return self.max_sequence_length,
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size((self.max_sequence_length, ))
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -301,7 +301,7 @@ class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):
 
     @property
     def output_shape(self) -> torch.Size:
-        return torch.Size([self.max_sequence_length, ])
+        return torch.Size([self.max_sequence_length])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -137,12 +137,9 @@ class SetInputFeature(SetFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return tf.bool
 
-    # def get_input_shape(self):
-    #     return len(self.vocab),
-
     @property
     def input_shape(self) -> torch.Size:
-        return torch.Size((len(self.vocab), ))
+        return torch.Size([len(self.vocab), ])
 
     @staticmethod
     def update_config_with_metadata(
@@ -236,12 +233,9 @@ class SetOutputFeature(SetFeatureMixin, OutputFeature):
     def get_output_dtype(cls):
         return tf.bool
 
-    # def get_output_shape(self):
-    #     return self.num_classes,
-
     @property
     def output_shape(self) -> torch.Size:
-        return torch.Size((self.num_classes, ))
+        return torch.Size([self.num_classes, ])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -139,7 +139,7 @@ class SetInputFeature(SetFeatureMixin, InputFeature):
 
     @property
     def input_shape(self) -> torch.Size:
-        return torch.Size([len(self.vocab), ])
+        return torch.Size([len(self.vocab)])
 
     @staticmethod
     def update_config_with_metadata(
@@ -235,7 +235,7 @@ class SetOutputFeature(SetFeatureMixin, OutputFeature):
 
     @property
     def output_shape(self) -> torch.Size:
-        return torch.Size([self.num_classes, ])
+        return torch.Size([self.num_classes])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -18,6 +18,7 @@ import logging
 import os
 
 import numpy as np
+import torch
 # import tensorflow as tf
 
 from ludwig.constants import *
@@ -136,8 +137,12 @@ class SetInputFeature(SetFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return tf.bool
 
-    def get_input_shape(self):
-        return len(self.vocab),
+    # def get_input_shape(self):
+    #     return len(self.vocab),
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size((len(self.vocab), ))
 
     @staticmethod
     def update_config_with_metadata(
@@ -231,8 +236,12 @@ class SetOutputFeature(SetFeatureMixin, OutputFeature):
     def get_output_dtype(cls):
         return tf.bool
 
-    def get_output_shape(self):
-        return self.num_classes,
+    # def get_output_shape(self):
+    #     return self.num_classes,
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size((self.num_classes, ))
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -287,9 +287,6 @@ class TextInputFeature(TextFeatureMixin, SequenceInputFeature):
     def get_input_dtype(cls):
         return tf.int32
 
-    def get_input_shape(self):
-        return None,
-
     @staticmethod
     def update_config_with_metadata(
             input_feature,
@@ -351,12 +348,9 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
     def get_output_dtype(cls):
         return tf.int32
 
-    # def get_output_shape(self):
-    #     return self.max_sequence_length,
-
     @property
     def output_shape(self) -> torch.Size:
-        return torch.Size((self.max_sequence_length, ))
+        return torch.Size([self.max_sequence_length, ])
 
     def overall_statistics_metadata(self):
         return {'level': self.level}

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -18,6 +18,7 @@ import logging
 from collections.abc import Iterable
 
 import numpy as np
+import torch
 # import tensorflow as tf
 
 from ludwig.constants import *
@@ -350,8 +351,12 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
     def get_output_dtype(cls):
         return tf.int32
 
-    def get_output_shape(self):
-        return self.max_sequence_length,
+    # def get_output_shape(self):
+    #     return self.max_sequence_length,
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size((self.max_sequence_length, ))
 
     def overall_statistics_metadata(self):
         return {'level': self.level}

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -350,7 +350,7 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
 
     @property
     def output_shape(self) -> torch.Size:
-        return torch.Size([self.max_sequence_length, ])
+        return torch.Size([self.max_sequence_length])
 
     def overall_statistics_metadata(self):
         return {'level': self.level}

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -174,12 +174,9 @@ class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
     def get_input_dtype(cls):
         return tf.float32
 
-    # def get_input_shape(self):
-    #     return self.max_sequence_length,
-
     @property
     def input_shape(self) -> torch.Size:
-        return torch.Size((self.max_sequence_length, ))
+        return torch.Size([self.max_sequence_length, ])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -176,7 +176,7 @@ class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
 
     @property
     def input_shape(self) -> torch.Size:
-        return torch.Size([self.max_sequence_length, ])
+        return torch.Size([self.max_sequence_length])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -17,6 +17,7 @@
 import logging
 
 import numpy as np
+import torch
 # import tensorflow as tf
 
 from ludwig.constants import *
@@ -173,8 +174,12 @@ class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
     def get_input_dtype(cls):
         return tf.float32
 
-    def get_input_shape(self):
-        return self.max_sequence_length,
+    # def get_input_shape(self):
+    #     return self.max_sequence_length,
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size((self.max_sequence_length, ))
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -146,12 +146,9 @@ class VectorInputFeature(VectorFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return tf.float32
 
-    # def get_input_shape(self):
-    #     return self.vector_size,
-
     @property
     def input_shape(self) -> torch.Size:
-        return torch.Size((self.vector_size, ))
+        return torch.Size([self.vector_size, ])
 
     @staticmethod
     def update_config_with_metadata(
@@ -251,12 +248,9 @@ class VectorOutputFeature(VectorFeatureMixin, OutputFeature):
     def get_output_dtype(cls):
         return tf.float32
 
-    # def get_output_shape(self):
-    #     return self.vector_size,
-
     @property
     def output_shape(self) -> torch.Size:
-        return torch.Size((self.vector_size, ))
+        return torch.Size([self.vector_size, ])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -148,7 +148,7 @@ class VectorInputFeature(VectorFeatureMixin, InputFeature):
 
     @property
     def input_shape(self) -> torch.Size:
-        return torch.Size([self.vector_size, ])
+        return torch.Size([self.vector_size])
 
     @staticmethod
     def update_config_with_metadata(
@@ -250,7 +250,7 @@ class VectorOutputFeature(VectorFeatureMixin, OutputFeature):
 
     @property
     def output_shape(self) -> torch.Size:
-        return torch.Size([self.vector_size, ])
+        return torch.Size([self.vector_size])
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -18,6 +18,7 @@ import logging
 import os
 
 import numpy as np
+import torch
 # import tensorflow as tf
 # from tensorflow.keras.metrics import \
 #     MeanAbsoluteError as MeanAbsoluteErrorMetric
@@ -145,8 +146,12 @@ class VectorInputFeature(VectorFeatureMixin, InputFeature):
     def get_input_dtype(cls):
         return tf.float32
 
-    def get_input_shape(self):
-        return self.vector_size,
+    # def get_input_shape(self):
+    #     return self.vector_size,
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size((self.vector_size, ))
 
     @staticmethod
     def update_config_with_metadata(
@@ -246,8 +251,12 @@ class VectorOutputFeature(VectorFeatureMixin, OutputFeature):
     def get_output_dtype(cls):
         return tf.float32
 
-    def get_output_shape(self):
-        return self.vector_size,
+    # def get_output_shape(self):
+    #     return self.vector_size,
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size((self.vector_size, ))
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -399,7 +399,7 @@ def build_outputs(
     output_features = {}
 
     for output_feature_def in output_features_def:
-        output_feature_def["input_size"] = combiner.get_output_shape()
+        output_feature_def["input_size"] = combiner.output_shape
         output_feature = build_single_output(
             output_feature_def,
             combiner,

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -18,12 +18,13 @@ import logging
 # import tensorflow as tf
 # from tensorflow.keras import Sequential
 # from tensorflow.keras.layers import Dense, Dropout, Layer, LayerNormalization
-from torch.nn import Module
+# from torch.nn import Module
+from ludwig.utils.torch_utils import LudwigComponent
 
 logger = logging.getLogger(__name__)
 
 
-class FeedForwardAttentionReducer(Module):
+class FeedForwardAttentionReducer(LudwigComponent):
     def __init__(self, hidden_size=256, activation='tanh'):
         super().__init__()
         self.layer1 = Dense(hidden_size, activation=activation)
@@ -38,7 +39,7 @@ class FeedForwardAttentionReducer(Module):
         return geated_inputs  # [b, h]
 
 
-class MultiHeadSelfAttention(Module):
+class MultiHeadSelfAttention(LudwigComponent):
     def __init__(self, hidden_size, num_heads=8):
         super().__init__()
         self.embedding_size = hidden_size
@@ -98,7 +99,7 @@ class MultiHeadSelfAttention(Module):
         return projected_outputs
 
 
-class TransformerBlock(Module):
+class TransformerBlock(LudwigComponent):
     def __init__(self, hidden_size, num_heads, fc_size, dropout=0.1):
         super().__init__()
         self.self_attention = MultiHeadSelfAttention(hidden_size, num_heads)
@@ -119,7 +120,7 @@ class TransformerBlock(Module):
         return self.layernorm2(ln1_output + fc_output)
 
 
-class TransformerStack(Module):
+class TransformerStack(LudwigComponent):
     def __init__(
             self,
             hidden_size=256,

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -18,7 +18,6 @@ import logging
 # import tensorflow as tf
 # from tensorflow.keras import Sequential
 # from tensorflow.keras.layers import Dense, Dropout, Layer, LayerNormalization
-# from torch.nn import Module
 from ludwig.utils.torch_utils import LudwigComponent
 
 logger = logging.getLogger(__name__)

--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -18,12 +18,12 @@ import logging
 # import tensorflow as tf
 # from tensorflow.keras import Sequential
 # from tensorflow.keras.layers import Dense, Dropout, Layer, LayerNormalization
-from ludwig.utils.torch_utils import LudwigComponent
+from ludwig.utils.torch_utils import LudwigModule
 
 logger = logging.getLogger(__name__)
 
 
-class FeedForwardAttentionReducer(LudwigComponent):
+class FeedForwardAttentionReducer(LudwigModule):
     def __init__(self, hidden_size=256, activation='tanh'):
         super().__init__()
         self.layer1 = Dense(hidden_size, activation=activation)
@@ -38,7 +38,7 @@ class FeedForwardAttentionReducer(LudwigComponent):
         return geated_inputs  # [b, h]
 
 
-class MultiHeadSelfAttention(LudwigComponent):
+class MultiHeadSelfAttention(LudwigModule):
     def __init__(self, hidden_size, num_heads=8):
         super().__init__()
         self.embedding_size = hidden_size
@@ -98,7 +98,7 @@ class MultiHeadSelfAttention(LudwigComponent):
         return projected_outputs
 
 
-class TransformerBlock(LudwigComponent):
+class TransformerBlock(LudwigModule):
     def __init__(self, hidden_size, num_heads, fc_size, dropout=0.1):
         super().__init__()
         self.self_attention = MultiHeadSelfAttention(hidden_size, num_heads)
@@ -119,7 +119,7 @@ class TransformerBlock(LudwigComponent):
         return self.layernorm2(ln1_output + fc_output)
 
 
-class TransformerStack(LudwigComponent):
+class TransformerStack(LudwigModule):
     def __init__(
             self,
             hidden_size=256,

--- a/ludwig/modules/convolutional_modules.py
+++ b/ludwig/modules/convolutional_modules.py
@@ -23,7 +23,6 @@ import logging
 #                                      Conv1D, Conv2D, Dropout, Layer,
 #                                      LayerNormalization, MaxPool1D, MaxPool2D,
 #                                      ZeroPadding2D)
-# from torch.nn import Module
 from ludwig.utils.torch_utils import LudwigComponent
 
 logger = logging.getLogger(__name__)

--- a/ludwig/modules/convolutional_modules.py
+++ b/ludwig/modules/convolutional_modules.py
@@ -23,12 +23,12 @@ import logging
 #                                      Conv1D, Conv2D, Dropout, Layer,
 #                                      LayerNormalization, MaxPool1D, MaxPool2D,
 #                                      ZeroPadding2D)
-from ludwig.utils.torch_utils import LudwigComponent
+from ludwig.utils.torch_utils import LudwigModule
 
 logger = logging.getLogger(__name__)
 
 
-class Conv1DLayer(LudwigComponent):
+class Conv1DLayer(LudwigModule):
 
     def __init__(
             self,
@@ -106,7 +106,7 @@ class Conv1DLayer(LudwigComponent):
         return hidden
 
 
-class Conv1DStack(LudwigComponent):
+class Conv1DStack(LudwigModule):
 
     def __init__(
             self,
@@ -253,7 +253,7 @@ class Conv1DStack(LudwigComponent):
         return hidden
 
 
-class ParallelConv1D(LudwigComponent):
+class ParallelConv1D(LudwigModule):
 
     def __init__(
             self,
@@ -389,7 +389,7 @@ class ParallelConv1D(LudwigComponent):
         return hidden
 
 
-class ParallelConv1DStack(LudwigComponent):
+class ParallelConv1DStack(LudwigModule):
 
     def __init__(
             self,
@@ -520,7 +520,7 @@ class ParallelConv1DStack(LudwigComponent):
         return hidden
 
 
-class Conv2DLayer(LudwigComponent):
+class Conv2DLayer(LudwigModule):
 
     def __init__(
             self,
@@ -598,7 +598,7 @@ class Conv2DLayer(LudwigComponent):
         return hidden
 
 
-class Conv2DStack(LudwigComponent):
+class Conv2DStack(LudwigModule):
 
     def __init__(
             self,
@@ -728,7 +728,7 @@ class Conv2DStack(LudwigComponent):
         return hidden
 
 
-class Conv2DLayerFixedPadding(LudwigComponent):
+class Conv2DLayerFixedPadding(LudwigModule):
 
     def __init__(
             self,
@@ -768,7 +768,7 @@ class Conv2DLayerFixedPadding(LudwigComponent):
         return hidden
 
 
-class ResNetBlock(LudwigComponent):
+class ResNetBlock(LudwigModule):
 
     def __init__(
             self,
@@ -842,7 +842,7 @@ class ResNetBlock(LudwigComponent):
         return hidden + shortcut
 
 
-class ResNetBottleneckBlock(LudwigComponent):
+class ResNetBottleneckBlock(LudwigModule):
 
     def __init__(
             self,
@@ -938,7 +938,7 @@ class ResNetBottleneckBlock(LudwigComponent):
         return hidden + shortcut
 
 
-class ResNetBlockLayer(LudwigComponent):
+class ResNetBlockLayer(LudwigModule):
     def __init__(
             self,
             num_filters,
@@ -995,7 +995,7 @@ class ResNetBlockLayer(LudwigComponent):
         return hidden
 
 
-class ResNet(LudwigComponent):
+class ResNet(LudwigModule):
     def __init__(
             self,
             resnet_size,

--- a/ludwig/modules/convolutional_modules.py
+++ b/ludwig/modules/convolutional_modules.py
@@ -23,12 +23,13 @@ import logging
 #                                      Conv1D, Conv2D, Dropout, Layer,
 #                                      LayerNormalization, MaxPool1D, MaxPool2D,
 #                                      ZeroPadding2D)
-from torch.nn import Module
+# from torch.nn import Module
+from ludwig.utils.torch_utils import LudwigComponent
 
 logger = logging.getLogger(__name__)
 
 
-class Conv1DLayer(Module):
+class Conv1DLayer(LudwigComponent):
 
     def __init__(
             self,
@@ -106,7 +107,7 @@ class Conv1DLayer(Module):
         return hidden
 
 
-class Conv1DStack(Module):
+class Conv1DStack(LudwigComponent):
 
     def __init__(
             self,
@@ -253,7 +254,7 @@ class Conv1DStack(Module):
         return hidden
 
 
-class ParallelConv1D(Module):
+class ParallelConv1D(LudwigComponent):
 
     def __init__(
             self,
@@ -389,7 +390,7 @@ class ParallelConv1D(Module):
         return hidden
 
 
-class ParallelConv1DStack(Module):
+class ParallelConv1DStack(LudwigComponent):
 
     def __init__(
             self,
@@ -520,7 +521,7 @@ class ParallelConv1DStack(Module):
         return hidden
 
 
-class Conv2DLayer(Module):
+class Conv2DLayer(LudwigComponent):
 
     def __init__(
             self,
@@ -598,7 +599,7 @@ class Conv2DLayer(Module):
         return hidden
 
 
-class Conv2DStack(Module):
+class Conv2DStack(LudwigComponent):
 
     def __init__(
             self,
@@ -728,7 +729,7 @@ class Conv2DStack(Module):
         return hidden
 
 
-class Conv2DLayerFixedPadding(Module):
+class Conv2DLayerFixedPadding(LudwigComponent):
 
     def __init__(
             self,
@@ -768,7 +769,7 @@ class Conv2DLayerFixedPadding(Module):
         return hidden
 
 
-class ResNetBlock(Module):
+class ResNetBlock(LudwigComponent):
 
     def __init__(
             self,
@@ -842,7 +843,7 @@ class ResNetBlock(Module):
         return hidden + shortcut
 
 
-class ResNetBottleneckBlock(Module):
+class ResNetBottleneckBlock(LudwigComponent):
 
     def __init__(
             self,
@@ -938,7 +939,7 @@ class ResNetBottleneckBlock(Module):
         return hidden + shortcut
 
 
-class ResNetBlockLayer(Module):
+class ResNetBlockLayer(LudwigComponent):
     def __init__(
             self,
             num_filters,
@@ -995,7 +996,7 @@ class ResNetBlockLayer(Module):
         return hidden
 
 
-class ResNet(Module):
+class ResNet(LudwigComponent):
     def __init__(
             self,
             resnet_size,

--- a/ludwig/modules/embedding_modules.py
+++ b/ludwig/modules/embedding_modules.py
@@ -26,7 +26,7 @@ from torch import nn
 from ludwig.constants import TYPE
 from ludwig.modules.initializer_modules import get_initializer
 from ludwig.utils.data_utils import load_pretrained_embeddings
-from ludwig.utils.torch_utils import reg_loss, LudwigModule, LudwigComponent
+from ludwig.utils.torch_utils import reg_loss, LudwigComponent
 
 import torch
 from torch.nn import Module

--- a/ludwig/modules/embedding_modules.py
+++ b/ludwig/modules/embedding_modules.py
@@ -26,7 +26,7 @@ from torch import nn
 from ludwig.constants import TYPE
 from ludwig.modules.initializer_modules import get_initializer
 from ludwig.utils.data_utils import load_pretrained_embeddings
-from ludwig.utils.torch_utils import reg_loss, LudwigComponent
+from ludwig.utils.torch_utils import reg_loss, LudwigModule
 
 import torch
 from torch.nn import Module
@@ -155,7 +155,7 @@ def embedding_matrix_on_device(
     return embeddings, embedding_size
 
 
-class Embed(LudwigComponent):
+class Embed(LudwigModule):
     def __init__(
             self,
             vocab,
@@ -211,7 +211,7 @@ class Embed(LudwigComponent):
         return embedded
 
 
-class EmbedWeighted(LudwigComponent):
+class EmbedWeighted(LudwigModule):
     def __init__(
             self,
             vocab,
@@ -280,7 +280,7 @@ class EmbedWeighted(LudwigComponent):
         return embedded_reduced
 
 
-class EmbedSparse(LudwigComponent):
+class EmbedSparse(LudwigModule):
     def __init__(
             self,
             vocab,
@@ -344,7 +344,7 @@ class EmbedSparse(LudwigComponent):
         return embedded_reduced
 
 
-class EmbedSequence(LudwigComponent):
+class EmbedSequence(LudwigModule):
     def __init__(
             self,
             vocab,
@@ -400,7 +400,7 @@ class EmbedSequence(LudwigComponent):
         return embedded
 
 
-class TokenAndPositionEmbedding(LudwigComponent):
+class TokenAndPositionEmbedding(LudwigModule):
     def __init__(self,
                  max_length,
                  vocab,

--- a/ludwig/modules/embedding_modules.py
+++ b/ludwig/modules/embedding_modules.py
@@ -26,7 +26,7 @@ from torch import nn
 from ludwig.constants import TYPE
 from ludwig.modules.initializer_modules import get_initializer
 from ludwig.utils.data_utils import load_pretrained_embeddings
-from ludwig.utils.torch_utils import (reg_loss, LudwigModule)
+from ludwig.utils.torch_utils import reg_loss, LudwigModule, LudwigComponent
 
 import torch
 from torch.nn import Module
@@ -155,7 +155,7 @@ def embedding_matrix_on_device(
     return embeddings, embedding_size
 
 
-class Embed(LudwigModule):
+class Embed(LudwigComponent):
     def __init__(
             self,
             vocab,
@@ -211,7 +211,7 @@ class Embed(LudwigModule):
         return embedded
 
 
-class EmbedWeighted(Module):
+class EmbedWeighted(LudwigComponent):
     def __init__(
             self,
             vocab,
@@ -280,7 +280,7 @@ class EmbedWeighted(Module):
         return embedded_reduced
 
 
-class EmbedSparse(Module):
+class EmbedSparse(LudwigComponent):
     def __init__(
             self,
             vocab,
@@ -344,7 +344,7 @@ class EmbedSparse(Module):
         return embedded_reduced
 
 
-class EmbedSequence(Module):
+class EmbedSequence(LudwigComponent):
     def __init__(
             self,
             vocab,
@@ -400,7 +400,7 @@ class EmbedSequence(Module):
         return embedded
 
 
-class TokenAndPositionEmbedding(Module):
+class TokenAndPositionEmbedding(LudwigComponent):
     def __init__(self,
                  max_length,
                  vocab,

--- a/ludwig/modules/fully_connected_modules.py
+++ b/ludwig/modules/fully_connected_modules.py
@@ -20,14 +20,14 @@ import logging
 
 from torch.nn import (Linear, LayerNorm, Dropout, ModuleList)
 
-from ludwig.utils.torch_utils import LudwigComponent, initializer_registry,\
+from ludwig.utils.torch_utils import LudwigModule, initializer_registry,\
     activations, reg_loss
 
 logger = logging.getLogger(__name__)
 
 
 
-class FCLayer(LudwigComponent):
+class FCLayer(LudwigModule):
 
     def __init__(
             self,
@@ -129,7 +129,7 @@ class FCLayer(LudwigComponent):
         return hidden
 
 
-class FCStack(LudwigComponent):
+class FCStack(LudwigModule):
 
     def __init__(
             self,

--- a/ludwig/modules/fully_connected_modules.py
+++ b/ludwig/modules/fully_connected_modules.py
@@ -18,15 +18,16 @@ import logging
 # from tensorflow.keras.layers import (Activation, BatchNormalization, Dense,
 #                                      Dropout, Layer, LayerNormalization)
 
-from torch.nn import (Linear, LayerNorm, Module, Dropout, ModuleList)
+from torch.nn import (Linear, LayerNorm, Dropout, ModuleList)
 
-from ludwig.utils.torch_utils import LudwigModule, initializer_registry, activations, reg_loss
+from ludwig.utils.torch_utils import LudwigComponent, initializer_registry,\
+    activations, reg_loss
 
 logger = logging.getLogger(__name__)
 
 
 
-class FCLayer(LudwigModule):
+class FCLayer(LudwigComponent):
 
     def __init__(
             self,
@@ -128,7 +129,7 @@ class FCLayer(LudwigModule):
         return hidden
 
 
-class FCStack(LudwigModule):
+class FCStack(LudwigComponent):
 
     def __init__(
             self,

--- a/ludwig/modules/mlp_mixer_modules.py
+++ b/ludwig/modules/mlp_mixer_modules.py
@@ -16,12 +16,13 @@
 # import tensorflow as tf
 # from tensorflow.keras.layers import Layer, Dense, Dropout, LayerNormalization, \
 #     Conv2D, GlobalAveragePooling1D
-from torch.nn import Module
+# from torch.nn import Module
+from ludwig.utils.torch_utils import LudwigComponent
 
 from ludwig.modules.activation_modules import gelu
 
 
-class MLP(Module):
+class MLP(LudwigComponent):
     def __init__(self, hidden_size, dropout=0.0):
         super().__init__()
         self.hidden_size = hidden_size
@@ -38,7 +39,7 @@ class MLP(Module):
         return self.dropout2(self.dense2(hidden))
 
 
-class MixerBlock(Module):
+class MixerBlock(LudwigComponent):
     def __init__(self, token_dim, channel_dim, dropout=0.0):
         super().__init__()
         self.mlp1 = MLP(token_dim, dropout)
@@ -58,7 +59,7 @@ class MixerBlock(Module):
         return hidden + mid
 
 
-class MLPMixer(Module):
+class MLPMixer(LudwigComponent):
     """MLPMixer
 
     Implements

--- a/ludwig/modules/mlp_mixer_modules.py
+++ b/ludwig/modules/mlp_mixer_modules.py
@@ -16,7 +16,6 @@
 # import tensorflow as tf
 # from tensorflow.keras.layers import Layer, Dense, Dropout, LayerNormalization, \
 #     Conv2D, GlobalAveragePooling1D
-# from torch.nn import Module
 from ludwig.utils.torch_utils import LudwigComponent
 
 from ludwig.modules.activation_modules import gelu

--- a/ludwig/modules/mlp_mixer_modules.py
+++ b/ludwig/modules/mlp_mixer_modules.py
@@ -16,12 +16,12 @@
 # import tensorflow as tf
 # from tensorflow.keras.layers import Layer, Dense, Dropout, LayerNormalization, \
 #     Conv2D, GlobalAveragePooling1D
-from ludwig.utils.torch_utils import LudwigComponent
+from ludwig.utils.torch_utils import LudwigModule
 
 from ludwig.modules.activation_modules import gelu
 
 
-class MLP(LudwigComponent):
+class MLP(LudwigModule):
     def __init__(self, hidden_size, dropout=0.0):
         super().__init__()
         self.hidden_size = hidden_size
@@ -38,7 +38,7 @@ class MLP(LudwigComponent):
         return self.dropout2(self.dense2(hidden))
 
 
-class MixerBlock(LudwigComponent):
+class MixerBlock(LudwigModule):
     def __init__(self, token_dim, channel_dim, dropout=0.0):
         super().__init__()
         self.mlp1 = MLP(token_dim, dropout)
@@ -58,7 +58,7 @@ class MixerBlock(LudwigComponent):
         return hidden + mid
 
 
-class MLPMixer(LudwigComponent):
+class MLPMixer(LudwigModule):
     """MLPMixer
 
     Implements

--- a/ludwig/modules/normalization_modules.py
+++ b/ludwig/modules/normalization_modules.py
@@ -1,10 +1,11 @@
 # import tensorflow as tf
-from torch.nn import Module
+# from torch.nn import Module
+from ludwig.utils.torch_utils import LudwigComponent
 
 # from tensorflow.keras.layers import BatchNormalization
 
 
-class GhostBatchNormalization(Module):
+class GhostBatchNormalization(LudwigComponent):
     def __init__(
             self,
             momentum: float = 0.9,

--- a/ludwig/modules/normalization_modules.py
+++ b/ludwig/modules/normalization_modules.py
@@ -1,10 +1,10 @@
 # import tensorflow as tf
-from ludwig.utils.torch_utils import LudwigComponent
+from ludwig.utils.torch_utils import LudwigModule
 
 # from tensorflow.keras.layers import BatchNormalization
 
 
-class GhostBatchNormalization(LudwigComponent):
+class GhostBatchNormalization(LudwigModule):
     def __init__(
             self,
             momentum: float = 0.9,

--- a/ludwig/modules/normalization_modules.py
+++ b/ludwig/modules/normalization_modules.py
@@ -1,5 +1,4 @@
 # import tensorflow as tf
-# from torch.nn import Module
 from ludwig.utils.torch_utils import LudwigComponent
 
 # from tensorflow.keras.layers import BatchNormalization

--- a/ludwig/modules/recurrent_modules.py
+++ b/ludwig/modules/recurrent_modules.py
@@ -20,7 +20,7 @@ import collections
 # import tensorflow as tf
 # import tensorflow_addons as tfa
 # from tensorflow.keras.layers import GRU, LSTM, Bidirectional, Layer, SimpleRNN
-from ludwig.utils.torch_utils import LudwigComponent
+from ludwig.utils.torch_utils import LudwigModule
 
 from ludwig.utils.misc_utils import get_from_registry
 
@@ -33,7 +33,7 @@ rnn_layers_registry = {
 }
 
 
-class RecurrentStack(LudwigComponent):
+class RecurrentStack(LudwigModule):
     def __init__(
             self,
             state_size=256,

--- a/ludwig/modules/recurrent_modules.py
+++ b/ludwig/modules/recurrent_modules.py
@@ -20,7 +20,6 @@ import collections
 # import tensorflow as tf
 # import tensorflow_addons as tfa
 # from tensorflow.keras.layers import GRU, LSTM, Bidirectional, Layer, SimpleRNN
-# from torch.nn import Module
 from ludwig.utils.torch_utils import LudwigComponent
 
 from ludwig.utils.misc_utils import get_from_registry

--- a/ludwig/modules/recurrent_modules.py
+++ b/ludwig/modules/recurrent_modules.py
@@ -20,7 +20,8 @@ import collections
 # import tensorflow as tf
 # import tensorflow_addons as tfa
 # from tensorflow.keras.layers import GRU, LSTM, Bidirectional, Layer, SimpleRNN
-from torch.nn import Module
+# from torch.nn import Module
+from ludwig.utils.torch_utils import LudwigComponent
 
 from ludwig.utils.misc_utils import get_from_registry
 
@@ -33,7 +34,7 @@ rnn_layers_registry = {
 }
 
 
-class RecurrentStack(Module):
+class RecurrentStack(LudwigComponent):
     def __init__(
             self,
             state_size=256,

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -19,17 +19,17 @@ import logging
 # from tensorflow.keras.layers import Layer
 
 import torch
-from torch.nn import Module
+# from torch.nn import Module
 
 from ludwig.modules.attention_modules import FeedForwardAttentionReducer
 from ludwig.utils.misc_utils import get_from_registry
 #from ludwig.utils.tf_utils import sequence_length_3D
-from ludwig.utils.torch_utils import sequence_length_3D, LudwigModule
+from ludwig.utils.torch_utils import sequence_length_3D, LudwigModule, LudwigComponent
 
 logger = logging.getLogger(__name__)
 
 
-class SequenceReducer(LudwigModule):
+class SequenceReducer(LudwigComponent):
 
     def __init__(self, reduce_mode=None):
         super().__init__()
@@ -46,7 +46,7 @@ class SequenceReducer(LudwigModule):
         return self._reduce_obj(inputs, training=training, mask=mask)
 
 
-class ReduceLast(LudwigModule):
+class ReduceLast(LudwigComponent):
 
     def forward(self, inputs, training=None, mask=None):
         #batch_size = tf.shape(inputs)[0]
@@ -72,28 +72,28 @@ class ReduceLast(LudwigModule):
         return gathered
 
 
-class ReduceSum(LudwigModule):
+class ReduceSum(LudwigComponent):
 
     def forward(self, inputs, training=None, mask=None):
         #return tf.reduce_sum(inputs, axis=1)
         return torch.sum(inputs, dim=1)
 
 
-class ReduceMean(LudwigModule):
+class ReduceMean(LudwigComponent):
 
     def forward(self, inputs, training=None, mask=None):
         #return tf.reduce_mean(inputs, axis=1)
         return torch.mean(inputs, dim=1)
 
 
-class ReduceMax(LudwigModule):
+class ReduceMax(LudwigComponent):
 
     def forward(self, inputs, training=None, mask=None):
         #return tf.reduce_max(inputs, axis=1)
         return torch.max(inputs, dim=1)
 
 
-class ReduceConcat(LudwigModule):
+class ReduceConcat(LudwigComponent):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -128,7 +128,7 @@ class ReduceConcat(LudwigModule):
 
 
 
-class ReduceNone(LudwigModule):
+class ReduceNone(LudwigComponent):
 
     def forward(self, inputs, training=None, mask=None):
         return inputs

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -19,12 +19,11 @@ import logging
 # from tensorflow.keras.layers import Layer
 
 import torch
-# from torch.nn import Module
 
 from ludwig.modules.attention_modules import FeedForwardAttentionReducer
 from ludwig.utils.misc_utils import get_from_registry
 #from ludwig.utils.tf_utils import sequence_length_3D
-from ludwig.utils.torch_utils import sequence_length_3D, LudwigModule, LudwigComponent
+from ludwig.utils.torch_utils import sequence_length_3D, LudwigComponent
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -23,12 +23,12 @@ import torch
 from ludwig.modules.attention_modules import FeedForwardAttentionReducer
 from ludwig.utils.misc_utils import get_from_registry
 #from ludwig.utils.tf_utils import sequence_length_3D
-from ludwig.utils.torch_utils import sequence_length_3D, LudwigComponent
+from ludwig.utils.torch_utils import sequence_length_3D, LudwigModule
 
 logger = logging.getLogger(__name__)
 
 
-class SequenceReducer(LudwigComponent):
+class SequenceReducer(LudwigModule):
 
     def __init__(self, reduce_mode=None):
         super().__init__()
@@ -45,7 +45,7 @@ class SequenceReducer(LudwigComponent):
         return self._reduce_obj(inputs, training=training, mask=mask)
 
 
-class ReduceLast(LudwigComponent):
+class ReduceLast(LudwigModule):
 
     def forward(self, inputs, training=None, mask=None):
         #batch_size = tf.shape(inputs)[0]
@@ -71,28 +71,28 @@ class ReduceLast(LudwigComponent):
         return gathered
 
 
-class ReduceSum(LudwigComponent):
+class ReduceSum(LudwigModule):
 
     def forward(self, inputs, training=None, mask=None):
         #return tf.reduce_sum(inputs, axis=1)
         return torch.sum(inputs, dim=1)
 
 
-class ReduceMean(LudwigComponent):
+class ReduceMean(LudwigModule):
 
     def forward(self, inputs, training=None, mask=None):
         #return tf.reduce_mean(inputs, axis=1)
         return torch.mean(inputs, dim=1)
 
 
-class ReduceMax(LudwigComponent):
+class ReduceMax(LudwigModule):
 
     def forward(self, inputs, training=None, mask=None):
         #return tf.reduce_max(inputs, axis=1)
         return torch.max(inputs, dim=1)
 
 
-class ReduceConcat(LudwigComponent):
+class ReduceConcat(LudwigModule):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -127,7 +127,7 @@ class ReduceConcat(LudwigComponent):
 
 
 
-class ReduceNone(LudwigComponent):
+class ReduceNone(LudwigModule):
 
     def forward(self, inputs, training=None, mask=None):
         return inputs

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -2,13 +2,14 @@ from typing import List, Tuple
 
 # import tensorflow as tf
 import torch
-from torch.nn import Module
+# from torch.nn import Module
 
 from ludwig.modules.activation_modules import glu
 from ludwig.modules.normalization_modules import GhostBatchNormalization
+from ludwig.utils.torch_utils import LudwigComponent
 
 
-class TabNet(Module):
+class TabNet(LudwigComponent):
     def __init__(
             self,
             size: int,
@@ -161,7 +162,7 @@ class TabNet(Module):
         return final_output, aggregated_mask, masks
 
 
-class FeatureBlock(Module):
+class FeatureBlock(LudwigComponent):
     def __init__(
             self,
             size: int,
@@ -195,7 +196,7 @@ class FeatureBlock(Module):
         return hidden
 
 
-class AttentiveTransformer(Module):
+class AttentiveTransformer(LudwigComponent):
     def __init__(
             self,
             size: int,
@@ -236,7 +237,7 @@ class AttentiveTransformer(Module):
 
 
 # adapted and modified from https://github.com/ostamand/tensorflow-tabnet/blob/master/tabnet/models/transformers.py
-class FeatureTransformer(Module):
+class FeatureTransformer(LudwigComponent):
     def __init__(
             self,
             size: int,
@@ -288,7 +289,7 @@ class FeatureTransformer(Module):
 
 # reimplementation of sparsemax to be more stable and fallback to softmax
 # adapted from https://github.com/tensorflow/addons/blob/v0.12.0/tensorflow_addons/activations/sparsemax.py#L21-L77
-class CustomSparsemax(Module):
+class CustomSparsemax(LudwigComponent):
     """Sparsemax activation function.
 
     The output shape is the same as the input shape.

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -2,7 +2,6 @@ from typing import List, Tuple
 
 # import tensorflow as tf
 import torch
-# from torch.nn import Module
 
 from ludwig.modules.activation_modules import glu
 from ludwig.modules.normalization_modules import GhostBatchNormalization

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -66,7 +66,7 @@ class TabNet(LudwigModule):
         self.feature_transforms: List[FeatureTransformer] = [
             FeatureTransformer(**kargs)
         ]
-        self.attentive_transforms: List[AttentiveTransformer] = [None, ]
+        self.attentive_transforms: List[AttentiveTransformer] = [None]
         for i in range(num_steps):
             self.feature_transforms.append(
                 FeatureTransformer(

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -5,10 +5,10 @@ import torch
 
 from ludwig.modules.activation_modules import glu
 from ludwig.modules.normalization_modules import GhostBatchNormalization
-from ludwig.utils.torch_utils import LudwigComponent
+from ludwig.utils.torch_utils import LudwigModule
 
 
-class TabNet(LudwigComponent):
+class TabNet(LudwigModule):
     def __init__(
             self,
             size: int,
@@ -161,7 +161,7 @@ class TabNet(LudwigComponent):
         return final_output, aggregated_mask, masks
 
 
-class FeatureBlock(LudwigComponent):
+class FeatureBlock(LudwigModule):
     def __init__(
             self,
             size: int,
@@ -195,7 +195,7 @@ class FeatureBlock(LudwigComponent):
         return hidden
 
 
-class AttentiveTransformer(LudwigComponent):
+class AttentiveTransformer(LudwigModule):
     def __init__(
             self,
             size: int,
@@ -236,7 +236,7 @@ class AttentiveTransformer(LudwigComponent):
 
 
 # adapted and modified from https://github.com/ostamand/tensorflow-tabnet/blob/master/tabnet/models/transformers.py
-class FeatureTransformer(LudwigComponent):
+class FeatureTransformer(LudwigModule):
     def __init__(
             self,
             size: int,
@@ -288,7 +288,7 @@ class FeatureTransformer(LudwigComponent):
 
 # reimplementation of sparsemax to be more stable and fallback to softmax
 # adapted from https://github.com/tensorflow/addons/blob/v0.12.0/tensorflow_addons/activations/sparsemax.py#L21-L77
-class CustomSparsemax(LudwigComponent):
+class CustomSparsemax(LudwigModule):
     """Sparsemax activation function.
 
     The output shape is the same as the input shape.

--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from torch.nn import Module, ModuleDict
 import torch
 from torch import nn
@@ -94,22 +95,6 @@ class LudwigModel(Module):
         return collected_losses
 
 
-class LudwigComponent(Module):
-    def __init__(self):
-        super().__init__()
-
-    @property
-    def input_shape(self) -> torch.Size:
-        """ Returns the size of the input tensor without the batch dimension. """
-        raise NotImplementedError('Abstract class.')
-
-    @property
-    def output_shape(self) -> torch.Size:
-        """ Returns the size of the output tensor without the batch dimension."""
-        output_tensor = self.forward(torch.rand(*self.input_shape))
-        return output_tensor.size()[1:]
-
-
 # I think I need this instead of what I have above:
 class LudwigModule(Module):
     def __init__(self):
@@ -138,6 +123,23 @@ class LudwigModule(Module):
     def add_loss(self, loss):
         if callable(loss):
             self._callable_losses.append(loss)
+
+
+class LudwigComponent(LudwigModule):
+    def __init__(self):
+        super().__init__()
+
+    @property
+    @abstractmethod
+    def input_shape(self) -> torch.Size:
+        """ Returns the size of the input tensor without the batch dimension. """
+        raise NotImplementedError('Abstract class.')
+
+    @property
+    def output_shape(self) -> torch.Size:
+        """ Returns the size of the output tensor without the batch dimension."""
+        output_tensor = self.forward(torch.rand(2, *self.input_shape))
+        return output_tensor.size()[1:]
 
 
 class Dense(LudwigModule):

--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -93,6 +93,23 @@ class LudwigModel(Module):
             collected_losses.extend(layer.losses)
         return collected_losses
 
+
+class LudwigComponent(Module):
+    def __init__(self):
+        super().__init__()
+
+    @property
+    def input_shape(self) -> torch.Size:
+        """ Returns the size of the input tensor without the batch dimension. """
+        raise NotImplementedError('Abstract class.')
+
+    @property
+    def output_shape(self) -> torch.Size:
+        """ Returns the size of the output tensor without the batch dimension."""
+        output_tensor = self.forward(torch.rand(*self.input_shape))
+        return output_tensor.size()[1:]
+
+
 # I think I need this instead of what I have above:
 class LudwigModule(Module):
     def __init__(self):

--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -124,11 +124,6 @@ class LudwigModule(Module):
         if callable(loss):
             self._callable_losses.append(loss)
 
-
-class LudwigComponent(LudwigModule):
-    def __init__(self):
-        super().__init__()
-
     @property
     @abstractmethod
     def input_shape(self) -> torch.Size:

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -327,8 +327,8 @@ def radar_chart(
         points.append(points[0])
         points = np.array(points)
 
-        codes = [path.Path.MOVETO, ] + \
-                [path.Path.LINETO, ] * (len(values) - 1) + \
+        codes = [path.Path.MOVETO] + \
+                [path.Path.LINETO] * (len(values) - 1) + \
                 [path.Path.CLOSEPOLY]
         _path = path.Path(points, codes)
         _patch = patches.PathPatch(_path, fill=True, color=color, linewidth=0,


### PR DESCRIPTION
This PR adds support for output and input shapes for all Ludwig components.

- Adds a `LudwigComponent` class that supports getting the `output_shape` via running `forward` on a dummy tensor of `input_shape`
- Adds `LudwigComponent` as the parent class of all modules.
- Adds `LudwigComponent` to encoders.
- Adds `LudwigComponent` to combiners.
- Update features to use `output_shape`, `input_shape` properties instead of methods `get_output_shape`, `get_input_shape`.