### PR TITLE
De-duplicate logging statements and logging formatting errors, caused by legacy workaround for tensorflow

### DIFF
--- a/ludwig/__init__.py
+++ b/ludwig/__init__.py
@@ -15,26 +15,6 @@
 import logging
 import sys
 
-import absl.logging
-
 from ludwig.globals import LUDWIG_VERSION as __version__  # noqa
 
-# Tensorflow 1.14 has compatibility issues with python native logging
-# This was one of the suggested solutions to continue using native logging
-# https://github.com/tensorflow/tensorflow/issues/26691
-logging.root.removeHandler(absl.logging._absl_handler)
-absl.logging._warn_preinit_stderr = False
-
-logger = logging.getLogger(__name__)
-# Default logging level for the project
-logger.setLevel(logging.INFO)
-
-# Configure stream handler
-ch = logging.StreamHandler(sys.stdout)
-ch.setLevel(logging.DEBUG)
-
-# Set formatter
-formatter = logging.Formatter("%(message)s")
-ch.setFormatter(formatter)
-
-logger.addHandler(ch)
+logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -94,6 +94,7 @@ from ludwig.utils.data_utils import (
 from ludwig.utils.defaults import default_preprocessing_parameters, default_random_seed
 from ludwig.utils.fs_utils import file_lock, path_exists
 from ludwig.utils.misc_utils import get_from_registry, merge_dict, resolve_pointers, set_random_seed
+from ludwig.utils.print_utils import print_boxed
 from ludwig.utils.type_utils import Column
 from ludwig.utils.types import DataFrame
 
@@ -1506,6 +1507,8 @@ def _preprocess_file_for_training(
     else:
         raise ValueError("either data or data_train have to be not None")
 
+    logger.info("Building dataset: DONE")
+
     data = backend.df_engine.persist(data)
     if SPLIT in data.columns:
         logger.debug("split on split column")
@@ -1534,16 +1537,16 @@ def _preprocess_df_for_training(
     This doesn't have the option to save the processed data as hdf5 as we don't expect users to do this as the data can
     be processed in memory
     """
+    print_boxed("Preprocessing")
+
     if dataset is not None:
         # needs preprocessing
         logger.info("Using full dataframe")
-        logger.info("Building dataset (it may take a while)")
-
     elif training_set is not None:
         # needs preprocessing
         logger.info("Using training dataframe")
-        logger.info("Building dataset (it may take a while)")
         dataset = concatenate_df(training_set, validation_set, test_set, backend)
+    logger.info("Building dataset (it may take a while)")
 
     dataset, training_set_metadata = build_dataset(
         dataset,
@@ -1555,6 +1558,8 @@ def _preprocess_df_for_training(
         callbacks=callbacks,
         mode="training",
     )
+
+    logger.info("Building dataset: DONE")
 
     dataset = backend.df_engine.persist(dataset)
     if SPLIT in dataset.columns:

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -718,7 +718,7 @@ class Trainer(BaseTrainer):
                 start_time = time.time()
                 if self.is_coordinator():
                     logger.info(
-                        "\nEpoch {epoch:{digits}d}".format(epoch=progress_tracker.epoch + 1, digits=digits_per_epochs)
+                        "Epoch {epoch:{digits}d}".format(epoch=progress_tracker.epoch + 1, digits=digits_per_epochs)
                     )
 
                 # Reset the metrics at the start of the next epoch
@@ -1070,21 +1070,14 @@ class Trainer(BaseTrainer):
             if self.is_coordinator() and not skip_save_model:
                 torch.save(self.model.state_dict(), model_weights_path)
                 logger.info(
-                    "Validation {} on {} improved, model saved".format(
-                        validation_metric, validation_output_feature_name
-                    )
+                    f"Validation {validation_metric} on {validation_output_feature_name} improved, model saved."
                 )
 
         progress_tracker.last_improvement = progress_tracker.epoch - progress_tracker.last_improvement_epoch
         if progress_tracker.last_improvement != 0 and self.is_coordinator():
             logger.info(
-                "Last improvement of {} validation {} "
-                "happened {} epoch{} ago".format(
-                    validation_output_feature_name,
-                    validation_metric,
-                    progress_tracker.last_improvement,
-                    "" if progress_tracker.last_improvement == 1 else "s",
-                )
+                f"Last improvement of {validation_output_feature_name} validation {validation_metric} happened "
+                + f"{progress_tracker.last_improvement} epoch(s) ago."
             )
 
         # ========== Reduce Learning Rate Plateau logic ========
@@ -1107,19 +1100,10 @@ class Trainer(BaseTrainer):
                 and not progress_tracker.num_reductions_learning_rate >= reduce_learning_rate_on_plateau
             ):
                 logger.info(
-                    "Last learning rate reduction "
-                    "happened {} epoch{} ago, "
-                    "improvement of {} {} {} "
-                    "happened {} epoch{} ago"
-                    "".format(
-                        progress_tracker.last_learning_rate_reduction,
-                        "" if progress_tracker.last_learning_rate_reduction == 1 else "s",
-                        validation_output_feature_name,
-                        reduce_learning_rate_eval_split,
-                        reduce_learning_rate_eval_metric,
-                        progress_tracker.last_reduce_learning_rate_eval_metric_improvement,
-                        "" if progress_tracker.last_reduce_learning_rate_eval_metric_improvement == 1 else "s",
-                    )
+                    f"Last learning rate reduction happened {progress_tracker.last_learning_rate_reduction} epoch(s) "
+                    f"ago, improvement of {validation_output_feature_name} {reduce_learning_rate_eval_split} "
+                    f"{reduce_learning_rate_eval_metric} happened "
+                    f"{progress_tracker.last_reduce_learning_rate_eval_metric_improvement} epoch(s) ago."
                 )
 
         # ========== Increase Batch Size Plateau logic =========
@@ -1145,17 +1129,10 @@ class Trainer(BaseTrainer):
             ):
                 logger.info(
                     "Last batch size increase "
-                    "happened {} epoch{} ago, "
-                    "improvement of {} {} {} "
-                    "happened {} epoch{} ago".format(
-                        progress_tracker.last_increase_batch_size,
-                        "" if progress_tracker.last_increase_batch_size == 1 else "s",
-                        validation_output_feature_name,
-                        increase_batch_size_eval_split,
-                        increase_batch_size_eval_metric,
-                        progress_tracker.last_increase_batch_size_eval_metric_improvement,
-                        "" if progress_tracker.last_increase_batch_size_eval_metric_improvement == 1 else "s",
-                    )
+                    f"happened {progress_tracker.last_increase_batch_size} epoch(s) ago, "
+                    f"improvement of {validation_output_feature_name} {increase_batch_size_eval_split} "
+                    f"{increase_batch_size_eval_metric} happened "
+                    f"{progress_tracker.last_increase_batch_size_eval_metric_improvement} epoch(s) ago."
                 )
 
         # ========== Early Stop logic ==========
@@ -1164,8 +1141,8 @@ class Trainer(BaseTrainer):
                 logger.info(
                     "\nEARLY STOPPING due to lack of "
                     "validation improvement, "
-                    "it has been {} epochs since last "
-                    "validation improvement\n".format(progress_tracker.epoch - progress_tracker.last_improvement_epoch)
+                    f"it has been {progress_tracker.epoch - progress_tracker.last_improvement_epoch} epoch(s) since "
+                    "last validation improvement.\n"
                 )
             should_break = True
         return should_break
@@ -1268,13 +1245,9 @@ class Trainer(BaseTrainer):
 
                     if self.is_coordinator():
                         logger.info(
-                            "PLATEAU REACHED, reducing learning rate to {} "
-                            "due to lack of improvement of {} {} {}".format(
-                                progress_tracker.learning_rate,
-                                validation_output_feature_name,
-                                reduce_learning_rate_eval_split,
-                                validation_metric,
-                            )
+                            f"PLATEAU REACHED, reducing learning rate to {progress_tracker.learning_rate} due to lack "
+                            f"of improvement of {validation_output_feature_name} {reduce_learning_rate_eval_split} "
+                            f"{validation_metric}."
                         )
 
                     progress_tracker.last_learning_rate_reduction_epoch = progress_tracker.epoch
@@ -1284,10 +1257,8 @@ class Trainer(BaseTrainer):
                     if progress_tracker.num_reductions_learning_rate >= reduce_learning_rate_on_plateau:
                         if self.is_coordinator():
                             logger.info(
-                                "Learning rate was already reduced "
-                                "{} times, not reducing it anymore".format(
-                                    progress_tracker.num_reductions_learning_rate
-                                )
+                                f"Learning rate was already reduced {progress_tracker.num_reductions_learning_rate} "
+                                "time(s), not reducing it anymore."
                             )
 
     def increase_batch_size(
@@ -1341,13 +1312,9 @@ class Trainer(BaseTrainer):
 
                     if self.is_coordinator():
                         logger.info(
-                            "PLATEAU REACHED, increasing batch size to {} "
-                            "due to lack of improvement of {} {} {}".format(
-                                progress_tracker.batch_size,
-                                validation_output_feature_name,
-                                increase_batch_size_eval_split,
-                                validation_metric,
-                            )
+                            f"PLATEAU REACHED, increasing batch size to {progress_tracker.batch_size} due to lack of "
+                            f"improvement of {validation_output_feature_name} {increase_batch_size_eval_split} "
+                            f"{validation_metric}."
                         )
 
                     progress_tracker.last_increase_batch_size_epoch = progress_tracker.epoch
@@ -1357,17 +1324,14 @@ class Trainer(BaseTrainer):
                     if progress_tracker.num_increases_batch_size >= increase_batch_size_on_plateau:
                         if self.is_coordinator():
                             logger.info(
-                                "Batch size was already increased "
-                                "{} times, not increasing it anymore".format(progress_tracker.num_increases_batch_size)
+                                f"Batch size was already increased {progress_tracker.num_increases_batch_size} times, "
+                                "not increasing it anymore."
                             )
                     elif progress_tracker.batch_size >= increase_batch_size_on_plateau_max:
                         if self.is_coordinator():
                             logger.info(
-                                "Batch size was already increased "
-                                "{} times, currently it is {}, "
-                                "the maximum allowed".format(
-                                    progress_tracker.num_increases_batch_size, progress_tracker.batch_size
-                                )
+                                f"Batch size was already increased {progress_tracker.num_increases_batch_size} times, "
+                                f"currently it is {progress_tracker.batch_size}, the maximum allowed."
                             )
 
     def is_coordinator(self):

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -50,7 +50,7 @@ default_combiner_type = "concat"
 
 default_training_params = {
     "optimizer": {TYPE: "adam"},
-    "epochs": 100,
+    "epochs": 1,
     "regularization_lambda": 0,
     "regularization_type": "l2",
     "learning_rate": 0.001,

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -50,7 +50,7 @@ default_combiner_type = "concat"
 
 default_training_params = {
     "optimizer": {TYPE: "adam"},
-    "epochs": 1,
+    "epochs": 100,
     "regularization_lambda": 0,
     "regularization_type": "l2",
     "learning_rate": 0.001,


### PR DESCRIPTION
Remove tensorflow's [workaround for collision with built in python logging](https://github.com/tensorflow/tensorflow/issues/26691), integrated into ludwig via #413. This workaround is not needed for Torch, and actually causes duplicate logging.

Also, clean up and repartition logging statements. Example of new output:

```
╒════════════════════════╕
│ EXPERIMENT DESCRIPTION │
╘════════════════════════╛

╒══════════════════╤═════════════════════════════════════════════════════════════════╕
│ Experiment name  │ simple_experiment                                               │
├──────────────────┼─────────────────────────────────────────────────────────────────┤
│ Model name       │ simple_model                                                    │
├──────────────────┼─────────────────────────────────────────────────────────────────┤
│ Output directory │ /Users/justinzhao/ludwig/results/simple_experiment_simple_model │
├──────────────────┼─────────────────────────────────────────────────────────────────┤
│ ludwig_version   │ '0.5.dev0'                                                      │
├──────────────────┼─────────────────────────────────────────────────────────────────┤
│ command          │ 'simple_model_training.py'                                      │
├──────────────────┼─────────────────────────────────────────────────────────────────┤
│ commit_hash      │ '0f4b5e8372f3'                                                  │
├──────────────────┼─────────────────────────────────────────────────────────────────┤
│ random_seed      │ 42                                                              │
├──────────────────┼─────────────────────────────────────────────────────────────────┤
│ data_format      │ "<class 'pandas.core.frame.DataFrame'>"                         │
├──────────────────┼─────────────────────────────────────────────────────────────────┤
│ torch_version    │ '1.10.0'                                                        │
├──────────────────┼─────────────────────────────────────────────────────────────────┤
│ compute          │ {'num_nodes': 1}                                                │
╘══════════════════╧═════════════════════════════════════════════════════════════════╛

╒═══════════════╕
│ LUDWIG CONFIG │
╘═══════════════╛

{   'combiner': {'type': 'concat'},
    'input_features': [   {   'column': 'Pclass',
                              'name': 'Pclass',
                              'proc_column': 'Pclass_mZFLky',
                              'tied': None,
                              'type': 'category'},
                          {   'column': 'Sex',
                              'name': 'Sex',
                              'proc_column': 'Sex_mZFLky',
                              'tied': None,
                              'type': 'category'},
                          {   'column': 'Age',
                              'name': 'Age',
                              'preprocessing': {   'missing_value_strategy': 'fill_with_mean'},
                              'proc_column': 'Age_DF6VxJ',
                              'tied': None,
                              'type': 'numerical'},
                          {   'column': 'SibSp',
                              'name': 'SibSp',
                              'proc_column': 'SibSp_mZFLky',
                              'tied': None,
                              'type': 'numerical'},
                          {   'column': 'Parch',
                              'name': 'Parch',
                              'proc_column': 'Parch_mZFLky',
                              'tied': None,
                              'type': 'numerical'},
                          {   'column': 'Fare',
                              'name': 'Fare',
                              'preprocessing': {   'missing_value_strategy': 'fill_with_mean'},
                              'proc_column': 'Fare_DF6VxJ',
                              'tied': None,
                              'type': 'numerical'},
                          {   'column': 'Embarked',
                              'name': 'Embarked',
                              'proc_column': 'Embarked_mZFLky',
                              'tied': None,
                              'type': 'category'}],
    'output_features': [   {   'column': 'Survived',
                               'dependencies': [],
                               'loss': {   'confidence_penalty': 0,
                                           'positive_class_weight': None,
                                           'robust_lambda': 0,
                                           'weight': 1},
                               'name': 'Survived',
                               'proc_column': 'Survived_mZFLky',
                               'reduce_dependencies': 'sum',
                               'reduce_input': 'sum',
                               'threshold': 0.5,
                               'type': 'binary'}],
    'preprocessing': {   'audio': {   'audio_feature': {'type': 'raw'},
                                      'audio_file_length_limit_in_s': 7.5,
                                      'in_memory': True,
                                      'missing_value_strategy': 'backfill',
                                      'norm': None,
                                      'padding_value': 0},
                         'bag': {   'fill_value': '<UNK>',
                                    'lowercase': False,
                                    'missing_value_strategy': 'fill_with_const',
                                    'most_common': 10000,
                                    'tokenizer': 'space'},
                         'binary': {   'fill_value': 0,
                                       'missing_value_strategy': 'fill_with_const'},
                         'category': {   'fill_value': '<UNK>',
                                         'lowercase': False,
                                         'missing_value_strategy': 'fill_with_const',
                                         'most_common': 10000},
                         'date': {   'datetime_format': None,
                                     'fill_value': '',
                                     'missing_value_strategy': 'fill_with_const'},
                         'force_split': False,
                         'h3': {   'fill_value': 576495936675512319,
                                   'missing_value_strategy': 'fill_with_const'},
                         'image': {   'in_memory': True,
                                      'infer_image_dimensions': True,
                                      'infer_image_max_height': 256,
                                      'infer_image_max_width': 256,
                                      'infer_image_num_channels': True,
                                      'infer_image_sample_size': 100,
                                      'missing_value_strategy': 'backfill',
                                      'num_processes': 1,
                                      'resize_method': 'interpolate',
                                      'scaling': 'pixel_normalization'},
                         'numerical': {   'fill_value': 0,
                                          'missing_value_strategy': 'fill_with_const',
                                          'normalization': None},
                         'sequence': {   'fill_value': '<UNK>',
                                         'lowercase': False,
                                         'missing_value_strategy': 'fill_with_const',
                                         'most_common': 20000,
                                         'padding': 'right',
                                         'padding_symbol': '<PAD>',
                                         'sequence_length_limit': 256,
                                         'tokenizer': 'space',
                                         'unknown_symbol': '<UNK>',
                                         'vocab_file': None},
                         'set': {   'fill_value': '<UNK>',
                                    'lowercase': False,
                                    'missing_value_strategy': 'fill_with_const',
                                    'most_common': 10000,
                                    'tokenizer': 'space'},
                         'split_probabilities': (0.7, 0.1, 0.2),
                         'stratify': None,
                         'text': {   'char_most_common': 70,
                                     'char_sequence_length_limit': 1024,
                                     'char_tokenizer': 'characters',
                                     'char_vocab_file': None,
                                     'fill_value': '<UNK>',
                                     'lowercase': True,
                                     'missing_value_strategy': 'fill_with_const',
                                     'padding': 'right',
                                     'padding_symbol': '<PAD>',
                                     'pretrained_model_name_or_path': None,
                                     'unknown_symbol': '<UNK>',
                                     'word_most_common': 20000,
                                     'word_sequence_length_limit': 256,
                                     'word_tokenizer': 'space_punct',
                                     'word_vocab_file': None},
                         'timeseries': {   'fill_value': '',
                                           'missing_value_strategy': 'fill_with_const',
                                           'padding': 'right',
                                           'padding_value': 0,
                                           'timeseries_length_limit': 256,
                                           'tokenizer': 'space'},
                         'vector': {   'fill_value': '',
                                       'missing_value_strategy': 'fill_with_const'}},
    'training': {   'batch_size': 128,
                    'bucketing_field': None,
                    'decay': False,
                    'decay_rate': 0.96,
                    'decay_steps': 10000,
                    'early_stop': 5,
                    'epochs': 2,
                    'eval_batch_size': None,
                    'gradient_clipping': None,
                    'increase_batch_size_on_plateau': 0,
                    'increase_batch_size_on_plateau_max': 512,
                    'increase_batch_size_on_plateau_patience': 5,
                    'increase_batch_size_on_plateau_rate': 2,
                    'learning_rate': 0.001,
                    'learning_rate_warmup_epochs': 1,
                    'optimizer': {   'betas': (0.9, 0.999),
                                     'eps': 1e-08,
                                     'lr': 0.001,
                                     'type': 'adam'},
                    'reduce_learning_rate_on_plateau': 0,
                    'reduce_learning_rate_on_plateau_patience': 5,
                    'reduce_learning_rate_on_plateau_rate': 0.5,
                    'regularization_lambda': 0,
                    'regularization_type': 'l2',
                    'staircase': False,
                    'validation_field': 'combined',
                    'validation_metric': 'loss'}}

╒═══════════════╕
│ PREPROCESSING │
╘═══════════════╛

Using full dataframe
Building dataset (it may take a while)
Building dataset: DONE
Writing preprocessed training set cache
Writing preprocessed test set cache
Writing preprocessed validation set cache
Writing train set metadata

Dataset sizes:
╒════════════╤════════╕
│ Dataset    │   Size │
╞════════════╪════════╡
│ Training   │    630 │
├────────────┼────────┤
│ Validation │     81 │
├────────────┼────────┤
│ Test       │    180 │
╘════════════╧════════╛

╒═══════╕
│ MODEL │
╘═══════╛

Warnings and other logs:
  embedding_size (50) is greater than vocab_size (4). Setting embedding size to be equal to vocab_size.
  embedding_size (50) is greater than vocab_size (3). Setting embedding size to be equal to vocab_size.
  embedding_size (50) is greater than vocab_size (4). Setting embedding size to be equal to vocab_size.
/Users/justinzhao/mambaforge/envs/ludwig/lib/python3.8/site-packages/torchmetrics/utilities/prints.py:36: UserWarning: Metric `AUROC` will save all targets and predictions in buffer. For large datasets this may lead to large memory footprint.
  warnings.warn(*args, **kwargs)

╒══════════╕
│ TRAINING │
╘══════════╛

Epoch 1
Training: 100%|████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 511.03it/s]
Evaluation train: 100%|████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 947.74it/s]
Evaluation vali : 100%|████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 931.86it/s]
Evaluation test : 100%|███████████████████████████████████████████████████████| 2/2 [00:00<00:00, 1019.40it/s]
Took 0.3052s
╒════════════╤═════════╤═══════════╤════════════╕
│ Survived   │    loss │   roc_auc │   accuracy │
╞════════════╪═════════╪═══════════╪════════════╡
│ train      │  7.9303 │    0.4085 │     0.6095 │
├────────────┼─────────┼───────────┼────────────┤
│ vali       │  9.3798 │    0.3368 │     0.6173 │
├────────────┼─────────┼───────────┼────────────┤
│ test       │ 11.1139 │    0.4834 │     0.6389 │
╘════════════╧═════════╧═══════════╧════════════╛
╒════════════╤════════╕
│ combined   │   loss │
╞════════════╪════════╡
│ train      │ 8.4933 │
├────────────┼────────┤
│ vali       │ 9.3798 │
├────────────┼────────┤
│ test       │ 9.3626 │
╘════════════╧════════╛
Validation loss on combined improved, model saved.
Saved checkpoint at /Users/justinzhao/ludwig/results/simple_experiment_simple_model/model/training_checkpoints/000000001.ckpt.

Epoch 2
Training: 100%|████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 823.32it/s]
Evaluation train: 100%|███████████████████████████████████████████████████████| 5/5 [00:00<00:00, 1224.61it/s]
Evaluation vali : 100%|████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 848.19it/s]
Evaluation test : 100%|███████████████████████████████████████████████████████| 2/2 [00:00<00:00, 1055.44it/s]
Took 0.1802s
╒════════════╤═════════╤═══════════╤════════════╕
│ Survived   │    loss │   roc_auc │   accuracy │
╞════════════╪═════════╪═══════════╪════════════╡
│ train      │  7.7796 │    0.4089 │     0.6095 │
├────────────┼─────────┼───────────┼────────────┤
│ vali       │  9.1996 │    0.3368 │     0.6173 │
├────────────┼─────────┼───────────┼────────────┤
│ test       │ 10.8782 │    0.4842 │     0.6389 │
╘════════════╧═════════╧═══════════╧════════════╛
╒════════════╤════════╕
│ combined   │   loss │
╞════════════╪════════╡
│ train      │ 8.3342 │
├────────────┼────────┤
│ vali       │ 9.1996 │
├────────────┼────────┤
│ test       │ 9.1718 │
╘════════════╧════════╛
Validation loss on combined improved, model saved.
Saved checkpoint at /Users/justinzhao/ludwig/results/simple_experiment_simple_model/model/training_checkpoints/000000002.ckpt.


╒═════════════════╕
│ TRAINING REPORT │
╘═════════════════╛

Best validation model epoch: 2
Best validation model loss on validation set combined: 9.199562072753906
Best validation model loss on test set combined: 9.171847343444824

Finished: simple_experiment_simple_model
Saved to: /Users/justinzhao/ludwig/results/simple_experiment_simple_model

╒══════════╕
│ FINISHED │
╘══════════╛

```

Fixes #1479.