### PR TITLE
Pin dulwich==0.20.26

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -221,6 +221,7 @@ jobs:
           else
             pip install torch==${PYTORCH}+cu111 -f https://download.pytorch.org/whl/torch_stable.html
           fi
+          pip install dulwich==0.20.26 # workaround for `/usr/bin/ld: cannot find -lpython3.7m`
           pip install --no-build-isolation --no-use-pep517 ConfigSpace # temporary fix: https://github.com/automl/ConfigSpace/issues/173
           pip install '.[test]'
           pip list


### PR DESCRIPTION
Error in GPU tests:

```
/usr/bin/ld: cannot find -lpython3.7m
```

This appears to be because there are no prebuilt wheels for the latest version of dulwich, released 1/4.

https://github.com/dulwich/dulwich/issues/919

Workaround is to pin to the previous version for now.