### PR TITLE
Specify default sampling method w/seed to improve AutoML sampling repeatability

### DIFF
--- a/ludwig/automl/defaults/base_automl_config.yaml
+++ b/ludwig/automl/defaults/base_automl_config.yaml
@@ -6,6 +6,10 @@ training:
 hyperopt:
   sampler:
     type: ray
+    search_alg:
+      type: hyperopt
+      # Specify seed to get sample sequence repeatability
+      random_state_seed: 42
     scheduler:
       type: async_hyperband
       time_attr: time_total_s

--- a/requirements_hyperopt.txt
+++ b/requirements_hyperopt.txt
@@ -1,4 +1,5 @@
 fiber
 bayesmark>=0.0.7
 pySOT
+hyperopt
 ray[tune]


### PR DESCRIPTION
Testing: Ran E2E testing of AutoML for 3 validation datasets (ames_housing, higgs, forest_cover);
observed same sequence in samples checked and got much less noisy experimental results.

Note that I can instead add random_seed to the auto_train API with a default value of default_random_seed,
as is done for a number of other ludwig APIs if that is preferred.