### PR TITLE
Update hyperopt: Choose best model from validation data; For stopped Ray Tune trials, run evaluate at search end

### DIFF
--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -1189,7 +1189,7 @@ class RayTuneExecutor(HyperoptExecutor):
                                 dataset=validation_set,
                                 data_format=data_format,
                                 batch_size=batch_size,
-                                output_directory=output_directory,
+                                output_directory=trial_path,
                                 skip_save_unprocessed_output=skip_save_unprocessed_output,
                                 skip_save_predictions=skip_save_predictions,
                                 skip_save_eval_stats=skip_save_eval_stats,

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -233,7 +233,7 @@ def test_hyperopt_run_hyperopt(csv_filename, samplers):
 def test_hyperopt_executor_get_metric_score():
     executor = EXECUTORS[0]
     output_feature = "of_name"
-    split = 'test'
+    split = 'validation'
 
     train_stats = {
         'training': {
@@ -293,17 +293,11 @@ def test_hyperopt_executor_get_metric_score():
     metric = 'loss'
     hyperopt_executor = get_build_hyperopt_executor(executor["type"])(
         None, output_feature, metric, split, **executor)
-    score = hyperopt_executor.get_metric_score(train_stats, eval_stats)
-    assert score == 1.0876318
+    score = hyperopt_executor.get_metric_score(train_stats)
+    assert score == 0.30233705
 
     metric = 'accuracy'
     hyperopt_executor = get_build_hyperopt_executor(executor["type"])(
         None, output_feature, metric, split, **executor)
-    score = hyperopt_executor.get_metric_score(train_stats, eval_stats)
-    assert score == 0.7
-
-    metric = 'overall_stats.kappa_score'
-    hyperopt_executor = get_build_hyperopt_executor(executor["type"])(
-        None, output_feature, metric, split, **executor)
-    score = hyperopt_executor.get_metric_score(train_stats, eval_stats)
-    assert score == 0.6
+    score = hyperopt_executor.get_metric_score(train_stats)
+    assert score == 1.0


### PR DESCRIPTION
Update hyperopt as discussed recently in automl community.
* Choose best model from Validation data
* For stopped Ray Tune trials, run evaluate at search end
* Set epochs appropriately when max_t is expressed in seconds
* Handle case where no trial reports any results [rare]

Details for the first item:
* Update Ludwig hyperopt operation to compute metric_score on training validation stats.
* This means that the best model will be chosen based on validation statistics, rather than on the test statistics corresponding to the best validation statistics as is done currently.
* An error will be reported if no validation set is provided.
* N.B.:
** The metric_score is constrained to stats computed during training; it cannot be drawn from
   those only computed during post-train overall stats model evaluation.  If needed, additional
   stats can be added to the training set.
** The post-train overall stats evaluation for the best model is computed on the validation set.
   An overall stats evaluation for the best model run on the test set can be performed by the
   use as a separate step after the hyperparameter optimization job is completed.

Details for the second item:
* For Ray Tune trials that are stopped before training/evaluation completes, load
and evaluate the trial's best model after the overall Ray Tune run completes.
* Currently, Ludwig calls tune.report to report a trial's intermediate results, which include
training_stats set to train_stats[TRAINING] and eval_stats set to train_stats[VALIDATION].
And when the trial's training completes normally, it then calls tune.report to report the
trial's final results, which include training_stats set to include all 3 train_stats
(train_stats[TRAINING],train_stats[VALIDATION],train_stats[TEST]) and eval_stats set to
the output of running an overall stats evaluation the trial's best model on the eval_set.
* For Ray Tune trials that are stopped before training/evaluation completes, the final
tune.report is never executed, meaning that the overall stats evaluation is not computed
and reported as eval_stats.  Also, the train_stats[TEST] is not reported in training_stats.
* This PR changes the intermediate tune.report calls so that training_stats includes all 3
train_stats (train_stats[TRAINING],train_stats[VALIDATION],train_stats[TEST]), with eval_stats
set to empty.  And when the overall Ray Tune run completes, for any stopped trials, it loads
and evaluates the trial's best model, setting eval_stats for that trial in ordered_trials,
which is returned and persisted in hyperopt_statistics.json.