### PR TITLE
Account for image extensions during image type inference

### DIFF
--- a/ludwig/automl/data_source.py
+++ b/ludwig/automl/data_source.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from typing import List
 
 from ludwig.automl.utils import avg_num_tokens
-from ludwig.utils.image_utils import is_image
+from ludwig.utils.image_utils import is_image_score
 
 
 class DataSource(ABC):
@@ -55,7 +55,7 @@ class DataframeSource(DataSource):
         return len(self.df[column].notnull())
 
     def get_image_values(self, column, sample_size=10) -> int:
-        return sum(is_image(None, x) for x in self.df[column].head(sample_size))
+        return int(sum(is_image_score(None, x) for x in self.df[column].head(sample_size)))
 
     def get_avg_num_tokens(self, column) -> int:
         return avg_num_tokens(self.df[column])

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -86,6 +86,16 @@ def is_image(src_path, img_entry):
         return False
 
 
+# For image inference, want to bias towards both readable images, but also account for unreadable (i.e. expired) urls
+# with image extensions
+def is_image_score(src_path, img_entry):
+    if is_image(src_path, img_entry):
+        return 1
+    elif isinstance(img_entry, str) and img_entry.lower().endswith(('.png', '.jpg', '.jpeg', '.tiff', '.bmp', '.gif')):
+        return 0.5
+    return 0
+
+
 def read_image(img):
     if isinstance(img, str):
         return read_image_from_str(img)


### PR DESCRIPTION
We currently infer image types by reading the first K samples using imghdr and making sure the number of readable images meets a threshold. However, many datasets have unreadable (usually expired) image urls, but we still want those urls to contribute to image inference.