### PR TITLE
Write out CSV predictions when using local backend

### DIFF
--- a/examples/titanic/simple_model_training.py
+++ b/examples/titanic/simple_model_training.py
@@ -17,7 +17,7 @@ from ludwig.datasets import titanic
 shutil.rmtree("./results", ignore_errors=True)
 
 # Download and prepare the dataset
-training_set, _, _ = titanic.load(split=True)
+training_set, test_set, _ = titanic.load(split=True)
 
 # Define Ludwig model object that drive model training
 model = LudwigModel(config="./model1_config.yaml", logging_level=logging.INFO)
@@ -33,3 +33,6 @@ model = LudwigModel(config="./model1_config.yaml", logging_level=logging.INFO)
 print("contents of output directory:", output_directory)
 for item in os.listdir(output_directory):
     print("\t", item)
+
+# batch prediction
+model.predict(test_set, skip_save_predictions=False)

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -733,12 +733,14 @@ class LudwigModel:
                 skip_save_unprocessed_output=skip_save_unprocessed_output or not self.backend.is_coordinator(),
             )
             converted_postproc_predictions = convert_predictions(
-                postproc_predictions, self.model.output_features, self.training_set_metadata, return_type=return_type
+                postproc_predictions, self.model.output_features, return_type=return_type
             )
 
             if self.backend.is_coordinator():
                 if not skip_save_predictions:
-                    save_prediction_outputs(postproc_predictions, output_directory, self.backend)
+                    save_prediction_outputs(
+                        postproc_predictions, self.model.output_features, output_directory, self.backend
+                    )
 
                     logger.info(f"Saved to: {output_directory}")
 
@@ -877,7 +879,9 @@ class LudwigModel:
                     collect_predictions and postproc_predictions is not None and not skip_save_predictions
                 )
                 if should_save_predictions:
-                    save_prediction_outputs(postproc_predictions, output_directory, self.backend)
+                    save_prediction_outputs(
+                        postproc_predictions, self.model.output_features, output_directory, self.backend
+                    )
 
                 print_evaluation_stats(eval_stats)
                 if not skip_save_eval_stats:
@@ -890,7 +894,6 @@ class LudwigModel:
                 postproc_predictions = convert_predictions(
                     postproc_predictions,
                     self.model.output_features,
-                    self.training_set_metadata,
                     return_type=return_type,
                 )
 

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -22,8 +22,6 @@ from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.data.dataset.base import DatasetManager
 from ludwig.data.dataset.pandas import PandasDatasetManager
 from ludwig.models.ecd import ECD
-from ludwig.models.predictor import Predictor
-from ludwig.models.trainer import Trainer
 from ludwig.utils.torch_utils import initialize_pytorch
 
 
@@ -98,9 +96,13 @@ class LocalTrainingMixin:
         initialize_pytorch(*args, **kwargs)
 
     def create_trainer(self, **kwargs):
+        from ludwig.models.trainer import Trainer
+
         return Trainer(**kwargs)
 
     def create_predictor(self, model: ECD, **kwargs):
+        from ludwig.models.predictor import Predictor
+
         return Predictor(model, **kwargs)
 
     def sync_model(self, model):

--- a/ludwig/data/postprocessing.py
+++ b/ludwig/data/postprocessing.py
@@ -64,19 +64,17 @@ def _save_as_numpy(predictions, output_directory, saved_keys):
             saved_keys.add(k)
 
 
-def convert_predictions(predictions, output_features, training_set_metadata, return_type="dict"):
+def convert_predictions(predictions, output_features, return_type="dict"):
     convert_fn = get_from_registry(return_type, conversion_registry)
     return convert_fn(
         predictions,
         output_features,
-        training_set_metadata,
     )
 
 
 def convert_to_dict(
     predictions,
     output_features,
-    training_set_metadata,
 ):
     output = {}
     for of_name, output_feature in output_features.items():
@@ -99,7 +97,6 @@ def convert_to_dict(
 def convert_to_df(
     predictions,
     output_features,
-    training_set_metadata,
 ):
     return predictions
 

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -226,11 +226,7 @@ def _get_cols_from_predictions(predictions_paths, cols, metadata):
     for predictions_path in predictions_paths:
         shapes_fname = replace_file_extension(predictions_path, "shapes.json")
         column_shapes = load_json(shapes_fname)
-        file_extension = figure_data_format_dataset(predictions_path)
-        if file_extension == _CSV_SUFFIX:
-            pred_df = pd.read_csv(predictions_path)
-        elif file_extension == _PARQUET_SUFFIX:
-            pred_df = pd.read_parquet(predictions_path)
+        pred_df = pd.read_parquet(predictions_path)
         pred_df = unflatten_df(pred_df, column_shapes, LOCAL_BACKEND)
         for col in cols:
             # Convert categorical features back to numerical indices


### PR DESCRIPTION
This PR adds back CSV predictions when using the local backend (Pandas). It is still not possible to efficiently write out the CSV when using Dask, so we only provide this capability when running in local mode.

This also takes the approach that we will continue to only use the Parquet predictions for visualization. This is because reworking the visualization utils to support both code paths will be complex, as the representation is very different between the two (unflattened csvs, one file per column vs flattened parquet, one file in total).

With this implementation, both CSV and Parquet will be written when running locally, with the CSV being dropped when using a remote backend.