### PR TITLE
Add dicts to initializer field types for combiners

### DIFF
--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -93,9 +93,8 @@ class ConcatCombinerConfig:
     num_fc_layers: int = schema.NonNegativeInteger(default=0)
     fc_size: int = schema.PositiveInteger(default=256)
     use_bias: bool = True
-    weights_initializer: str = schema.InitializerOptions(
-        default='xavier_uniform')
-    bias_initializer: str = schema.InitializerOptions(default='zeros')
+    weights_initializer: Union[str, Dict] = schema.InitializerOrDict(default='xavier_uniform')
+    bias_initializer: Union[str, Dict] = schema.InitializerOrDict(default='zeros')
     norm: Optional[str] = schema.StringOptions(['batch', 'layer'])
     norm_params: Optional[dict] = schema.Dict()
     activation: str = 'relu'
@@ -583,9 +582,8 @@ class TransformerCombinerConfig:
     num_fc_layers: int = schema.NonNegativeInteger(default=0)
     fc_size: int = schema.PositiveInteger(default=256)
     use_bias: bool = True
-    weights_initializer: str = schema.InitializerOptions(
-        default='xavier_uniform')
-    bias_initializer: str = schema.InitializerOptions(default='zeros')
+    weights_initializer: Union[str, Dict] = schema.InitializerOrDict(default='xavier_uniform')
+    bias_initializer: Union[str, Dict] = schema.InitializerOrDict(default='zeros')
     norm: Optional[str] = schema.StringOptions(['batch', 'layer'])
     norm_params: Optional[dict] = schema.Dict()
     fc_activation: str = 'relu'
@@ -722,9 +720,8 @@ class TabTransformerCombinerConfig:
     num_fc_layers: int = schema.NonNegativeInteger(default=0)
     fc_size: int = schema.PositiveInteger(default=256)
     use_bias: bool = True
-    weights_initializer: str = schema.InitializerOptions(
-        default='xavier_uniform')
-    bias_initializer: str = schema.InitializerOptions(default='zeros')
+    weights_initializer: Union[str, Dict] = schema.InitializerOrDict(default='xavier_uniform')
+    bias_initializer: Union[str, Dict] = schema.InitializerOrDict(default='zeros')
     norm: Optional[str] = schema.StringOptions(['batch', 'layer'])
     norm_params: Optional[dict] = schema.Dict()
     fc_activation: str = 'relu'
@@ -963,9 +960,8 @@ class ComparatorCombinerConfig:
     num_fc_layers: int = schema.NonNegativeInteger(default=1)
     fc_size: int = schema.PositiveInteger(default=256)
     use_bias: bool = True
-    weights_initializer: str = schema.InitializerOptions(
-        default='xavier_uniform')
-    bias_initializer: str = schema.InitializerOptions(default='zeros')
+    weights_initializer: Union[str, Dict] = schema.InitializerOrDict(default='xavier_uniform')
+    bias_initializer: Union[str, Dict] = schema.InitializerOrDict(default='zeros')
     norm: Optional[str] = schema.StringOptions(['batch', 'layer'])
     norm_params: Optional[dict] = schema.Dict()
     activation: str = 'relu'

--- a/tests/ludwig/utils/test_schema.py
+++ b/tests/ludwig/utils/test_schema.py
@@ -267,9 +267,12 @@ def test_config_bad_combiner_types_enums():
     config['combiner']['weights_initializer'] = {}
     with pytest.raises(ValidationError, match=r"Failed validating 'type'"):
         validate_config(config)
-    config['combiner']['weights_initializer'] = {'type':'normal'}
-    validate_config(config)
-    
+    config['combiner']['weights_initializer'] = {'type':'fail'}
+    with pytest.raises(ValidationError, match=r"'fail' is not one of*"):
+        validate_config(config)  
+    config['combiner']['weights_initializer'] = {'type':'normal', 'stddev': 0}
+    validate_config(config)  
+
     # Test bias initializer:
     del config['combiner']['weights_initializer']
     config['combiner']['bias_initializer'] = 'kaiming_uniform'
@@ -280,8 +283,11 @@ def test_config_bad_combiner_types_enums():
     config['combiner']['bias_initializer'] = {}
     with pytest.raises(ValidationError, match=r"Failed validating 'type'"):
         validate_config(config)
-    config['combiner']['bias_initializer'] = {'type':'zeros'}
-    validate_config(config)
+    config['combiner']['bias_initializer'] = {'type':'fail'}
+    with pytest.raises(ValidationError, match=r"'fail' is not one of*"):
+        validate_config(config)  
+    config['combiner']['bias_initializer'] = {'type':'zeros', 'stddev': 0}
+    validate_config(config)  
 
     # Test norm:
     del config['combiner']['bias_initializer']

--- a/tests/ludwig/utils/test_schema.py
+++ b/tests/ludwig/utils/test_schema.py
@@ -264,6 +264,11 @@ def test_config_bad_combiner_types_enums():
     config['combiner']['weights_initializer'] = 'fail'
     with pytest.raises(ValidationError, match=r"'fail' is not of*"):
         validate_config(config)
+    config['combiner']['weights_initializer'] = {}
+    with pytest.raises(ValidationError, match=r"Failed validating 'type'"):
+        validate_config(config)
+    config['combiner']['weights_initializer'] = {'type':'normal'}
+    validate_config(config)
     
     # Test bias initializer:
     del config['combiner']['weights_initializer']
@@ -272,6 +277,11 @@ def test_config_bad_combiner_types_enums():
     config['combiner']['bias_initializer'] = 'fail'
     with pytest.raises(ValidationError, match=r"'fail' is not of*"):
         validate_config(config)
+    config['combiner']['bias_initializer'] = {}
+    with pytest.raises(ValidationError, match=r"Failed validating 'type'"):
+        validate_config(config)
+    config['combiner']['bias_initializer'] = {'type':'zeros'}
+    validate_config(config)
 
     # Test norm:
     del config['combiner']['bias_initializer']


### PR DESCRIPTION
Creates a marshmallow field `InitializerOrDict` modeled after `Embed` and `InitializerOptions` that allows valid initializer strings or dicts with a 'type' parameter ([ref](https://ludwig-ai.github.io/ludwig-docs/user_guide/configuration/#concat-combiner) - see `initializer` description). Sets `weights_initializer` and `bias_initializer` fields in `combiners.py` to use this instead of `InitializerOptions`

Having some Torch issues locally, but hopefully tests pass here...