### PR TITLE
fix: error creating fc layer w/ no bias

### DIFF
--- a/ludwig/modules/fully_connected_modules.py
+++ b/ludwig/modules/fully_connected_modules.py
@@ -75,8 +75,9 @@ class FCLayer(LudwigModule):
         weights_initializer = initializer_registry[weights_initializer]
         weights_initializer(fc.weight)
 
-        bias_initializer = initializer_registry[bias_initializer]
-        bias_initializer(fc.bias)
+        if use_bias:
+            bias_initializer = initializer_registry[bias_initializer]
+            bias_initializer(fc.bias)
 
         self.activity_regularizer = None
 


### PR DESCRIPTION
# Code Pull Requests

Creating `ludwig.modules.fully_connected_modules.FCLayer` w/o bias fails with this error:
```
Traceback (most recent call last):
  File "/opt/project/sandbox/pytorch/pytorch_sandbox.py", line 20, in <module>
    fc_layer = FCLayer(128,256, use_bias=False)
  File "/opt/project/ludwig/modules/fully_connected_modules.py", line 79, in __init__
    bias_initializer(fc.bias)
  File "/usr/local/lib/python3.7/site-packages/torch/nn/init.py", line 212, in zeros_
    return _no_grad_zero_(tensor)
  File "/usr/local/lib/python3.7/site-packages/torch/nn/init.py", line 64, in _no_grad_zero_
    return tensor.zero_()
AttributeError: 'NoneType' object has no attribute 'zero_'
``` 

Root Cause: current code initializes the bias tensor even if `use_bias` parameter is set to `False`.  

This change will initialize the bias only if `use_bias=True`.