### PR TITLE
Keep search_alg type in dict to record in hyperopt_statistics.json

### DIFF
--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -1060,7 +1060,7 @@ class RayTuneExecutor(HyperoptExecutor):
                 )
                 search_alg = None
             else:
-                search_alg_type = self.search_alg_dict.pop(TYPE)
+                search_alg_type = self.search_alg_dict[TYPE]
                 search_alg = tune.create_searcher(
                     search_alg_type, metric=metric, mode=mode, **self.search_alg_dict)
         else:


### PR DESCRIPTION
As titled.  Without this change, the search_alg type that was used is not recorded in hyperopt_statistics.json.
[It is logged correctly in the run output, which is recorded before this pop op, but users don't typically retain that output.]