### PR TITLE
Update Ludwig AutoML Feature Type Selection

### DIFF
--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -22,9 +22,11 @@ from typing import List, Union
 import pandas as pd
 
 from ludwig.automl.data_source import DataSource, DataframeSource
-from ludwig.automl.utils import (FieldInfo, get_available_resources, _ray_init, FieldMetadata, FieldConfig)
+from ludwig.automl.utils import (
+    FieldInfo, get_available_resources, _ray_init, FieldMetadata, FieldConfig)
 from ludwig.constants import BINARY, CATEGORY, CONFIG, IMAGE, NUMERICAL, TEXT, TYPE
 from ludwig.utils.data_utils import load_yaml, load_dataset
+from ludwig.utils import strings_utils
 
 try:
     import dask.dataframe as dd
@@ -159,6 +161,7 @@ def get_dataset_info_from_source(source: DataSource) -> DatasetInfo:
     for field in source.columns:
         dtype = source.get_dtype(field)
         distinct_values = source.get_distinct_values(field)
+        num_distinct_values = source.get_num_distinct_values(field)
         nonnull_values = source.get_nonnull_values(field)
         image_values = source.get_image_values(field)
         avg_words = None
@@ -169,6 +172,7 @@ def get_dataset_info_from_source(source: DataSource) -> DatasetInfo:
                 name=field,
                 dtype=dtype,
                 distinct_values=distinct_values,
+                num_distinct_values=num_distinct_values,
                 nonnull_values=nonnull_values,
                 image_values=image_values,
                 avg_words=avg_words
@@ -252,7 +256,8 @@ def get_field_metadata(
                     column=field.name,
                     type=dtype,
                 ),
-                excluded=should_exclude(idx, field, dtype, row_count, target_name),
+                excluded=should_exclude(
+                    idx, field, dtype, row_count, target_name),
                 mode=infer_mode(field, target_name),
                 missing_values=missing_value_percent,
             )
@@ -293,14 +298,21 @@ def infer_type(
     # Return
     :return: (str) feature type
     """
+    num_distinct_values = field.num_distinct_values
     distinct_values = field.distinct_values
-    if distinct_values == 2 and missing_value_percent == 0:
-        return BINARY
+    if num_distinct_values <= 2 and missing_value_percent == 0:
+        # Check that all distinct values are conventional bools.
+        if strings_utils.are_conventional_bools(distinct_values):
+            return BINARY
 
     if field.image_values >= 3:
         return IMAGE
 
-    if distinct_values < 20:
+    # If small number of distinct values, use CATEGORY if either not all are numerical or
+    # they form a sequential list of integers suggesting the values represent categories
+    if (num_distinct_values < 20 and
+        ((not strings_utils.are_all_numericals(distinct_values)) or
+         strings_utils.are_sequential_integers(distinct_values))):
         # TODO (tgaddair): come up with something better than this, maybe attempt to fit to Gaussian
         # NOTE (ASN): edge case -- there are less than 20 samples in dataset
         return CATEGORY
@@ -310,6 +322,13 @@ def infer_type(
         return TEXT
 
     # TODO (ASN): add other modalities (image, etc. )
+
+    # If either of 2 examples is not numerical, use CATEGORY type.  We examine 2 since missing
+    # values can be coded as NaN, which is numerical, even for fields that are otherwise strings.
+    if (num_distinct_values > 1 and
+        ((not strings_utils.is_numerical(distinct_values[0])) or
+         (not strings_utils.is_numerical(distinct_values[1])))):
+        return CATEGORY
 
     return NUMERICAL
 
@@ -321,10 +340,10 @@ def should_exclude(idx: int, field: FieldInfo, dtype: str, row_count: int, targe
     if field.name == target_name:
         return False
 
-    distinct_value_percent = float(field.distinct_values) / row_count
+    distinct_value_percent = float(field.num_distinct_values) / row_count
     if distinct_value_percent == 1.0:
         upper_name = field.name.upper()
-        if (idx == 0 and dtype == NUMERICAL) or upper_name.endswith("ID"):
+        if (idx == 0 and dtype == NUMERICAL) or upper_name.endswith("ID") or upper_name.startswith("ID"):
             return True
 
     return False

--- a/ludwig/automl/data_source.py
+++ b/ludwig/automl/data_source.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from typing import List, Set
+from typing import List
 
 from ludwig.automl.utils import avg_num_tokens
 from ludwig.utils.image_utils import is_image_score
@@ -17,11 +17,7 @@ class DataSource(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_num_distinct_values(self, column) -> int:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def get_distinct_values(self, column) -> Set:
+    def get_distinct_values(self, column, max_values_to_return) -> (int, List[str]):
         raise NotImplementedError()
 
     @abstractmethod
@@ -52,11 +48,10 @@ class DataframeSource(DataSource):
     def get_dtype(self, column) -> str:
         return self.df[column].dtype.name
 
-    def get_num_distinct_values(self, column) -> int:
-        return len(self.df[column].unique())
-
-    def get_distinct_values(self, column) -> int:
-        return self.df[column].unique()
+    def get_distinct_values(self, column, max_values_to_return) -> (int, List[str]):
+        unique_values = self.df[column].unique()
+        num_unique_values = len(unique_values)
+        return (num_unique_values, unique_values[:max_values_to_return])
 
     def get_nonnull_values(self, column) -> int:
         return len(self.df[column].notnull())

--- a/ludwig/automl/data_source.py
+++ b/ludwig/automl/data_source.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from typing import List
+from typing import List, Set
 
 from ludwig.automl.utils import avg_num_tokens
 from ludwig.utils.image_utils import is_image_score
@@ -17,7 +17,11 @@ class DataSource(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_distinct_values(self, column) -> int:
+    def get_num_distinct_values(self, column) -> int:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_distinct_values(self, column) -> Set:
         raise NotImplementedError()
 
     @abstractmethod
@@ -48,8 +52,11 @@ class DataframeSource(DataSource):
     def get_dtype(self, column) -> str:
         return self.df[column].dtype.name
 
-    def get_distinct_values(self, column) -> int:
+    def get_num_distinct_values(self, column) -> int:
         return len(self.df[column].unique())
+
+    def get_distinct_values(self, column) -> int:
+        return self.df[column].unique()
 
     def get_nonnull_values(self, column) -> int:
         return len(self.df[column].notnull())

--- a/ludwig/automl/utils.py
+++ b/ludwig/automl/utils.py
@@ -1,6 +1,7 @@
 import logging
 
-from dataclasses import dataclass
+from typing import List
+from dataclasses import dataclass, field
 from dataclasses_json import LetterCase, dataclass_json
 from pandas import Series
 
@@ -26,7 +27,8 @@ class FieldInfo:
     name: str
     dtype: str
     key: str = None
-    distinct_values: int = 0
+    distinct_values: List = field(default_factory=lambda: [])
+    num_distinct_values: int = 0
     nonnull_values: int = 0
     image_values: int = 0
     avg_words: int = None

--- a/ludwig/automl/utils.py
+++ b/ludwig/automl/utils.py
@@ -27,7 +27,7 @@ class FieldInfo:
     name: str
     dtype: str
     key: str = None
-    distinct_values: List = field(default_factory=lambda: [])
+    distinct_values: List = None
     num_distinct_values: int = 0
     nonnull_values: int = 0
     image_values: int = 0

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -39,6 +39,8 @@ UNDERSCORE_REGEX = re.compile(r'\s*_\s*')
 
 BOOL_TRUE_STRS = {'yes', 'y', 'true', 't', '1'}
 BOOL_FALSE_STRS = {'no', 'n', 'false', 'f', '0'}
+# Update the following if BOOL_TRUE_STRS or BOOL_FALSE_STRS changes
+MAX_DISTINCT_BOOL_PERMUTATIONS = 70
 
 
 def all_bool_strs():

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -84,6 +84,52 @@ def str2bool(v, fallback_true_label=None):
     return v == fallback_true_label
 
 
+def are_conventional_bools(values):
+    """Returns whether all values are conventional booleans."""
+    for value in values:
+        lower_value = str(value).lower()
+        if lower_value not in BOOL_TRUE_STRS and lower_value not in BOOL_FALSE_STRS:
+            return False
+    return True
+
+
+def is_numerical(s):
+    """Returns whether specified value is numerical."""
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
+
+def are_all_numericals(values):
+    """Returns whether all values are numericals."""
+    for value in values:
+        if not is_numerical(value):
+            return False
+    return True
+
+
+def is_integer(s):
+    """Returns whether specified value is an integer."""
+    try:
+        float(s)
+    except ValueError:
+        return False
+    else:
+        return float(s).is_integer() and not np.isnan(float(s))
+
+
+def are_sequential_integers(values):
+    """Returns whether distinct values form sequential integer list."""
+    int_list = []
+    for value in values:
+        if not is_integer(value):
+            return False
+        int_list.append(int(value))
+    return (max(int_list) - min(int_list) + 1) == len(int_list)
+
+
 def match_replace(string_to_match, list_regex):
     """Matches strings against regular expressions.
 

--- a/tests/ludwig/utils/test_strings_utils.py
+++ b/tests/ludwig/utils/test_strings_utils.py
@@ -22,3 +22,14 @@ def test_str_to_bool():
 
     # Fallback label is used, strictly as a fallback.
     assert strings_utils.str2bool('True', fallback_true_label='False') == True
+
+
+def test_are_conventional_bools():
+    assert strings_utils.are_conventional_bools(['True', 'False']) == True
+    assert strings_utils.are_conventional_bools(['T', 'F']) == True
+    assert strings_utils.are_conventional_bools(['t', 'f']) == True
+    assert strings_utils.are_conventional_bools(['True', 'Fales']) == False
+    assert strings_utils.are_conventional_bools(['0', '1']) == True
+    assert strings_utils.are_conventional_bools(['0', '2']) == False
+    assert strings_utils.are_conventional_bools(['high', 'low']) == False
+    assert strings_utils.are_conventional_bools(['human', 'bot']) == False


### PR DESCRIPTION
This Pull Request is intended to improve Ludwig AutoML automatic feature type selection.  The change set includes Justin's PR (not yet landed) to improve binary feature type selection as well as additional feature type selection updates to address opportunities observed relative to the types selected for LBT and/or by practitioner(s) on the 12 tabular datasets used to develop AutoML heuristics.  The additional feature type selection updates were largely adapted from ideas discussed in the Ludwig AutoML meetings.

The PR is based on the tf-legacy branch, and comprises the following:
* Justin's PR to improve binary feature type selection
https://github.com/ludwig-ai/ludwig/pull/1473
* Changes in ludwig/automl/base_config.py and ludwig/utils/strings_utils.py
** Refinement of binary type identification to support binary for single distinct values
** Refinement of category type identification for small-count distinct values to further specify that those values either not be all numericals or all be sequential integers, the latter suggesting that the numbers were chosen to represent categories.
** Refinement of fall-through remaining case type selection as category if sampling finds non-numerical values; else numerical.

The impact of the PR was assessed by comparing its type output for the create_auto_config API with that produced by the current tf-legacy branch code and that chosen for LBT and manually by practitioners for the 12 tabular datasets used to develop AutoML heuristics.  Given the positive impact, it is proposed to land this change to Ludwig’s tf-legacy and master branches.  The results of this testing are available here: https://docs.google.com/document/d/1nLDbkYtg5J5Xb3sqRF25EGu3O2OOUwOSnbvQKdNhz68/edit?usp=sharing
