### PR TITLE
TF to Torch Migrate TimeSeries Feature

### DIFF
--- a/ludwig/encoders/sequence_encoders.py
+++ b/ludwig/encoders/sequence_encoders.py
@@ -1843,7 +1843,7 @@ class StackedCNNRNN(SequenceEncoder):
         if self.reduce_output is not None:
             logger.debug('  FCStack')
             self.fc_stack = FCStack(
-                self.conv1d_stack.output_shape[0],
+                self.conv1d_stack.output_shape[-1],
                 layers=fc_layers,
                 num_layers=num_fc_layers,
                 default_fc_size=fc_size,

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -157,13 +157,13 @@ class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
     def __init__(self, feature, encoder_obj=None):
         super().__init__(feature, encoder_obj=encoder_obj)
 
-    def call(self, inputs, training=None, mask=None):
-        assert isinstance(inputs, tf.Tensor)
-        assert inputs.dtype == tf.float16 or inputs.dtype == tf.float32 or \
-               inputs.dtype == tf.float64
+    def forward(self, inputs, training=None, mask=None):
+        assert isinstance(inputs, torch.Tensor)
+        assert inputs.dtype == torch.float16 or inputs.dtype == torch.float32 \
+               or inputs.dtype == torch.float64
         assert len(inputs.shape) == 2
 
-        inputs_exp = tf.cast(inputs, dtype=tf.float32)
+        inputs_exp = inputs.type(torch.float32)
         encoder_output = self.encoder_obj(
             inputs_exp, training=training, mask=mask
         )

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -155,6 +155,11 @@ class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
     max_sequence_length = None
 
     def __init__(self, feature, encoder_obj=None):
+        # add required sequence encoder parameters for time series
+        feature['embedding_size'] = 1
+        feature['should_embed'] = False
+
+        # initialize encoder for time series
         super().__init__(feature, encoder_obj=encoder_obj)
 
     def forward(self, inputs, training=None, mask=None):
@@ -183,8 +188,6 @@ class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
     ):
         input_feature['max_sequence_length'] = feature_metadata[
             'max_timeseries_length']
-        input_feature['embedding_size'] = 1
-        input_feature['should_embed'] = False
 
     @staticmethod
     def populate_defaults(input_feature):

--- a/tests/integration_tests/test_timeseries_feature.py
+++ b/tests/integration_tests/test_timeseries_feature.py
@@ -1,0 +1,52 @@
+import os
+import shutil
+import pytest
+import pandas as pd
+
+import torch
+
+from ludwig.features.timeseries_feature import TimeseriesInputFeature
+from tests.integration_tests.utils import timeseries_feature
+
+BATCH_SIZE = 2
+SEQ_SIZE = 20
+DEFAULT_FC_SIZE = 256
+
+
+@pytest.mark.parametrize(
+    'enc_encoder',
+    [
+        'stacked_cnn', 'parallel_cnn', 'stacked_parallel_cnn', 'rnn', 'cnnrnn',
+        'passthrough'
+    ]
+)
+def test_timeseries_feature(enc_encoder):
+    # synthetic timeseries tensor
+    timeseries_tensor = torch.randn([BATCH_SIZE, SEQ_SIZE],
+                                    dtype=torch.float32)
+
+    # generate audio feature config
+    timeseries_feature_config = timeseries_feature(
+        encoder=enc_encoder,
+        max_len=SEQ_SIZE,
+        max_sequence_length=SEQ_SIZE,
+        embedding_size=1,
+        should_embed=False,
+    )
+
+    # instantiate audio input feature object
+    timeseries_input_feature = TimeseriesInputFeature(timeseries_feature_config)
+
+    # pass synthetic audio tensor through the audio input feature
+    encoder_output = timeseries_input_feature(timeseries_tensor)
+
+    # confirm correctness of the the audio encoder output
+    assert isinstance(encoder_output, dict)
+    assert 'encoder_output' in encoder_output
+    assert isinstance(encoder_output['encoder_output'], torch.Tensor)
+    if enc_encoder == 'passthrough':
+        assert encoder_output['encoder_output'].shape \
+               == (BATCH_SIZE, SEQ_SIZE, 1)
+    else:
+        assert encoder_output['encoder_output'].shape \
+               == (BATCH_SIZE, DEFAULT_FC_SIZE)

--- a/tests/integration_tests/test_timeseries_feature.py
+++ b/tests/integration_tests/test_timeseries_feature.py
@@ -9,7 +9,7 @@ from ludwig.features.timeseries_feature import TimeseriesInputFeature
 from tests.integration_tests.utils import timeseries_feature
 
 BATCH_SIZE = 2
-SEQ_SIZE = 20
+SEQ_SIZE = 10
 DEFAULT_FC_SIZE = 256
 
 
@@ -29,9 +29,10 @@ def test_timeseries_feature(enc_encoder):
     timeseries_feature_config = timeseries_feature(
         encoder=enc_encoder,
         max_len=SEQ_SIZE,
+        # simulated parameters determined by pre-processing
         max_sequence_length=SEQ_SIZE,
         embedding_size=1,
-        should_embed=False,
+        should_embed=False
     )
 
     # instantiate audio input feature object

--- a/tests/integration_tests/test_timeseries_feature.py
+++ b/tests/integration_tests/test_timeseries_feature.py
@@ -29,8 +29,6 @@ def test_timeseries_feature(enc_encoder):
         fc_layers=[{'fc_size': DEFAULT_FC_SIZE}],
         # simulated parameters determined by pre-processing
         max_sequence_length=SEQ_SIZE,
-        embedding_size=1,
-        should_embed=False
     )
 
     # instantiate input feature object

--- a/tests/integration_tests/test_timeseries_feature.py
+++ b/tests/integration_tests/test_timeseries_feature.py
@@ -7,7 +7,7 @@ from tests.integration_tests.utils import timeseries_feature
 
 BATCH_SIZE = 2
 SEQ_SIZE = 10
-DEFAULT_FC_SIZE = 256
+DEFAULT_FC_SIZE = 4
 
 
 @pytest.mark.parametrize(
@@ -26,6 +26,7 @@ def test_timeseries_feature(enc_encoder):
     timeseries_feature_config = timeseries_feature(
         encoder=enc_encoder,
         max_len=SEQ_SIZE,
+        fc_layers=[{'fc_size': DEFAULT_FC_SIZE}],
         # simulated parameters determined by pre-processing
         max_sequence_length=SEQ_SIZE,
         embedding_size=1,

--- a/tests/integration_tests/test_timeseries_feature.py
+++ b/tests/integration_tests/test_timeseries_feature.py
@@ -1,7 +1,4 @@
-import os
-import shutil
 import pytest
-import pandas as pd
 
 import torch
 
@@ -21,11 +18,11 @@ DEFAULT_FC_SIZE = 256
     ]
 )
 def test_timeseries_feature(enc_encoder):
-    # synthetic timeseries tensor
+    # synthetic time series tensor
     timeseries_tensor = torch.randn([BATCH_SIZE, SEQ_SIZE],
                                     dtype=torch.float32)
 
-    # generate audio feature config
+    # generate feature config
     timeseries_feature_config = timeseries_feature(
         encoder=enc_encoder,
         max_len=SEQ_SIZE,
@@ -35,13 +32,13 @@ def test_timeseries_feature(enc_encoder):
         should_embed=False
     )
 
-    # instantiate audio input feature object
+    # instantiate input feature object
     timeseries_input_feature = TimeseriesInputFeature(timeseries_feature_config)
 
-    # pass synthetic audio tensor through the audio input feature
+    # pass synthetic tensor through input feature
     encoder_output = timeseries_input_feature(timeseries_tensor)
 
-    # confirm correctness of the the audio encoder output
+    # confirm correctness of the encoder output
     assert isinstance(encoder_output, dict)
     assert 'encoder_output' in encoder_output
     assert isinstance(encoder_output['encoder_output'], torch.Tensor)


### PR DESCRIPTION
# Code Pull Requests

Closes #1323.

Summary of changes
* Modified `TimeSeriesInputFeature` to work in PyTorch
* Add unit test `test_timeseries_feature.py` 

```
root@4ba4e6a3d53d:/opt/project/sandbox/pytest_area# pytest -v --tb=line /opt/project/tests/integration_tests/test_timeseries_feature.py
=========================================================== test session starts ============================================================
platform linux -- Python 3.7.11, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /opt/project, configfile: pytest.ini
plugins: timeout-1.4.2, xdist-2.3.0, cov-2.12.1, forked-1.3.0, pycharm-0.7.0, anyio-3.3.0
collected 6 items

../../tests/integration_tests/test_timeseries_feature.py::test_timeseries_feature[stacked_cnn] PASSED                                [ 16%]
../../tests/integration_tests/test_timeseries_feature.py::test_timeseries_feature[parallel_cnn] PASSED                               [ 33%]
../../tests/integration_tests/test_timeseries_feature.py::test_timeseries_feature[stacked_parallel_cnn] PASSED                       [ 50%]
../../tests/integration_tests/test_timeseries_feature.py::test_timeseries_feature[rnn] PASSED                                        [ 66%]
../../tests/integration_tests/test_timeseries_feature.py::test_timeseries_feature[cnnrnn] PASSED                                     [ 83%]
../../tests/integration_tests/test_timeseries_feature.py::test_timeseries_feature[passthrough] PASSED                                [100%]

============================================================= warnings summary =============================================================
../../../../usr/local/lib/python3.7/site-packages/pyDOE2/doe_factorial.py:16
  /usr/local/lib/python3.7/site-packages/pyDOE2/doe_factorial.py:16: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

tests/integration_tests/test_timeseries_feature.py::test_timeseries_feature[stacked_cnn]
  /usr/local/lib/python3.7/site-packages/torch/nn/functional.py:652: UserWarning: Named tensors and all their associated APIs are an experimental feature and subject to change. Please do not use them for anything important until they are released as stable. (Triggered internally at  /pytorch/c10/core/TensorImpl.h:1156.)
    return torch.max_pool1d(input, kernel_size, stride, padding, dilation, ceil_mode)

tests/integration_tests/test_timeseries_feature.py::test_timeseries_feature[parallel_cnn]
  /usr/local/lib/python3.7/site-packages/torch/nn/modules/conv.py:295: UserWarning: Using padding='same' with even kernel lengths and odd dilation may require a zero-padded copy of the input be created (Triggered internally at  /pytorch/aten/src/ATen/native/Convolution.cpp:660.)
    self.padding, self.dilation, self.groups)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
====================================================== 6 passed, 3 warnings in 0.30s =======================================================
```