### PR TITLE
Modify combiners to accept input_features as a dict instead of a list

### DIFF
--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -79,7 +79,7 @@ class ConcatCombinerConfig:
 class ConcatCombiner(tf.keras.Model):
     def __init__(
             self,
-            input_features: Optional[List] = None,
+            input_features: Optional[Dict] = None,
             config: ConcatCombinerConfig = None,
             **kwargs
     ):
@@ -507,7 +507,7 @@ class TransformerCombinerConfig:
 class TransformerCombiner(tf.keras.Model):
     def __init__(
             self,
-            input_features: Optional[List] = None,
+            input_features: Optional[Dict] = None,
             config: TransformerCombinerConfig = None,
             **kwargs
     ):
@@ -638,7 +638,7 @@ class TabTransformerCombinerConfig:
 class TabTransformerCombiner(tf.keras.Model):
     def __init__(
             self,
-            input_features: Optional[List] = None,
+            input_features: Optional[Dict] = None,
             config: TabTransformerCombinerConfig = None,
             **kwargs
     ):
@@ -655,8 +655,9 @@ class TabTransformerCombiner(tf.keras.Model):
 
         self.embed_input_feature_name = config.embed_input_feature_name
         if self.embed_input_feature_name:
-            vocab = [i_f for i_f in input_features
-                     if i_f[TYPE] != NUMERICAL or i_f[TYPE] != BINARY]
+            vocab = [i_f
+                     for i_f in input_features
+                     if input_features[i_f].type != NUMERICAL or input_features[i_f].type != BINARY]
             if self.embed_input_feature_name == 'add':
                 self.embed_i_f_name_layer = Embed(vocab, config.hidden_size,
                                                   force_embedding_size=True)
@@ -688,9 +689,9 @@ class TabTransformerCombiner(tf.keras.Model):
 
         logger.debug('  Projectors')
         self.projectors = [Dense(projector_size) for i_f in input_features
-                           if i_f[TYPE] != NUMERICAL and i_f[TYPE] != BINARY]
-        self.skip_features = [i_f[NAME] for i_f in input_features
-                              if i_f[TYPE] == NUMERICAL or i_f[TYPE] == BINARY]
+                           if input_features[i_f].type != NUMERICAL and input_features[i_f].type != BINARY]
+        self.skip_features = [i_f for i_f in input_features
+                              if input_features[i_f].type == NUMERICAL or input_features[i_f].type == BINARY]
 
         logger.debug('  TransformerStack')
         self.transformer_stack = TransformerStack(

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -400,7 +400,7 @@ def test_tabtransformer_combiner(encoder_outputs):
 
     # setup combiner to test
     combiner = TabTransformerCombiner(
-        input_features=input_features_def,
+        input_features=build_inputs(input_features_def),
         config=load_config(
             TabTransformerCombinerConfig,
             embed_input_feature_name=56
@@ -415,7 +415,7 @@ def test_tabtransformer_combiner(encoder_outputs):
 
     # setup combiner to test
     combiner = TabTransformerCombiner(
-        input_features=input_features_def,
+        input_features=build_inputs(input_features_def),
         config=load_config(
             TabTransformerCombinerConfig,
             embed_input_feature_name='add'

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -20,6 +20,7 @@ from ludwig.combiners.combiners import (
     TransformerCombinerConfig,
     sequence_encoder_registry,
 )
+from ludwig.models.ecd import build_inputs
 from ludwig.utils.schema_utils import load_config
 
 logger = logging.getLogger(__name__)
@@ -387,7 +388,7 @@ def test_tabtransformer_combiner(encoder_outputs):
 
     # setup combiner to test
     combiner = TabTransformerCombiner(
-        input_features=input_features_def,
+        input_features=build_inputs(input_features_def),
         config=load_config(TabTransformerCombinerConfig)
     )
 

--- a/tests/integration_tests/test_combiners.py
+++ b/tests/integration_tests/test_combiners.py
@@ -383,7 +383,7 @@ def test_tabtransformer_combiner(encoder_outputs):
 
     input_features_def = [
         {'name': 'feature_1', 'type': 'numerical'},
-        {'name': 'feature_2', 'type': 'category'}
+        {'name': 'feature_2', 'type': 'category', 'vocab': ['a', 'b', 'c']}
     ]
 
     # setup combiner to test


### PR DESCRIPTION
Fixes #1617.

This is a quick patch to fix a bug specific to the tf-legacy branch. The underlying issue should already be resolved in master.

Since `build_inputs` outputs a dict, not a list, this PR modifies the `TabTransformerCombiner` to work properly with a dict. Other combiners were and should remain unaffected.