### PR TITLE
For ames_housing, remove test.csv from processing; it has no label column which prevents test split eval

### DIFF
--- a/ludwig/datasets/ames_housing/config.yaml
+++ b/ludwig/datasets/ames_housing/config.yaml
@@ -3,6 +3,5 @@ competition: house-prices-advanced-regression-techniques
 archive_filename: house-prices-advanced-regression-techniques.zip
 split_filenames:
   train_file: train.csv
-  test_file: test.csv
 download_file_type: csv
 csv_filename: ames_housing.csv

--- a/ludwig/datasets/forest_cover/__init__.py
+++ b/ludwig/datasets/forest_cover/__init__.py
@@ -25,7 +25,7 @@ from sklearn.model_selection import train_test_split
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False,
-         use_tabnet_split=False):
+         use_tabnet_split=True):
     dataset = ForestCover(cache_dir=cache_dir,
                           use_tabnet_split=use_tabnet_split)
     return dataset.load(split=split)
@@ -44,7 +44,7 @@ class ForestCover(UncompressedFileDownloadMixin, CSVLoadMixin, BaseDataset):
     processed_dataset_path: str
 
     def __init__(self, cache_dir=DEFAULT_CACHE_LOCATION,
-                 use_tabnet_split=False):
+                 use_tabnet_split=True):
         super().__init__(dataset_name="forest_cover", cache_dir=cache_dir)
         self.use_tabnet_split = use_tabnet_split
 


### PR DESCRIPTION
Also, for forest_cover, set use_tabnet_split to True by default; existing default split seems to be biased.