### PR TITLE
TF to Torch Migration  Combiner Port Part3

### DIFF
--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -1015,11 +1015,10 @@ class ComparatorCombiner(CombinerClass):
         element_wise_mul = e1_hidden * e2_hidden  # [bs, fc_size]
         dot_product = torch.sum(element_wise_mul, 1, keepdim=True)  # [bs, 1]
         abs_diff = torch.abs(e1_hidden - e2_hidden)  # [bs, fc_size]
-        bilinear_prod = torch.sum(
-            torch.mm(e1_hidden, self.bilinear_weights) * e2_hidden,
-            # [bs, fc_size]
-            1, keepdim=True
-        )  # [bs, 1]
+        bilinear_prod = torch.bmm(
+            torch.mm(e1_hidden, self.bilinear_weights).unsqueeze(1),
+            e2_hidden.unsqueeze(-1)
+        ).squeeze(-1)  # [bs, 1]
 
         logger.debug(
             'preparing combiner output by concatenating these tensors: '

--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -848,7 +848,7 @@ class TabTransformerCombiner(Module):
         return return_data
 
 
-class ComparatorCombiner(Module):
+class ComparatorCombiner(CombinerClass):
     def __init__(
             self,
             input_features: dict,
@@ -939,6 +939,20 @@ class ComparatorCombiner(Module):
         for k in entity:
             size += np.prod(self.input_features[k].output_shape)
         return torch.Size([size])
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size([2 * self.fc_size])
+        # todo: deterimine if we want to use this method
+        # psuedo_encoder_outputs = {}
+        # for f in self.entity_1 + self.entity_2:
+        #     psuedo_encoder_outputs[f] = {
+        #         'encoder_output':
+        #         torch.randn(2, *self.input_features[f].output_shape,
+        #                     dtype=self.input_dtype)
+        #     }
+        # combiner_output = self.forward(psuedo_encoder_outputs)
+        # return combiner_output['combiner_output'].size()[1:]
 
     def forward(
             self,

--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -565,7 +565,9 @@ class TransformerCombiner(CombinerClass):
 
         logger.debug('  Projectors')
         self.projectors = ModuleList(
-            [Linear(input_features[inp]['encoder_output'].shape[-1],
+            # regardless of rank-2 or rank-3 input, np.prod() calculates size
+            # after flattening the encoder output tensor
+            [Linear(np.int(np.prod(input_features[inp].output_shape)),
                     hidden_size)
              for inp in input_features]
         )

--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -605,6 +605,14 @@ class TransformerCombiner(CombinerClass):
                 fc_residual=fc_residual,
             )
 
+    @property
+    def concatenated_shape(self) -> torch.Size:
+        # compute the size of the last dimension for the incoming encoder outputs
+        # this is required to setup the fully connected layer
+        shapes = [np.prod(self.input_features[k].output_shape) for k in
+                  self.input_features]
+        return torch.Size([sum(shapes)])
+
     def forward(
             self,
             inputs,  # encoder outputs

--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -1017,7 +1017,7 @@ class ComparatorCombiner(CombinerClass):
         )  # [bs, 1]
 
         logger.debug(
-            'preparing combiner output by concatenating: '
+            'preparing combiner output by concatenating these tensors: '
             f'dot_product: {dot_product.shape}, element_size_mul: {element_wise_mul.shape}'
             f', abs_diff: {abs_diff.shape}, bilinear_prod {bilinear_prod.shape}'
         )

--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -978,7 +978,8 @@ class ComparatorCombiner(CombinerClass):
             e1_hidden = list(e1_enc_outputs)[0]
 
         # ================ Fully Connected ================
-        e1_hidden = self.e1_fc_stack(e1_hidden, training=training, mask=mask)
+        e1_hidden = self.e1_fc_stack(e1_hidden, training=training,
+                                     mask=mask)  # [bs, fc_size]
 
         ############
         # Entity 2 #
@@ -998,7 +999,8 @@ class ComparatorCombiner(CombinerClass):
             e2_hidden = list(e2_enc_outputs)[0]
 
         # ================ Fully Connected ================
-        e2_hidden = self.e2_fc_stack(e2_hidden, training=training, mask=mask)
+        e2_hidden = self.e2_fc_stack(e2_hidden, training=training,
+                                     mask=mask)  # [bs, fc_size]
 
         ###########
         # Compare #

--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -1014,7 +1014,7 @@ class ComparatorCombiner(CombinerClass):
         dot_product = torch.sum(element_wise_mul, 1, keepdim=True)  # [bs, 1]
         abs_diff = torch.abs(e1_hidden - e2_hidden)  # [bs, fc_size]
         bilinear_prod = torch.sum(
-            torch.matmul(e1_hidden, self.bilinear_weights) * e2_hidden,
+            torch.mm(e1_hidden, self.bilinear_weights) * e2_hidden,
             # [bs, fc_size]
             1, keepdim=True
         )  # [bs, 1]

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -384,15 +384,23 @@ def test_transformer_combiner(encoder_outputs):
             dtype=torch.float32
         )
     }
+    encoder_outputs['feature_3'] = {
+        'encoder_output': torch.randn(
+            [128, 8],
+            dtype=torch.float32
+        )
+    }
 
     input_features_def = [
         {'name': 'feature_1', 'type': 'numerical'},
-        {'name': 'feature_2', 'type': 'numerical'}
+        {'name': 'feature_2', 'type': 'numerical'},
+        {'name': 'feature_3', 'type': 'numerical'},
+
     ]
 
     # setup combiner to test
     combiner = TransformerCombiner(
-        input_features=input_features_def
+        input_features=encoder_outputs
     )
 
     # concatenate encoder outputs

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -346,7 +346,7 @@ def test_tabnet_combiner(encoder_outputs_key):
 
 
 @pytest.mark.parametrize("fc_layer",
-                         [None, [{"fc_size": 64}, {"fc_size": 64}]])
+                         [None, [{"fc_size": 64}, {"fc_size": 32}]])
 @pytest.mark.parametrize("entity_1", [["text_feature_1", "text_feature_2"]])
 @pytest.mark.parametrize("entity_2", [["image_feature_1", "image_feature_2"]])
 def test_comparator_combiner(encoder_comparator_outputs, fc_layer, entity_1,
@@ -375,18 +375,9 @@ def test_comparator_combiner(encoder_comparator_outputs, fc_layer, entity_1,
     assert "combiner_output" in combiner_output
     assert isinstance(combiner_output['combiner_output'], torch.Tensor)
 
-    # todo: decide which approach for testing output shape
     # confirm correct shape
     assert combiner_output['combiner_output'].shape == \
-           (BATCH_SIZE, (2 * BATCH_SIZE) + combiner.output_shape[-1])
-
-    # confirm correct output shapes
-    # concat on axis=1
-    # because of dot products, 2 of the shapes added will be the fc_size
-    #   other 2 will be of shape BATCH_SIZE
-    # this assumes dimensionality = 2
-    size = BATCH_SIZE * 2 + fc_size * 2
-    assert combiner_output["combiner_output"].shape == (BATCH_SIZE, size)
+           (BATCH_SIZE, combiner.output_shape[-1])
 
 
 @pytest.mark.parametrize('fc_size', [8, 16])

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -369,7 +369,13 @@ def test_comparator_combiner(encoder_comparator_outputs, fc_layer, entity_1,
     assert results["combiner_output"].shape.as_list() == [BATCH_SIZE, size]
 
 
-def test_transformer_combiner(encoder_outputs):
+@pytest.mark.parametrize('fc_size', [8, 16])
+@pytest.mark.parametrize('transformer_fc_size', [4, 12])
+def test_transformer_combiner(
+        encoder_outputs: tuple,
+        transformer_fc_size: int,
+        fc_size: int
+) -> None:
     encoder_outputs_dict, input_feature_dict = encoder_outputs
 
     # setup combiner to test

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -1,6 +1,6 @@
 import logging
 from collections import OrderedDict
-
+import numpy as np
 import pytest
 import torch
 
@@ -393,10 +393,11 @@ def test_transformer_combiner(
     # calculate expected hidden size for concatenated tensors
     hidden_size = 0
     for k in encoder_outputs_dict:
-        hidden_size += encoder_outputs_dict[k]["encoder_output"].shape[-1]
+        hidden_size += np.prod(
+            encoder_outputs_dict[k]["encoder_output"].shape[1:])
 
     # confirm correctness of effective_input_shape
-    assert combiner.effective_input_shape[-1] == hidden_size
+    assert combiner.concatenated_shape[-1] == hidden_size
 
     # concatenate encoder outputs
     combiner_output = combiner(encoder_outputs_dict)

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -366,10 +366,19 @@ def test_comparator_combiner(encoder_comparator_outputs, fc_layer, entity_1,
     )
 
     # concatenate encoder outputs
-    results = combiner(encoder_comparator_outputs_dict)
+    combiner_output = combiner(encoder_comparator_outputs_dict)
 
-    # required key present
-    assert "combiner_output" in results
+    # correct data structure
+    assert isinstance(combiner_output, dict)
+
+    # required key present and correct data type
+    assert "combiner_output" in combiner_output
+    assert isinstance(combiner_output['combiner_output'], torch.Tensor)
+
+    # todo: decide which approach for testing output shape
+    # confirm correct shape
+    assert combiner_output['combiner_output'].shape == \
+           (BATCH_SIZE, (2 * BATCH_SIZE) + combiner.output_shape[-1])
 
     # confirm correct output shapes
     # concat on axis=1
@@ -377,7 +386,7 @@ def test_comparator_combiner(encoder_comparator_outputs, fc_layer, entity_1,
     #   other 2 will be of shape BATCH_SIZE
     # this assumes dimensionality = 2
     size = BATCH_SIZE * 2 + fc_size * 2
-    assert results["combiner_output"].shape == (BATCH_SIZE, size)
+    assert combiner_output["combiner_output"].shape == (BATCH_SIZE, size)
 
 
 @pytest.mark.parametrize('fc_size', [8, 16])

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -366,7 +366,7 @@ def test_comparator_combiner(encoder_comparator_outputs, fc_layer, entity_1,
     #   other 2 will be of shape BATCH_SIZE
     # this assumes dimensionality = 2
     size = BATCH_SIZE * 2 + fc_size * 2
-    assert results["combiner_output"].shape.as_list() == [BATCH_SIZE, size]
+    assert results["combiner_output"].shape == (BATCH_SIZE, size)
 
 
 @pytest.mark.parametrize('fc_size', [8, 16])


### PR DESCRIPTION
# Code Pull Requests

Work is part of Issue #1324.

Summary of changes:
* Working `ComparatorCombiner`
* Working `TransformerCombiner`
* Updated unit test for these two combiners.

At this point only the `TabTransformer` and `TabNet` combiners remain to be ported.  Status of combiner unit tests:
```
root@6b51e610429a:/opt/project/sandbox/pytest_area# pytest -v --tb=line /opt/project/tests/integration_tests/test_combiners.py
======================================================= test session starts ========================================================
platform linux -- Python 3.7.11, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /opt/project, configfile: pytest.ini
plugins: timeout-1.4.2, xdist-2.3.0, cov-2.12.1, forked-1.3.0, pycharm-0.7.0, anyio-3.3.0
collected 41 items

../../tests/integration_tests/test_combiners.py::test_concat_combiner[None-True-None] PASSED                                 [  2%]
../../tests/integration_tests/test_combiners.py::test_concat_combiner[None-True-1] PASSED                                    [  4%]
../../tests/integration_tests/test_combiners.py::test_concat_combiner[None-False-None] PASSED                                [  7%]
../../tests/integration_tests/test_combiners.py::test_concat_combiner[None-False-1] PASSED                                   [  9%]
../../tests/integration_tests/test_combiners.py::test_concat_combiner[fc_layer1-True-None] PASSED                            [ 12%]
../../tests/integration_tests/test_combiners.py::test_concat_combiner[fc_layer1-True-1] PASSED                               [ 14%]
../../tests/integration_tests/test_combiners.py::test_concat_combiner[fc_layer1-False-None] PASSED                           [ 17%]
../../tests/integration_tests/test_combiners.py::test_concat_combiner[fc_layer1-False-1] PASSED                              [ 19%]
../../tests/integration_tests/test_combiners.py::test_sequence_concat_combiner[None-None] PASSED                             [ 21%]
../../tests/integration_tests/test_combiners.py::test_sequence_concat_combiner[None-sum] PASSED                              [ 24%]
../../tests/integration_tests/test_combiners.py::test_sequence_concat_combiner[feature_3-None] PASSED                        [ 26%]
../../tests/integration_tests/test_combiners.py::test_sequence_concat_combiner[feature_3-sum] PASSED                         [ 29%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-stacked_cnn-None] PASSED                        [ 31%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-stacked_cnn-sum] PASSED                         [ 34%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-parallel_cnn-None] PASSED                       [ 36%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-parallel_cnn-sum] PASSED                        [ 39%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-stacked_parallel_cnn-None] PASSED               [ 41%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-stacked_parallel_cnn-sum] PASSED                [ 43%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-rnn-None] PASSED                                [ 46%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-rnn-sum] PASSED                                 [ 48%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-cnnrnn-None] PASSED                             [ 51%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[None-cnnrnn-sum] PASSED                              [ 53%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-stacked_cnn-None] PASSED                   [ 56%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-stacked_cnn-sum] PASSED                    [ 58%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-parallel_cnn-None] PASSED                  [ 60%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-parallel_cnn-sum] PASSED                   [ 63%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-stacked_parallel_cnn-None] PASSED          [ 65%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-stacked_parallel_cnn-sum] PASSED           [ 68%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-rnn-None] PASSED                           [ 70%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-rnn-sum] PASSED                            [ 73%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-cnnrnn-None] PASSED                        [ 75%]
../../tests/integration_tests/test_combiners.py::test_sequence_combiner[feature_3-cnnrnn-sum] PASSED                         [ 78%]
../../tests/integration_tests/test_combiners.py::test_tabnet_combiner[batch_128] FAILED                                      [ 80%]
../../tests/integration_tests/test_combiners.py::test_tabnet_combiner[inputs] FAILED                                         [ 82%]
../../tests/integration_tests/test_combiners.py::test_comparator_combiner[entity_20-entity_10-None] PASSED                   [ 85%]
../../tests/integration_tests/test_combiners.py::test_comparator_combiner[entity_20-entity_10-fc_layer1] PASSED              [ 87%]
../../tests/integration_tests/test_combiners.py::test_transformer_combiner[4-8] PASSED                                       [ 90%]
../../tests/integration_tests/test_combiners.py::test_transformer_combiner[4-16] PASSED                                      [ 92%]
../../tests/integration_tests/test_combiners.py::test_transformer_combiner[12-8] PASSED                                      [ 95%]
../../tests/integration_tests/test_combiners.py::test_transformer_combiner[12-16] PASSED                                     [ 97%]
../../tests/integration_tests/test_combiners.py::test_tabtransformer_combiner FAILED                                         [100%]

```