### PR TITLE
Added csv prediction file compatibility with visualize

### DIFF
--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -51,6 +51,8 @@ logger = logging.getLogger(__name__)
 
 _PREDICTIONS_SUFFIX = "_predictions"
 _PROBABILITIES_SUFFIX = "_probabilities"
+_CSV_SUFFIX = "csv"
+_PARQUET_SUFFIX = "parquet"
 
 
 def _vectorize_ground_truth(
@@ -224,10 +226,12 @@ def _get_cols_from_predictions(predictions_paths, cols, metadata):
     for predictions_path in predictions_paths:
         shapes_fname = replace_file_extension(predictions_path, "shapes.json")
         column_shapes = load_json(shapes_fname)
-
-        pred_df = pd.read_parquet(predictions_path)
+        file_extension = figure_data_format_dataset(predictions_path)
+        if file_extension == _CSV_SUFFIX:
+            pred_df = pd.read_csv(predictions_path)
+        elif file_extension == _PARQUET_SUFFIX:
+            pred_df = pd.read_parquet(predictions_path)
         pred_df = unflatten_df(pred_df, column_shapes, LOCAL_BACKEND)
-
         for col in cols:
             # Convert categorical features back to numerical indices
             if col.endswith(_PREDICTIONS_SUFFIX):


### PR DESCRIPTION
# Code Pull Requests

Fixes issue https://github.com/ludwig-ai/ludwig/issues/1234

Provides the ability for visualize utilities to work with CSV prediction files in case of local backend
