### PR TITLE
Add random_seed to auto_train API to improve repeatability

### DIFF
--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -27,6 +27,7 @@ from ludwig.automl.utils import (
 from ludwig.constants import BINARY, CATEGORY, CONFIG, IMAGE, NUMERICAL, TEXT, TYPE
 from ludwig.utils.data_utils import load_yaml, load_dataset
 from ludwig.utils import strings_utils
+from ludwig.utils.defaults import default_random_seed
 
 try:
     import dask.dataframe as dd
@@ -101,7 +102,8 @@ def allocate_experiment_resources(resources: dict) -> dict:
 def _create_default_config(
     dataset: Union[str, dd.core.DataFrame, pd.DataFrame, DatasetInfo],
     target_name: Union[str, List[str]] = None,
-    time_limit_s: Union[int, float] = None
+    time_limit_s: Union[int, float] = None,
+    random_seed: int = default_random_seed,
 ) -> dict:
     """
     Returns auto_train configs for three available combiner models.
@@ -119,6 +121,10 @@ def _create_default_config(
     :param target_name: (str, List[str]) name of target feature
     :param time_limit_s: (int, float) total time allocated to auto_train. acts
                                     as the stopping parameter
+    :param random_seed: (int, default: `42`) a random seed that will be used anywhere
+                        there is a call to a random number generator, including
+                        hyperparameter search sampling, as well as data splitting,
+                        parameter initialization and training set shuffling
 
     # Return
     :return: (dict) dictionaries contain auto train config files for all available
@@ -152,6 +158,8 @@ def _create_default_config(
     ] = time_limit_s
     if time_limit_s is not None:
         base_automl_config["hyperopt"]["sampler"]["scheduler"]["max_t"] = time_limit_s
+    base_automl_config["hyperopt"]["sampler"][
+        "search_alg"]["random_state_seed"] = random_seed
     base_automl_config.update(input_and_output_feature_config)
 
     model_configs["base_config"] = base_automl_config

--- a/ludwig/automl/defaults/base_automl_config.yaml
+++ b/ludwig/automl/defaults/base_automl_config.yaml
@@ -6,6 +6,9 @@ training:
 hyperopt:
   sampler:
     type: ray
+    search_alg:
+      # Gives results like default + supports random_state_seed for sample sequence repeatability
+      type: hyperopt
     scheduler:
       type: async_hyperband
       time_attr: time_total_s

--- a/requirements_hyperopt.txt
+++ b/requirements_hyperopt.txt
@@ -1,4 +1,5 @@
 fiber
 bayesmark>=0.0.7
 pySOT
+hyperopt
 ray[tune]


### PR DESCRIPTION
Add random_seed (set by default to default_random_seed) to the auto_train API to improve repeatability.

This option is passed to the Ray hyperparameter search algorithm, as a seed to the random
generation of hyperparameter sample order, and to the hyperparameter training job, as seed
where possible to data splitting, parameter initialization, and training set shuffling.

Change the default AutoML search_alg from BasicVariantGenerator, which does not currently take a random
seed parameter, to HyperOptSearch, which does take a random seed parameter.  Testing across the 5
validation datasets has shown that HyperOptSearch yielded results similar to BasicVariantGenerator, and
with the random seed specified, the results were much less noisy.