### PR TITLE
Fix makedirs call to path_exists to pass url

### DIFF
--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -76,7 +76,7 @@ def rename(src, tgt):
 def makedirs(url, exist_ok=False):
     fs, path = get_fs_and_path(url)
     fs.makedirs(path, exist_ok=exist_ok)
-    if not path_exists(path):
+    if not path_exists(url):
         with fsspec.open(url, mode="wb") as f:
             pass
 


### PR DESCRIPTION
This defect was exposed from auto_train API saving to s3 the hyperparameter search results from ray on K8s cluster.

