### PR TITLE
Remove remaining tensorflow imports

### DIFF
--- a/ludwig/data/dataset/parquet.py
+++ b/ludwig/data/dataset/parquet.py
@@ -17,7 +17,6 @@
 import contextlib
 import math
 
-import tensorflow as tf
 from ludwig.data.dataset.pandas import PandasDataset
 from ludwig.data.dataset.partitioned import RayDataset
 from ludwig.utils.data_utils import DATA_TRAIN_HDF5_FP

--- a/ludwig/data/dataset/tfrecord.py
+++ b/ludwig/data/dataset/tfrecord.py
@@ -5,7 +5,6 @@ import math
 import os
 from distutils.version import LooseVersion
 
-import tensorflow as tf
 from ludwig.constants import NAME, PROC_COLUMN
 from ludwig.data.batcher.iterable import IterableBatcher
 from ludwig.data.dataset.base import Dataset
@@ -16,10 +15,10 @@ from ludwig.utils.misc_utils import get_combined_features, get_proc_features
 from ludwig.utils.data_utils import load_json
 
 
-if LooseVersion(tf.__version__) >= LooseVersion('2.4'):
-    AUTOTUNE = tf.data.AUTOTUNE
-else:
-    AUTOTUNE = tf.data.experimental.AUTOTUNE
+# if LooseVersion(tf.__version__) >= LooseVersion('2.4'):
+#     AUTOTUNE = tf.data.AUTOTUNE
+# else:
+#     AUTOTUNE = tf.data.experimental.AUTOTUNE
 
 
 class TFRecordDataset(Dataset):

--- a/ludwig/decoders/sequence_decoders.py
+++ b/ludwig/decoders/sequence_decoders.py
@@ -16,8 +16,6 @@
 from abc import ABC
 import logging
 
-# import tensorflow as tf
-# import tensorflow_addons as tfa
 # from tensorflow.keras.layers import GRUCell, SimpleRNNCell, LSTMCell, \
 #     StackedRNNCells
 # from tensorflow.keras.layers import Dense, Embedding

--- a/ludwig/encoders/binary_encoders.py
+++ b/ludwig/encoders/binary_encoders.py
@@ -17,8 +17,6 @@
 import logging
 from abc import ABC
 
-# import tensorflow as tf
-
 from ludwig.encoders.base import Encoder
 from ludwig.utils.registry import Registry, register_default
 from ludwig.encoders.generic_encoders import DenseEncoder

--- a/ludwig/encoders/h3_encoders.py
+++ b/ludwig/encoders/h3_encoders.py
@@ -17,8 +17,6 @@
 import logging
 from abc import ABC
 
-# import tensorflow as tf
-
 from ludwig.encoders.base import Encoder
 from ludwig.utils.registry import Registry, register
 from ludwig.modules.embedding_modules import Embed

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -18,8 +18,6 @@ import logging
 import sys
 from abc import ABC
 
-# import tensorflow as tf
-
 from ludwig.encoders import sequence_encoders
 from ludwig.encoders.base import Encoder
 from ludwig.utils.registry import Registry, register

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -17,7 +17,6 @@
 import logging
 
 import numpy as np
-# import tensorflow as tf
 # from tensorflow.keras.metrics import Accuracy as BinaryAccuracy
 import torch
 

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -18,7 +18,6 @@ import logging
 
 import numpy as np
 import torch
-# import tensorflow as tf
 
 from ludwig.constants import *
 from ludwig.encoders.h3_encoders import ENCODER_REGISTRY

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -18,7 +18,6 @@ import logging
 
 import numpy as np
 import torch
-# import tensorflow as tf
 
 from ludwig.constants import *
 from ludwig.encoders.sequence_encoders import StackedCNN, ParallelCNN, \

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -2,8 +2,6 @@ import copy
 import logging
 from collections import OrderedDict
 
-#import tensorflow as tf
-
 from ludwig.combiners.combiners import get_combiner_class
 from ludwig.constants import *
 from ludwig.features.feature_registries import input_type_registry, \

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, OrderedDict
 from pprint import pformat
 
-#import tensorflow as tf
 import torch
 from tqdm import tqdm
 

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -32,7 +32,6 @@ from random import random
 from re import M
 import numpy as np
 
-#import tensorflow as tf
 import torch
 from torch.utils.tensorboard import SummaryWriter
 from tabulate import tabulate

--- a/ludwig/modules/normalization_modules.py
+++ b/ludwig/modules/normalization_modules.py
@@ -1,4 +1,3 @@
-# import tensorflow as tf
 from ludwig.utils.torch_utils import LudwigModule
 
 # from tensorflow.keras.layers import BatchNormalization

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -1,6 +1,5 @@
 from typing import List, Tuple
 
-# import tensorflow as tf
 import torch
 
 from ludwig.modules.activation_modules import glu

--- a/ludwig/utils/tf_utils.py
+++ b/ludwig/utils/tf_utils.py
@@ -22,7 +22,6 @@ import multiprocessing
 import warnings
 import zipfile
 
-# import tensorflow as tf
 from ludwig.globals import MODEL_WEIGHTS_FILE_NAME
 
 _TF_INIT_PARAMS = None

--- a/requirements_ray.txt
+++ b/requirements_ray.txt
@@ -2,4 +2,4 @@ ray[default,tune]>=1.6.0
 pickle5
 tensorboardX<2.3
 GPUtil
-
+tblib

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,6 @@ def init_tensorflow_cpu(request):
     and order of magnitude for small tests. Tests that execute in subprocesses, and tests
     in `test_graph_execution.py` still run in graph mode.
     """
-    # import tensorflow as tf
     # tf.config.experimental_run_functions_eagerly(True)
     # initialize_tensorflow(gpus=-1)
     pass

--- a/tests/integration_tests/test_cache_manager.py
+++ b/tests/integration_tests/test_cache_manager.py
@@ -6,7 +6,7 @@ import pytest
 
 from ludwig.constants import META, TRAINING, VALIDATION, TEST, CHECKSUM
 from ludwig.data.cache.manager import CacheManager, alphanum
-from ludwig.data.dataset import PandasDatasetManager
+from ludwig.data.dataset import pandas_manager
 
 from tests.integration_tests.utils import sequence_feature, category_feature, LocalTestBackend
 
@@ -14,7 +14,7 @@ from tests.integration_tests.utils import sequence_feature, category_feature, Lo
 @pytest.mark.parametrize('use_split', [True, False], ids=['split', 'no_split'])
 @pytest.mark.parametrize('use_cache_dir', [True, False], ids=['cache_dir', 'no_cache_dir'])
 def test_cache_dataset(use_cache_dir, use_split, tmpdir):
-    dataset_manager = PandasDatasetManager(backend=LocalTestBackend())
+    dataset_manager = pandas_manager()(backend=LocalTestBackend())
     cache_dir = os.path.join(tmpdir, 'cache') if use_cache_dir else None
     manager = CacheManager(dataset_manager, cache_dir=cache_dir)
 

--- a/tests/integration_tests/test_collect.py
+++ b/tests/integration_tests/test_collect.py
@@ -18,7 +18,6 @@ import shutil
 import tempfile
 
 import numpy as np
-import tensorflow as tf
 
 from ludwig.api import LudwigModel
 from ludwig.collect import collect_activations, collect_weights

--- a/tests/integration_tests/test_dask.py
+++ b/tests/integration_tests/test_dask.py
@@ -17,7 +17,6 @@ import os
 import tempfile
 
 import pytest
-import tensorflow as tf
 
 from ludwig.backend import LOCAL_BACKEND
 from ludwig.backend.dask import DaskBackend

--- a/tests/integration_tests/test_dependencies.py
+++ b/tests/integration_tests/test_dependencies.py
@@ -1,7 +1,6 @@
 import logging
 
 import pytest
-import tensorflow as tf
 
 from ludwig.features.numerical_feature import NumericalOutputFeature
 from tests.integration_tests.utils import numerical_feature

--- a/tests/integration_tests/test_graph_execution.py
+++ b/tests/integration_tests/test_graph_execution.py
@@ -16,8 +16,6 @@
 import contextlib
 
 import pytest
-import tensorflow as tf
-import tensorflow_addons as tfa
 
 from tests.integration_tests.utils import category_feature
 from tests.integration_tests.utils import generate_data

--- a/tests/integration_tests/test_horovod.py
+++ b/tests/integration_tests/test_horovod.py
@@ -21,7 +21,7 @@ import subprocess
 import sys
 
 import pytest
-import tensorflow as tf
+import torch
 
 try:
     from horovod.common.util import nccl_built
@@ -93,7 +93,7 @@ def test_horovod_implicit(csv_filename):
                     reason="Horovod is not supported on Windows")
 @pytest.mark.skipif(not _nccl_available(),
                     reason="test requires Horovod with NCCL support")
-@pytest.mark.skipif(not tf.test.is_gpu_available(cuda_only=True),
+@pytest.mark.skipif(not torch.cuda.is_available(),
                     reason="test requires multi-GPU machine")
 @pytest.mark.distributed
 def test_horovod_gpu_memory_limit(csv_filename):

--- a/tests/integration_tests/test_model_save_and_load.py
+++ b/tests/integration_tests/test_model_save_and_load.py
@@ -3,7 +3,6 @@ import tempfile
 
 import numpy as np
 import pandas as pd
-import tensorflow as tf
 
 from ludwig.api import LudwigModel
 from ludwig.constants import SPLIT

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -7,7 +7,6 @@ import logging
 import numpy as np
 import pandas as pd
 import pytest
-import tensorflow as tf
 from sklearn.model_selection import train_test_split
 
 from ludwig import globals as global_vars

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -20,7 +20,6 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
-import tensorflow as tf
 from unittest import mock
 
 from ludwig.api import LudwigModel

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -19,7 +19,6 @@ import tempfile
 
 import pytest
 import ray
-import tensorflow as tf
 
 from ludwig.backend.ray import RayBackend, get_horovod_kwargs
 

--- a/tests/integration_tests/test_regularizers.py
+++ b/tests/integration_tests/test_regularizers.py
@@ -6,7 +6,6 @@ from collections import namedtuple
 import numpy as np
 import pandas as pd
 import pytest
-import tensorflow as tf
 
 from ludwig.constants import PROC_COLUMN, NAME
 from ludwig.data.dataset_synthesizer import build_synthetic_dataset

--- a/tests/integration_tests/test_savedmodel.py
+++ b/tests/integration_tests/test_savedmodel.py
@@ -20,7 +20,6 @@ from copy import deepcopy
 
 import numpy as np
 import pytest
-import tensorflow as tf
 
 from ludwig.api import LudwigModel
 from ludwig.data.preprocessing import preprocess_for_prediction

--- a/tests/ludwig/modules/test_attention.py
+++ b/tests/ludwig/modules/test_attention.py
@@ -1,5 +1,4 @@
 import pytest
-import tensorflow as tf
 
 from ludwig.modules.attention_modules import FeedForwardAttentionReducer
 

--- a/tests/ludwig/modules/test_encoder.py
+++ b/tests/ludwig/modules/test_encoder.py
@@ -16,7 +16,6 @@
 import random
 
 import numpy as np
-import tensorflow as tf
 
 from ludwig.data.dataset_synthesizer import build_vocab
 from ludwig.encoders.image_encoders import ResNetEncoder, Stacked2DCNN, \


### PR DESCRIPTION
This change unblocks integration tests from running to help with detecting regressions.