### PR TITLE
[Bug Fix] Fix the issue of loading the img dataset with 'local' backend

### DIFF
--- a/examples/insurance_lite/config.yaml
+++ b/examples/insurance_lite/config.yaml
@@ -6,6 +6,7 @@ input_features:
       height: 32
       width: 32
       in_memory: true
+      num_channels: 3
     encoder: vit
     image_size: 32
     patch_size: 4

--- a/examples/insurance_lite/train.py
+++ b/examples/insurance_lite/train.py
@@ -20,7 +20,7 @@ dataset = insurance_lite.load()
 # Define Ludwig model object that drive model training
 model = LudwigModel(config='./config.yaml',
                     logging_level=logging.INFO,
-                    backend='ray')
+                    backend='local')
 
 
 # initiate model training

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -197,7 +197,7 @@ class ImageFeatureMixin:
         """
 
         explicit_height_width = HEIGHT in preprocessing_parameters or WIDTH in preprocessing_parameters
-        explicit_num_channels = NUM_CHANNELS in preprocessing_parameters
+        explicit_num_channels = NUM_CHANNELS in preprocessing_parameters and preprocessing_parameters[NUM_CHANNELS]
 
         if explicit_num_channels:
             first_image = read_image(first_img_entry, preprocessing_parameters[NUM_CHANNELS])

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -119,7 +119,7 @@ class ImageFeatureMixin:
         images to the specifications by dropping channels/padding 0 channels
         """
 
-        img = read_image(img_entry)
+        img = read_image(img_entry, num_channels)
         if img is None:
             logger.info(f"{img_entry} cannot be read")
             return None
@@ -195,10 +195,14 @@ class ImageFeatureMixin:
         that all the images in the data are expected be of the same size with
         the same number of channels
         """
-        first_image = read_image(first_img_entry)
 
         explicit_height_width = HEIGHT in preprocessing_parameters or WIDTH in preprocessing_parameters
         explicit_num_channels = NUM_CHANNELS in preprocessing_parameters
+
+        if explicit_num_channels:
+            first_image = read_image(first_img_entry, preprocessing_parameters[NUM_CHANNELS])
+        else:
+            first_image = read_image(first_img_entry)
 
         inferred_sample = None
         if preprocessing_parameters[INFER_IMAGE_DIMENSIONS] and not (explicit_height_width and explicit_num_channels):


### PR DESCRIPTION
# Code Pull Requests

Hi folks,
I ran into the following errors when I change the backend from 'ray' to 'local' in the train.py. (I ran into other issues when running with 'ray' backend, but didn't bother to fix it)
```sh
Message: 'reading image url /home/tan/.ludwig_cache/insurance_lite_1.0/raw/Fast_Furious_Insured/trainImages/img_4638035.jpg failed'
Arguments: (ValueError('Invalid num_channels=None, value must be one of 1, 2, 3, 4.'),)
```

As suggested by @w4nderlust , I merged the master, but it still didn't work.
By skimming through the codebase, I realized that the config file is not using the right keyword when specifying the number of channels and there are two places not passing the num_channel value to lower-level configurations.
Once these diffs are applied, the insurance_lite example is able to successfully generate datasets from disk.
```sh
Using in_memory = False is not supported with dataframe data format.
Using full dataframe
Building dataset (it may take a while)
Writing preprocessed training set cache
Writing preprocessed test set cache
Writing preprocessed validation set cache
Writing train set metadata
Training set: 979
Validation set: 131
Test set: 289
```

Not sure whether this is the right fix or not.
But thought it's a good idea to make a PR at least.
Let me know if my understanding of the codebase is not right, since I am still learning the codebase.
Really appreciate it!