### PR TITLE
Remove trailing dot in income label field in adult_census_income test data

### DIFF
--- a/ludwig/datasets/adult_census_income/__init__.py
+++ b/ludwig/datasets/adult_census_income/__init__.py
@@ -80,6 +80,8 @@ class AdultCensusIncome(UncompressedFileDownloadMixin, CSVLoadMixin,
         ]
         train_df.columns = columns
         test_df.columns = columns
+        # Remove the trailing period on the income field in adult.test (not in adult.data)
+        test_df['income'] = test_df['income'].str.rstrip('.')
 
         train_df['split'] = 0
         test_df['split'] = 2


### PR DESCRIPTION
As titled.  The issue can be tested by running the following and confirming that the test accuracy is not 0.
https://github.com/ludwig-ai/experiments/blob/main/automl/heuristics/adult_census_income/train_tabnet_reference_laptop.py
