### PR TITLE
fix: TypeError in sequence_length_3D () with torch.sign function call

### DIFF
--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -8,7 +8,7 @@ from torch.nn import Module, ModuleDict
 
 
 def sequence_length_3D(sequence):
-    used = torch.sign(torch.max(torch.abs(sequence), dim=2).values)
+    used = torch.sign(torch.amax(torch.abs(sequence), dim=2))
     length = torch.sum(used, 1)
     length = length.int()
     return length

--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -8,7 +8,7 @@ from torch.nn import Module, ModuleDict
 
 
 def sequence_length_3D(sequence):
-    used = torch.sign(torch.max(torch.abs(sequence), dim=2))
+    used = torch.sign(torch.max(torch.abs(sequence), dim=2).values)
     length = torch.sum(used, 1)
     length = length.int()
     return length


### PR DESCRIPTION
# Code Pull Requests

Fixes this error in `torch_utils.sequence_length_3D()`
```
    def sequence_length_3D(sequence):
>       used = torch.sign(torch.max(torch.abs(sequence), dim=2))
E       TypeError: sign(): argument 'input' (position 1) must be Tensor, not torch.return_types.max
```