### PR TITLE
Added init_config and render_config command-line utils

### DIFF
--- a/ludwig/automl/__init__.py
+++ b/ludwig/automl/__init__.py
@@ -1,1 +1,2 @@
 from ludwig.automl.automl import auto_train, create_auto_config, train_with_config
+from ludwig.automl.automl import cli_init_config

--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -11,7 +11,7 @@ Driver script which:
 import argparse
 import os
 import warnings
-from typing import Dict, Union
+from typing import Dict, Union, List
 
 import numpy as np
 import pandas as pd
@@ -101,7 +101,7 @@ def auto_train(
 
 def create_auto_config(
     dataset: Union[str, pd.DataFrame, dd.core.DataFrame, DatasetInfo],
-    target: str,
+    target: Union[str, List[str]],
     time_limit_s: Union[int, float],
     tune_for_memory: bool,
 ) -> dict:
@@ -112,9 +112,11 @@ def create_auto_config(
 
     # Inputs
     :param dataset: (str) filepath to dataset.
-    :param target: (str) name of target feature
+    :param target: (str, List[str]) name of target feature
     :param time_limit_s: (int, float) total time allocated to auto_train. acts
-                                    as the stopping parameter
+                         as the stopping parameter
+    :param tune_for_memroy: (bool) refine hyperopt search space for available
+                            host / GPU memory
 
     # Return
     :return: (dict) selected model configuration
@@ -204,7 +206,7 @@ def _train(
 
 def init_config(
     dataset: str,
-    target: str,
+    target: Union[str, List[str]],
     time_limit_s: Union[int, float],
     tune_for_memory: bool,
     hyperopt: bool = False,
@@ -245,8 +247,7 @@ def cli_init_config(sys_argv):
         '--target',
         type=str,
         help='target(s) to predict as output features of the model',
-        nargs='+',
-        default=[],
+        action='append',
         required=False,
     )
     parser.add_argument(

--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -21,7 +21,7 @@ from ludwig.api import LudwigModel
 from ludwig.automl.base_config import _create_default_config, DatasetInfo
 from ludwig.automl.auto_tune_config import memory_tune_config
 from ludwig.automl.utils import _ray_init, get_model_name
-from ludwig.constants import COMBINER, TYPE
+from ludwig.constants import COMBINER, TYPE, HYPEROPT
 from ludwig.contrib import add_contrib_callback_args
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.hyperopt.run import hyperopt
@@ -207,6 +207,7 @@ def init_config(
     target: str,
     time_limit_s: Union[int, float],
     tune_for_memory: bool,
+    hyperopt: bool = False,
     output: str = None,
     **kwargs
 ):
@@ -216,6 +217,10 @@ def init_config(
         time_limit_s=time_limit_s,
         tune_for_memory=tune_for_memory,
     )
+
+    if HYPEROPT in config and not hyperopt:
+        del config[HYPEROPT]
+
     if output is None:
         print(yaml.safe_dump(config, None, sort_keys=False))
     else:
@@ -254,6 +259,13 @@ def cli_init_config(sys_argv):
         '--tune_for_memory',
         type=bool,
         help='refine hyperopt search space based on available host / GPU memory',
+        default=False,
+        required=False,
+    )
+    parser.add_argument(
+        '--hyperopt',
+        type=bool,
+        help='include automl hyperopt config',
         default=False,
         required=False,
     )

--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -8,20 +8,24 @@ Driver script which:
 (2) Tunes config based on resource constraints
 (3) Runs hyperparameter optimization experiment
 """
-
+import argparse
 import os
 import warnings
 from typing import Dict, Union
 
 import numpy as np
 import pandas as pd
+import yaml
 
 from ludwig.api import LudwigModel
 from ludwig.automl.base_config import _create_default_config, DatasetInfo
 from ludwig.automl.auto_tune_config import memory_tune_config
 from ludwig.automl.utils import _ray_init, get_model_name
 from ludwig.constants import COMBINER, TYPE
+from ludwig.contrib import add_contrib_callback_args
+from ludwig.globals import LUDWIG_VERSION
 from ludwig.hyperopt.run import hyperopt
+from ludwig.utils.print_utils import print_ludwig
 
 try:
     import dask.dataframe as dd
@@ -196,3 +200,77 @@ def _train(
         **kwargs
     )
     return hyperopt_results
+
+
+def init_config(
+    dataset: str,
+    target: str,
+    time_limit_s: Union[int, float],
+    tune_for_memory: bool,
+    output: str = None,
+    **kwargs
+):
+    config = create_auto_config(
+        dataset=dataset,
+        target=target,
+        time_limit_s=time_limit_s,
+        tune_for_memory=tune_for_memory,
+    )
+    if output is None:
+        print(yaml.safe_dump(config, None, sort_keys=False))
+    else:
+        with open(output, 'w') as f:
+            yaml.safe_dump(config, f, sort_keys=False)
+
+
+def cli_init_config(sys_argv):
+    parser = argparse.ArgumentParser(
+        description='This script initializes a valid config from a dataset.',
+        prog='ludwig init_config',
+        usage='%(prog)s [options]'
+    )
+    parser.add_argument(
+        '-d',
+        '--dataset',
+        type=str,
+        help='input data file path',
+    )
+    parser.add_argument(
+        '-t',
+        '--target',
+        type=str,
+        help='target(s) to predict as output features of the model',
+        nargs='+',
+        default=[],
+        required=False,
+    )
+    parser.add_argument(
+        '--time_limit_s',
+        type=int,
+        help='time limit to train the model in seconds when using hyperopt',
+        required=False,
+    )
+    parser.add_argument(
+        '--tune_for_memory',
+        type=bool,
+        help='refine hyperopt search space based on available host / GPU memory',
+        default=False,
+        required=False,
+    )
+    parser.add_argument(
+        '-o',
+        '--output',
+        type=str,
+        help='output initialized YAML config path',
+        required=False,
+    )
+
+    add_contrib_callback_args(parser)
+    args = parser.parse_args(sys_argv)
+
+    args.callbacks = args.callbacks or []
+    for callback in args.callbacks:
+        callback.on_cmdline('init_config', *sys_argv)
+
+    print_ludwig('Init Config', LUDWIG_VERSION)
+    init_config(**vars(args))

--- a/ludwig/cli.py
+++ b/ludwig/cli.py
@@ -58,6 +58,7 @@ Available sub-commands:
    export_mlflow         Exports Ludwig models to MLflow
    preprocess            Preprocess data and saves it into HDF5 and JSON format
    synthesize_dataset    Creates synthetic data for tesing purposes
+   init_config           Initialize a user config from a dataset and targets
    render_config         Renders the fully populated config with all defaults set
 ''')
         parser.add_argument('command', help='Subcommand to run')
@@ -131,9 +132,13 @@ Available sub-commands:
         from ludwig.data import dataset_synthesizer
         dataset_synthesizer.cli(sys.argv[2:])
 
+    def init_config(self):
+        from ludwig import automl
+        automl.cli_init_config(sys.argv[2:])
+
     def render_config(self):
         from ludwig.utils import defaults
-        defaults.cli(sys.argv[2:])
+        defaults.cli_render_config(sys.argv[2:])
 
 
 def main():

--- a/ludwig/cli.py
+++ b/ludwig/cli.py
@@ -58,6 +58,7 @@ Available sub-commands:
    export_mlflow         Exports Ludwig models to MLflow
    preprocess            Preprocess data and saves it into HDF5 and JSON format
    synthesize_dataset    Creates synthetic data for tesing purposes
+   render_config         Renders the fully populated config with all defaults set
 ''')
         parser.add_argument('command', help='Subcommand to run')
         # parse_args defaults to [1:] for args, but you need to
@@ -129,6 +130,10 @@ Available sub-commands:
     def synthesize_dataset(self):
         from ludwig.data import dataset_synthesizer
         dataset_synthesizer.cli(sys.argv[2:])
+
+    def render_config(self):
+        from ludwig.utils import defaults
+        defaults.cli(sys.argv[2:])
 
 
 def main():

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -299,7 +299,7 @@ def merge_with_defaults(config):
     return config
 
 
-def cli_render_config(config=None, output=None, **kwargs):
+def render_config(config=None, output=None, **kwargs):
     output_config = merge_with_defaults(config)
     if output is None:
         print(yaml.safe_dump(output_config, None, sort_keys=False))
@@ -308,7 +308,7 @@ def cli_render_config(config=None, output=None, **kwargs):
             yaml.safe_dump(output_config, f, sort_keys=False)
 
 
-def cli(sys_argv):
+def cli_render_config(sys_argv):
     parser = argparse.ArgumentParser(
         description='This script renders the full config from a user config.',
         prog='ludwig render_config',
@@ -336,7 +336,7 @@ def cli(sys_argv):
         callback.on_cmdline('render_config', *sys_argv)
 
     print_ludwig('Render Config', LUDWIG_VERSION)
-    cli_render_config(**vars(args))
+    render_config(**vars(args))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds two command-line utilities:

- `init_config`: uses the experimental automl package to generate a base config from a dataset and list of target columns.
- `render_config`: fully populates a base config with all defaults so users can see exactly what Ludwig is setting for them