### PR TITLE
In automl, fallback to TEXT features by default, instead of NUMERICAL.

### DIFF
--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -303,8 +303,8 @@ def infer_type(
     if field.image_values >= 3:
         return IMAGE
 
-    # If small number of distinct values, use CATEGORY if either not all are numerical or
-    # they form a sequential list of integers suggesting the values represent categories
+    # Use CATEGORY if there are a small number of distinct values if they are either not all numerical or if they
+    # comprise of a perfectly sequential list of integers that suggests the values represent categories.
     if num_distinct_values < SMALL_DISTINCT_COUNT and (
         (not strings_utils.are_all_numericals(distinct_values))
         or strings_utils.are_sequential_integers(distinct_values)
@@ -313,20 +313,13 @@ def infer_type(
         # NOTE (ASN): edge case -- there are less than SMALL_DISTINCT_COUNT samples in dataset
         return CATEGORY
 
-    # add criteria for number of spaces
-    if field.avg_words and field.avg_words > 2:
-        return TEXT
+    # Use numerical if all of the distinct values are numerical.
+    if strings_utils.are_all_numericals(distinct_values):
+        return NUMERICAL
 
     # TODO (ASN): add other modalities (image, etc. )
-
-    # If either of 2 examples is not numerical, use CATEGORY type.  We examine 2 since missing
-    # values can be coded as NaN, which is numerical, even for fields that are otherwise strings.
-    if num_distinct_values > 1 and (
-        (not strings_utils.is_numerical(distinct_values[0])) or (not strings_utils.is_numerical(distinct_values[1]))
-    ):
-        return CATEGORY
-
-    return NUMERICAL
+    # Fallback to TEXT.
+    return TEXT
 
 
 def should_exclude(idx: int, field: FieldInfo, dtype: str, row_count: int, targets: Set[str]) -> bool:

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -66,7 +66,7 @@ def str2bool(v, fallback_true_label=None):
     """Returns bool representation of the given value v.
 
     Check the value against global bool string lists.
-    Fallback to using fallback_true_label as True if the value isn't in the global bool string lists.
+    Fallback to using fallback_true_label as True if the value isn't in the global bool lists.
 
     args:
         v: Value to get the bool representation for.
@@ -93,6 +93,8 @@ def are_conventional_bools(values):
 
 def is_numerical(s):
     """Returns whether specified value is numerical."""
+    if s.lower() == "nan":
+        return True
     try:
         float(s)
         return True
@@ -942,7 +944,9 @@ class ChineseLemmatizeRemoveStopwordsFilterTokenizer(BaseTokenizer):
 
 class MultiTokenizer(BaseTokenizer):
     def __call__(self, text):
-        return process_text(text, load_nlp_pipeline("xx"))
+        return process_text(
+            text, load_nlp_pipeline("xx"), filter_numbers=True, filter_punctuation=True, filter_short_tokens=True
+        )
 
 
 class MultiFilterTokenizer(BaseTokenizer):

--- a/tests/ludwig/automl/test_base_config.py
+++ b/tests/ludwig/automl/test_base_config.py
@@ -20,7 +20,8 @@ TARGET_NAME = "target"
         (ROW_COUNT, [str(random.random()) for _ in range(ROW_COUNT - 1)] + ["NaN"], 0, 0.0, NUMERICAL),
         # Finite list of numbers.
         (10, ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"], 0, 0.0, CATEGORY),
-        (2, ["1.5", "3.7"], 0, 0.1, CATEGORY),
+        (2, ["1.5", "3.7"], 0, 0.1, NUMERICAL),
+        (2, ["1.5", "3.7", "nan"], 0, 0.1, NUMERICAL),
         # Bool-like values.
         (2, ["0", "1"], 0, 0.0, BINARY),
         # Mostly bool-like values.

--- a/tests/ludwig/automl/test_base_config.py
+++ b/tests/ludwig/automl/test_base_config.py
@@ -1,33 +1,45 @@
+import random
+
 import pytest
 
 from ludwig.automl.base_config import infer_type, should_exclude
 from ludwig.automl.utils import FieldInfo
 from ludwig.constants import BINARY, CATEGORY, IMAGE, NUMERICAL, TEXT
+from ludwig.data.dataset_synthesizer import generate_string
 
 ROW_COUNT = 100
 TARGET_NAME = "target"
 
 
 @pytest.mark.parametrize(
-    "num_distinct_values,distinct_values,avg_words,img_values,missing_vals,expected",
+    "num_distinct_values,distinct_values,img_values,missing_vals,expected",
     [
-        (ROW_COUNT, ["1.1", "2.2"], 0, 0, 0.0, NUMERICAL),
-        (10, ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"], 0, 0, 0.0, CATEGORY),
-        (2, ["0", "1"], 0, 0, 0.0, BINARY),
-        (2, ["human", "bot"], 0, 0, 0.0, CATEGORY),
-        (2, ["1.5", "3.7"], 0, 0, 0.1, NUMERICAL),
-        (ROW_COUNT, [], 3, 0, 0.0, TEXT),
-        (ROW_COUNT, [], 1, ROW_COUNT, 0.0, IMAGE),
-        (0, [], 0, 0, 0.0, CATEGORY),
+        # Random numbers.
+        (ROW_COUNT, [str(random.random()) for _ in range(ROW_COUNT)], 0, 0.0, NUMERICAL),
+        # Random numbers with NaNs.
+        (ROW_COUNT, [str(random.random()) for _ in range(ROW_COUNT - 1)] + ["NaN"], 0, 0.0, NUMERICAL),
+        # Finite list of numbers.
+        (10, ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"], 0, 0.0, CATEGORY),
+        (2, ["1.5", "3.7"], 0, 0.1, CATEGORY),
+        # Bool-like values.
+        (2, ["0", "1"], 0, 0.0, BINARY),
+        # Mostly bool-like values.
+        (3, ["0", "1", "True"], 0, 0.0, CATEGORY),
+        # Finite list of strings.
+        (2, ["human", "bot"], 0, 0.0, CATEGORY),
+        (10, [generate_string(5) for _ in range(10)], 0, 0.0, CATEGORY),
+        # Random strings.
+        (ROW_COUNT, [generate_string(5) for _ in range(ROW_COUNT)], 0, 0.0, TEXT),
+        # Images.
+        (ROW_COUNT, [], ROW_COUNT, 0.0, IMAGE),
     ],
 )
-def test_infer_type(num_distinct_values, distinct_values, avg_words, img_values, missing_vals, expected):
+def test_infer_type(num_distinct_values, distinct_values, img_values, missing_vals, expected):
     field = FieldInfo(
         name="foo",
         dtype="object",
         num_distinct_values=num_distinct_values,
         distinct_values=distinct_values,
-        avg_words=avg_words,
         image_values=img_values,
     )
     assert infer_type(field, missing_vals) == expected

--- a/tests/ludwig/utils/test_strings_utils.py
+++ b/tests/ludwig/utils/test_strings_utils.py
@@ -3,6 +3,15 @@ import pytest
 from ludwig.utils import strings_utils
 
 
+def test_is_numerical():
+    assert strings_utils.is_numerical("1.1")
+    assert strings_utils.is_numerical("1.000001")
+    assert strings_utils.is_numerical("1000001")
+    assert strings_utils.is_numerical("Nan")
+    assert strings_utils.is_numerical("NaN")
+    assert not strings_utils.is_numerical("NaNaaa")
+
+
 def test_str_to_bool():
     # Global bool mappings are used.
     assert strings_utils.str2bool("True")


### PR DESCRIPTION
`TEXT` seems like a better overall fallback feature type instead of `NUMERICAL`. 

I've added unit tests to illustrate the new typing assignment logic.

This change to automl is also better aligned with the feature types I used for the twitterbots dataset, which classifies features like "username" and "description" as `TEXT` features.