### PR TITLE
Require that there must be 2 non-fill distinct values for binary features.

### DIFF
--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -215,6 +215,7 @@ class RayTrainerV2(BaseTrainer):
 
         # load state dict back into the model
         state_dict, *args = results
+        # print(f"state_dict: {state_dict}")
         self.model.load_state_dict(state_dict)
         results = (self.model, *args)
 

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -215,7 +215,6 @@ class RayTrainerV2(BaseTrainer):
 
         # load state dict back into the model
         state_dict, *args = results
-        # print(f"state_dict: {state_dict}")
         self.model.load_state_dict(state_dict)
         results = (self.model, *args)
 

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -62,7 +62,7 @@ class BinaryFeatureMixin(BaseFeatureMixin):
     def preprocessing_defaults() -> Dict[str, Any]:
         return {
             "missing_value_strategy": FILL_WITH_CONST,
-            "fill_value": "False",  # Default False.
+            "fill_value": "False",
         }
 
     @staticmethod

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -62,7 +62,7 @@ class BinaryFeatureMixin(BaseFeatureMixin):
     def preprocessing_defaults() -> Dict[str, Any]:
         return {
             "missing_value_strategy": FILL_WITH_CONST,
-            "fill_value": False,  # Default False.
+            "fill_value": "False",  # Default False.
         }
 
     @staticmethod

--- a/tests/ludwig/features/test_binary_feature.py
+++ b/tests/ludwig/features/test_binary_feature.py
@@ -1,9 +1,11 @@
 from typing import Dict
 
+import pandas as pd
 import pytest
 import torch
 
-from ludwig.features.binary_feature import BinaryInputFeature
+from ludwig.features.binary_feature import BinaryFeatureMixin, BinaryInputFeature
+from tests.integration_tests.utils import LocalTestBackend
 
 SEQ_SIZE = 2
 BINARY_W_SIZE = 1
@@ -25,3 +27,17 @@ def test_binary_input_feature(binary_config: Dict, encoder: str) -> None:
     binary_tensor = torch.randn([SEQ_SIZE, BINARY_W_SIZE], dtype=torch.float32).to(DEVICE)
     encoder_output = binary_input_feature(binary_tensor)
     assert encoder_output["encoder_output"].shape[1:] == binary_input_feature.output_shape
+
+
+def test_add_feature_data():
+    feature_meta = BinaryFeatureMixin.get_feature_meta(pd.Series(["0", "T", "F"]), {}, LocalTestBackend())
+
+    assert feature_meta["str2bool"] == {"0": False, "T": True, "F": False}
+    assert feature_meta["bool2str"] == ["0", "F", "T"]
+    assert feature_meta["fallback_true_label"] is None
+
+    feature_meta = BinaryFeatureMixin.get_feature_meta(pd.Series(["1", "T", "F"]), {}, LocalTestBackend())
+
+    assert feature_meta["str2bool"] == {"1": True, "T": True, "F": False}
+    assert feature_meta["bool2str"] == ["F", "1", "T"]
+    assert feature_meta["fallback_true_label"] is None


### PR DESCRIPTION
Fill values may appear as a distinct value if the original binary column contained missing values. This can create a situation where there are 3 distinct values, where multiple elements map to a single boolean value, i.e. "T", "F", and "False" (filled).

We now permit 3 distinct values, if one of them is the fill value, while ensuring that the elements used for `bool2str` postprocessing list use non-fill values.

Table describing the [implemented behavior](https://docs.google.com/spreadsheets/d/1EAJCDX1qLlToRYzsMesmgASsZDfwmXYyeBDbDdHGSvQ/edit#gid=0).

Verified that IEEE successfully trains with this change.

A potentially cleaner solution would be to set the default true label and fill_value explicitly during automl config generation. This would be good to revisit when extending automl to preprocessing in automl 2.0.