### PR TITLE
[tf-legacy] Employ a fallback str2bool mapping from the feature column's distinct values when the feature's values aren't boolean-like. 

### DIFF
--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -102,7 +102,7 @@ class BinaryFeatureMixin:
             "fallback_true_label": fallback_true_label
         }
 
-    @ staticmethod
+    @staticmethod
     def add_feature_data(
         feature,
         input_df,
@@ -152,20 +152,20 @@ class BinaryInputFeature(BinaryFeatureMixin, InputFeature):
 
         return encoder_outputs
 
-    @ classmethod
+    @classmethod
     def get_input_dtype(cls):
         return tf.bool
 
     def get_input_shape(self):
         return ()
 
-    @ staticmethod
+    @staticmethod
     def update_config_with_metadata(
         input_feature, feature_metadata, *args, **kwargs
     ):
         pass
 
-    @ staticmethod
+    @staticmethod
     def populate_defaults(input_feature):
         set_default_value(input_feature, TIED, None)
 
@@ -239,20 +239,20 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
     #         else:
     #             metric_fn.update_state(targets, predictions[PREDICTIONS])
 
-    @ classmethod
+    @classmethod
     def get_output_dtype(cls):
         return tf.bool
 
     def get_output_shape(self):
         return ()
 
-    @ staticmethod
+    @staticmethod
     def update_config_with_metadata(
         input_feature, feature_metadata, *args, **kwargs
     ):
         pass
 
-    @ staticmethod
+    @staticmethod
     def calculate_overall_stats(predictions, targets, train_set_metadata):
         overall_stats = {}
         confusion_matrix = ConfusionMatrix(
@@ -329,7 +329,7 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
 
         return result
 
-    @ staticmethod
+    @staticmethod
     def populate_defaults(output_feature):
         # If Loss is not defined, set an empty dictionary
         set_default_value(output_feature, LOSS, {})

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -65,8 +65,23 @@ def strip_accents(s):
                    if unicodedata.category(c) != 'Mn')
 
 
-def str2bool(v):
-    return str(v).lower() in BOOL_TRUE_STRS
+def str2bool(v, fallback_true_label=None):
+    """Returns bool representation of the given value v.
+    Check the value against global bool string lists.
+    Fallback to using fallback_true_label as True if the value isn't in the global bool string lists.
+    args:
+        v: Value to get the bool representation for.
+        fallback_true_label: (str) label to use as 'True'.
+    """
+    v_str = str(v).lower()
+    if v_str in BOOL_TRUE_STRS:
+        return True
+    if v_str in BOOL_FALSE_STRS:
+        return False
+    if fallback_true_label is None:
+        raise ValueError(
+            f'Cannot automatically map value {v} to a boolean and no `fallback_true_label` specified.')
+    return v == fallback_true_label
 
 
 def match_replace(string_to_match, list_regex):
@@ -149,7 +164,8 @@ def create_vocabulary(
     elif vocab_file is not None:
         vocab = load_vocabulary(vocab_file)
 
-    processed_lines = data.map(lambda line: tokenizer(line.lower() if lowercase else line))
+    processed_lines = data.map(lambda line: tokenizer(
+        line.lower() if lowercase else line))
     processed_counts = processed_lines.explode().value_counts(sort=False)
     processed_counts = processor.compute(processed_counts)
     unit_counts = Counter(dict(processed_counts))

--- a/tests/ludwig/utils/test_strings_utils.py
+++ b/tests/ludwig/utils/test_strings_utils.py
@@ -1,0 +1,24 @@
+import pytest
+
+from ludwig.utils import strings_utils
+
+
+def test_str_to_bool():
+    # Global bool mappings are used.
+    assert strings_utils.str2bool('True') == True
+    assert strings_utils.str2bool('true') == True
+    assert strings_utils.str2bool('0') == False
+
+    # Error raised if non-mapped value is encountered and no fallback is specified.
+    with pytest.raises(Exception):
+        strings_utils.str2bool('bot')
+
+    # Fallback label is used.
+    assert strings_utils.str2bool('bot', fallback_true_label='bot') == True
+    assert strings_utils.str2bool('human', fallback_true_label='bot') == False
+    assert strings_utils.str2bool('human', fallback_true_label='human') == True
+    assert strings_utils.str2bool(
+        'human', fallback_true_label='Human') == False
+
+    # Fallback label is used, strictly as a fallback.
+    assert strings_utils.str2bool('True', fallback_true_label='False') == True


### PR DESCRIPTION
Mirror of #1469, but for the tf-legacy branch.