### PR TITLE
Adds unit test for generic encoders (test_generic_encoders.py)

### DIFF
--- a/tests/ludwig/encoders/test_category_encoders.py
+++ b/tests/ludwig/encoders/test_category_encoders.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pytest
 import torch
 
@@ -6,7 +8,7 @@ from ludwig.encoders.category_encoders import CategoricalEmbedEncoder, Categoric
 
 @pytest.mark.parametrize("vocab", [["red", "orange", "yellow", "green", "blue", "violet"], ["a", "b", "c"]])
 @pytest.mark.parametrize("embedding_size", [4, 6, 10])
-def test_categorical_dense_encoder(vocab, embedding_size):
+def test_categorical_dense_encoder(vocab: List[str], embedding_size: int):
     dense_encoder = CategoricalEmbedEncoder(vocab=vocab, embedding_size=embedding_size)
     inputs = torch.randint(len(vocab), (10,))  # Chooses 10 items from vocab with replacement.
     inputs = torch.unsqueeze(inputs, 1)
@@ -18,7 +20,7 @@ def test_categorical_dense_encoder(vocab, embedding_size):
 
 
 @pytest.mark.parametrize("vocab", [["red", "orange", "yellow", "green", "blue", "violet"], ["a", "b", "c"]])
-def test_categorical_sparse_encoder(vocab):
+def test_categorical_sparse_encoder(vocab: List[str]):
     sparse_encoder = CategoricalSparseEncoder(vocab=vocab)
     inputs = torch.randint(len(vocab), (10,))  # Chooses 10 items from vocab with replacement.
     inputs = torch.unsqueeze(inputs, 1)

--- a/tests/ludwig/encoders/test_category_encoders.py
+++ b/tests/ludwig/encoders/test_category_encoders.py
@@ -1,14 +1,11 @@
 import pytest
-
 import torch
 
-from ludwig.encoders.category_encoders import CategoricalEmbedEncoder
-from ludwig.encoders.category_encoders import CategoricalSparseEncoder
+from ludwig.encoders.category_encoders import CategoricalEmbedEncoder, CategoricalSparseEncoder
 
 
-@pytest.mark.parametrize('vocab', [['red', 'orange', 'yellow', 'green', 'blue', 'violet'],
-                                   ['a', 'b', 'c']])
-@pytest.mark.parametrize('embedding_size', [4, 6, 10])
+@pytest.mark.parametrize("vocab", [["red", "orange", "yellow", "green", "blue", "violet"], ["a", "b", "c"]])
+@pytest.mark.parametrize("embedding_size", [4, 6, 10])
 def test_categorical_dense_encoder(vocab, embedding_size):
     dense_encoder = CategoricalEmbedEncoder(vocab=vocab, embedding_size=embedding_size)
     inputs = torch.randint(len(vocab), (10,))  # Chooses 10 items from vocab with replacement.
@@ -20,9 +17,7 @@ def test_categorical_dense_encoder(vocab, embedding_size):
     assert outputs.shape[1:] == dense_encoder.output_shape
 
 
-@pytest.mark.parametrize('vocab', [['red', 'orange', 'yellow', 'green', 'blue', 'violet'],
-                                   ['a', 'b', 'c']]
-)
+@pytest.mark.parametrize("vocab", [["red", "orange", "yellow", "green", "blue", "violet"], ["a", "b", "c"]])
 def test_categorical_sparse_encoder(vocab):
     sparse_encoder = CategoricalSparseEncoder(vocab=vocab)
     inputs = torch.randint(len(vocab), (10,))  # Chooses 10 items from vocab with replacement.

--- a/tests/ludwig/encoders/test_generic_encoders.py
+++ b/tests/ludwig/encoders/test_generic_encoders.py
@@ -6,7 +6,7 @@ from ludwig.encoders.generic_encoders import DenseEncoder, PassthroughEncoder
 
 @pytest.mark.parametrize("input_size", [1, 2, 10])
 @pytest.mark.parametrize("categorical", [True, False])
-def test_generic_passthrough_encoder(input_size, categorical):
+def test_generic_passthrough_encoder(input_size: int, categorical: bool):
     passthrough_encoder = PassthroughEncoder(input_size)
     # Passthrough encoder allows categorical input feature (int), dense encoder's input must be float.
     if categorical:
@@ -23,7 +23,7 @@ def test_generic_passthrough_encoder(input_size, categorical):
 @pytest.mark.parametrize("input_size", [1, 2, 10])
 @pytest.mark.parametrize("num_layers", [1, 3, 6])
 @pytest.mark.parametrize("fc_size", [1, 2, 10, 256])
-def test_generic_dense_encoder(input_size, num_layers, fc_size):
+def test_generic_dense_encoder(input_size: int, num_layers: int, fc_size: int):
     dense_encoder = DenseEncoder(input_size, num_layers=num_layers, fc_size=fc_size)
     inputs = torch.rand((10, input_size))
     outputs = dense_encoder(inputs)

--- a/tests/ludwig/encoders/test_generic_encoders.py
+++ b/tests/ludwig/encoders/test_generic_encoders.py
@@ -14,10 +14,8 @@ def test_generic_passthrough_encoder(input_size: int, categorical: bool):
     else:
         inputs = torch.rand((10, input_size))
     outputs = passthrough_encoder(inputs)
-    assert "encoder_output" in outputs
-    encoder_output = outputs["encoder_output"]
     # Ensures output shape matches encoder expected output shape.
-    assert encoder_output.shape[1:] == passthrough_encoder.output_shape
+    assert outputs["encoder_output"].shape[1:] == passthrough_encoder.output_shape
 
 
 @pytest.mark.parametrize("input_size", [1, 2, 10])
@@ -27,7 +25,5 @@ def test_generic_dense_encoder(input_size: int, num_layers: int, fc_size: int):
     dense_encoder = DenseEncoder(input_size, num_layers=num_layers, fc_size=fc_size)
     inputs = torch.rand((10, input_size))
     outputs = dense_encoder(inputs)
-    assert "encoder_output" in outputs
-    encoder_output = outputs["encoder_output"]
     # Ensures output shape matches encoder expected output shape.
-    assert encoder_output.shape[1:] == dense_encoder.output_shape
+    assert outputs["encoder_output"].shape[1:] == dense_encoder.output_shape

--- a/tests/ludwig/encoders/test_generic_encoders.py
+++ b/tests/ludwig/encoders/test_generic_encoders.py
@@ -1,13 +1,11 @@
 import pytest
-
 import torch
 
-from ludwig.encoders.generic_encoders import PassthroughEncoder
-from ludwig.encoders.generic_encoders import DenseEncoder
+from ludwig.encoders.generic_encoders import DenseEncoder, PassthroughEncoder
 
 
-@pytest.mark.parametrize('input_size', [1, 2, 10])
-@pytest.mark.parametrize('categorical', [True, False])
+@pytest.mark.parametrize("input_size", [1, 2, 10])
+@pytest.mark.parametrize("categorical", [True, False])
 def test_generic_passthrough_encoder(input_size, categorical):
     passthrough_encoder = PassthroughEncoder(input_size)
     # Passthrough encoder allows categorical input feature (int), dense encoder's input must be float.
@@ -16,20 +14,20 @@ def test_generic_passthrough_encoder(input_size, categorical):
     else:
         inputs = torch.rand((10, input_size))
     outputs = passthrough_encoder(inputs)
-    assert 'encoder_output' in outputs
-    encoder_output = outputs['encoder_output']
+    assert "encoder_output" in outputs
+    encoder_output = outputs["encoder_output"]
     # Ensures output shape matches encoder expected output shape.
     assert encoder_output.shape[1:] == passthrough_encoder.output_shape
 
 
-@pytest.mark.parametrize('input_size', [1, 2, 10])
-@pytest.mark.parametrize('num_layers', [1, 3, 6])
-@pytest.mark.parametrize('fc_size', [1, 2, 10, 256])
+@pytest.mark.parametrize("input_size", [1, 2, 10])
+@pytest.mark.parametrize("num_layers", [1, 3, 6])
+@pytest.mark.parametrize("fc_size", [1, 2, 10, 256])
 def test_generic_dense_encoder(input_size, num_layers, fc_size):
     dense_encoder = DenseEncoder(input_size, num_layers=num_layers, fc_size=fc_size)
     inputs = torch.rand((10, input_size))
     outputs = dense_encoder(inputs)
-    assert 'encoder_output' in outputs
-    encoder_output = outputs['encoder_output']
+    assert "encoder_output" in outputs
+    encoder_output = outputs["encoder_output"]
     # Ensures output shape matches encoder expected output shape.
     assert encoder_output.shape[1:] == dense_encoder.output_shape

--- a/tests/ludwig/encoders/test_generic_encoders.py
+++ b/tests/ludwig/encoders/test_generic_encoders.py
@@ -1,0 +1,35 @@
+import pytest
+
+import torch
+
+from ludwig.encoders.generic_encoders import PassthroughEncoder
+from ludwig.encoders.generic_encoders import DenseEncoder
+
+
+@pytest.mark.parametrize('input_size', [1, 2, 10])
+@pytest.mark.parametrize('categorical', [True, False])
+def test_generic_passthrough_encoder(input_size, categorical):
+    passthrough_encoder = PassthroughEncoder(input_size)
+    # Passthrough encoder allows categorical input feature (int), dense encoder's input must be float.
+    if categorical:
+        inputs = torch.randint(10, (10, input_size))
+    else:
+        inputs = torch.rand((10, input_size))
+    outputs = passthrough_encoder(inputs)
+    assert 'encoder_output' in outputs
+    encoder_output = outputs['encoder_output']
+    # Ensures output shape matches encoder expected output shape.
+    assert encoder_output.shape[1:] == passthrough_encoder.output_shape
+
+
+@pytest.mark.parametrize('input_size', [1, 2, 10])
+@pytest.mark.parametrize('num_layers', [1, 3, 6])
+@pytest.mark.parametrize('fc_size', [1, 2, 10, 256])
+def test_generic_dense_encoder(input_size, num_layers, fc_size):
+    dense_encoder = DenseEncoder(input_size, num_layers=num_layers, fc_size=fc_size)
+    inputs = torch.rand((10, input_size))
+    outputs = dense_encoder(inputs)
+    assert 'encoder_output' in outputs
+    encoder_output = outputs['encoder_output']
+    # Ensures output shape matches encoder expected output shape.
+    assert encoder_output.shape[1:] == dense_encoder.output_shape


### PR DESCRIPTION
Adds unit tests for:
- PassthroughEncoder
- DenseEncoder

from ludwig.encoders.generic_encoders

Also adds missing type annotations for parameters in test_category_encoders.py.