### PR TITLE
[cross-port from tf-legacy] For ames_housing, remove test.csv from pr…

### DIFF
--- a/ludwig/datasets/ames_housing/config.yaml
+++ b/ludwig/datasets/ames_housing/config.yaml
@@ -3,6 +3,5 @@ competition: house-prices-advanced-regression-techniques
 archive_filename: house-prices-advanced-regression-techniques.zip
 split_filenames:
   train_file: train.csv
-  test_file: test.csv
 download_file_type: csv
 csv_filename: ames_housing.csv

--- a/ludwig/datasets/forest_cover/__init__.py
+++ b/ludwig/datasets/forest_cover/__init__.py
@@ -24,7 +24,7 @@ from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.utils.fs_utils import makedirs, rename
 
 
-def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, use_tabnet_split=False):
+def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, use_tabnet_split=True):
     dataset = ForestCover(cache_dir=cache_dir, use_tabnet_split=use_tabnet_split)
     return dataset.load(split=split)
 
@@ -41,7 +41,7 @@ class ForestCover(UncompressedFileDownloadMixin, CSVLoadMixin, BaseDataset):
     raw_dataset_path: str
     processed_dataset_path: str
 
-    def __init__(self, cache_dir=DEFAULT_CACHE_LOCATION, use_tabnet_split=False):
+    def __init__(self, cache_dir=DEFAULT_CACHE_LOCATION, use_tabnet_split=True):
         super().__init__(dataset_name="forest_cover", cache_dir=cache_dir)
         self.use_tabnet_split = use_tabnet_split
 


### PR DESCRIPTION
…ocessing; it has no label column which prevents test split eval

Also, for forest_cover, set use_tabnet_split to True by default; existing default split seems to be biased.