### PR TITLE
Add hdf5 support for ground_truth in visualization

### DIFF
--- a/ludwig/globals.py
+++ b/ludwig/globals.py
@@ -22,6 +22,13 @@ TRAIN_SET_METADATA_FILE_NAME = "training_set_metadata.json"
 TRAINING_PROGRESS_TRACKER_FILE_NAME = "training_progress.json"
 TRAINING_CHECKPOINTS_DIR_PATH = "training_checkpoints"
 
+TEST_STATISTICS_FILE_NAME = "test_statistics.json"
+
+PREDICTIONS_PARQUET_FILE_NAME = "predictions.parquet"
+PREDICTIONS_SHAPES_FILE_NAME = "predictions.shapes.json"
+
+TRAINING_PREPROC_FILE_NAME = "training.hdf5"
+
 DISABLE_PROGRESSBAR = False
 
 

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -13,7 +13,8 @@ from tqdm import tqdm
 
 from ludwig.constants import COMBINED, LAST_HIDDEN, LOGITS
 from ludwig.data.dataset.base import Dataset
-from ludwig.globals import is_progressbar_disabled
+from ludwig.globals import is_progressbar_disabled, PREDICTIONS_PARQUET_FILE_NAME, PREDICTIONS_SHAPES_FILE_NAME, \
+    TEST_STATISTICS_FILE_NAME
 from ludwig.models.ecd import ECD
 from ludwig.utils.data_utils import flatten_df, from_numpy_dataset, save_json
 from ludwig.utils.horovod_utils import initialize_horovod, return_first
@@ -282,12 +283,12 @@ def save_prediction_outputs(
     backend,
 ):
     postprocessed_output, column_shapes = flatten_df(postprocessed_output, backend)
-    postprocessed_output.to_parquet(os.path.join(output_directory, "predictions.parquet"))
-    save_json(os.path.join(output_directory, "predictions.shapes.json"), column_shapes)
+    postprocessed_output.to_parquet(os.path.join(output_directory, PREDICTIONS_PARQUET_FILE_NAME))
+    save_json(os.path.join(output_directory, PREDICTIONS_SHAPES_FILE_NAME), column_shapes)
 
 
 def save_evaluation_stats(test_stats, output_directory):
-    test_stats_fn = os.path.join(output_directory, "test_statistics.json")
+    test_stats_fn = os.path.join(output_directory, TEST_STATISTICS_FILE_NAME)
     save_json(test_stats_fn, test_stats)
 
 

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -201,7 +201,7 @@ def read_stata(data_fp, df_lib):
     return df_lib.read_stata(data_fp)
 
 
-def read_hdf5(data_fp):
+def read_hdf5(data_fp, **kwargs):
     return load_hdf5(data_fp, clean_cols=True)
 
 

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -201,6 +201,10 @@ def read_stata(data_fp, df_lib):
     return df_lib.read_stata(data_fp)
 
 
+def read_hdf5(data_fp):
+    return load_hdf5(data_fp, clean_cols=True)
+
+
 def save_csv(data_fp, data):
     with open_file(data_fp, "w", encoding="utf-8") as csv_file:
         writer = csv.writer(csv_file)
@@ -327,13 +331,15 @@ def save_hdf5(data_fp, data):
             h5_file.create_dataset(column, data=numpy_dataset[column])
 
 
-def load_hdf5(data_fp):
+def load_hdf5(data_fp, clean_cols: bool = False):
     with download_h5(data_fp) as hdf5_data:
         columns = [s.decode("utf-8") for s in hdf5_data[HDF5_COLUMNS_KEY][()].tolist()]
 
         numpy_dataset = {}
         for column in columns:
-            numpy_dataset[column] = hdf5_data[column][()]
+            # Column names from training hdf5 will be in the form 'Survived_a2fv4'
+            np_col = column.rsplit("_", 1)[0] if clean_cols else column
+            numpy_dataset[np_col] = hdf5_data[column][()]
 
     return from_numpy_dataset(numpy_dataset)
 
@@ -783,6 +789,7 @@ external_data_reader_registry = {
     **{fmt: read_sas for fmt in SAS_FORMATS},
     **{fmt: read_spss for fmt in SPSS_FORMATS},
     **{fmt: read_stata for fmt in STATA_FORMATS},
+    **{fmt: read_hdf5 for fmt in HDF5_FORMATS},
 }
 
 

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -53,7 +53,9 @@ _PREDICTIONS_SUFFIX = "_predictions"
 _PROBABILITIES_SUFFIX = "_probabilities"
 
 
-def _vectorize_ground_truth(ground_truth: pd.Series, str2idx: np.array, ground_truth_apply_idx: bool = True) -> np.array:
+def _vectorize_ground_truth(
+    ground_truth: pd.Series, str2idx: np.array, ground_truth_apply_idx: bool = True
+) -> np.array:
     # raw hdf5 files generated during preprocessing don't need to be converted with str2idx
     if not ground_truth_apply_idx:
         return np.vectorize(lambda x, y: x)(ground_truth, str2idx)

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -53,9 +53,7 @@ _PREDICTIONS_SUFFIX = "_predictions"
 _PROBABILITIES_SUFFIX = "_probabilities"
 
 
-def _vectorize_ground_truth(
-    ground_truth: pd.Series, str2idx: np.array, ground_truth_apply_idx: bool = True
-) -> Union[pd.Series, np.ndarray]:
+def _vectorize_ground_truth(ground_truth: pd.Series, str2idx: np.array, ground_truth_apply_idx: bool = True) -> np.array:
     # raw hdf5 files generated during preprocessing don't need to be converted with str2idx
     if not ground_truth_apply_idx:
         return np.vectorize(lambda x, y: x)(ground_truth, str2idx)

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -53,6 +53,18 @@ _PREDICTIONS_SUFFIX = "_predictions"
 _PROBABILITIES_SUFFIX = "_probabilities"
 
 
+def _vectorize_ground_truth(ground_truth: pd.Series, str2idx: np.array, ground_truth_apply_idx: bool = True) -> Union[pd.Series, np.ndarray]:
+    # raw hdf5 files generated during preprocessing don't need to be converted with str2idx
+    if not ground_truth_apply_idx:
+        return np.vectorize(lambda x, y: x)(ground_truth, str2idx)
+
+    try:
+        return np.vectorize(_encode_categorical_feature)(ground_truth, str2idx)
+    except KeyError as e:
+        logger.info(f"Unable to vectorize using str2idx with exception {e}. Falling back to ignoring str2idx")
+        return np.vectorize(lambda x, y: x)(ground_truth, str2idx)
+
+
 def validate_conf_treshholds_and_probabilities_2d_3d(probabilities, treshhold_output_feature_names):
     """Ensure probabilities and treshhold output_feature_names arrays have two members each.
 
@@ -1033,6 +1045,7 @@ def calibration_1_vs_all_cli(
     ground_truth_metadata: str,
     output_feature_name: str,
     output_directory: str,
+    ground_truth_apply_idx: bool = True,
     **kwargs: dict,
 ) -> None:
     """Load model data from files to be shown by calibration_1_vs_all_cli.
@@ -1052,6 +1065,8 @@ def calibration_1_vs_all_cli(
     :param output_directory: (str) name of output directory containing training
          results.
     :param kwargs: (dict) parameters for the requested visualizations.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
 
@@ -1064,8 +1079,7 @@ def calibration_1_vs_all_cli(
     # retrieve ground truth from source data set
     ground_truth = _extract_ground_truth_values(ground_truth, output_feature_name, ground_truth_split, split_file)
     feature_metadata = metadata[output_feature_name]
-    vfunc = np.vectorize(_encode_categorical_feature)
-    ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+    ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     col = f"{output_feature_name}{_PROBABILITIES_SUFFIX}"
     probabilities_per_model = _get_cols_from_predictions(probabilities, [col], metadata)
@@ -1350,6 +1364,7 @@ def compare_classifiers_performance_from_prob(
     model_names: Union[str, List[str]] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Produces model comparison barplot visualization from probabilities.
@@ -1376,6 +1391,8 @@ def compare_classifiers_performance_from_prob(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
 
@@ -1385,8 +1402,7 @@ def compare_classifiers_performance_from_prob(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     top_n_classes_list = convert_to_list(top_n_classes)
     k = top_n_classes_list[0]
@@ -1443,6 +1459,7 @@ def compare_classifiers_performance_from_pred(
     model_names: Union[str, List[str]] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Produces model comparison barplot visualization from predictions.
@@ -1466,6 +1483,8 @@ def compare_classifiers_performance_from_pred(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
 
@@ -1475,8 +1494,7 @@ def compare_classifiers_performance_from_pred(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     predictions_per_model = [np.ndarray.flatten(np.array(pred)) for pred in predictions_per_model]
 
@@ -1529,6 +1547,7 @@ def compare_classifiers_performance_subset(
     model_names: Union[str, List[str]] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Produces model comparison barplot visualization from train subset.
@@ -1559,6 +1578,8 @@ def compare_classifiers_performance_subset(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
 
@@ -1567,8 +1588,7 @@ def compare_classifiers_performance_subset(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     top_n_classes_list = convert_to_list(top_n_classes)
     k = top_n_classes_list[0]
@@ -1648,6 +1668,7 @@ def compare_classifiers_performance_changing_k(
     model_names: Union[str, List[str]] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Produce lineplot that show Hits@K metric while k goes from 1 to `top_k`.
@@ -1674,6 +1695,8 @@ def compare_classifiers_performance_changing_k(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
 
@@ -1682,8 +1705,7 @@ def compare_classifiers_performance_changing_k(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     k = top_k
     if labels_limit > 0:
@@ -1880,6 +1902,7 @@ def compare_classifiers_predictions(
     model_names: Union[str, List[str]] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Show two models comparison of their output_feature_name predictions.
@@ -1900,6 +1923,8 @@ def compare_classifiers_predictions(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
 
@@ -1908,8 +1933,7 @@ def compare_classifiers_predictions(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     model_names_list = convert_to_list(model_names)
     name_c1 = model_names_list[0] if model_names is not None and len(model_names) > 0 else "c1"
@@ -2018,6 +2042,7 @@ def compare_classifiers_predictions_distribution(
     model_names: Union[str, List[str]] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Show comparision of models predictions distribution for 10 output_feature_name classes.
@@ -2042,6 +2067,8 @@ def compare_classifiers_predictions_distribution(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
 
@@ -2050,8 +2077,7 @@ def compare_classifiers_predictions_distribution(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     model_names_list = convert_to_list(model_names)
     if labels_limit > 0:
@@ -2089,6 +2115,7 @@ def confidence_thresholding(
     model_names: Union[str, List[str]] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Show models accuracy and data coverage while increasing treshold.
@@ -2113,6 +2140,8 @@ def confidence_thresholding(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
 
@@ -2121,8 +2150,7 @@ def confidence_thresholding(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     if labels_limit > 0:
         ground_truth[ground_truth > labels_limit] = labels_limit
@@ -2178,6 +2206,7 @@ def confidence_thresholding_data_vs_acc(
     model_names: Union[str, List[str]] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Show models comparison of confidence threshold data vs accuracy.
@@ -2205,6 +2234,8 @@ def confidence_thresholding_data_vs_acc(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
     :return: (None)
@@ -2212,8 +2243,7 @@ def confidence_thresholding_data_vs_acc(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     if labels_limit > 0:
         ground_truth[ground_truth > labels_limit] = labels_limit
@@ -2275,6 +2305,7 @@ def confidence_thresholding_data_vs_acc_subset(
     model_names: Union[str, List[str]] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Show models comparison of confidence threshold data vs accuracy on a subset of data.
@@ -2317,6 +2348,8 @@ def confidence_thresholding_data_vs_acc_subset(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
 
@@ -2325,8 +2358,7 @@ def confidence_thresholding_data_vs_acc_subset(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     top_n_classes_list = convert_to_list(top_n_classes)
     k = top_n_classes_list[0]
@@ -2409,6 +2441,7 @@ def confidence_thresholding_data_vs_acc_subset_per_class(
     model_names: Union[str, List[str]] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Show models comparison of confidence threshold data vs accuracy on a subset of data per class in top n
@@ -2458,6 +2491,8 @@ def confidence_thresholding_data_vs_acc_subset_per_class(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
     :return: (None)
@@ -2465,8 +2500,7 @@ def confidence_thresholding_data_vs_acc_subset_per_class(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     filename_template = "confidence_thresholding_data_vs_acc_subset_per_class_{}." + file_format
     filename_template_path = generate_filename_template_path(output_directory, filename_template)
@@ -2867,6 +2901,7 @@ def binary_threshold_vs_metric(
     model_names: List[str] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Show confidence of the model against metric for the specified output_feature_name.
@@ -2898,6 +2933,8 @@ def binary_threshold_vs_metric(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
 
@@ -2907,8 +2944,7 @@ def binary_threshold_vs_metric(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     probs = probabilities_per_model
     model_names_list = convert_to_list(model_names)
@@ -2979,6 +3015,7 @@ def roc_curves(
     model_names: Union[str, List[str]] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Show the roc curves for output features in the specified models.
@@ -3006,6 +3043,8 @@ def roc_curves(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
 
@@ -3014,8 +3053,7 @@ def roc_curves(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     probs = probabilities_per_model
     model_names_list = convert_to_list(model_names)
@@ -3089,6 +3127,7 @@ def calibration_1_vs_all(
     model_names: List[str] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Show models probability of predictions for the specified output_feature_name.
@@ -3124,6 +3163,8 @@ def calibration_1_vs_all(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # String
 
@@ -3132,8 +3173,7 @@ def calibration_1_vs_all(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     probs = probabilities_per_model
     model_names_list = convert_to_list(model_names)
@@ -3219,6 +3259,7 @@ def calibration_multiclass(
     model_names: Union[str, List[str]] = None,
     output_directory: str = None,
     file_format: str = "pdf",
+    ground_truth_apply_idx: bool = True,
     **kwargs,
 ) -> None:
     """Show models probability of predictions for each class of the specified output_feature_name.
@@ -3239,6 +3280,8 @@ def calibration_multiclass(
         plots. If not specified, plots will be displayed in a window
     :param file_format: (str, default: `'pdf'`) file format of output plots -
         `'pdf'` or `'png'`.
+    :param ground_truth_apply_idx: (bool, default: `True`) whether to use
+        metadata['str2idx'] in np.vectorize
 
     # Return
 
@@ -3247,8 +3290,7 @@ def calibration_multiclass(
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
         feature_metadata = metadata[output_feature_name]
-        vfunc = np.vectorize(_encode_categorical_feature)
-        ground_truth = vfunc(ground_truth, feature_metadata["str2idx"])
+        ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     probs = probabilities_per_model
     model_names_list = convert_to_list(model_names)

--- a/tests/integration_tests/test_cache_manager.py
+++ b/tests/integration_tests/test_cache_manager.py
@@ -7,6 +7,7 @@ import pytest
 from ludwig.constants import CHECKSUM, META, TEST, TRAINING, VALIDATION
 from ludwig.data.cache.manager import alphanum, CacheManager
 from ludwig.data.dataset.pandas import PandasDatasetManager
+from ludwig.globals import TRAINING_PREPROC_FILE_NAME
 from tests.integration_tests.utils import category_feature, LocalTestBackend, sequence_feature
 
 
@@ -56,7 +57,7 @@ def test_cache_dataset(use_cache_dir, use_split, tmpdir):
         val_path = os.path.join(tmpdir, "validation")
 
     assert cache_map[META] == f"{train_path}.meta.json"
-    assert cache_map[TRAINING] == f"{train_path}.training.hdf5"
+    assert cache_map[TRAINING] == f"{train_path}.{TRAINING_PREPROC_FILE_NAME}"
     assert cache_map[TEST] == f"{test_path}.test.hdf5"
     assert cache_map[VALIDATION] == f"{val_path}.validation.hdf5"
 

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -15,6 +15,7 @@ from ludwig.api import LudwigModel
 from ludwig.backend import LOCAL_BACKEND
 from ludwig.experiment import experiment_cli
 from ludwig.features.numerical_feature import numeric_transformation_registry
+from ludwig.globals import TRAINING_PREPROC_FILE_NAME
 from ludwig.modules.optimization_modules import optimizers_registry
 from ludwig.utils.data_utils import load_json, replace_file_extension
 from ludwig.utils.misc_utils import get_from_registry
@@ -352,7 +353,7 @@ def test_cache_checksum(csv_filename, tmp_path):
     }
 
     backend = LocalTestBackend()
-    cache_fname = replace_file_extension(source_dataset, "training.hdf5")
+    cache_fname = replace_file_extension(source_dataset, TRAINING_PREPROC_FILE_NAME)
 
     # conduct initial training
     output_directory = os.path.join(tmp_path, "results")

--- a/tests/integration_tests/test_visualization.py
+++ b/tests/integration_tests/test_visualization.py
@@ -25,6 +25,7 @@ import shutil
 import subprocess
 
 from ludwig.experiment import experiment_cli
+from ludwig.globals import PREDICTIONS_PARQUET_FILE_NAME, TEST_STATISTICS_FILE_NAME
 from ludwig.utils.data_utils import get_split_path
 from ludwig.visualize import _extract_ground_truth_values
 from tests.integration_tests.test_visualization_api import obtain_df_splits
@@ -152,7 +153,7 @@ def test_visualization_confusion_matrix_output_saved(csv_filename):
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth_metadata = experiment_source_data_name + ".meta.json"
-    test_stats = os.path.join(exp_dir_name, "test_statistics.json")
+    test_stats = os.path.join(exp_dir_name, TEST_STATISTICS_FILE_NAME)
     test_cmd_pdf = [
         "python",
         "-m",
@@ -205,7 +206,7 @@ def test_visualization_compare_performance_output_saved(csv_filename):
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     experiment_source_data_name = csv_filename.split(".")[0]
-    test_stats = os.path.join(exp_dir_name, "test_statistics.json")
+    test_stats = os.path.join(exp_dir_name, TEST_STATISTICS_FILE_NAME)
 
     test_cmd_pdf = [
         "python",
@@ -260,7 +261,7 @@ def test_visualization_compare_classifiers_from_prob_csv_output_saved(csv_filena
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = get_split_path(csv_filename)
@@ -325,7 +326,7 @@ def test_visualization_compare_classifiers_from_prob_npy_output_saved(csv_filena
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -389,7 +390,7 @@ def test_visualization_compare_classifiers_from_pred_npy_output_saved(csv_filena
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    prediction = os.path.join(exp_dir_name, "predictions.parquet")
+    prediction = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -454,7 +455,7 @@ def test_visualization_compare_classifiers_from_pred_csv_output_saved(csv_filena
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    prediction = os.path.join(exp_dir_name, "predictions.parquet")
+    prediction = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -518,7 +519,7 @@ def test_visualization_compare_classifiers_subset_output_saved(csv_filename):
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -579,7 +580,7 @@ def test_visualization_compare_classifiers_changing_k_output_pdf(csv_filename):
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -644,7 +645,7 @@ def test_visualization_compare_classifiers_multiclass_multimetric_output_saved(c
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    test_stats = os.path.join(exp_dir_name, "test_statistics.json")
+    test_stats = os.path.join(exp_dir_name, TEST_STATISTICS_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth_metadata = experiment_source_data_name + ".meta.json"
     test_cmd_pdf = [
@@ -700,7 +701,7 @@ def test_visualization_compare_classifiers_predictions_npy_output_saved(csv_file
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    prediction = os.path.join(exp_dir_name, "predictions.parquet")
+    prediction = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -764,7 +765,7 @@ def test_visualization_compare_classifiers_predictions_csv_output_saved(csv_file
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    prediction = os.path.join(exp_dir_name, "predictions.parquet")
+    prediction = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -827,7 +828,7 @@ def test_visualization_cmp_classifiers_predictions_distribution_output_saved(csv
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    prediction = os.path.join(exp_dir_name, "predictions.parquet")
+    prediction = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -890,7 +891,7 @@ def test_visualization_cconfidence_thresholding_output_saved(csv_filename):
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -953,7 +954,7 @@ def test_visualization_confidence_thresholding_data_vs_acc_output_saved(csv_file
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -1016,7 +1017,7 @@ def test_visualization_confidence_thresholding_data_vs_acc_subset_output_saved(c
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -1081,7 +1082,7 @@ def test_vis_confidence_thresholding_data_vs_acc_subset_per_class_output_saved(c
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -1158,7 +1159,7 @@ def test_vis_confidence_thresholding_2thresholds_2d_output_saved(csv_filename):
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     treshhold_output_feature_name1 = get_output_feature_name(exp_dir_name)
     treshhold_output_feature_name2 = get_output_feature_name(exp_dir_name, output_feature=1)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -1232,7 +1233,7 @@ def test_vis_confidence_thresholding_2thresholds_3d_output_saved(csv_filename):
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     treshhold_output_feature_name1 = get_output_feature_name(exp_dir_name)
     treshhold_output_feature_name2 = get_output_feature_name(exp_dir_name, output_feature=1)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -1301,7 +1302,7 @@ def test_visualization_binary_threshold_vs_metric_output_saved(csv_filename):
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -1368,7 +1369,7 @@ def test_visualization_roc_curves_output_saved(csv_filename):
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -1435,7 +1436,7 @@ def test_visualization_roc_curves_from_test_statistics_output_saved(csv_filename
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    test_stats = os.path.join(exp_dir_name, "test_statistics.json")
+    test_stats = os.path.join(exp_dir_name, TEST_STATISTICS_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     test_cmd_pdf = [
         "python",
@@ -1488,7 +1489,7 @@ def test_visualization_calibration_1_vs_all_output_saved(csv_filename):
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -1555,7 +1556,7 @@ def test_visualization_calibration_multiclass_output_saved(csv_filename):
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    probability = os.path.join(exp_dir_name, "predictions.parquet")
+    probability = os.path.join(exp_dir_name, PREDICTIONS_PARQUET_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth = experiment_source_data_name + ".csv"
     split_file = experiment_source_data_name + ".split.csv"
@@ -1618,7 +1619,7 @@ def test_visualization_frequency_vs_f1_output_saved(csv_filename):
     vis_output_pattern_pdf = os.path.join(exp_dir_name, "*.pdf")
     vis_output_pattern_png = os.path.join(exp_dir_name, "*.png")
     output_feature_name = get_output_feature_name(exp_dir_name)
-    test_stats = os.path.join(exp_dir_name, "test_statistics.json")
+    test_stats = os.path.join(exp_dir_name, TEST_STATISTICS_FILE_NAME)
     experiment_source_data_name = csv_filename.split(".")[0]
     ground_truth_metadata = experiment_source_data_name + ".meta.json"
     test_cmd_pdf = [


### PR DESCRIPTION
Unlike csv ground_truth, `train.hdf5` already has category columns mapped to indices, so there is no need to apply `ground_truth_metadata['str2idx']`. Pass in `ground_truth_apply_idx` to check whether or not we should skip this step.

Additionally, when we pass in `train.hdf5` as `ground_truth`, the number of rows may not match the `_get_cols_from_predictions()` call, so we limit probabilities rows to `len(ground_truth)`