### PR TITLE
Address issues in AutoML managing time-budget while exploring trial space

### DIFF
--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -151,13 +151,7 @@ def _create_default_config(
         "time_budget_s"
     ] = time_limit_s
     if time_limit_s is not None:
-        num_samples = base_automl_config["hyperopt"]["sampler"]["num_samples"]
-        if num_samples is not None:
-            # allow trials to get 2x even division, since some trials perform better than avg
-            base_automl_config["hyperopt"]["sampler"]["scheduler"][
-                "max_t"] = (time_limit_s / num_samples) * 2.0
-        else:
-            base_automl_config["hyperopt"]["sampler"]["scheduler"]["max_t"] = time_limit_s
+        base_automl_config["hyperopt"]["sampler"]["scheduler"]["max_t"] = time_limit_s
     base_automl_config.update(input_and_output_feature_config)
 
     model_configs["base_config"] = base_automl_config

--- a/ludwig/automl/defaults/base_automl_config.yaml
+++ b/ludwig/automl/defaults/base_automl_config.yaml
@@ -9,10 +9,12 @@ hyperopt:
     scheduler:
       type: async_hyperband
       time_attr: time_total_s
-      # (time_budget_s / num_samples) * 2
-      max_t: 600
-    num_samples: 20
+      max_t: 7200
+      grace_period: 72
+      # Increased over default to get more pruning/exploration
+      reduction_factor: 5
+    num_samples: 10
 
   executor:
     type: ray
-    time_budget_s: 6000
+    time_budget_s: 7200


### PR DESCRIPTION
Previously it was observed that if the time-budget per trial (max_t) were set to match 
the overall time_budget_s for auto_train, then no trials other than those initially
launched on the available computing resources would ever run, i.e., the desired exploration 
of the trial space would not occur.  To enable full trial space exploration, max_t was set
much lower than time_budget_s.  While this lower setting allowed the trial space to be fully
explored, the training time for the best trials was artificially capped by max_t way below
time_budget_s, and the overall time budget wasn't used effectively.  This issue was seen
in all 5 experiments validation datasets.

Antoni Baum from the Ray team indicated that the lack of search space exploration was an 
async_hyperband tuning issue with reduction_factor and that increasing its value above the 
default (4) would cause configurations to be pruned more aggressively, leading to more exploration.  
Running with reduction_factor set to 5 and max_t==time_budget_s was found to fix the time-budget 
issues on the experimments validation datasets.  For higgs, forest_cover, synthetic_fraud, & 
ames_housing, the hyperparameter searches covered the full trial space while also allowing the
best trials to use as much of time_budget_s as possible.  For mushroom_edibility, several trials 
reached essentially minimal loss (perfect accuracy) before the time budget; pending trials after 
that point were not explored, which is not considered to be a problem.

This change set also reduces the default num_samples from 20 to 10, to better match the default 
time_budget_s and average and median best model training times seen for the heuristics datasets.
A future area of exploration could be scaling num_samples based on factors including the time
budget, the estimated training time for the dataset being input, and the target resources available.