### PR TITLE
Removes regularization_lambda: 1 from higgs tabnet configs. 

### DIFF
--- a/examples/tabnet/higgs/medium_config.yaml
+++ b/examples/tabnet/higgs/medium_config.yaml
@@ -82,6 +82,5 @@ training:
   decay_steps: 10000
   decay_rate: 0.9
   staircase: true
-  regularization_lambda: 1
   validation_field: label
   shuffle_buffer_size: 1500000

--- a/examples/tabnet/higgs/small_config.yaml
+++ b/examples/tabnet/higgs/small_config.yaml
@@ -82,5 +82,4 @@ training:
   decay_steps: 20000
   decay_rate: 0.9
   staircase: true
-  regularization_lambda: 1
   validation_field: label


### PR DESCRIPTION
Removes regularization_lambda: 1 from higgs tabnet configs. 

regularization_type is l2 by default, which should not be used with TabNet.  This does not affect sparsity loss.

The lambda was needed for TF because the tabnet internal sparsity loss was treated as a regularization loss and summed up with the lambda multiplier. We changed that codepath and now each loss is summed up independently and lambda is only for l1/l2 regularization. Before the default reg was set to None and turning on lambda in tabnet meant turning on only the tabnet loss. Now the tabnet loss is not dependent on lambda (as it should be) and the default reg il l2, so setting lambda to 0 achieves the same loss calculation as before.


Fixes [1677](https://github.com/ludwig-ai/ludwig/issues/1677)

cc @anneholler 

