### PR TITLE
Use binary file download for sarcos dataset which is matlab

### DIFF
--- a/ludwig/datasets/mixins/download.py
+++ b/ludwig/datasets/mixins/download.py
@@ -124,6 +124,26 @@ class GZipDownloadMixin:
         return self.config["download_urls"]
 
 
+class BinaryFileDownloadMixin:
+    """Downloads the binary file containing the training data."""
+
+    config: dict
+    raw_dataset_path: str
+    raw_temp_path: str
+
+    def download_raw_dataset(self):
+        """Download the raw dataset and store that in the cache location."""
+        with upload_output_directory(self.raw_dataset_path) as (tmpdir, _):
+            for file_download_url in self.download_urls:
+                filename = file_download_url.split("/")[-1]
+                with TqdmUpTo(unit="B", unit_scale=True, unit_divisor=1024, miniters=1, desc=filename) as t:
+                    urllib.request.urlretrieve(file_download_url, os.path.join(tmpdir, filename), t.update_to)
+
+    @property
+    def download_urls(self):
+        return self.config["download_urls"]
+
+
 class UncompressedFileDownloadMixin:
     """Downloads the json file containing the training data and extracts the contents."""
 

--- a/ludwig/datasets/sarcos/__init__.py
+++ b/ludwig/datasets/sarcos/__init__.py
@@ -19,7 +19,7 @@ import pandas as pd
 from scipy.io import loadmat
 
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
-from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
+from ludwig.datasets.mixins.download import BinaryFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
 from ludwig.utils.fs_utils import open_file
@@ -30,7 +30,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
     return dataset.load(split=split)
 
 
-class Sarcos(UncompressedFileDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
+class Sarcos(BinaryFileDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """The Sarcos dataset.
 
     Details:


### PR DESCRIPTION
UncompressedFileDownloadMixin download files using fsspec get, which previously worked on binary files,
but in the version used by master, it reports UnicodeDecodeError on non-text files.  Sarcos raw data is matlab
binary file format, and fails to download correctly on master.

This PR introduces a BinaryFileDownloadMixin class and uses it for sarcos.

Validated that this addresses the download of the sarcos dataset on master.