### PR TITLE
FIX: mnist example failing in image preprocessing

### DIFF
--- a/examples/mnist/simple_model_training.py
+++ b/examples/mnist/simple_model_training.py
@@ -22,10 +22,10 @@ with open('./config.yaml', 'r') as f:
 
 # Define Ludwig model object that drive model training
 model = LudwigModel(config,
-                    logging_level=logging.DEBUG)
+                    logging_level=logging.INFO)
 
 # load and split MNIST dataset
-training_set, test_set, _ = mnist.load(cache_dir='./image_dir', split=True)
+training_set, test_set, _ = mnist.load(split=True)
 
 # initiate model training
 (

--- a/examples/mnist/simple_model_training.py
+++ b/examples/mnist/simple_model_training.py
@@ -22,10 +22,10 @@ with open('./config.yaml', 'r') as f:
 
 # Define Ludwig model object that drive model training
 model = LudwigModel(config,
-                    logging_level=logging.INFO)
+                    logging_level=logging.DEBUG)
 
 # load and split MNIST dataset
-training_set, test_set, _ = mnist.load(split=True)
+training_set, test_set, _ = mnist.load(cache_dir='./image_dir', split=True)
 
 # initiate model training
 (

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -209,13 +209,14 @@ class OutputFeature(BaseFeature, LudwigModule, ABC):
     def eval_loss(self, targets: Tensor, predictions: Dict[str, Tensor]):
         loss_class = type(self.train_loss_function)
         prediction_key = LOSS_INPUTS_REGISTRY[loss_class]
-        return self.eval_loss_function(predictions[prediction_key], targets)
+        return self.eval_loss_function(predictions[prediction_key].detach(),
+                                       targets)
 
     def update_metrics(self, targets: Tensor, predictions: Dict[str, Tensor]):
         for _, metric_fn in self.metric_functions.items():
             metric_class = type(metric_fn)
             prediction_key = METRICS_INPUTS_REGISTRY[metric_class]
-            metric_fn.update(predictions[prediction_key], targets)
+            metric_fn.update(predictions[prediction_key].detach(), targets)
 
     def get_metrics(self):
         metric_vals = {}

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -206,8 +206,10 @@ class ImageFeatureMixin:
                 explicit_height_width and explicit_num_channels):
             sample_size = min(len(input_feature_col),
                               preprocessing_parameters[INFER_IMAGE_SAMPLE_SIZE])
-            sample = [read_image(get_image_from_path(src_path, img)) for img in
-                      input_feature_col.head(sample_size)]
+            sample = [
+                read_image(get_image_from_path(src_path, img, ret_bytes=True))
+                for img in
+                input_feature_col.head(sample_size)]
             inferred_sample = [img for img in sample if img is not None]
             if len(inferred_sample) == 0:
                 raise ValueError(
@@ -234,12 +236,13 @@ class ImageFeatureMixin:
             if preprocessing_parameters[INFER_IMAGE_DIMENSIONS]:
                 should_resize = True
 
+                # assumed image format is channels first [channels, height, width]
                 height_avg = min(
-                    sum(x.shape[0]
+                    sum(x.shape[1]
                         for x in inferred_sample) / len(inferred_sample),
                     preprocessing_parameters[INFER_IMAGE_MAX_HEIGHT])
                 width_avg = min(
-                    sum(x.shape[1]
+                    sum(x.shape[2]
                         for x in inferred_sample) / len(inferred_sample),
                     preprocessing_parameters[INFER_IMAGE_MAX_WIDTH])
 
@@ -322,7 +325,8 @@ class ImageFeatureMixin:
                 .format(type(first_img_entry))
             )
 
-        first_img_entry = get_image_from_path(src_path, first_img_entry)
+        first_img_entry = get_image_from_path(src_path, first_img_entry,
+                                              ret_bytes=True)
 
         (
             should_resize,

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -1,14 +1,11 @@
 import copy
 import logging
-import os
-import psutil
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
 import torchmetrics
-from torch.nn import Module
 
 from ludwig.combiners.combiners import get_combiner_class
 from ludwig.constants import *
@@ -117,11 +114,6 @@ class ECD(LudwigModule):
         Returns:
             A dictionary of output names to output tensors.
         """
-        logger.debug(
-            f'>>>>>model.forward(): entering the method '
-            f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
-        )
-
         if isinstance(inputs, tuple):
             inputs, targets = inputs
             # Convert targets to tensors.
@@ -142,27 +134,13 @@ class ECD(LudwigModule):
             else:
                 inputs[input_feature_name] = input_values
 
-        logger.debug(
-            f'>>>>>model.forward(): after converting inputs to tensors'
-            f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
-        )
-
         encoder_outputs = {}
         for input_feature_name, input_values in inputs.items():
             encoder = self.input_features[input_feature_name]
             encoder_output = encoder(input_values)
             encoder_outputs[input_feature_name] = encoder_output
 
-        logger.debug(
-            f'>>>>>model.forward(): after generating encoder output '
-            f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
-        )
-
         combiner_outputs = self.combiner(encoder_outputs)
-        logger.debug(
-            f'>>>>>model.forward(): after combiner '
-            f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
-        )
 
         output_logits = {}
         output_last_hidden = {}
@@ -179,11 +157,6 @@ class ECD(LudwigModule):
             output_logits[output_feature_name] = decoder_outputs
             output_last_hidden[output_feature_name] = decoder_outputs[
                 'last_hidden']
-
-        logger.debug(
-            f'>>>>>model.forward(): after output feature logits '
-            f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
-        )
 
         return output_logits
 
@@ -219,38 +192,18 @@ class ECD(LudwigModule):
                 "of output features"
             )
 
-        logger.debug(
-            f'>>>>>predictions: before model.forward() '
-            f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
-        )
         outputs = self(inputs)
-        logger.debug(
-            f'>>>>predictions: after model.forward() '
-            f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
-        )
 
         predictions = {}
         for of_name in of_list:
             predictions[of_name] = self.output_features[of_name].predictions(
                 outputs[of_name]
             )
-        logger.debug(
-            f'>>>>predictions: about to return predictions '
-            f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
-        )
 
         return predictions
 
     def evaluation_step(self, inputs, targets):
-        logger.debug(
-            f'evaluation_step: before predictions '
-            f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
-        )
         predictions = self.predictions(inputs, output_features=None)
-        logger.debug(
-            f'evaluation_step: after predictions '
-            f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
-        )
         self.update_metrics(targets, predictions)
         return predictions
 

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -195,15 +195,8 @@ class Predictor(BasePredictor):
                         batch[o_feat.proc_column])
                     for o_feat in model.output_features.values()
                 }
-                logger.debug(
-                    f'evaluation for {dataset_name}: before evaluation_step '
-                    f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
-                )
+
                 preds = model.evaluation_step(inputs, targets)
-                logger.debug(
-                    f'evaluation for {dataset_name}: after evaluation_step '
-                    f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
-                )
 
                 # accumulate predictions from batch for each output feature
                 if collect_predictions:

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import psutil
 import sys
 from abc import ABC, abstractmethod
 from collections import defaultdict, OrderedDict
@@ -204,6 +205,10 @@ class Predictor(BasePredictor):
 
                 if self.is_coordinator():
                     progress_bar.update(1)
+                    logger.debug(
+                        f'evaluation for {dataset_name}: completed batch {progress_bar.n} '
+                        f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
+                    )
 
             if self.is_coordinator():
                 progress_bar.close()

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -182,7 +182,10 @@ class Predictor(BasePredictor):
             predictions = defaultdict(list)
             while not batcher.last_batch():
                 batch = batcher.next_batch()
-
+                logger.debug(
+                    f'evaluation for {dataset_name}: obtained next batch '
+                    f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
+                )
                 inputs = {
                     i_feat.feature_name: batch[i_feat.proc_column]
                     for i_feat in model.input_features.values()
@@ -192,8 +195,15 @@ class Predictor(BasePredictor):
                         batch[o_feat.proc_column])
                     for o_feat in model.output_features.values()
                 }
-
+                logger.debug(
+                    f'evaluation for {dataset_name}: before evaluation_step '
+                    f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
+                )
                 preds = model.evaluation_step(inputs, targets)
+                logger.debug(
+                    f'evaluation for {dataset_name}: after evaluation_step '
+                    f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
+                )
 
                 # accumulate predictions from batch for each output feature
                 if collect_predictions:

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -21,6 +21,7 @@ import gc
 import logging
 import os
 import os.path
+import psutil
 import signal
 import sys
 import threading
@@ -909,6 +910,10 @@ class Trainer(BaseTrainer):
                     progress_tracker.steps += 1
                     if self.is_coordinator():
                         progress_bar.update(1)
+                        logger.debug(
+                            f'training: completed batch {progress_bar.n} '
+                            f'memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB'
+                        )
                     first_batch = False
 
                     self.callback(lambda c: c.on_batch_end(

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -117,8 +117,11 @@ def read_image(img: Union[str, torch.Tensor], num_channels: Optional[int] = None
     if isinstance(img, str):
         return read_image_from_str(img, num_channels)
     elif isinstance(img, bytes):
-        buffer = BytesIO(img).read()
-        return decode_image(torch.frombuffer(buffer, dtype=torch.uint8))
+        with BytesIO(img) as buffer:
+            buffer_view = buffer.getbuffer()
+            image_tensor = decode_image(torch.frombuffer(buffer_view, dtype=torch.uint8))
+            del(buffer_view)
+            return image_tensor
     return img
 
 

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import copy
 import functools
 import logging
 import os
@@ -26,6 +27,7 @@ from urllib.error import HTTPError
 import numpy as np
 import torch
 import torchvision.transforms.functional as F
+from torchvision.io import decode_image
 
 from ludwig.constants import CROP_OR_PAD, INTERPOLATE
 from ludwig.utils.data_utils import get_abs_path
@@ -114,6 +116,9 @@ def read_image(img: Union[str, torch.Tensor], num_channels: Optional[int] = None
     """
     if isinstance(img, str):
         return read_image_from_str(img, num_channels)
+    elif isinstance(img, bytes):
+        buffer = BytesIO(img).read()
+        return decode_image(torch.frombuffer(buffer, dtype=torch.uint8))
     return img
 
 

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -359,6 +359,10 @@ def test_experiment_infer_image_metadata(csv_filename: str):
     ]
 
     rel_path = generate_data(input_features, output_features, csv_filename)
+
+    # remove image preprocessing section to force inferring image meta data
+    input_features[0].pop('preprocessing')
+
     run_experiment(
         input_features,
         output_features,

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -338,6 +338,37 @@ def test_basic_image_feature(num_channels, image_source, in_memory,
     shutil.rmtree(image_dest_folder, ignore_errors=True)
 
 
+def test_experiment_infer_image_metadata(csv_filename: str):
+    # Image Inputs
+    image_dest_folder = os.path.join(os.getcwd(), 'generated_images')
+
+    # Resnet encoder
+    input_features = [
+        image_feature(
+            folder=image_dest_folder,
+            encoder='stacked_cnn',
+            fc_size=16,
+            num_filters=8
+        ),
+        text_feature(encoder='embed', min_len=1),
+        numerical_feature(normalization='zscore')
+    ]
+    output_features = [
+        category_feature(vocab_size=2, reduce_input='sum'),
+        numerical_feature()
+    ]
+
+    rel_path = generate_data(input_features, output_features, csv_filename)
+    run_experiment(
+        input_features,
+        output_features,
+        dataset=rel_path
+    )
+
+    # Delete the temporary data created
+    shutil.rmtree(image_dest_folder)
+
+
 ImageParams = namedtuple(
     'ImageTestParams',
     'image_encoder in_memory_flag skip_save_processed_input'


### PR DESCRIPTION
# Code Pull Requests

When running the MNIST example, this error occurs:
```
Traceback (most recent call last):
  File "/opt/project/examples/mnist/simple_model_training.py", line 35, in <module>
    ) = model.train(
  File "/opt/project/ludwig/api.py", line 488, in train
    self.model = LudwigModel.create_model(self.config,
  File "/opt/project/ludwig/api.py", line 1596, in create_model
    return ECD(
  File "/opt/project/ludwig/models/ecd.py", line 49, in __init__
    self.input_features.update(build_inputs(input_features_def))
  File "/opt/project/ludwig/models/ecd.py", line 307, in build_inputs
    input_features[input_feature_def[NAME]] = build_single_input(
  File "/opt/project/ludwig/models/ecd.py", line 336, in build_single_input
    input_feature_obj = input_feature_class(input_feature_def, encoder_obj)
  File "/opt/project/ludwig/features/image_feature.py", line 446, in __init__
    self.encoder_obj = self.initialize_encoder(feature)
  File "/opt/project/ludwig/features/base_feature.py", line 111, in initialize_encoder
    return get_from_registry(self.encoder, self.encoder_registry)(
  File "/opt/project/ludwig/encoders/image_encoders.py", line 126, in __init__
    self.fc_stack = FCStack(
  File "/opt/project/ludwig/modules/fully_connected_modules.py", line 163, in __init__
    FCLayer(
  File "/opt/project/ludwig/modules/fully_connected_modules.py", line 57, in __init__
    fc = Linear(
  File "/usr/local/lib/python3.8/site-packages/torch/nn/modules/linear.py", line 85, in __init__
    self.weight = Parameter(torch.empty((out_features, in_features), **factory_kwargs))
RuntimeError: Trying to create tensor with negative dimension -320: [128, -320]
```

This PR changes how images are read in when inferring the height/width of images.