### PR TITLE
Fix automl to treat binary as categorical when missing values present

### DIFF
--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -241,7 +241,7 @@ def get_field_metadata(
     metadata = []
     for idx, field in enumerate(fields):
         missing_value_percent = 1 - float(field.nonnull_values) / row_count
-        dtype = infer_type(field)
+        dtype = infer_type(field, missing_value_percent)
         metadata.append(
             FieldMetadata(
                 name=field.name,
@@ -278,19 +278,21 @@ def get_field_metadata(
 
 
 def infer_type(
-    field: FieldInfo
+    field: FieldInfo,
+    missing_value_percent: float,
 ) -> str:
     """
     Perform type inference on field
 
     # Inputs
     :param field: (FieldInfo) object describing field
+    :param missing_value_percent: (float) percent of missing values in the column
 
     # Return
     :return: (str) feature type
     """
     distinct_values = field.distinct_values
-    if distinct_values == 2:
+    if distinct_values == 2 and missing_value_percent == 0:
         return BINARY
 
     if field.image_values >= 3:

--- a/tests/ludwig/automl/test_base_config.py
+++ b/tests/ludwig/automl/test_base_config.py
@@ -8,14 +8,15 @@ ROW_COUNT = 100
 TARGET_NAME = 'target'
 
 
-@pytest.mark.parametrize("distinct_values,avg_words,img_values,expected", [
-    (ROW_COUNT, 0, 0, NUMERICAL),
-    (10, 0, 0, CATEGORY),
-    (2, 0, 0, BINARY),
-    (ROW_COUNT, 3, 0, TEXT),
-    (ROW_COUNT, 1, ROW_COUNT, IMAGE),
+@pytest.mark.parametrize("distinct_values,avg_words,img_values,missing_vals,expected", [
+    (ROW_COUNT, 0, 0, 0.0, NUMERICAL),
+    (10, 0, 0, 0.0, CATEGORY),
+    (2, 0, 0, 0.0, BINARY),
+    (2, 0, 0, 0.1, CATEGORY),
+    (ROW_COUNT, 3, 0, 0.0, TEXT),
+    (ROW_COUNT, 1, ROW_COUNT, 0.0, IMAGE),
 ])
-def test_infer_type(distinct_values, avg_words, img_values, expected):
+def test_infer_type(distinct_values, avg_words, img_values, missing_vals, expected):
     field = FieldInfo(
         name='foo',
         dtype='object',
@@ -23,7 +24,7 @@ def test_infer_type(distinct_values, avg_words, img_values, expected):
         avg_words=avg_words,
         image_values=img_values,
     )
-    assert infer_type(field) == expected
+    assert infer_type(field, missing_vals) == expected
 
 
 @pytest.mark.parametrize("idx,distinct_values,dtype,name,expected", [


### PR DESCRIPTION
This is a temporary workaround to handle the following error:

```
...
 File "/home/ray/anaconda3/lib/python3.7/site-packages/ludwig/api.py", line 428, in train
    **kwargs,
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ludwig/api.py", line 1317, in preprocess
    random_seed=random_seed
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ludwig/data/preprocessing.py", line 1496, in preprocess_for_training
    random_seed=random_seed
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ludwig/data/preprocessing.py", line 197, in preprocess_for_training
    random_seed=random_seed
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ludwig/data/preprocessing.py", line 1677, in _preprocess_df_for_training
    backend=backend
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ludwig/data/preprocessing.py", line 1142, in build_dataset
    backend
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ludwig/data/preprocessing.py", line 1255, in build_metadata
    backend
  File "/home/ray/anaconda3/lib/python3.7/site-packages/ludwig/features/binary_feature.py", line 79, in get_feature_meta
    f"Binary feature column {column.name} expects 2 distinct values, "
ValueError: Binary feature column gender expects 2 distinct values, found: ['Female', 'Male', '0']
```

Essentially, the feature was treated as binary because it had 2 distinct values, but because there were also NaNs, they were coerced into '0', which led to there being 3 distinct values during preprocessing.

Long-term, we should instead coerce NaNs for binary columns into the correct "false" type by default (or replace with mode). If no false type can be determined, we should treat the column as categorical in automl.