### PR TITLE
Bug fix for type_utils.Column attribute error

### DIFF
--- a/ludwig/utils/type_utils.py
+++ b/ludwig/utils/type_utils.py
@@ -8,6 +8,6 @@ import pandas as pd
 
 
 if dd is not None:
-    Column: Union[str, pd.Series, dd.Series]
+    Column = Union[str, pd.Series, dd.Series]
 else:
-    Column: Union[str, pd.Series]
+    Column = Union[str, pd.Series]


### PR DESCRIPTION
This PR fixes the following bug:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'ludwig.utils.type_utils' has no attribute 'Column'
```