### PR TITLE
Refactor: Tf to torch implement input_dtype property in LudwigModule

### DIFF
--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -443,10 +443,6 @@ class AudioInputFeature(AudioFeatureMixin, SequenceInputFeature):
 
         return encoder_output
 
-    @classmethod
-    def get_input_dtype(cls):
-        return torch.float32
-
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size([self.max_sequence_length, self.embedding_size])

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -126,10 +126,6 @@ class BagInputFeature(BagFeatureMixin, InputFeature):
 
         return {'encoder_output': encoder_output}
 
-    @classmethod
-    def get_input_dtype(cls):
-        return torch.float32
-
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size([len(self.vocab)])

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -83,11 +83,6 @@ class InputFeature(BaseFeature, LudwigModule, ABC):
                               dtype=self.get_input_dtype(),
                               name=self.name + '_input')
 
-    @classmethod
-    @abstractmethod
-    def get_input_dtype(cls):
-        """Returns the Tensor data type this input accepts."""
-        pass
 
     @staticmethod
     @abstractmethod

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -141,9 +141,9 @@ class BinaryInputFeature(BinaryFeatureMixin, InputFeature):
 
         return encoder_outputs
 
-    @classmethod
-    def get_input_dtype(cls):
-        return tf.bool
+    @property
+    def input_dtype(self):
+        return torch.bool
 
     @property
     def input_shape(self) -> torch.Size:
@@ -151,7 +151,7 @@ class BinaryInputFeature(BinaryFeatureMixin, InputFeature):
 
     @staticmethod
     def update_config_with_metadata(
-        input_feature, feature_metadata, *args, **kwargs
+            input_feature, feature_metadata, *args, **kwargs
     ):
         pass
 

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -133,8 +133,8 @@ class CategoryInputFeature(CategoryFeatureMixin, InputFeature):
 
         return {'encoder_output': encoder_output}
 
-    @classmethod
-    def get_input_dtype(cls):
+    @property
+    def input_dtype(self):
         return torch.int32
 
     @property

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -144,9 +144,9 @@ class DateInputFeature(DateFeatureMixin, InputFeature):
 
         return inputs_encoded
 
-    @classmethod
-    def get_input_dtype(cls):
-        return tf.int16
+    @property
+    def input_dtype(self):
+        return torch.int16
 
     @property
     def input_shape(self) -> torch.Size:

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -114,9 +114,9 @@ class H3InputFeature(H3FeatureMixin, InputFeature):
 
         return inputs_encoded
 
-    @classmethod
-    def get_input_dtype(cls):
-        return tf.uint8
+    @property
+    def input_dtype(self):
+        return torch.uint8
 
     @property
     def input_shape(self) -> torch.Size:

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -426,8 +426,8 @@ class ImageInputFeature(ImageFeatureMixin, InputFeature):
 
         return inputs_encoded
 
-    @classmethod
-    def get_input_dtype(cls):
+    @property
+    def input_dtype(self):
         return torch.uint8
 
     @property

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -218,10 +218,6 @@ class NumericalInputFeature(NumericalFeatureMixin, InputFeature):
 
         return inputs_encoded
 
-    @classmethod
-    def get_input_dtype(cls):
-        return torch.float32
-
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size([1])

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -168,9 +168,9 @@ class SequenceInputFeature(SequenceFeatureMixin, InputFeature):
         encoder_output[LENGTHS] = lengths
         return encoder_output
 
-    @classmethod
-    def get_input_dtype(cls):
-        return tf.int32
+    @property
+    def input_dtype(self):
+        return torch.int32
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -133,9 +133,9 @@ class SetInputFeature(SetFeatureMixin, InputFeature):
 
         return {'encoder_output': encoder_output}
 
-    @classmethod
-    def get_input_dtype(cls):
-        return tf.bool
+    @property
+    def input_dtype(self):
+        return torch.bool
 
     @property
     def input_shape(self) -> torch.Size:

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -283,9 +283,9 @@ class TextInputFeature(TextFeatureMixin, SequenceInputFeature):
         encoder_output[LENGTHS] = lengths
         return encoder_output
 
-    @classmethod
-    def get_input_dtype(cls):
-        return tf.int32
+    @property
+    def input_dtype(self):
+        return torch.int32
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -170,10 +170,6 @@ class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
 
         return encoder_output
 
-    @classmethod
-    def get_input_dtype(cls):
-        return tf.float32
-
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size([self.max_sequence_length])

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -142,10 +142,6 @@ class VectorInputFeature(VectorFeatureMixin, InputFeature):
 
         return inputs_encoded
 
-    @classmethod
-    def get_input_dtype(cls):
-        return tf.float32
-
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size([self.vector_size])

--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -75,6 +75,10 @@ class LudwigModule(Module):
         super().__init__()
         self._callable_losses = []
 
+    @property
+    def input_dtype(self):
+        return torch.float32
+
     def losses(self):
         collected_losses = []
         for loss_fn in self._callable_losses:

--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -115,7 +115,8 @@ class LudwigModule(Module):
 
     @lru_cache(maxsize=1)
     def _compute_output_shape(self) -> torch.Size:
-        output_tensor = self.forward(torch.rand(2, *self.input_shape))
+        output_tensor = self.forward(torch.rand(2, *self.input_shape,
+                                                dtype=self.input_dtype))
         return output_tensor.size()[1:]
 
 

--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -75,10 +75,6 @@ class LudwigModule(Module):
         super().__init__()
         self._callable_losses = []
 
-    @property
-    def input_dtype(self):
-        return torch.float32
-
     def losses(self):
         collected_losses = []
         for loss_fn in self._callable_losses:
@@ -101,6 +97,10 @@ class LudwigModule(Module):
     def add_loss(self, loss):
         if callable(loss):
             self._callable_losses.append(loss)
+
+    @property
+    def input_dtype(self):
+        return torch.float32
 
     @property
     @abstractmethod


### PR DESCRIPTION
# Code Pull Requests

Implement the following refactoring:

- Move get_input_dtype() from InputFeature to LudwigModule
- change get_input_dtype() from method to property input_dtype
- Have the default behavior be return torch.float32 and allow subclasses to override

Successfully tested this change with the sequence encoders.