### PR TITLE
Cast `max_length` to int in `build_sequence_matrix::pad`

### DIFF
--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -259,7 +259,7 @@ def build_sequence_matrix(
     max_length = length_limit
 
     def pad(vector):
-        sequence = np.full((max_length,),
+        sequence = np.full((int(max_length),),
                            inverse_vocabulary[padding_symbol],
                            dtype=format_dtype)
         limit = min(vector.shape[0], max_length)


### PR DESCRIPTION
Running `tests/integration_tests/test_ray.py ` using Ray Client caused an exception due to `max_length` in  `build_sequence_matrix::pad` being of `numpy.float64` dtype. Casting it to int fixed the exception.
