### PR TITLE
Removes lr from default_optimizer_params_registry

### DIFF
--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -247,6 +247,7 @@ def merge_with_defaults(config):
 
     # ===== Training Optimizer =====
     optimizer = config[TRAINING]["optimizer"]
+    set_default_value(optimizer, 'lr', config[TRAINING]["learning_rate"])
     default_optimizer_params = get_default_optimizer_params(optimizer[TYPE])
     for param in default_optimizer_params:
         set_default_value(optimizer, param, default_optimizer_params[param])

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -76,10 +76,10 @@ default_training_params = {
 }
 
 default_optimizer_params_registry = {
-    "sgd": {"lr": 0.001},
-    "stochastic_gradient_descent": {"lr": 0.001},
-    "gd": {"lr": 0.001},
-    "gradient_descent": {"lr": 0.001},
+    "sgd": {},
+    "stochastic_gradient_descent": {},
+    "gd": {},
+    "gradient_descent": {},
     "adam": {
         "betas": (0.9, 0.999),
         # 'beta_1': 0.9,

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -247,7 +247,7 @@ def merge_with_defaults(config):
 
     # ===== Training Optimizer =====
     optimizer = config[TRAINING]["optimizer"]
-    set_default_value(optimizer, 'lr', config[TRAINING]["learning_rate"])
+    set_default_value(optimizer, "lr", config[TRAINING]["learning_rate"])
     default_optimizer_params = get_default_optimizer_params(optimizer[TYPE])
     for param in default_optimizer_params:
         set_default_value(optimizer, param, default_optimizer_params[param])


### PR DESCRIPTION
Fixes #1621

Removes `training.optimizer.lr` defaults from `default_optimizer_params_registry`.

Use `training.learning_rate` as default value for`training.optimizer.lr` instead.

`training.learning_rate` will always be present, either from config or `default_training_params`
```
default_training_params = {
    "learning_rate": 0.001,
```