### PR TITLE
Adding whylogs to requirements, removing from test requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ tensorboard
 torchmetrics>=0.6.0
 torchinfo
 filelock
+whylogs
 
 # new data format support
 xlwt            # excel

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,6 @@ six>=1.13.0
 wandb
 comet_ml
 mlflow
-whylogs
 
 # For testing BOHB with Ray Tune
 hpbandster


### PR DESCRIPTION

Moving the whylogs requirement to the `requirements.txt` file since whylogs is a dependency of core ludwig now. If a downstream service tries to install ludwig and accesses a file with whylogs changes, it will throw an exception. 

