### PR TITLE
Reset MeanMetric's running average on reset()

### DIFF
--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -961,7 +961,7 @@ class Trainer(BaseTrainer):
 
             # training step loop
             progress_bar = tqdm(
-                desc="Trainining online",
+                desc="Training online",
                 total=batcher.steps_per_epoch,
                 file=sys.stdout,
                 disable=is_progressbar_disabled(),

--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -161,6 +161,10 @@ class MeanMetric(LudwigMetric):
     def compute(self) -> Tensor:
         return self.avg.compute()[0]
 
+    def reset(self):
+        super().reset()
+        self.avg = _MeanMetric()
+
     @abstractmethod
     def get_current_value(self, preds: Tensor, target: Tensor) -> Tensor:
         raise NotImplementedError()

--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -93,7 +93,7 @@ class LudwigMetric(Metric, ABC):
         should_unsync: bool = True,
         distributed_available: Optional[Callable] = jit_distributed_available,
     ) -> Generator:
-        """Override the beahvior of this in the base class to support Horovod."""
+        """Override the behavior of this in the base class to support Horovod."""
         self.sync(
             dist_sync_fn=gather_all_tensors,
             process_group=process_group,


### PR DESCRIPTION
MeanMetric instances do not reset their running average when the .reset() method is called.

This is causing the epoch eval loss to show a cumulative average instead of the average at each epoch.

This chart shows training set metrics.  Note the step loss vs epoch loss:

<img width="1421" alt="148465005-38b4f7f5-40b2-41ed-82a1-77049d15e631" src="https://user-images.githubusercontent.com/687280/148597832-11704052-138b-409a-b98b-259bce0c3e80.png">

After the change, epoch loss average is reset properly, and epoch loss vs batch loss match up:
![Screen Shot 2022-01-07 at 11 42 35 AM](https://user-images.githubusercontent.com/687280/148598297-42d9d6f6-f5b3-4db1-9338-5deb21915c12.png)

