### PR TITLE
Removed bugs to enable training on insurance lite dataset

### DIFF
--- a/examples/insurance_lite/config.yaml
+++ b/examples/insurance_lite/config.yaml
@@ -3,19 +3,18 @@ input_features:
     name: image_path
     type: image
     preprocessing:
-      height: 32
-      width: 32
+      height: 224
+      width: 224
       in_memory: true
       num_channels: 3
     encoder: vit
-    image_size: 32
-    patch_size: 4
-    num_layers: 4
-    d_model: 64
-    num_heads: 4
-    mlp_dim: 128
-    channels: 3
-    dropout: 0.1
+    img_height: 224
+    in_channels: 3
+    use_pretrained: true
+    hidden_size: 768
+    num_hidden_layers: 12
+    num_attention_heads: 12
+    intermediate_size: 3072
   -
     name: insurance_company
     type: category
@@ -64,8 +63,9 @@ output_features:
     preprocessing:
       normalization: zscore
 training:
-  epochs: 1000
+  epochs: 10
   early_stop: 0
+  batch_size: 8
 preprocessing:
   force_split: false
   split_probabilities: [0.7, 0.1, 0.2]

--- a/ludwig/encoders/image_encoders.py
+++ b/ludwig/encoders/image_encoders.py
@@ -317,7 +317,8 @@ class ViTEncoder(ImageEncoder):
             layer_norm_eps: float = 1e-12,
             gradient_checkpointing: bool = False,
             patch_size: int = 16,
-            trainable: bool = True
+            trainable: bool = True,
+            **kwargs
     ):
         """ Creates a ViT encoder using transformers.ViTModel.
 

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -105,6 +105,7 @@ class CategoryFeatureMixin:
             input_df[feature[COLUMN]].astype(str),
             metadata[feature[NAME]],
         )
+
         return proc_df
 
 
@@ -124,6 +125,7 @@ class CategoryInputFeature(CategoryFeatureMixin, InputFeature):
         assert inputs.dtype == torch.int8 or inputs.dtype == torch.int16 or \
                inputs.dtype == torch.int32 or inputs.dtype == torch.int64
         assert len(inputs.shape) == 1
+        inputs = inputs.unsqueeze(dim=1)
 
         if inputs.dtype == torch.int8 or inputs.dtype == torch.int16:
             inputs = inputs.type(torch.IntTensor)

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -135,13 +135,11 @@ class DateInputFeature(DateFeatureMixin, InputFeature):
         else:
             self.encoder_obj = self.initialize_encoder(feature)
 
-    def forward(self, inputs, training=None, mask=None):
+    def forward(self, inputs):
         assert isinstance(inputs, torch.Tensor)
         assert inputs.dtype in [torch.int16, torch.int64]
 
-        inputs_encoded = self.encoder_obj(
-            inputs, training=training, mask=mask
-        )
+        inputs_encoded = self.encoder_obj(inputs)
 
         return inputs_encoded
 
@@ -152,6 +150,10 @@ class DateInputFeature(DateFeatureMixin, InputFeature):
     @property
     def input_shape(self) -> torch.Size:
         return torch.Size([DATE_VECTOR_LENGTH])
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return self.encoder_obj.output_shape
 
     @staticmethod
     def update_config_with_metadata(

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -456,6 +456,10 @@ class ImageInputFeature(ImageFeatureMixin, InputFeature):
     def input_shape(self) -> torch.Size:
         return torch.Size([self.num_channels, self.height, self.width])
 
+    @property
+    def output_shape(self) -> torch.Size:
+        return self.encoder_obj.output_shape
+
     @staticmethod
     def update_config_with_metadata(
             input_feature,


### PR DESCRIPTION
This PR
- Added `kwargs` to ViT
- Made config args for ViT consistent with encoder args
- Cleaned up feature migrations for images, categories and dates.