### PR TITLE
Simplify model summary CLI integration test

### DIFF
--- a/ludwig/automl/auto_tune_config.py
+++ b/ludwig/automl/auto_tune_config.py
@@ -86,7 +86,6 @@ def get_machine_memory():
 def compute_memory_usage(config, training_set_metadata) -> int:
     update_config_with_metadata(config, training_set_metadata)
     lm = LudwigModel.create_model(config)
-    lm.get_connected_model()
     model_tensors = lm.collect_weights()
     total_size = 0
     batch_size = config[TRAINING][BATCH_SIZE]

--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -198,18 +198,16 @@ def print_model_summary(
     :return: (`None`)
     """
     model = LudwigModel.load(model_path)
-    collected_tensors = model.collect_weights()
-    names = [name for name, w in collected_tensors]
+    # TODO(justin): Enable when torchsummary supports dict inputs.
+    # https://pypi.org/project/torch-summary/
+    # torchsummary.summary(model.model, model.model.get_model_inputs(training=False))
 
-    keras_model = model.model.get_connected_model(training=False)
-    keras_model.summary()
+    print('\nModel children:\n')
+    for name, _ in model.model.named_children():
+        print(name)
 
-    print('\nLayers:\n')
-    for layer in keras_model.layers:
-        print(layer.name)
-
-    print('\nWeights:\n')
-    for name in names:
+    print('\nParameters:\n')
+    for name, _ in model.model.named_parameters():
         print(name)
 
 

--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -202,7 +202,7 @@ def print_model_summary(
     # https://pypi.org/project/torch-summary/
     # torchsummary.summary(model.model, model.model.get_model_inputs(training=False))
 
-    print('\nModel children:\n')
+    print('\nModules:\n')
     for name, _ in model.model.named_children():
         print(name)
 

--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -21,6 +21,7 @@ import sys
 from typing import List, Union
 
 import numpy as np
+import torchinfo
 
 from ludwig.api import LudwigModel
 from ludwig.backend import ALL_BACKENDS,  Backend
@@ -198,9 +199,9 @@ def print_model_summary(
     :return: (`None`)
     """
     model = LudwigModel.load(model_path)
-    # TODO(justin): Enable when torchsummary supports dict inputs.
-    # https://pypi.org/project/torch-summary/
-    # torchsummary.summary(model.model, model.model.get_model_inputs(training=False))
+    # Model's dict inputs are wrapped in a list, required by torchinfo.
+    torchinfo.summary(
+        model.model, input_data=[model.model.get_model_inputs(training=False)])
 
     print('\nModules:\n')
     for name, _ in model.model.named_children():

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -85,7 +85,7 @@ class InputFeature(BaseFeature, LudwigModule, ABC):
         super().__init__(*args, **kwargs)
 
     def create_input(self):
-        return torch.rand(self.input_shape, dtype=self.input_dtype)
+        return torch.rand([2, *self.input_shape]).to(self.input_dtype)
 
     @staticmethod
     @abstractmethod

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -321,7 +321,6 @@ def test_collect_summary_activations_weights_cli(csv_filename):
                                         )
         stdout = completed_process.stdout.decode('utf-8')
 
-        # TODO(justin): Check that more summary information was printed using torchsummary.
         assert 'Modules' in stdout
         assert 'Parameters' in stdout
 

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -177,40 +177,42 @@ def test_train_cli_horovod(csv_filename):
         )
 
 
-@pytest.mark.distributed
-def test_export_savedmodel_cli(csv_filename):
-    """Test exporting Ludwig model to Tensorflows savedmodel format."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        config_filename = os.path.join(tmpdir,
-                                       'config.yaml')
-        dataset_filename = _prepare_data(csv_filename,
-                                         config_filename)
-        _run_ludwig('train',
-                    dataset=dataset_filename,
-                    config_file=config_filename,
-                    output_directory=tmpdir)
-        _run_ludwig('export_savedmodel',
-                    model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
-                    output_path=os.path.join(tmpdir, 'savedmodel')
-                    )
+# TODO(https://github.com/ludwig-ai/ludwig/projects/3#card-71743513): Re-enable.
+# @pytest.mark.distributed
+# def test_export_savedmodel_cli(csv_filename):
+#     """Test exporting Ludwig model to Tensorflows savedmodel format."""
+#     with tempfile.TemporaryDirectory() as tmpdir:
+#         config_filename = os.path.join(tmpdir,
+#                                        'config.yaml')
+#         dataset_filename = _prepare_data(csv_filename,
+#                                          config_filename)
+#         _run_ludwig('train',
+#                     dataset=dataset_filename,
+#                     config_file=config_filename,
+#                     output_directory=tmpdir)
+#         _run_ludwig('export_savedmodel',
+#                     model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
+#                     output_path=os.path.join(tmpdir, 'savedmodel')
+#                     )
 
 
-@pytest.mark.distributed
-def test_export_neuropod_cli(csv_filename):
-    """Test exporting Ludwig model to neuropod format."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        config_filename = os.path.join(tmpdir,
-                                       'config.yaml')
-        dataset_filename = _prepare_data(csv_filename,
-                                         config_filename)
-        _run_ludwig('train',
-                    dataset=dataset_filename,
-                    config_file=config_filename,
-                    output_directory=tmpdir)
-        _run_ludwig('export_neuropod',
-                    model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
-                    output_path=os.path.join(tmpdir, 'neuropod')
-                    )
+# TODO: Enable or remove.
+# @pytest.mark.distributed
+# def test_export_neuropod_cli(csv_filename):
+#     """Test exporting Ludwig model to neuropod format."""
+#     with tempfile.TemporaryDirectory() as tmpdir:
+#         config_filename = os.path.join(tmpdir,
+#                                        'config.yaml')
+#         dataset_filename = _prepare_data(csv_filename,
+#                                          config_filename)
+#         _run_ludwig('train',
+#                     dataset=dataset_filename,
+#                     config_file=config_filename,
+#                     output_directory=tmpdir)
+#         _run_ludwig('export_neuropod',
+#                     model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
+#                     output_path=os.path.join(tmpdir, 'neuropod')
+#                     )
 
 
 @pytest.mark.distributed
@@ -319,53 +321,9 @@ def test_collect_summary_activations_weights_cli(csv_filename):
                                         )
         stdout = completed_process.stdout.decode('utf-8')
 
-        # parse output of collect_summary to find tensor names to use
-        # in the collect_wights and collect_activations.
-        # This part of test is sensitive to output format of collect_summary
-        # search for substring with layer names
-        layers = re.search(
-            "Layers(\w|\d|\:|\/|\n)*Weights",
-            stdout
-        )
-        substring = stdout[layers.start(): layers.end()]
-
-        # extract layer names
-        layers_list = []
-        with StringIO(substring) as f:
-            for _, line in enumerate(f):
-                if not (line[:6] == 'Layers' or line[:6] == 'Weight') and len(
-                        line) > 1:
-                    layers_list.append(line[:-1])
-
-        # search for substring with weights names
-        weights = re.search(
-            "Weights(\w|\d|\:|\/|\n)*",
-            stdout
-        )
-        substring = stdout[weights.start(): weights.end()]
-
-        # extract weights names
-        weights_list = []
-        with StringIO(substring) as f:
-            for _, line in enumerate(f):
-                if (not (line[:6] == 'Layers' or line[:6] == 'Weight')
-                        and len(line) > 1):
-                    weights_list.append(line[:-1])
-
-        # collect activations
-        _run_ludwig('collect_activations',
-                    dataset=dataset_filename,
-                    model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
-                    layers=' '.join(layers_list),
-                    output_directory=tmpdir
-                    )
-
-        # collect weights
-        _run_ludwig('collect_weights',
-                    model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
-                    tensors=' '.join(weights_list),
-                    output_directory=tmpdir
-                    )
+        # TODO(justin): Check that more summary information was printed using torchsummary.
+        assert 'Model children' in stdout
+        assert 'Parameters' in stdout
 
 
 @pytest.mark.distributed

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -177,42 +177,42 @@ def test_train_cli_horovod(csv_filename):
         )
 
 
-# TODO(https://github.com/ludwig-ai/ludwig/projects/3#card-71743513): Re-enable.
-# @pytest.mark.distributed
-# def test_export_savedmodel_cli(csv_filename):
-#     """Test exporting Ludwig model to Tensorflows savedmodel format."""
-#     with tempfile.TemporaryDirectory() as tmpdir:
-#         config_filename = os.path.join(tmpdir,
-#                                        'config.yaml')
-#         dataset_filename = _prepare_data(csv_filename,
-#                                          config_filename)
-#         _run_ludwig('train',
-#                     dataset=dataset_filename,
-#                     config_file=config_filename,
-#                     output_directory=tmpdir)
-#         _run_ludwig('export_savedmodel',
-#                     model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
-#                     output_path=os.path.join(tmpdir, 'savedmodel')
-#                     )
+@pytest.mark.skip(reason="Issue #1451: Use torchscript.")
+@pytest.mark.distributed
+def test_export_savedmodel_cli(csv_filename):
+    """Test exporting Ludwig model to Tensorflows savedmodel format."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_filename = os.path.join(tmpdir,
+                                       'config.yaml')
+        dataset_filename = _prepare_data(csv_filename,
+                                         config_filename)
+        _run_ludwig('train',
+                    dataset=dataset_filename,
+                    config_file=config_filename,
+                    output_directory=tmpdir)
+        _run_ludwig('export_savedmodel',
+                    model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
+                    output_path=os.path.join(tmpdir, 'savedmodel')
+                    )
 
 
-# TODO: Enable or remove.
-# @pytest.mark.distributed
-# def test_export_neuropod_cli(csv_filename):
-#     """Test exporting Ludwig model to neuropod format."""
-#     with tempfile.TemporaryDirectory() as tmpdir:
-#         config_filename = os.path.join(tmpdir,
-#                                        'config.yaml')
-#         dataset_filename = _prepare_data(csv_filename,
-#                                          config_filename)
-#         _run_ludwig('train',
-#                     dataset=dataset_filename,
-#                     config_file=config_filename,
-#                     output_directory=tmpdir)
-#         _run_ludwig('export_neuropod',
-#                     model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
-#                     output_path=os.path.join(tmpdir, 'neuropod')
-#                     )
+@pytest.mark.skip(reason="Issue #1451: Use torchscript.")
+@pytest.mark.distributed
+def test_export_neuropod_cli(csv_filename):
+    """Test exporting Ludwig model to neuropod format."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_filename = os.path.join(tmpdir,
+                                       'config.yaml')
+        dataset_filename = _prepare_data(csv_filename,
+                                         config_filename)
+        _run_ludwig('train',
+                    dataset=dataset_filename,
+                    config_file=config_filename,
+                    output_directory=tmpdir)
+        _run_ludwig('export_neuropod',
+                    model_path=os.path.join(tmpdir, 'experiment_run', 'model'),
+                    output_path=os.path.join(tmpdir, 'neuropod')
+                    )
 
 
 @pytest.mark.distributed

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -322,7 +322,7 @@ def test_collect_summary_activations_weights_cli(csv_filename):
         stdout = completed_process.stdout.decode('utf-8')
 
         # TODO(justin): Check that more summary information was printed using torchsummary.
-        assert 'Model children' in stdout
+        assert 'Modules' in stdout
         assert 'Parameters' in stdout
 
 

--- a/tests/integration_tests/test_collect.py
+++ b/tests/integration_tests/test_collect.py
@@ -21,7 +21,7 @@ import numpy as np
 import torch
 
 from ludwig.api import LudwigModel
-from ludwig.collect import collect_activations, collect_weights
+from ludwig.collect import collect_activations, collect_weights, print_model_summary
 from tests.integration_tests.utils import category_feature, generate_data, \
     sequence_feature, spawn, ENCODERS
 
@@ -114,3 +114,10 @@ def test_collect_activations(csv_filename):
     finally:
         if output_dir:
             shutil.rmtree(output_dir, ignore_errors=True)
+
+
+def test_print_model_summary(csv_filename):
+    output_dir = None
+    model, output_dir = _train(*_prepare_data(csv_filename))
+    model_path = os.path.join(output_dir, 'model')
+    print_model_summary(model_path)


### PR DESCRIPTION
ludwig's `collect_summary` CLI prints a model summary, keras weight, and keras layer names.

In a torch world, we replace keras' model summary with `torchinfo`.

The concept of keras `layers` conceptually matches to torch `modules`, and the modules for the top-level `model` can be accessed using `model.children()`. Keras `weight` names conceptually matches to torch `parameter` names.

The corresponding CLI unit test is quite complex -- it invokes the summary (which prints to stdout), parses the stdout output using custom regexes, and checks that the parsed names are "compatible" with other APIs, specifically `collect_weights` and `collect_activations`. `collect_weights` and `collect_activations` are also complicated -- in addition to their primary function collecting information from the model, they also take a separate list of names as an optional input and raise an error if any of the received names are not found -- a functionality that doesn't seem to be used anywhere except for this specific CLI unit test.

I'll propose a simpler design:
- Maintain that collecting weights and layers is tested in `test_collect.py`.
- Remove all stdout parsing using custom regexes from the `collect_summary` CLI integration test. Instead, keep the scope of the integration test to simply check that a CLI command executes as expected (i.e. something is printed to stdout).
- Remove all "name checking" functionality from `collect_weights` and `collect_activations`. We can probably rely on Pytorch's naming conventions out of the box. If this is insufficient for whatever reason, checking for specific naming can be done within a separate test like in `test_collect.py`.

We can rely on `torchino`'s unit testing tools if we are interested in checking for specific summary stdout content in the CLI integration test.