### PR TITLE
Fix minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Translated in [🇰🇷 Korean](README_KR.md)/
 Ludwig is a data-centric deep learning framework that allows users to train and test deep learning models by specifying a declarative configuration tht matches the schema of the data.
 It is built on top of PyTorch.
 
-To train a model you need to provide is a file containing your data, a list of columns to use as inputs, and a list of columns to use as outputs, Ludwig will do the rest.
+To train a model all you need to provide is a file containing your data, a list of columns to use as inputs, and a list of columns to use as outputs, Ludwig will do the rest.
 Simple commands can be used to train models both locally and in a distributed way, and to use them to predict new data.
 
 A programmatic API is also available to use Ludwig from Python.


### PR DESCRIPTION
Hi! 
I think there's a small typo in the readme. I add the word "all", based on the rest of the sentence and my best guess of the authors intent :)

We could perhaps remove "is" instead as well. If you prefer this wording please let me know, I'll prepare a new patch!

Many thanks!
