### PR TITLE
TabNet training issues

### DIFF
--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -144,6 +144,8 @@ class Predictor(BasePredictor):
             predictions[key] = torch.cat(pred_value_list, dim=0).clone().detach().cpu().numpy()
 
     def batch_evaluation(self, dataset, collect_predictions=False, dataset_name=None):
+        model_training_mode = self.model.training
+        self.model.eval()  # Sets model training mode to False.
         with dataset.initialize_batcher(self._batch_size, should_shuffle=False, horovod=self._horovod) as batcher:
 
             progress_bar = None
@@ -198,7 +200,7 @@ class Predictor(BasePredictor):
 
         metrics = self.model.get_metrics()
         self.model.reset_metrics()
-
+        self.model.train(model_training_mode)  # Restores previous model training mode.
         return metrics, from_numpy_dataset(predictions)
 
     def batch_collect_activations(self, layer_names, dataset, bucketing_field=None):

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -380,6 +380,7 @@ class Trainer(BaseTrainer):
         total_steps: int = 3,
     ):
         """Function to be used by tune_batch_size."""
+        self.model.train()  # Sets model training mode.
         with dataset.initialize_batcher(batch_size=batch_size, should_shuffle=False, horovod=None) as batcher:
 
             step_count = 0
@@ -441,6 +442,7 @@ class Trainer(BaseTrainer):
             except Exception:
                 return None
 
+        self.model.train()  # Sets model training mode.
         with training_set.initialize_batcher(
             batch_size=self.batch_size, should_shuffle=self.should_shuffle, horovod=self.horovod
         ) as batcher:
@@ -720,6 +722,7 @@ class Trainer(BaseTrainer):
                     )
 
                 # Reset the metrics at the start of the next epoch
+                self.model.train()  # Sets model to training mode.
                 self.model.reset_metrics()
 
                 # ================ Train ================
@@ -955,6 +958,7 @@ class Trainer(BaseTrainer):
         )
 
     def train_online(self, dataset):
+        self.model.train()  # Sets model training mode.
         with dataset.initialize_batcher(
             batch_size=self.batch_size, should_shuffle=self.should_shuffle, horovod=self.horovod
         ) as batcher:

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -147,7 +147,6 @@ class TabNet(LudwigModule):
         final_output = self.final_projection(out_accumulator)  # [b_s, o_s]
 
         sparsity_loss = torch.multiply(self.sparsity, total_entropy)
-        setattr(sparsity_loss, "loss_name", "sparsity_loss")
         self.update_loss("sparsity_loss", sparsity_loss)
 
         return final_output, aggregated_mask, masks

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -148,7 +148,7 @@ class TabNet(LudwigModule):
 
         sparsity_loss = torch.multiply(self.sparsity, total_entropy)
         setattr(sparsity_loss, "loss_name", "sparsity_loss")
-        self.add_loss(sparsity_loss)
+        self.update_loss("sparsity_loss", sparsity_loss)
 
         return final_output, aggregated_mask, masks
 

--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -128,7 +128,7 @@ def reg_loss(model: nn.Module, regularizer: str, l1: float = 0.01, l2: float = 0
 class LudwigModule(Module):
     def __init__(self):
         super().__init__()
-        self._callable_losses = []
+        self._losses = {}
         self.register_buffer("device_tensor", torch.zeros(0))
 
     @property
@@ -137,8 +137,8 @@ class LudwigModule(Module):
 
     def losses(self):
         collected_losses = []
-        for loss_fn in self._callable_losses:
-            collected_losses.append(loss_fn())
+        for loss in self._losses.values():
+            collected_losses.append(loss)
 
         for child in self.children():
             if isinstance(child, LudwigModule):
@@ -154,9 +154,9 @@ class LudwigModule(Module):
 
         return collected_losses
 
-    def add_loss(self, loss):
-        if callable(loss):
-            self._callable_losses.append(loss)
+    def update_loss(self, key: str, loss: torch.Tensor):
+        """This should be called in the forward pass to add a custom loss term to the combined loss."""
+        self._losses[key] = loss
 
     @property
     def input_dtype(self):


### PR DESCRIPTION
- Fixes loss metrics using MeanMetric not resetting.  Descendants of MeanMetric (any LossMetric) were not getting reset between epoch, and thus were reporting a global cumulative average, not an epoch average.

- Changes LudwigModule's `_callable_losses` property to just `_losses`, and changes `add_loss` to `update_loss`.  This is only used for one thing: TabNet's Sparsity loss term.  In tensorflow, `add_loss` made sense because the call operator is only really called once to build the graph, as opposed to Torch's `forward` method which is called on every forward pass.  So, now we update the sparsity loss on every forward pass and include it in the overall train loss.

- Sets model into evaluation mode when generating predictions  using `model.train()` and `model.eval()`.  TorchModule's `training` property controls whether batch norm updates its running statistics, and whether drop out drops channels.  If we generate predictions while `training` is True, the predictions will be wrong if dropout or batch norm are used.