### PR TITLE
Use tempfile to automatically garbage collect data and modeling artifacts in ludwig integration tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # ludwig specific #
 ###################
 
+*.lock_preprocessing
 results/
 ludwig/results/
 results_*/

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -67,7 +67,7 @@ def experiment_cli(
     random_seed: int = default_random_seed,
     debug: bool = False,
     logging_level: int = logging.INFO,
-    **kwargs
+    **kwargs,
 ):
     """Trains a model on a dataset's training and validation splits and uses it to predict on the test split. It
     saves the trained model and the statistics of training and testing.
@@ -252,7 +252,7 @@ def kfold_cross_validate_cli(
     output_directory="results",
     random_seed=default_random_seed,
     skip_save_k_fold_split_indices=False,
-    **kwargs
+    **kwargs,
 ):
     """Wrapper function to performs k-fold cross validation.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,70 +19,30 @@ import uuid
 import pytest
 
 from ludwig.hyperopt.run import hyperopt
-from ludwig.utils.data_utils import replace_file_extension
 from tests.integration_tests.utils import category_feature, generate_data, text_feature
-
-
-@pytest.fixture(scope="session", autouse=True)
-def init_tensorflow_cpu(request):
-    """Initialize tensorflow at the start of testing to only use CPUs.
-
-    This fixture runs once before any tests, and ensures that the main process
-    running pytest does not claim any GPU resources.
-
-    This is critical to avoid OOM errors when running subprocesses that need GPUs (e.g., hyperopt),
-    as otherwise the main process will consume all the memory and cause the subprocesses to crash.
-
-    Run most tests eagerly as the cost of graph construction can easily increase runtime by
-    and order of magnitude for small tests. Tests that execute in subprocesses, and tests
-    in `test_graph_execution.py` still run in graph mode.
-    """
-    # tf.config.experimental_run_functions_eagerly(True)
-    # initialize_tensorflow(gpus=-1)
-    pass
 
 
 @pytest.fixture()
 def csv_filename():
-    """This methods returns a random filename for the tests to use for generating temporary data.
-
-    After the data is used, all the temporary data is deleted.
-    :return: None
-    """
+    """Yields a csv filename for holding temporary data."""
     with tempfile.TemporaryDirectory() as tmpdir:
         csv_filename = os.path.join(tmpdir, uuid.uuid4().hex[:10].upper() + ".csv")
         yield csv_filename
 
 
 @pytest.fixture()
-def yaml_filename():
-    """This methods returns a random filename for the tests to use for generating a config file.
+def tmpdir():
+    """Yields a temporary directory for holding temporary data."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
 
-    After the test runs, this file will be deleted
-    :return: None
-    """
+
+@pytest.fixture()
+def yaml_filename():
+    """Yields a yaml filename for holding a temporary config."""
     with tempfile.TemporaryDirectory() as tmpdir:
         yaml_filename = os.path.join(tmpdir, "model_def_" + uuid.uuid4().hex[:10].upper() + ".yaml")
         yield yaml_filename
-
-
-def delete_temporary_data(csv_path):
-    """Helper method to delete temporary data created for running tests. Deletes the csv and hdf5/json data (if
-    any)
-
-    :param csv_path: path to the csv data file
-    :return: None
-    """
-    if os.path.isfile(csv_path):
-        os.remove(csv_path)
-
-    json_path = replace_file_extension(csv_path, "meta.json")
-    if os.path.isfile(json_path):
-        os.remove(json_path)
-
-    hdf5_path = replace_file_extension(csv_path, "hdf5")
-    if os.path.isfile(hdf5_path):
-        os.remove(hdf5_path)
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,13 +31,6 @@ def csv_filename():
 
 
 @pytest.fixture()
-def tmpdir():
-    """Yields a temporary directory for holding temporary data."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        yield tmpdir
-
-
-@pytest.fixture()
 def yaml_filename():
     """Yields a yaml filename for holding a temporary config."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -116,9 +116,8 @@ def convert_to_batch_form(data_df):
     return files
 
 
-def test_server_integration_with_images(csv_filename):
+def test_server_integration_with_images(tmpdir):
     # Image Inputs
-    tmpdir = os.path.dirname(csv_filename)
     image_dest_folder = os.path.join(tmpdir, "generated_images")
 
     # Resnet encoder
@@ -135,7 +134,7 @@ def test_server_integration_with_images(csv_filename):
     output_features = [category_feature(vocab_size=4), numerical_feature()]
 
     np.random.seed(123)  # reproducible synthetic data
-    rel_path = generate_data(input_features, output_features, csv_filename)
+    rel_path = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"))
 
     model = train_and_predict_model(input_features, output_features, data_csv=rel_path, output_directory=tmpdir)
 
@@ -182,8 +181,7 @@ def test_server_integration_with_images(csv_filename):
 
 
 @pytest.mark.parametrize("single_record", [False, True])
-def test_server_integration_with_audio(single_record, csv_filename):
-    tmpdir = os.path.dirname(csv_filename)
+def test_server_integration_with_audio(single_record, tmpdir):
     # Audio Inputs
     audio_dest_folder = os.path.join(tmpdir, "generated_audio")
 
@@ -197,7 +195,7 @@ def test_server_integration_with_audio(single_record, csv_filename):
     ]
     output_features = [category_feature(vocab_size=4), numerical_feature()]
 
-    rel_path = generate_data(input_features, output_features, csv_filename)
+    rel_path = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"))
 
     model = train_and_predict_model(input_features, output_features, data_csv=rel_path, output_directory=tmpdir)
 

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -199,7 +199,7 @@ def test_server_integration_with_audio(single_record, csv_filename):
 
     rel_path = generate_data(input_features, output_features, csv_filename)
 
-    model = train_and_predict_model(input_features, output_features, data_csv=rel_path, output_dir=tmpdir)
+    model = train_and_predict_model(input_features, output_features, data_csv=rel_path, output_directory=tmpdir)
 
     app = server(model)
     client = TestClient(app)

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -15,8 +15,8 @@
 import json
 import logging
 import os
-import shutil
 import sys
+import tempfile
 
 import numpy as np
 import pytest
@@ -47,12 +47,13 @@ except ImportError:
     sys.exit(-1)
 
 
-def train_model(input_features, output_features, data_csv):
-    """Helper method to avoid code repetition in running an experiment.
+def train_and_predict_model(input_features, output_features, data_csv, output_directory):
+    """Helper method to avoid code repetition for training a model and using it for prediction.
 
     :param input_features: input schema
     :param output_features: output schema
     :param data_csv: path to data
+    :param output_directory: model output directory
     :return: None
     """
     config = {
@@ -60,14 +61,14 @@ def train_model(input_features, output_features, data_csv):
         "output_features": output_features,
         "combiner": {"type": "concat", "fc_size": 14},
         "training": {"epochs": 2},
+        "output_dir": output_directory,
     }
     model = LudwigModel(config, backend=LocalTestBackend())
-    _, _, output_dir = model.train(
+    model.train(
         dataset=data_csv, skip_save_processed_input=True, skip_save_progress=True, skip_save_unprocessed_output=True
     )
-    model.predict(dataset=data_csv, output_directory=output_dir)
-
-    return model, output_dir
+    model.predict(dataset=data_csv, output_directory=output_directory)
+    return model
 
 
 def output_keys_for(output_features):
@@ -114,104 +115,41 @@ def convert_to_batch_form(data_df):
 
 
 def test_server_integration_with_images(csv_filename):
-    # Image Inputs
-    image_dest_folder = os.path.join(os.getcwd(), "generated_images")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Image Inputs
+        image_dest_folder = os.path.join(tmpdir, "generated_images")
 
-    # Resnet encoder
-    input_features = [
-        image_feature(
-            folder=image_dest_folder,
-            preprocessing={"in_memory": True, "height": 8, "width": 8, "num_channels": 3},
-            fc_size=16,
-            num_filters=8,
-        ),
-        text_feature(encoder="embed", min_len=1),
-        numerical_feature(normalization="zscore"),
-    ]
-    output_features = [category_feature(vocab_size=4), numerical_feature()]
+        # Resnet encoder
+        input_features = [
+            image_feature(
+                folder=image_dest_folder,
+                preprocessing={"in_memory": True, "height": 8, "width": 8, "num_channels": 3},
+                fc_size=16,
+                num_filters=8,
+            ),
+            text_feature(encoder="embed", min_len=1),
+            numerical_feature(normalization="zscore"),
+        ]
+        output_features = [category_feature(vocab_size=4), numerical_feature()]
 
-    np.random.seed(123)  # reproducible synthetic data
-    rel_path = generate_data(input_features, output_features, csv_filename)
-    model, output_dir = train_model(input_features, output_features, data_csv=rel_path)
+        np.random.seed(123)  # reproducible synthetic data
+        rel_path = generate_data(input_features, output_features, csv_filename)
 
-    app = server(model)
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.status_code == 200
+        model = train_and_predict_model(input_features, output_features, data_csv=rel_path, output_directory=tmpdir)
 
-    response = client.post("/predict")
-    # expect the HTTP 400 error code for this situation
-    assert response.status_code == 400
-    assert response.json() == ALL_FEATURES_PRESENT_ERROR
+        app = server(model)
+        client = TestClient(app)
+        response = client.get("/")
+        assert response.status_code == 200
 
-    data_df = read_csv(rel_path)
+        response = client.post("/predict")
+        # expect the HTTP 400 error code for this situation
+        assert response.status_code == 400
+        assert response.json() == ALL_FEATURES_PRESENT_ERROR
 
-    # One-off prediction
-    first_entry = data_df.T.to_dict()[0]
-    data, files = convert_to_form(first_entry)
-    server_response = client.post("/predict", data=data, files=files)
-    assert server_response.status_code == 200
-    server_response = server_response.json()
+        data_df = read_csv(rel_path)
 
-    server_response_keys = sorted(list(server_response.keys()))
-    assert server_response_keys == sorted(output_keys_for(output_features))
-
-    model_output, _ = model.predict(dataset=[first_entry], data_format=dict)
-    model_output = model_output.to_dict("records")[0]
-    assert model_output == server_response
-
-    # Batch prediction
-    assert len(data_df) > 1
-    files = convert_to_batch_form(data_df)
-    server_response = client.post("/batch_predict", files=files)
-    assert server_response.status_code == 200
-    server_response = server_response.json()
-
-    server_response_keys = sorted(server_response["columns"])
-    assert server_response_keys == sorted(output_keys_for(output_features))
-    assert len(data_df) == len(server_response["data"])
-
-    model_output, _ = model.predict(dataset=data_df)
-    model_output = model_output.to_dict("split")
-    assert model_output == server_response
-
-    # Cleanup
-    shutil.rmtree(output_dir, ignore_errors=True)
-    shutil.rmtree(image_dest_folder, ignore_errors=True)
-
-
-@pytest.mark.parametrize("single_record", [False, True])
-def test_server_integration_with_audio(single_record, csv_filename):
-    # Audio Inputs
-    audio_dest_folder = os.path.join(os.getcwd(), "generated_audio")
-
-    # Resnet encoder
-    input_features = [
-        audio_feature(
-            folder=audio_dest_folder,
-        ),
-        text_feature(encoder="embed", min_len=1),
-        numerical_feature(normalization="zscore"),
-    ]
-    output_features = [category_feature(vocab_size=4), numerical_feature()]
-
-    rel_path = generate_data(input_features, output_features, csv_filename)
-    model, output_dir = train_model(input_features, output_features, data_csv=rel_path)
-
-    app = server(model)
-    client = TestClient(app)
-    response = client.get("/")
-    assert response.status_code == 200
-
-    response = client.post("/predict")
-    # expect the HTTP 400 error code for this situation
-    assert response.status_code == 400
-    assert response.json() == ALL_FEATURES_PRESENT_ERROR
-
-    data_df = read_csv(rel_path)
-
-    if single_record:
-        # Single record prediction
+        # One-off prediction
         first_entry = data_df.T.to_dict()[0]
         data, files = convert_to_form(first_entry)
         server_response = client.post("/predict", data=data, files=files)
@@ -224,7 +162,7 @@ def test_server_integration_with_audio(single_record, csv_filename):
         model_output, _ = model.predict(dataset=[first_entry], data_format=dict)
         model_output = model_output.to_dict("records")[0]
         assert model_output == server_response
-    else:
+
         # Batch prediction
         assert len(data_df) > 1
         files = convert_to_batch_form(data_df)
@@ -240,6 +178,65 @@ def test_server_integration_with_audio(single_record, csv_filename):
         model_output = model_output.to_dict("split")
         assert model_output == server_response
 
-    # Cleanup
-    shutil.rmtree(output_dir, ignore_errors=True)
-    shutil.rmtree(audio_dest_folder, ignore_errors=True)
+
+@pytest.mark.parametrize("single_record", [False, True])
+def test_server_integration_with_audio(single_record, csv_filename):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Audio Inputs
+        audio_dest_folder = os.path.join(tmpdir, "generated_audio")
+
+        # Resnet encoder
+        input_features = [
+            audio_feature(
+                folder=audio_dest_folder,
+            ),
+            text_feature(encoder="embed", min_len=1),
+            numerical_feature(normalization="zscore"),
+        ]
+        output_features = [category_feature(vocab_size=4), numerical_feature()]
+
+        rel_path = generate_data(input_features, output_features, csv_filename)
+
+        model = train_and_predict_model(input_features, output_features, data_csv=rel_path, output_dir=tmpdir)
+
+        app = server(model)
+        client = TestClient(app)
+        response = client.get("/")
+        assert response.status_code == 200
+
+        response = client.post("/predict")
+        # expect the HTTP 400 error code for this situation
+        assert response.status_code == 400
+        assert response.json() == ALL_FEATURES_PRESENT_ERROR
+
+        data_df = read_csv(rel_path)
+
+        if single_record:
+            # Single record prediction
+            first_entry = data_df.T.to_dict()[0]
+            data, files = convert_to_form(first_entry)
+            server_response = client.post("/predict", data=data, files=files)
+            assert server_response.status_code == 200
+            server_response = server_response.json()
+
+            server_response_keys = sorted(list(server_response.keys()))
+            assert server_response_keys == sorted(output_keys_for(output_features))
+
+            model_output, _ = model.predict(dataset=[first_entry], data_format=dict)
+            model_output = model_output.to_dict("records")[0]
+            assert model_output == server_response
+        else:
+            # Batch prediction
+            assert len(data_df) > 1
+            files = convert_to_batch_form(data_df)
+            server_response = client.post("/batch_predict", files=files)
+            assert server_response.status_code == 200
+            server_response = server_response.json()
+
+            server_response_keys = sorted(server_response["columns"])
+            assert server_response_keys == sorted(output_keys_for(output_features))
+            assert len(data_df) == len(server_response["data"])
+
+            model_output, _ = model.predict(dataset=data_df)
+            model_output = model_output.to_dict("split")
+            assert model_output == server_response

--- a/tests/integration_tests/test_simple_features.py
+++ b/tests/integration_tests/test_simple_features.py
@@ -14,13 +14,11 @@
 # ==============================================================================
 import logging
 import os
-import shutil
 
 import pandas as pd
 import pytest
 
 from ludwig.constants import NAME
-from ludwig.experiment import experiment_cli
 from tests.integration_tests.utils import (
     bag_feature,
     binary_feature,
@@ -31,47 +29,12 @@ from tests.integration_tests.utils import (
     set_feature,
     text_feature,
     vector_feature,
+    run_experiment,
 )
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 logging.getLogger("ludwig").setLevel(logging.INFO)
-
-
-def run_experiment(input_features, output_features, **kwargs):
-    """Helper method to avoid code repetition in running an experiment. Deletes the data saved to disk after
-    running the experiment.
-
-    :param input_features: list of input feature dictionaries
-    :param output_features: list of output feature dictionaries
-    **kwargs you may also pass extra parameters to the experiment as keyword
-    arguments
-    :return: None
-    """
-    config = None
-    if input_features is not None and output_features is not None:
-        # This if is necessary so that the caller can call with
-        # config_file (and not config)
-        config = {
-            "backend": "local",
-            "input_features": input_features,
-            "output_features": output_features,
-            "combiner": {"type": "concat", "fc_size": 64, "num_fc_layers": 5},
-            "training": {"epochs": 2},
-        }
-
-    args = {
-        "config": config,
-        "skip_save_processed_input": True,
-        "skip_save_progress": True,
-        "skip_save_unprocessed_output": True,
-        "skip_save_model": True,
-        "skip_save_log": True,
-    }
-    args.update(kwargs)
-
-    exp_dir_name = experiment_cli(**args)
-    shutil.rmtree(exp_dir_name, ignore_errors=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -178,12 +178,6 @@ def test_torchscript(csv_filename, should_load_model):
         restored_weights = deepcopy(list(restored_model.parameters()))
         restored_weights = [t.cpu() for t in restored_weights]
 
-        #########
-        # Cleanup
-        #########
-        shutil.rmtree(ludwigmodel_path, ignore_errors=True)
-        shutil.rmtree(torchscript_path, ignore_errors=True)
-
         ###############################################
         # Check if weights and predictions are the same
         ###############################################


### PR DESCRIPTION
When running integration tests, there's often leftover generated data or modeling files that stick around in your workspace when the test fails.

Try/finally works, but a more pythonic design would be to use Python's tempfile context manager to generate a temporary directory that will always get cleaned up at the end of the test.

`pytest` has a built in `tmpdir` fixture, so we can just use that. 