### PR TITLE
TF to Torch port of concat and sequence combiners

### DIFF
--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -17,6 +17,7 @@
 import logging
 from typing import List
 import numpy as np
+from typing import Union
 
 import torch
 from torch.nn import Module
@@ -42,24 +43,24 @@ logger = logging.getLogger(__name__)
 class ConcatCombiner(LudwigModule):
     def __init__(
             self,
-            input_features=None,
-            fc_layers=None,
-            num_fc_layers=None,
-            fc_size=256,
-            use_bias=True,
-            weights_initializer='xavier_uniform',
-            bias_initializer='zeros',
-            weights_regularizer=None,
-            bias_regularizer=None,
-            activity_regularizer=None,
+            input_features: dict = None,
+            fc_layers: Union[list, None] = None,
+            num_fc_layers: Union[None, int] = None,
+            fc_size: int = 256,
+            use_bias: bool = True,
+            weights_initializer: str = 'xavier_uniform',
+            bias_initializer: str = 'zeros',
+            weights_regularizer: Union[None, str] = None,
+            bias_regularizer: Union[None, str] = None,
+            activity_regularizer: Union[None, str] = None,
             # weights_constraint=None,
             # bias_constraint=None,
-            norm=None,
-            norm_params=None,
-            activation='relu',
-            dropout=0,
-            flatten_inputs=False,
-            residual=False,
+            norm: Union[None, str] = None,
+            norm_params: Union[None, dict] = None,
+            activation: str = 'relu',
+            dropout: float = 0,
+            flatten_inputs: bool = False,
+            residual: bool = False,
             **kwargs
     ):
         super().__init__()
@@ -169,6 +170,7 @@ class SequenceConcatCombiner(LudwigModule):
             **kwargs
     ):
         super().__init__()
+        self.name = 'SequenceConcatCombiner'
         logger.debug(' {}'.format(self.name))
 
         self.reduce_output = reduce_output
@@ -177,7 +179,7 @@ class SequenceConcatCombiner(LudwigModule):
             self.supports_masking = True
         self.main_sequence_feature = main_sequence_feature
 
-    def __call__(
+    def forward(
             self,
             inputs,  # encoder outputs
             training=None,

--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -21,7 +21,8 @@ from typing import Union
 
 import torch
 from torch.nn import Module
-from ludwig.utils.torch_utils import LudwigModule
+from ludwig.utils.torch_utils import LudwigModule, \
+    sequence_mask as torch_sequence_mask
 
 from ludwig.constants import NUMERICAL, BINARY, TYPE, NAME
 from ludwig.encoders.sequence_encoders import ParallelCNN
@@ -282,13 +283,13 @@ class SequenceConcatCombiner(LudwigModule):
 
         # ================ Mask ================
         # todo future: maybe modify this with TF2 mask mechanics
-        sequence_mask = tf.sequence_mask(
+        sequence_mask = torch_sequence_mask(
             sequence_length,
             sequence_max_length
         )
-        hidden = tf.multiply(
+        hidden = torch.multiply(
             hidden,
-            tf.cast(tf.expand_dims(sequence_mask, -1), dtype=tf.float32)
+            torch.unsqueeze(sequence_mask, -1).type(torch.float32)
         )
 
         # ================ Reduce ================

--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -145,7 +145,7 @@ class ConcatCombiner(LudwigModule):
 
     @property
     def input_shape(self) -> torch.Size:
-        shapes = [self.input_features[k].shape[-1] for k in
+        shapes = [self.input_features[k].output_shape[-1] for k in
                   self.input_features]  # output shape not input shape
         return torch.Size([sum(shapes)])
 

--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -17,11 +17,6 @@
 import logging
 from typing import List
 
-# import tensorflow as tf
-# from tensorflow.keras.layers import LayerNormalization
-# from tensorflow.keras.layers import Dense
-# from tensorflow.keras.layers import concatenate
-
 import torch
 from torch.nn import Module
 from ludwig.utils.torch_utils import LudwigModule
@@ -150,7 +145,7 @@ class ConcatCombiner(LudwigModule):
 
     @property
     def input_shape(self) -> torch.Size:
-        shapes = [self.input_features[k].output_shape[-1] for k in
+        shapes = [self.input_features[k].shape[-1] for k in
                   self.input_features]  # output shape not input shape
         return torch.Size([sum(shapes)])
 

--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -308,15 +308,20 @@ class SequenceConcatCombiner(LudwigModule):
 class SequenceCombiner(LudwigModule):
     def __init__(
             self,
-            reduce_output=None,
-            main_sequence_feature=None,
-            encoder=None,
+            input_features: dict,
+            reduce_output: Union[None, str] = None,
+            main_sequence_feature: Union[None, str] = None,
+            encoder: Union[None, str] = None,
             **kwargs
     ):
         super().__init__()
+        self.name = 'SequenceCombiner'
         logger.debug(' {}'.format(self.name))
 
+        self.input_features = input_features
+
         self.combiner = SequenceConcatCombiner(
+            input_features,
             reduce_output=None,
             main_sequence_feature=main_sequence_feature
         )
@@ -332,7 +337,7 @@ class SequenceCombiner(LudwigModule):
                 self.encoder_obj.supports_masking):
             self.supports_masking = True
 
-    def __call__(
+    def forward(
             self,
             inputs,  # encoder outputs
             training=None,

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-import tensorflow as tf
+import torch
 
 from ludwig.combiners.combiners import (
     ConcatCombiner,
@@ -46,12 +46,12 @@ def encoder_outputs():
 
     for feature_name, batch_shape in zip(feature_names, shapes_list):
         encoder_outputs[feature_name] = {
-            "encoder_output": tf.random.normal(batch_shape, dtype=tf.float32)
+            "encoder_output": torch.randn(batch_shape, dtype=torch.float32)
         }
         if len(batch_shape) > 2:
             encoder_outputs[feature_name][
-                "encoder_output_state"] = tf.random.normal(
-                [batch_shape[0], batch_shape[2]], dtype=tf.float32
+                "encoder_output_state"] = torch.randn(
+                [batch_shape[0], batch_shape[2]], dtype=torch.float32
             )
 
     return encoder_outputs
@@ -85,13 +85,13 @@ def encoder_comparator_outputs():
         if i == 0 or i == 3:
             dot_product_shape = [batch_shape[0], BASE_FC_SIZE]
             encoder_outputs[feature_name] = {
-                "encoder_output": tf.random.normal(dot_product_shape,
-                                                   dtype=tf.float32)
+                "encoder_output": torch.randn(dot_product_shape,
+                                              dtype=torch.float32)
             }
         else:
             encoder_outputs[feature_name] = {
-                "encoder_output": tf.random.normal(batch_shape,
-                                                   dtype=tf.float32)
+                "encoder_output": torch.randn(batch_shape,
+                                              dtype=torch.float32)
             }
 
     for i, (feature_name, batch_shape) in enumerate(
@@ -100,13 +100,13 @@ def encoder_comparator_outputs():
         if i == 0 or i == 3:
             dot_product_shape = [batch_shape[0], BASE_FC_SIZE]
             encoder_outputs[feature_name] = {
-                "encoder_output": tf.random.normal(dot_product_shape,
-                                                   dtype=tf.float32)
+                "encoder_output": torch.randn(dot_product_shape,
+                                              dtype=torch.float32)
             }
         else:
             encoder_outputs[feature_name] = {
-                "encoder_output": tf.random.normal(batch_shape,
-                                                   dtype=tf.float32)
+                "encoder_output": torch.randn(batch_shape,
+                                              dtype=torch.float32)
             }
 
     return encoder_outputs
@@ -131,16 +131,14 @@ def test_concat_combiner(encoder_outputs, fc_layer):
 
     # confirm correct output shapes
     if fc_layer:
-        assert results["combiner_output"].shape.as_list() == [BATCH_SIZE,
-                                                              FC_SIZE]
+        assert results["combiner_output"].shape == (BATCH_SIZE, FC_SIZE)
     else:
         # calculate expected hidden size for concatenated tensors
         hidden_size = 0
         for k in encoder_outputs:
             hidden_size += encoder_outputs[k]["encoder_output"].shape[1]
 
-        assert results["combiner_output"].shape.as_list() == [BATCH_SIZE,
-                                                              hidden_size]
+        assert results["combiner_output"].shape == (BATCH_SIZE, hidden_size)
 
 
 # test for sequence concatenation combiner
@@ -227,15 +225,15 @@ def tabnet_encoder_outputs():
     return {
         'batch_128': {
             'feature_1': {
-                'encoder_output': tf.random.normal(
+                'encoder_output': torch.randn(
                     [128, 1],
-                    dtype=tf.float32
+                    dtype=torch.float32
                 )
             },
             'feature_2': {
-                'encoder_output': tf.random.normal(
+                'encoder_output': torch.randn(
                     [128, 1],
-                    dtype=tf.float32
+                    dtype=torch.float32
                 )
             },
         },
@@ -243,14 +241,14 @@ def tabnet_encoder_outputs():
             'feature_1': {
                 'encoder_output': tf.keras.Input(
                     (),
-                    dtype=tf.float32,
+                    dtype=torch.float32,
                     name='feature_1',
                 )
             },
             'feature_2': {
                 'encoder_output': tf.keras.Input(
                     (),
-                    dtype=tf.float32,
+                    dtype=torch.float32,
                     name='feature_2',
                 )
             },
@@ -317,15 +315,15 @@ def test_transformer_combiner(encoder_outputs):
     # clean out unneeded encoder outputs
     encoder_outputs = {}
     encoder_outputs['feature_1'] = {
-        'encoder_output': tf.random.normal(
+        'encoder_output': torch.randn(
             [128, 1],
-            dtype=tf.float32
+            dtype=torch.float32
         )
     }
     encoder_outputs['feature_2'] = {
-        'encoder_output': tf.random.normal(
+        'encoder_output': torch.randn(
             [128, 1],
-            dtype=tf.float32
+            dtype=torch.float32
         )
     }
 
@@ -350,15 +348,15 @@ def test_tabtransformer_combiner(encoder_outputs):
     # clean out unneeded encoder outputs
     encoder_outputs = {}
     encoder_outputs['feature_1'] = {
-        'encoder_output': tf.random.normal(
+        'encoder_output': torch.randn(
             [128, 1],
-            dtype=tf.float32
+            dtype=torch.float32
         )
     }
     encoder_outputs['feature_2'] = {
-        'encoder_output': tf.random.normal(
+        'encoder_output': torch.randn(
             [128, 16],
-            dtype=tf.float32
+            dtype=torch.float32
         )
     }
 

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -235,7 +235,10 @@ def test_sequence_concat_combiner(
 def test_sequence_combiner(
         encoder_outputs, main_sequence_feature, encoder, reduce_output
 ):
+    encoder_outputs_dict, input_features_dict = encoder_outputs
+
     combiner = SequenceCombiner(
+        input_features_dict,
         main_sequence_feature=main_sequence_feature,
         encoder=encoder,
         reduce_output=reduce_output,

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -21,10 +21,10 @@ logging.getLogger("ludwig").setLevel(logging.INFO)
 
 BATCH_SIZE = 16
 SEQ_SIZE = 12
-HIDDEN_SIZE = 128
+HIDDEN_SIZE = 24
 OTHER_HIDDEN_SIZE = 32
-FC_SIZE = 64
-BASE_FC_SIZE = 256
+FC_SIZE = 8
+BASE_FC_SIZE = 16
 
 
 # emulate Input Feature class.  Need to provide output_shape property to
@@ -134,7 +134,7 @@ def encoder_comparator_outputs():
 @pytest.mark.parametrize("number_inputs", [None, 1])
 @pytest.mark.parametrize("flatten_inputs", [True, False])
 @pytest.mark.parametrize("fc_layer",
-                         [None, [{"fc_size": 64}, {"fc_size": 64}]])
+                         [None, [{"fc_size": FC_SIZE}, {"fc_size": FC_SIZE}]])
 def test_concat_combiner(encoder_outputs, fc_layer, flatten_inputs,
                          number_inputs):
     encoder_outputs_dict, input_features_dict = encoder_outputs

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -191,18 +191,23 @@ def test_concat_combiner(encoder_outputs, fc_layer, flatten_inputs,
 def test_sequence_concat_combiner(
         encoder_outputs, main_sequence_feature, reduce_output
 ):
+    # extract encoder outputs and input feature dictionaries
+    encoder_outputs_dict, input_feature_dict = encoder_outputs
+
+    # setup combiner for testing
     combiner = SequenceConcatCombiner(
+        input_feature_dict,
         main_sequence_feature=main_sequence_feature,
         reduce_output=reduce_output
     )
 
     # calculate expected hidden size for concatenated tensors
     hidden_size = 0
-    for k in encoder_outputs:
-        hidden_size += encoder_outputs[k]["encoder_output"].shape[-1]
+    for k in encoder_outputs_dict:
+        hidden_size += encoder_outputs_dict[k]["encoder_output"].shape[-1]
 
     # concatenate encoder outputs
-    results = combiner(encoder_outputs)
+    results = combiner(encoder_outputs_dict)
 
     # required key present
     assert "combiner_output" in results

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -207,21 +207,25 @@ def test_sequence_concat_combiner(
         hidden_size += encoder_outputs_dict[k]["encoder_output"].shape[-1]
 
     # concatenate encoder outputs
-    results = combiner(encoder_outputs_dict)
+    combiner_output = combiner(encoder_outputs_dict)
 
-    # required key present
-    assert "combiner_output" in results
+    # correct data structure
+    assert isinstance(combiner_output, dict)
+
+    # required key present and correct data type
+    assert "combiner_output" in combiner_output
+    assert isinstance(combiner_output['combiner_output'], torch.Tensor)
 
     # confirm correct shape
     if reduce_output is None:
-        assert results["combiner_output"].shape.as_list() == [
+        assert combiner_output["combiner_output"].shape == (
             BATCH_SIZE,
             SEQ_SIZE,
             hidden_size,
-        ]
+        )
     else:
-        assert results["combiner_output"].shape.as_list() == [BATCH_SIZE,
-                                                              hidden_size]
+        assert combiner_output["combiner_output"].shape == (
+        BATCH_SIZE, hidden_size)
 
 
 # test for sequence combiner


### PR DESCRIPTION
# Code Pull Requests

Addresses Issue #1324

This is the start of porting `combiner.py` to Torch.  This first drop has ported `ConcatCombiner` and updated `test_combiners.py` for `ConcatCombiner`.

**Significant change to `test_combiner.py`**
* added test for combination of these parameters
```
# test for simple concatenation combiner
@pytest.mark.parametrize("number_inputs", [None, 1])
@pytest.mark.parametrize("flatten_inputs", [True, False])
@pytest.mark.parametrize("fc_layer",
                         [None, [{"fc_size": 64}, {"fc_size": 64}]])
```

* add a class to emulate a stripped down Input Feature object that provides the `output_shape` property.  Needed this to simulate what happens in `ECD.forward()` processing.
```
# emulate Input Feature class.  Need to provide output_shape property to
# mimic what happens during ECD.forward() processing.
class PseudoInputFeature:
    def __init__(self, feature_name, output_shape):
        self.name = feature_name
        self._output_shape = output_shape

    @property
    def output_shape(self):
        return torch.Size(self._output_shape[1:])
```

**Significant change to `combiner.py`**
* Updated `ConcatCombiner.input_shape` property to account for the effect of the `flatten_inputs` parameter for the combiner.