### PR TITLE
TF to Torch: Demo of reusable functions to setup input and output feature testing

### DIFF
--- a/ludwig/encoders/generic_encoders.py
+++ b/ludwig/encoders/generic_encoders.py
@@ -104,7 +104,7 @@ class DenseEncoder(Encoder):
     def forward(self, inputs, training=None, mask=None):
         """
             :param inputs: The inputs fed into the encoder.
-                   Shape: [batch x 1], type tf.float32
+                   Shape: [batch x 1], type torch.float32
         """
         return {'encoder_output': self.fc_stack(inputs)}
 

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -116,6 +116,8 @@ class BinaryInputFeature(BinaryFeatureMixin, InputFeature):
     def __init__(self, feature, encoder_obj=None):
         super().__init__(feature)
         self.overwrite_defaults(feature)
+        if feature['encoder'] == 'dense':
+            feature['input_size'] = 1
         if encoder_obj:
             self.encoder_obj = encoder_obj
         else:
@@ -128,7 +130,7 @@ class BinaryInputFeature(BinaryFeatureMixin, InputFeature):
 
         if len(inputs.shape) == 1:
             inputs = inputs[:, None]
-        encoder_outputs = self.encoder_obj(inputs)
+        encoder_outputs = self.encoder_obj(inputs.type(torch.float32))
         return encoder_outputs
 
     @property

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -116,8 +116,7 @@ class BinaryInputFeature(BinaryFeatureMixin, InputFeature):
     def __init__(self, feature, encoder_obj=None):
         super().__init__(feature)
         self.overwrite_defaults(feature)
-        if feature['encoder'] == 'dense':
-            feature['input_size'] = 1
+        feature['input_size'] = 1
         if encoder_obj:
             self.encoder_obj = encoder_obj
         else:

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -207,11 +207,14 @@ class NumericalInputFeature(NumericalFeatureMixin, InputFeature):
     def forward(self, inputs):
         assert isinstance(inputs, torch.Tensor)
         assert inputs.dtype == torch.float32 or inputs.dtype == torch.float64
-        assert len(inputs.shape) == 1 or (len(inputs.shape) == 2 and inputs.shape[1] == 1)
+        assert len(inputs.shape) == 1 or (
+                    len(inputs.shape) == 2 and inputs.shape[1] == 1)
 
         if len(inputs.shape) == 1:
             inputs = inputs[:, None]
-        inputs_encoded = self.encoder_obj(inputs)
+
+        # ensure inputs are torch.float32 to avoid problems with use of nn.Linear
+        inputs_encoded = self.encoder_obj(inputs.type(torch.float32))
 
         return inputs_encoded
 

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -157,7 +157,7 @@ class SequenceInputFeature(SequenceFeatureMixin, InputFeature):
         else:
             self.encoder_obj = self.initialize_encoder(feature)
 
-    def forward(self, inputs: torch.Tensor, mask=None):
+    def forward(self, inputs: torch.Tensor, mask=None) -> Dict:
         assert isinstance(inputs, torch.Tensor)
         assert inputs.dtype in [torch.int8, inputs.dtype, torch.int16,
                                 torch.int32, torch.int64]

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -735,6 +735,8 @@ def setup_input_feature_test(
 # This covers pre-processing functionality and
 # converting raw data to combiner output specific tensors.
 # This setup assumes no dependencies
+# todo: revisit when output sequence work is complete need to assess to deal
+#       with rnn state tensor, which is not currently supported
 def setup_output_feature_test(
         batch_size: int = None,
         hidden_size: int = None,

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -713,7 +713,7 @@ def setup_input_feature_test(
         training_set_metadata=metadata
     )
     feature_class.update_config_with_metadata(
-        feature_definition
+        feature_definition,
         metadata[feature_definition['name']]
     )
     input_tensor = torch.tensor(

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -702,7 +702,7 @@ def setup_input_feature_test(
         batch_size,
         [feature_definition]
     )
-    raw_data = '\n'.join([r[0] for r in dataset])
+    raw_data = '\n'.join([str(r[0]) for r in dataset])
     df = pd.read_csv(io.StringIO(raw_data))
 
     # preprocess raw data to create feature specific tensors
@@ -713,12 +713,11 @@ def setup_input_feature_test(
         training_set_metadata=metadata
     )
     feature_class.update_config_with_metadata(
-        feature_definition,
+        feature_definition
         metadata[feature_definition['name']]
     )
     input_tensor = torch.tensor(
-        np.vstack(input_data[feature_definition['proc_column']]),
-        dtype=torch.int32
+        np.vstack(input_data[feature_definition['proc_column']])
     )
 
     return input_tensor, feature_definition

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -735,8 +735,6 @@ def setup_input_feature_test(
 # This covers pre-processing functionality and
 # converting raw data to combiner output specific tensors.
 # This setup assumes no dependencies
-# todo: revisit when output sequence work is complete need to assess to deal
-#       with rnn state tensor, which is not currently supported
 def setup_output_feature_test(
         batch_size: int = None,
         hidden_size: int = None,
@@ -776,6 +774,8 @@ def setup_output_feature_test(
         combiner_output = torch.randn([batch_size, hidden_size],
                                       dtype=torch.float32)
     else:
+        # todo: revisit when output sequence work is complete need to assess to deal
+        #       with rnn state tensor, which is not currently supported
         pass
 
     # update feature definition with combiner output hidden size

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -813,7 +813,8 @@ def setup_output_feature_test(
     else:
         # todo: revisit when output sequence work is complete need to assess to deal
         #       with rnn state tensor, which is not currently supported
-        pass
+        combiner_output = torch.randn([batch_size, seq_size, hidden_size],
+                                      dtype=torch.float32)
 
     # update feature definition with combiner output hidden size
     feature_definition['input_size'] = hidden_size

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -688,14 +688,31 @@ def train_with_backend(
         shutil.rmtree(output_dir, ignore_errors=True)
 
 
-# creates synthetic data and update feature definitions
-# This covers pre-processing functionality and
-# converting raw data to input specific tensors.
+
 def setup_input_feature_test(
         batch_size: int = None,
         feature_definition: Dict = None,
         feature_class: Type[InputFeature] = None
 ) -> Tuple:
+    """
+    Creates synthetic data and update feature definitions
+    This covers pre-processing functionality and converting raw data
+    to input specific tensors.
+
+    Args:
+        batch_size (int): Number of synthetic records to create for testing.
+        feature_definition (dict): Ludwig configuration specification for the
+            feature under test.
+        feature_class (Tupe[InputFeature]): Class of the input feature under
+            test.
+
+    Returns:
+        Tuple(input_tensor, feature_definition)
+        input_tensor (Torch.tensor): tensor created from the raw syntentic data.
+            Shape will vary based on the type of input feature being tested.
+        feature_definition (dict): feature definition dictionary updated with
+            metadata collected during pre-processing.
+    """
     # generate synthetic raw data for testing
     np.random.seed(1919)
     dataset = build_synthetic_dataset(
@@ -731,10 +748,6 @@ def setup_input_feature_test(
     return input_tensor, feature_definition
 
 
-# creates synthetic data and update feature definitions
-# This covers pre-processing functionality and
-# converting raw data to combiner output specific tensors.
-# This setup assumes no dependencies
 def setup_output_feature_test(
         batch_size: int = None,
         hidden_size: int = None,
@@ -742,6 +755,30 @@ def setup_output_feature_test(
         feature_definition: Dict = None,
         feature_class: Type[OutputFeature] = None
 ) -> Tuple:
+    """
+    Creates synthetic data and update feature definitions.
+    This covers pre-processing functionality and
+    converting raw data to combiner output specific tensors.
+    This setup assumes no dependencies for the output feature
+    under test.
+    Args:
+        batch_size (int): Number of synthetic records to create for testing.
+        hidden_size (int): Size of the hidden dimension for the simulate
+            combiner output.
+        seq_size (int): If specified, simulated combiner output will be a
+            sequence of the specified size.
+        feature_definition (dict): Ludwig configuration specification for the
+            feature under test.
+        feature_class (Tupe[OutputFeature]): Class of the output feature under
+            test.
+
+    Returns:
+        Tuple((combiner_output, None), feature_definition)
+        combiner_output (dict): simulated combiner output containing shaped
+            per the function arguments, e.g, [batch_size, hidden_size]
+        feature_definition (dict): feature definition dictionary updated with
+            metadata collected during pre-processing.
+    """
     # generate synthetic raw data for testing
     np.random.seed(1919)
     dataset = build_synthetic_dataset(

--- a/tests/ludwig/features/test_binary_feature.py
+++ b/tests/ludwig/features/test_binary_feature.py
@@ -24,10 +24,10 @@ def test_binary_input_feature(enc_encoder: str) -> None:
     )
 
     # instantiate binary input feature object
-    input_feature_obj = BinaryInputFeature(feature_definition)
+    feature_obj = BinaryInputFeature(feature_definition)
 
     # pass synthetic binary tensor through the input feature
-    encoder_output = input_feature_obj(input_tensor)
+    encoder_output = feature_obj(input_tensor)
 
     # confirm correctness of the the binary encoder output
     assert isinstance(encoder_output, dict)
@@ -59,11 +59,11 @@ def test_binary_output_feature(num_fc_layers: int) -> None:
     )
 
     # instantiate binary output feature object
-    input_feature_obj = BinaryOutputFeature(feature_definition)
+    feature_obj = BinaryOutputFeature(feature_definition)
 
     # pass synthetic binary tensor through the input feature
     # specify no dependencies
-    feature_output = input_feature_obj(input_for_output_feature)
+    feature_output = feature_obj(input_for_output_feature)
 
     # confirm correctness of the the binary encoder output structure
     assert isinstance(feature_output, dict)

--- a/tests/ludwig/features/test_binary_feature.py
+++ b/tests/ludwig/features/test_binary_feature.py
@@ -2,37 +2,32 @@ import pytest
 
 import torch
 
-from ludwig.features.binary_feature import BinaryInputFeature
-from tests.integration_tests.utils import binary_feature
+from ludwig.features.binary_feature import BinaryInputFeature, \
+    BinaryOutputFeature
+from tests.integration_tests.utils import binary_feature, \
+    setup_input_feature_test, setup_output_feature_test
 
 BATCH_SIZE = 2
-SEQ_SIZE = 20
-DEFAULT_FC_SIZE = 256
+FC_SIZE = 64
+HIDDEN_SIZE = 16
 
 
-@pytest.mark.parametrize(
-    'enc_encoder',
-    [
-        'passthrough'
-    ]
-)
-def test_binary_feature(enc_encoder):
-    # synthetic binary tensor
-    binary_tensor = torch.randn([BATCH_SIZE, SEQ_SIZE],
-                               dtype=torch.float32)
+@pytest.mark.parametrize('enc_encoder', ['passthrough', 'dense'])
+def test_binary_input_feature(enc_encoder: str) -> None:
+    feature_to_test = binary_feature(encoder=enc_encoder, fc_size=FC_SIZE)
 
-    # generate binary feature config
-    binary_feature_config = binary_feature(
-        folder='.',
-        encoder=enc_encoder,
-        max_sequence_length=SEQ_SIZE
+    # setup synthetic tensor and feature definition
+    input_tensor, feature_definition = setup_input_feature_test(
+        batch_size=BATCH_SIZE,
+        feature_definition=feature_to_test,
+        feature_class=BinaryInputFeature
     )
 
     # instantiate binary input feature object
-    binary_input_feature = BinaryInputFeature(binary_feature_config)
+    input_feature_obj = BinaryInputFeature(feature_definition)
 
     # pass synthetic binary tensor through the input feature
-    encoder_output = binary_input_feature(binary_tensor)
+    encoder_output = input_feature_obj(input_tensor)
 
     # confirm correctness of the the binary encoder output
     assert isinstance(encoder_output, dict)
@@ -40,7 +35,47 @@ def test_binary_feature(enc_encoder):
     assert isinstance(encoder_output['encoder_output'], torch.Tensor)
     if enc_encoder == 'passthrough':
         assert encoder_output['encoder_output'].shape \
-               == (BATCH_SIZE, 1, SEQ_SIZE)
+               == (BATCH_SIZE, 1)
     else:
         assert encoder_output['encoder_output'].shape \
-               == (BATCH_SIZE, DEFAULT_FC_SIZE)
+               == (BATCH_SIZE, FC_SIZE)
+
+
+@pytest.mark.parametrize('num_fc_layers', [0, 1])
+def test_binary_output_feature(num_fc_layers: int) -> None:
+    feature_to_test = binary_feature(
+        num_fc_layers=num_fc_layers,
+        fc_size=FC_SIZE,
+        loss={'type': 'cross_entropy'}
+    )
+
+    # setup synthetic tensor and feature definition
+    # ignore generated synthentic data
+    input_for_output_feature, feature_definition = setup_output_feature_test(
+        batch_size=BATCH_SIZE,
+        hidden_size=HIDDEN_SIZE,
+        feature_definition=feature_to_test,
+        feature_class=BinaryOutputFeature
+    )
+
+    # instantiate binary output feature object
+    input_feature_obj = BinaryOutputFeature(feature_definition)
+
+    # pass synthetic binary tensor through the input feature
+    # specify no dependencies
+    feature_output = input_feature_obj(input_for_output_feature)
+
+    # confirm correctness of the the binary encoder output structure
+    assert isinstance(feature_output, dict)
+
+    # confirm expected components of feature output
+    assert 'logits' in feature_output
+    assert feature_output['logits'].shape == (BATCH_SIZE,)
+
+    assert 'last_hidden' in feature_output
+    if num_fc_layers == 0:
+        assert feature_output['last_hidden'].shape \
+               == (BATCH_SIZE, HIDDEN_SIZE)
+    else:
+        assert feature_output['last_hidden'].shape \
+               == (BATCH_SIZE, FC_SIZE)

--- a/tests/ludwig/features/test_numercial_feature.py
+++ b/tests/ludwig/features/test_numercial_feature.py
@@ -1,0 +1,88 @@
+import pytest
+
+import torch
+
+from ludwig.features.numerical_feature import NumericalInputFeature, \
+    NumericalOutputFeature
+from tests.integration_tests.utils import numerical_feature, \
+    setup_input_feature_test, setup_output_feature_test
+
+BATCH_SIZE = 2
+FC_SIZE = 64
+HIDDEN_SIZE = 16
+
+
+@pytest.mark.parametrize('enc_encoder', ['passthrough', 'dense'])
+def test_numerical_input_feature(enc_encoder: str) -> None:
+    feature_to_test = numerical_feature(encoder=enc_encoder, fc_size=FC_SIZE)
+
+    # setup synthetic tensor and feature definition
+    input_tensor, feature_definition = setup_input_feature_test(
+        batch_size=BATCH_SIZE,
+        feature_definition=feature_to_test,
+        feature_class=NumericalInputFeature
+    )
+
+    # instantiate binary input feature object
+    input_feature_obj = NumericalInputFeature(feature_definition)
+
+    # pass synthetic binary tensor through the input feature
+    encoder_output = input_feature_obj(input_tensor)
+
+    # confirm correctness of the the binary encoder output
+    assert isinstance(encoder_output, dict)
+    assert 'encoder_output' in encoder_output
+    assert isinstance(encoder_output['encoder_output'], torch.Tensor)
+    if enc_encoder == 'passthrough':
+        assert encoder_output['encoder_output'].shape \
+               == (BATCH_SIZE, 1)
+    else:
+        assert encoder_output['encoder_output'].shape \
+               == (BATCH_SIZE, FC_SIZE)
+
+
+@pytest.mark.parametrize(
+    'loss_type',
+    ['mean_squared_error', 'mean_absolute_error']
+)
+@pytest.mark.parametrize('num_fc_layers', [0, 1])
+def test_numerical_output_feature(
+        num_fc_layers: int,
+        loss_type: str
+) -> None:
+    feature_to_test = numerical_feature(
+        num_fc_layers=num_fc_layers,
+        fc_size=FC_SIZE,
+        loss={'type': loss_type}
+    )
+
+    # setup synthetic tensor and feature definition
+    # ignore generated synthentic data
+    input_for_output_feature, feature_definition = setup_output_feature_test(
+        batch_size=BATCH_SIZE,
+        hidden_size=HIDDEN_SIZE,
+        feature_definition=feature_to_test,
+        feature_class=NumericalOutputFeature
+    )
+
+    # instantiate binary output feature object
+    input_feature_obj = NumericalOutputFeature(feature_definition)
+
+    # pass synthetic binary tensor through the input feature
+    # specify no dependencies
+    feature_output = input_feature_obj(input_for_output_feature)
+
+    # confirm correctness of the the binary encoder output structure
+    assert isinstance(feature_output, dict)
+
+    # confirm expected components of feature output
+    assert 'logits' in feature_output
+    assert feature_output['logits'].shape == (BATCH_SIZE,)
+
+    assert 'last_hidden' in feature_output
+    if num_fc_layers == 0:
+        assert feature_output['last_hidden'].shape \
+               == (BATCH_SIZE, HIDDEN_SIZE)
+    else:
+        assert feature_output['last_hidden'].shape \
+               == (BATCH_SIZE, FC_SIZE)

--- a/tests/ludwig/features/test_numerical_feature.py
+++ b/tests/ludwig/features/test_numerical_feature.py
@@ -24,10 +24,10 @@ def test_numerical_input_feature(enc_encoder: str) -> None:
     )
 
     # instantiate binary input feature object
-    input_feature_obj = NumericalInputFeature(feature_definition)
+    feature_obj = NumericalInputFeature(feature_definition)
 
     # pass synthetic binary tensor through the input feature
-    encoder_output = input_feature_obj(input_tensor)
+    encoder_output = feature_obj(input_tensor)
 
     # confirm correctness of the the binary encoder output
     assert isinstance(encoder_output, dict)
@@ -66,11 +66,11 @@ def test_numerical_output_feature(
     )
 
     # instantiate binary output feature object
-    input_feature_obj = NumericalOutputFeature(feature_definition)
+    feature_obj = NumericalOutputFeature(feature_definition)
 
     # pass synthetic binary tensor through the input feature
     # specify no dependencies
-    feature_output = input_feature_obj(input_for_output_feature)
+    feature_output = feature_obj(input_for_output_feature)
 
     # confirm correctness of the the binary encoder output structure
     assert isinstance(feature_output, dict)

--- a/tests/ludwig/features/test_sequence_features.py
+++ b/tests/ludwig/features/test_sequence_features.py
@@ -7,35 +7,13 @@ import torch
 
 from ludwig.features.sequence_feature import SequenceInputFeature
 from ludwig.features.text_feature import TextInputFeature
-from tests.integration_tests.utils import sequence_feature, set_feature
+from tests.integration_tests.utils import sequence_feature, \
+    setup_input_feature_test
 from tests.integration_tests.utils import ENCODERS
 
-BATCH_SIZE = 8
+BATCH_SIZE = 2  # 8
 SEQ_SIZE = 6
 VOCAB_SIZE = 64
-
-
-@pytest.fixture(scope='module')
-def input_sequence() -> Tuple[torch.Tensor, List]:
-    # generates a realistic looking synthetic sequence tensor, i.e.
-    # each sequence will have non-zero tokens at the beginning with
-    # trailing zero tokens, including a max length token with a single
-    # zero token at the end.  Example:
-    # [
-    #   [3, 5, 6, 0, 0, 0],
-    #   [10, 11, 12, 13, 14, 0],   # max length sequence
-    #   [32, 0, 0, 0, 0, 0]        # minimum length sequence
-    # ]
-    input_tensor = torch.zeros([BATCH_SIZE, SEQ_SIZE], dtype=torch.int32)
-    sequence_lengths = np.random.randint(1, SEQ_SIZE, size=BATCH_SIZE)
-    for i in range(input_tensor.shape[0]):
-        input_tensor[i, :sequence_lengths[i]] = torch.tensor(
-            np.random.randint(2, VOCAB_SIZE, size=sequence_lengths[i]))
-
-    # emulate idx2str structure
-    idx2str = ['<PAD>', '<UNK>'] + [str(i) for i in range(2, VOCAB_SIZE)]
-
-    return input_tensor, idx2str
 
 
 @pytest.mark.parametrize('encoder', ENCODERS)
@@ -44,41 +22,42 @@ def input_sequence() -> Tuple[torch.Tensor, List]:
     [SequenceInputFeature, TextInputFeature]
 )
 def test_sequence_input_feature(
-        input_sequence: tuple,
         encoder: str,
         sequence_type: Union[SequenceInputFeature]
 ) -> None:
-    # test assumes "sequence data" has been tokenized and converted to
-    # numeric representation.  Focus of this test is primarily on
-    # integration with encoder with correctly sized encoder tensor and
-    # required properties are present
-
-    input_sequence, idx2str = input_sequence
-
-    # setup input sequence feature definition
-    # use sequence_feature() to generate baseline
-    # sequence definition and then augment with
-    # pre-processing metadata parameters
-    input_feature_defn = sequence_feature(
-        encoder=encoder,
+    feature_to_test = sequence_feature(
+        vocab_size=VOCAB_SIZE,
+        min_len=2,
         max_len=SEQ_SIZE,
-        # augment with emulated pre-processing metadata
-        max_sequence_length=SEQ_SIZE,
-        vocab=idx2str
+        encoder='rnn',
+    )
+
+    # setup synthetic tensor and feature definition
+    input_tensor, feature_definition = setup_input_feature_test(
+        BATCH_SIZE,
+        feature_to_test,
+        SequenceInputFeature
     )
 
     # create sequence input feature object
-    input_feature_obj = sequence_type(input_feature_defn)
+    input_feature_obj = sequence_type(feature_definition)
 
     # confirm dtype property
     assert input_feature_obj.input_dtype == torch.int32
 
-    # confirm input_shape property
-    assert input_feature_obj.input_shape == (SEQ_SIZE,)
+    # todo: confirm how to check for input_shape when all sequences
+    #   are not maximum length
+    # assert input_feature_obj.input_shape == (SEQ_SIZE,)
 
-    # confirm output_shape property default output shape
-    # from sequence_feature() function
-    encoder_output = input_feature_obj(input_sequence)
+    # do one forward pass through input feature/encoder
+    encoder_output = input_feature_obj(input_tensor)
+
+    # confirm encoder output has required parts
+    assert 'encoder_output' in encoder_output
+    assert 'encoder_output_state' in encoder_output
+    assert 'lengths' in encoder_output
+
+    # confirm encoder output shape
     assert encoder_output['encoder_output'].shape == \
            (BATCH_SIZE, *input_feature_obj.output_shape)
 

--- a/tests/ludwig/features/test_sequence_features.py
+++ b/tests/ludwig/features/test_sequence_features.py
@@ -40,17 +40,17 @@ def test_sequence_input_feature(
     )
 
     # create sequence input feature object
-    input_feature_obj = sequence_type(feature_definition)
+    feature_obj = sequence_type(feature_definition)
 
     # confirm dtype property
-    assert input_feature_obj.input_dtype == torch.int32
+    assert feature_obj.input_dtype == torch.int32
 
     # todo: confirm how to check for input_shape when all sequences
     #   are not maximum length
     # assert input_feature_obj.input_shape == (SEQ_SIZE,)
 
     # do one forward pass through input feature/encoder
-    encoder_output = input_feature_obj(input_tensor)
+    encoder_output = feature_obj(input_tensor)
 
     # confirm encoder output has required parts
     assert 'encoder_output' in encoder_output
@@ -59,7 +59,7 @@ def test_sequence_input_feature(
 
     # confirm encoder output shape
     assert encoder_output['encoder_output'].shape == \
-           (BATCH_SIZE, *input_feature_obj.output_shape)
+           (BATCH_SIZE, *feature_obj.output_shape)
 
 
 # todo: add unit test for sequence output feature

--- a/tests/ludwig/features/test_sequence_features.py
+++ b/tests/ludwig/features/test_sequence_features.py
@@ -34,9 +34,9 @@ def test_sequence_input_feature(
 
     # setup synthetic tensor and feature definition
     input_tensor, feature_definition = setup_input_feature_test(
-        BATCH_SIZE,
-        feature_to_test,
-        SequenceInputFeature
+        batch_size=BATCH_SIZE,
+        feature_definition=feature_to_test,
+        feature_class=SequenceInputFeature
     )
 
     # create sequence input feature object


### PR DESCRIPTION
# Code Pull Requests

While working on `test_sequence_features.py` developed two reusable functions that could facilitate testing input and output features.  These functions perform the following:
* generate synthetic data
* use  pre-processing methods to collect feature specific metadata
* augment the feature's definition with the collected metadata
* generate a suitable data structure that can be used by either the input feature's `forward()` method or the output `forward()` method (i.e., simulates what comes out of the combiner).

By using these functions, the developer does not have to deal with the mechanics of creating synthetic data in a suitable form and manipulating the feature's definition.  

The new functions are
* `tests/integration_tests.utils.setup_input_feature_test()`
* `tests/integration_tests.utils.setup_output_feature_test()`

 Two existing tests were adapted to use these new functions for purposes of demonstration:
* `tests/ludwig/features/test_binary_feature.py`
* `tests/ludwig/features/test_sequence_features.py`

Here is output from a test run with the new functions
```
platform linux -- Python 3.8.12, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /opt/project, configfile: pytest.ini
plugins: timeout-2.0.1, cov-3.0.0, xdist-2.4.0, pycharm-0.7.0, forked-1.3.0, anyio-3.3.4
collected 19 items

../../tests/ludwig/features/test_binary_feature.py::test_binary_input_feature[passthrough] PASSED                                    [  5%]
../../tests/ludwig/features/test_binary_feature.py::test_binary_input_feature[dense] PASSED                                          [ 10%]
../../tests/ludwig/features/test_binary_feature.py::test_binary_output_feature[0] PASSED                                             [ 15%]
../../tests/ludwig/features/test_binary_feature.py::test_binary_output_feature[1] PASSED                                             [ 21%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[SequenceInputFeature-embed] PASSED                [ 26%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[SequenceInputFeature-rnn] PASSED                  [ 31%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[SequenceInputFeature-parallel_cnn] PASSED         [ 36%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[SequenceInputFeature-cnnrnn] PASSED               [ 42%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[SequenceInputFeature-stacked_parallel_cnn] PASSED [ 47%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[SequenceInputFeature-stacked_cnn] PASSED          [ 52%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[SequenceInputFeature-transformer] PASSED          [ 57%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[TextInputFeature-embed] PASSED                    [ 63%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[TextInputFeature-rnn] PASSED                      [ 68%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[TextInputFeature-parallel_cnn] PASSED             [ 73%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[TextInputFeature-cnnrnn] PASSED                   [ 78%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[TextInputFeature-stacked_parallel_cnn] PASSED     [ 84%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[TextInputFeature-stacked_cnn] PASSED              [ 89%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_input_feature[TextInputFeature-transformer] PASSED              [ 94%]
../../tests/ludwig/features/test_sequence_features.py::test_sequence_output_feature PASSED                                           [100%]

====================================================== 19 passed, 6 warnings in 1.04s ======================================================
```
