### PR TITLE
For ray, move all tensors back to CPU before returning to the head node.

### DIFF
--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -215,7 +215,6 @@ class RayTrainerV2(BaseTrainer):
 
         # load state dict back into the model
         state_dict, *args = results
-        # print(f"state_dict: {state_dict}")
         self.model.load_state_dict(state_dict)
         results = (self.model, *args)
 

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -79,7 +79,8 @@ class DatasetCache:
     def delete(self):
         for fname in self.cache_map.values():
             if path_exists(fname):
-                delete(fname)
+                # Parquet entries in the cache_ma can be pointers to directories.
+                delete(fname, recursive=True)
 
 
 class CacheManager:


### PR DESCRIPTION
This addresses an error encountered when training text (with HF) to category models on Ray: `(BackendExecutor pid=None) RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.`

Also, set `recursive=True` for deleting the cache. Preprocessed data in the form of Parquet files may be directories rather than individual files.
