### PR TITLE
Made whylogs a lazy import

### DIFF
--- a/ludwig/contribs/whylogs/__init__.py
+++ b/ludwig/contribs/whylogs/__init__.py
@@ -1,5 +1,7 @@
 from ludwig.callbacks import Callback
-from whylogs import get_or_create_session
+from ludwig.utils.package_utils import LazyLoader
+
+whylogs = LazyLoader('whylogs', globals(), 'whylogs')
 
 
 class WhyLogsCallback(Callback):
@@ -8,7 +10,7 @@ class WhyLogsCallback(Callback):
 
     def on_build_metadata_start(self, df, mode=None):
         def log_dataframe(df_aux):
-            session = get_or_create_session(self.path_to_config)
+            session = whylogs.get_or_create_session(self.path_to_config)
             session.log_dataframe(
                 df_aux,
                 mode,

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ tensorboard
 torchmetrics>=0.6.0
 torchinfo
 filelock
-whylogs
 
 # new data format support
 xlwt            # excel

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,6 +4,7 @@ six>=1.13.0
 wandb
 comet_ml
 mlflow
+whylogs
 
 # For testing BOHB with Ray Tune
 hpbandster


### PR DESCRIPTION
# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
Made whylogs a lazy import
- if applicable, a reference to an issue
https://github.com/ludwig-ai/ludwig/issues/1545
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
