### PR TITLE
fix: error when setting up to run unit test

### DIFF
--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -169,7 +169,7 @@ class FeatureBlock(LudwigModule):
             bn_momentum: float = 0.9,
             bn_epsilon: float = 1e-3,
             bn_virtual_bs: int = None,
-            shared_fc_layer: Module = None,
+            shared_fc_layer: LudwigModule = None,
     ):
         super().__init__()
         self.apply_glu = apply_glu
@@ -240,7 +240,7 @@ class FeatureTransformer(LudwigModule):
     def __init__(
             self,
             size: int,
-            shared_fc_layers: List[Module] = [],
+            shared_fc_layers: List[LudwigModule] = [],
             num_total_blocks: int = 4,
             num_shared_blocks: int = 2,
             bn_momentum: float = 0.9,


### PR DESCRIPTION
# Code Pull Requests

With the last PR merge, this updated tablet_modules to refer to `LudwigModule`.  Changes to two references to the old name were missed.  This results in this error when running unit tests.
```
ImportError while loading conftest '/opt/project/tests/conftest.py'.
../../tests/conftest.py:21: in <module>
    from ludwig.hyperopt.run import hyperopt
../../ludwig/hyperopt/run.py:9: in <module>
    from ludwig.hyperopt.execution import executor_registry
../../ludwig/hyperopt/execution.py:14: in <module>
    from ludwig.api import LudwigModel
../../ludwig/api.py:54: in <module>
    from ludwig.models.ecd import ECD
../../ludwig/models/ecd.py:7: in <module>
    from ludwig.combiners.combiners import get_combiner_class
../../ludwig/combiners/combiners.py:39: in <module>
    from ludwig.modules.tabnet_modules import TabNet
../../ludwig/modules/tabnet_modules.py:164: in <module>
    class FeatureBlock(LudwigModule):
../../ludwig/modules/tabnet_modules.py:172: in FeatureBlock
    shared_fc_layer: Module = None,
E   NameError: name 'Module' is not defined
```

this PR  updates the two out-dated references.
