### PR TITLE
Fix test_api.py tests

### DIFF
--- a/ludwig/backend/__init__.py
+++ b/ludwig/backend/__init__.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 # ==============================================================================
 
+import os
+
 from ludwig.backend.base import Backend, LocalBackend
 from ludwig.utils.horovod_utils import has_horovodrun
 
@@ -35,6 +37,11 @@ ALL_BACKENDS = [LOCAL, DASK, HOROVOD, RAY]
 
 
 def _has_ray():
+    # Temporary workaround to prevent tests from automatically using the Ray backend. Taken from
+    # https://stackoverflow.com/questions/25188119/test-if-code-is-executed-from-within-a-py-test-session
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        return False
+
     if _ray is None:
         return False
 

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -87,6 +87,7 @@ class Predictor(BasePredictor):
                                     file=sys.stdout,
                                     disable=is_progressbar_disabled())
 
+            model.to(self.device)
             predictions = defaultdict(list)
             while not batcher.last_batch():
                 batch = batcher.next_batch()
@@ -104,7 +105,8 @@ class Predictor(BasePredictor):
 
         return from_numpy_dataset(predictions)
 
-    def predict_single(self, model, batch):
+    def predict_single(self, model: ECD, batch):
+        model.to(self.device)
         predictions = defaultdict(list)
         preds = self._predict(model, batch)
         self._accumulate_preds(preds, predictions)
@@ -156,6 +158,7 @@ class Predictor(BasePredictor):
                                     file=sys.stdout,
                                     disable=is_progressbar_disabled())
 
+            model.to(self.device)
             predictions = defaultdict(list)
             while not batcher.last_batch():
                 batch = batcher.next_batch()
@@ -213,6 +216,7 @@ class Predictor(BasePredictor):
                                 file=sys.stdout,
                                 disable=is_progressbar_disabled())
 
+            model.to(self.device)
             collected_tensors = []
             while not batcher.last_batch():
                 batch = batcher.next_batch()

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -126,7 +126,7 @@ def get_output_directory(
         output_directory,
         experiment_name + ('_' if model_name else '') + model_name
     )
-    return find_non_existing_dir_by_adding_suffix(base_dir_name)
+    return os.path.abspath(find_non_existing_dir_by_adding_suffix(base_dir_name))
 
 
 def get_file_names(output_directory):

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 import numpy as np
 import pytest
+import torch
 
 from ludwig.api import LudwigModel
 from ludwig.utils.data_utils import read_csv
@@ -256,13 +257,13 @@ def test_api_training_determinism(csv_filename):
 
         divergence = False
         for weight_1, weight_2 in zip(model_weights_1, model_weights_2):
-            if not np.allclose(weight_1, weight_2):
+            if not torch.allclose(weight_1, weight_2):
                 divergence = True
                 break
         assert divergence, 'model_1 and model_2 have identical weights with different seeds!'
 
         for weight_1, weight_3 in zip(model_weights_1, model_weights_3):
-            assert np.allclose(weight_1, weight_3)
+            assert torch.allclose(weight_1, weight_3)
 
 
 def run_api_commands(

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -26,7 +26,6 @@ import uuid
 from distutils.util import strtobool
 
 import cloudpickle
-import numpy as np
 import pandas as pd
 import torch
 
@@ -525,7 +524,7 @@ def run_api_experiment(input_features, output_features, data_csv):
         model_weights = get_weights(model.model)
         loaded_weights = get_weights(loaded_model.model)
         for model_weight, loaded_weight in zip(model_weights, loaded_weights):
-            assert np.allclose(model_weight, loaded_weight)
+            assert torch.allclose(model_weight, loaded_weight)
     finally:
         # Remove results/intermediate data saved to disk
         shutil.rmtree(output_dir, ignore_errors=True)


### PR DESCRIPTION
Set of small changes to get tests in `test_api.py` working. Notably:

1. Disables auto-detection of Ray backend if running under pytest. This is a workaround to allow testing to run properly on AWS even in the presence of a Ray cluster and Pandas dataframes, which we currently don't support on Ray.
2. Use absolute filepaths in output directory.
3. Replace some numpy functions with their torch equivalents.
4. Move the entire ECD module (and by extension its submodules) onto GPU if one is available.