### PR TITLE
Don't index 0-dim tensors.  This is an error in PyTorch 1.10.0.

### DIFF
--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -159,7 +159,7 @@ class MeanMetric(LudwigMetric):
         self.avg.update(self.get_current_value(preds, target))
 
     def compute(self) -> Tensor:
-        return self.avg.compute()[0]
+        return self.avg.compute()
 
     def reset(self):
         super().reset()


### PR DESCRIPTION
Can be reproduced by training any model with an average loss metric, e.x. `examples/titanic/simple_model_training.py`

Observed: training fails with error

IndexError: invalid index of a 0-dim tensor. Use `tensor.item()` in Python or `tensor.item<T>()` in C++ to convert a 0-dim tensor to a number

```
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/examples/titanic/simple_model_training.py", line 30, in <module>
    ) = model.train(dataset=training_set, experiment_name="simple_experiment", model_name="simple_model")
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/api.py", line 534, in train
    train_stats = trainer.train(
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/models/trainer.py", line 758, in train
    self.evaluation(
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/models/trainer.py", line 1037, in evaluation
    metrics, predictions = predictor.batch_evaluation(dataset, collect_predictions=False, dataset_name=dataset_name)
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/models/predictor.py", line 177, in batch_evaluation
    preds = self.model.evaluation_step(inputs, targets)
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/models/ecd.py", line 170, in evaluation_step
    self.update_metrics(targets, predictions)
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/models/ecd.py", line 225, in update_metrics
    self.eval_loss_metric.update(self.eval_loss(targets, predictions)[0])
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/models/ecd.py", line 215, in eval_loss
    of_eval_loss = of_obj.eval_loss(targets[of_name], predictions[of_name])
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/features/base_feature.py", line 283, in eval_loss
    return self.eval_loss_function(predictions[prediction_key].detach(), targets)
  File "/Users/daniel/mambaforge/envs/test39/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1102, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/daniel/mambaforge/envs/test39/lib/python3.9/site-packages/torchmetrics/metric.py", line 218, in forward
    self._forward_cache = self.compute()
  File "/Users/daniel/mambaforge/envs/test39/lib/python3.9/site-packages/torchmetrics/metric.py", line 380, in wrapped_func
    value = compute(*args, **kwargs)
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/modules/metric_modules.py", line 162, in compute
    return self.avg.compute()[0]
IndexError: invalid index of a 0-dim tensor. Use `tensor.item()` in Python or `tensor.item<T>()` in C++ to convert a 0-dim tensor to a number
```