### PR TITLE
Tabnet Combiner: correct class hierarchy

### DIFF
--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -483,7 +483,7 @@ class TabNetCombinerConfig:
         unknown = INCLUDE
 
 
-class TabNetCombiner(Module):
+class TabNetCombiner(CombinerClass):
     def __init__(
             self,
             input_features: Dict,


### PR DESCRIPTION
# Code Pull Requests

Corrects superclass specification for Tabnet combiner.  Without this correction, a missing `output_shape` attribute error will occur if Tabnet combiner is used model.