### PR TITLE
FIX: Issue 1181 resolves the ZeroDivisionError when calculating sample variance

### DIFF
--- a/ludwig/utils/audio_utils.py
+++ b/ludwig/utils/audio_utils.py
@@ -237,9 +237,8 @@ def calculate_incr_mean(count, mean, length):
 
 
 def calculate_var(sum1, sum2, count):
-    # todo: revert from 'max(1, count -1)' back to 'count - 1' in denominator
-    #    when GH Issue #1181 is addressed
-    return (sum2 - ((sum1 * sum1) / float(count))) / float(max(1, count - 1))
+    return (sum2 - ((sum1 * sum1) / float(count))) / float(count - 1) \
+        if count > 1 else 0.0
 
 
 def calculate_mean(sum1, count):


### PR DESCRIPTION
# Code Pull Requests

Fix #1181:  resolves the zerodivisionerror when calculating sample
variance in a batch of 1 audio input record.

Summary of change:
* update sample variance calculation to return zero when there is only one record
* refactored location where the computation and logging of audio statistics to better encapsulate the function.

After the change, no error occurs in `test_server.py` unit test
```
root@4cea96445ec1:/opt/project/sandbox/pytest_area# pytest -v --tb=line /opt/project/tests/integration_tests/test_server.py
================================================ test session starts ================================================
platform linux -- Python 3.7.11, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /opt/project, configfile: pytest.ini
plugins: typeguard-2.12.1, timeout-1.4.2, xdist-2.3.0, cov-2.12.1, forked-1.3.0, pycharm-0.7.0, anyio-3.3.0
collected 3 items

../../tests/integration_tests/test_server.py::test_server_integration_with_images PASSED                      [ 33%]
../../tests/integration_tests/test_server.py::test_server_integration_with_audio[False] PASSED                [ 66%]
../../tests/integration_tests/test_server.py::test_server_integration_with_audio[True] PASSED                 [100%]

================================================= warnings summary ==================================================
../../../../usr/local/lib/python3.7/site-packages/tensorflow/python/autograph/impl/api.py:22
  /usr/local/lib/python3.7/site-packages/tensorflow/python/autograph/impl/api.py:22: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

tests/integration_tests/test_server.py::test_server_integration_with_images
tests/integration_tests/test_server.py::test_server_integration_with_audio[False]
tests/integration_tests/test_server.py::test_server_integration_with_audio[True]
  /opt/project/ludwig/utils/tf_utils.py:63: UserWarning: TensorFlow has already been initialized. Changes to `gpus`, `gpu_memory_limit`, and `allow_parallel_threads` will be ignored. Start a new Python process to modify these values.
    'TensorFlow has already been initialized. Changes to `gpus`, '

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=========================================== 3 passed, 4 warnings in 8.35s ===========================================
```
