### PR TITLE
Employ a fallback str2bool mapping from the feature column's distinct values when the feature's values aren't boolean-like.

### DIFF
--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -76,6 +76,11 @@ class BinaryFeatureMixin:
         if 'fallback_true_label' in preprocessing_parameters:
             fallback_true_label = preprocessing_parameters['fallback_true_label']
         else:
+            logger.warning(
+                f"In case binary feature {column.name} doesn't have conventional boolean values, "
+                f"we will interpret {fallback_true_label} as 1 and the other values as 0. "
+                f"If this is incorrect, please use the category feature type or "
+                f"manually specify the true value with `preprocessing.fallback_true_label`.")
             fallback_true_label = sorted(distinct_values)[0]
 
         str2bool = {v: strings_utils.str2bool(

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -76,12 +76,12 @@ class BinaryFeatureMixin:
         if 'fallback_true_label' in preprocessing_parameters:
             fallback_true_label = preprocessing_parameters['fallback_true_label']
         else:
+            fallback_true_label = sorted(distinct_values)[0]
             logger.warning(
                 f"In case binary feature {column.name} doesn't have conventional boolean values, "
                 f"we will interpret {fallback_true_label} as 1 and the other values as 0. "
                 f"If this is incorrect, please use the category feature type or "
                 f"manually specify the true value with `preprocessing.fallback_true_label`.")
-            fallback_true_label = sorted(distinct_values)[0]
 
         str2bool = {v: strings_utils.str2bool(
             v, fallback_true_label) for v in distinct_values}

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -18,7 +18,6 @@ import logging
 import numpy as np
 import torch
 
-
 from ludwig.constants import *
 from ludwig.decoders.generic_decoders import Regressor
 from ludwig.encoders.binary_encoders import ENCODER_REGISTRY
@@ -73,8 +72,10 @@ class BinaryFeatureMixin:
                 f"Binary feature column {column.name} expects 2 distinct values, "
                 f"found: {distinct_values.values.tolist()}"
             )
+        fallback_true_value = sorted(distinct_values)[0]
 
-        str2bool = {v: strings_utils.str2bool(v) for v in distinct_values}
+        str2bool = {v: strings_utils.str2bool(
+            v, fallback_true_value) for v in distinct_values}
         bool2str = [
             k for k, v in sorted(str2bool.items(), key=lambda item: item[1])
         ]
@@ -82,6 +83,7 @@ class BinaryFeatureMixin:
         return {
             "str2bool": str2bool,
             "bool2str": bool2str,
+            "fallback_true_value": fallback_true_value
         }
 
     @staticmethod

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -53,6 +53,7 @@ class BinaryFeatureMixin:
         },
         "fill_value": fill_value_schema,
         "computed_fill_value": fill_value_schema,
+        "fallback_true_label": {'type': 'string'},
     }
 
     @staticmethod
@@ -72,10 +73,13 @@ class BinaryFeatureMixin:
                 f"Binary feature column {column.name} expects 2 distinct values, "
                 f"found: {distinct_values.values.tolist()}"
             )
-        fallback_true_value = sorted(distinct_values)[0]
+        if 'fallback_true_label' in preprocessing_parameters:
+            fallback_true_label = preprocessing_parameters['fallback_true_label']
+        else:
+            fallback_true_label = sorted(distinct_values)[0]
 
         str2bool = {v: strings_utils.str2bool(
-            v, fallback_true_value) for v in distinct_values}
+            v, fallback_true_label) for v in distinct_values}
         bool2str = [
             k for k, v in sorted(str2bool.items(), key=lambda item: item[1])
         ]
@@ -83,7 +87,7 @@ class BinaryFeatureMixin:
         return {
             "str2bool": str2bool,
             "bool2str": bool2str,
-            "fallback_true_value": fallback_true_value
+            "fallback_true_label": fallback_true_label
         }
 
     @staticmethod

--- a/ludwig/hyperopt/sampling.py
+++ b/ludwig/hyperopt/sampling.py
@@ -173,7 +173,7 @@ class RandomSampler(HyperoptSampler):
                     value_type = type(value)
                     if value_type == bool:
                         value_str = str(value)
-                        value_type = str2bool(value_str)
+                        value_type = str2bool
                     elif value_type == str or value_type == int or \
                             value_type == float:
                         value_str = str(value)
@@ -295,7 +295,7 @@ class PySOTSampler(HyperoptSampler):
                     value_type = type(value)
                     if value_type == bool:
                         value_str = str(value)
-                        value_type = str2bool(value_str)
+                        value_type = str2bool
                     elif value_type == str or value_type == int or \
                             value_type == float:
                         value_str = str(value)

--- a/ludwig/hyperopt/sampling.py
+++ b/ludwig/hyperopt/sampling.py
@@ -173,7 +173,7 @@ class RandomSampler(HyperoptSampler):
                     value_type = type(value)
                     if value_type == bool:
                         value_str = str(value)
-                        value_type = str2bool
+                        value_type = str2bool(value_str)
                     elif value_type == str or value_type == int or \
                             value_type == float:
                         value_str = str(value)
@@ -295,7 +295,7 @@ class PySOTSampler(HyperoptSampler):
                     value_type = type(value)
                     if value_type == bool:
                         value_str = str(value)
-                        value_type = str2bool
+                        value_type = str2bool(value_str)
                     elif value_type == str or value_type == int or \
                             value_type == float:
                         value_str = str(value)

--- a/ludwig/utils/schema.py
+++ b/ludwig/utils/schema.py
@@ -27,6 +27,7 @@ INPUT_FEATURE_TYPES = sorted(list(input_type_registry.keys()))
 OUTPUT_FEATURE_TYPES = sorted(list(output_type_registry.keys()))
 COMBINER_TYPES = sorted(list(combiner_registry.keys()))
 
+
 def get_schema():
     schema = {
         'type': 'object',
@@ -154,8 +155,10 @@ def get_combiner_conds():
         conds.append(combiner_cond)
     return conds
 
+
 def get_custom_definitions():
     return {}
+
 
 def create_cond(if_pred, then_pred):
     return {

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -65,25 +65,25 @@ def strip_accents(s):
                    if unicodedata.category(c) != 'Mn')
 
 
-def str2bool(v, fallback_true_value=None):
+def str2bool(v, fallback_true_label=None):
     """Returns bool representation of the given value v.
 
-    Check the value against global bool value lists.
-    Fallback to the fallback_true_value if the value isn't defined in the global lists.
+    Check the value against global bool string lists.
+    Fallback to using fallback_true_label as True if the value isn't in the global bool string lists.
 
     args:
         v: Value to get the bool representation for.
-        fallback_true_value: (str) fallback value to use as 'True'.
+        fallback_true_label: (str) label to use as 'True'.
     """
     v_str = str(v).lower()
     if v_str in BOOL_TRUE_STRS:
         return True
     if v_str in BOOL_FALSE_STRS:
         return False
-    if fallback_true_value is None:
+    if fallback_true_label is None:
         raise ValueError(
-            f'Cannot automatically map value {v} to a boolean and no `fallback_true_value` specified.')
-    return v == fallback_true_value
+            f'Cannot automatically map value {v} to a boolean and no `fallback_true_label` specified.')
+    return v == fallback_true_label
 
 
 def match_replace(string_to_match, list_regex):

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -65,8 +65,25 @@ def strip_accents(s):
                    if unicodedata.category(c) != 'Mn')
 
 
-def str2bool(v):
-    return str(v).lower() in BOOL_TRUE_STRS
+def str2bool(v, fallback_true_value=None):
+    """Returns bool representation of the given value v.
+
+    Check the value against global bool value lists.
+    Fallback to the fallback_true_value if the value isn't defined in the global lists.
+
+    args:
+        v: Value to get the bool representation for.
+        fallback_true_value: (str) fallback value to use as 'True'.
+    """
+    v_str = str(v).lower()
+    if v_str in BOOL_TRUE_STRS:
+        return True
+    if v_str in BOOL_FALSE_STRS:
+        return False
+    if fallback_true_value is None:
+        raise ValueError(
+            f'Cannot automatically map value {v} to a boolean and no `fallback_true_value` specified.')
+    return v == fallback_true_value
 
 
 def match_replace(string_to_match, list_regex):
@@ -149,7 +166,8 @@ def create_vocabulary(
     elif vocab_file is not None:
         vocab = load_vocabulary(vocab_file)
 
-    processed_lines = data.map(lambda line: tokenizer(line.lower() if lowercase else line))
+    processed_lines = data.map(lambda line: tokenizer(
+        line.lower() if lowercase else line))
     processed_counts = processed_lines.explode().value_counts(sort=False)
     processed_counts = processor.compute(processed_counts)
     unit_counts = Counter(dict(processed_counts))

--- a/tests/ludwig/utils/test_strings_utils.py
+++ b/tests/ludwig/utils/test_strings_utils.py
@@ -13,12 +13,12 @@ def test_str_to_bool():
     with pytest.raises(Exception):
         strings_utils.str2bool('bot')
 
-    # Fallback value is used.
-    assert strings_utils.str2bool('bot', fallback_true_value='bot') == True
-    assert strings_utils.str2bool('human', fallback_true_value='bot') == False
-    assert strings_utils.str2bool('human', fallback_true_value='human') == True
+    # Fallback label is used.
+    assert strings_utils.str2bool('bot', fallback_true_label='bot') == True
+    assert strings_utils.str2bool('human', fallback_true_label='bot') == False
+    assert strings_utils.str2bool('human', fallback_true_label='human') == True
     assert strings_utils.str2bool(
-        'human', fallback_true_value='Human') == False
+        'human', fallback_true_label='Human') == False
 
-    # Fallback value is used, strictly as a fallback.
-    assert strings_utils.str2bool('True', fallback_true_value='False') == True
+    # Fallback label is used, strictly as a fallback.
+    assert strings_utils.str2bool('True', fallback_true_label='False') == True

--- a/tests/ludwig/utils/test_strings_utils.py
+++ b/tests/ludwig/utils/test_strings_utils.py
@@ -1,0 +1,22 @@
+from ludwig.utils import strings_utils
+
+
+def test_str_to_bool():
+    # Global bool mappings are used.
+    assert strings_utils.str2bool('True') == True
+    assert strings_utils.str2bool('true') == True
+    assert strings_utils.str2bool('0') == False
+
+    # Error raised if non-mapped value is encountered and no fallback is specified.
+    with pytest.raises(Exception):
+        strings_utils.str2bool('bot')
+
+    # Fallback value is used.
+    assert strings_utils.str2bool('bot', fallback_true_value='bot') == True
+    assert strings_utils.str2bool('human', fallback_true_value='bot') == False
+    assert strings_utils.str2bool('human', fallback_true_value='human') == True
+    assert strings_utils.str2bool(
+        'human', fallback_true_value='Human') == False
+
+    # Fallback value is used, strictly as a fallback.
+    assert strings_utils.str2bool('True', fallback_true_value='False') == True

--- a/tests/ludwig/utils/test_strings_utils.py
+++ b/tests/ludwig/utils/test_strings_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ludwig.utils import strings_utils
 
 


### PR DESCRIPTION
In [hyperopt](https://github.com/ludwig-ai/ludwig/blob/master/ludwig/automl/base_config.py#L297), we infer a `BINARY` feature type if there are two distinct values.

Currently, we use a rather [limited whitelist](https://github.com/ludwig-ai/ludwig/blob/master/ludwig/utils/strings_utils.py#L40) to automatically map string values to booleans. This means that any binary feature column that uses values that aren't in our whitelists explicitly (high/low, good/bad, human/bot) would all be mapped to `False`.

This is the culprit behind oddly perfect training curves, 0% loss, 100% accuracy on multiple datatsets  seen on `staging` and `king` (see slack threads [1](https://predibase.slack.com/archives/C01HRVAR1NE/p1633248351068500), [2](https://predibase.slack.com/archives/C01FDHU1UP9/p1635822561041300?thread_ts=1635814840.040800&cid=C01FDHU1UP9)).

The `training_set_metadata` also reveals this issue, e.g. twitterbots:

```
  'str2bool': {'bot': False, 'human': False},
  'bool2str': ['bot', 'human'],
```

The proposed solution is to use a fallback str2bool mapping derived from the feature column's distinct values when the feature's values aren't boolean-like, using the first distinct value as the value for `True` (alphabetical order).

```
  'str2bool': {'bot': True, 'human': False},
  'bool2str': ['human', 'bot'], 
  'fallback_true_label': 'bot',
```

This appears to fix the training loss curves and accuracy metrics (no longer 100%) 👍 

There may still be some performance differences between representing the feature as a binary vs. category, which also use slightly different metrics for loss (BWCE vs. SoftmaxCrossEntropy) and accuracy (CategoryAccuracy vs. Accuracy). Binary could be an honest description of a feature with only two distinct possible values, but category may be more semantically correct for what the feature is supposed to represent. It’s also not impossible that some specific configuration of the model performs better or produces more useful metrics with the output feature represented as a binary, category, or textual representation. 

We improve the default preprocessing behavior for binary features, but we still leave this configuration choice choice up to the user, with the option of specifying `preprocessing.fallback_true_label` to explicitly specify which label to use as true.