### PR TITLE
fix: incompatibility error in numeric input feature with  use of dense encoder

### DIFF
--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -207,11 +207,14 @@ class NumericalInputFeature(NumericalFeatureMixin, InputFeature):
     def forward(self, inputs):
         assert isinstance(inputs, torch.Tensor)
         assert inputs.dtype == torch.float32 or inputs.dtype == torch.float64
-        assert len(inputs.shape) == 1 or (len(inputs.shape) == 2 and inputs.shape[1] == 1)
+        assert len(inputs.shape) == 1 or (
+                    len(inputs.shape) == 2 and inputs.shape[1] == 1)
 
         if len(inputs.shape) == 1:
             inputs = inputs[:, None]
-        inputs_encoded = self.encoder_obj(inputs)
+
+        # ensure inputs are torch.float32 to avoid problems with use of nn.Linear
+        inputs_encoded = self.encoder_obj(inputs.type(torch.float32))
 
         return inputs_encoded
 


### PR DESCRIPTION
# Code Pull Requests

Resolve error that occurs with the `dense` encoder with `NumericalInputFeature`.
```
 def linear(input: Tensor, weight: Tensor, bias: Optional[Tensor] = None) -> Tensor:
        r"""
        Applies a linear transformation to the incoming data: :math:`y = xA^T + b`.
    
        This operator supports :ref:`TensorFloat32<tf32_on_ampere>`.
    
        Shape:
    
            - Input: :math:`(N, *, in\_features)` N is the batch size, `*` means any number of
              additional dimensions
            - Weight: :math:`(out\_features, in\_features)`
            - Bias: :math:`(out\_features)`
            - Output: :math:`(N, *, out\_features)`
        """
        if has_torch_function_variadic(input, weight, bias):
            return handle_torch_function(linear, (input, weight, bias), input, weight, bias=bias)
>       return torch._C._nn.linear(input, weight, bias)
E       RuntimeError: expected scalar type Float but found Double
```