### PR TITLE
Log ray import failures.  Wraps from horovod.ray import RayExecutor in a try block.

### DIFF
--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -24,7 +24,6 @@ import numpy as np
 import pandas as pd
 import ray
 import torch
-from horovod.ray import RayExecutor
 from ray import ObjectRef
 from ray.data.dataset_pipeline import DatasetPipeline
 from ray.data.extensions import TensorDtype
@@ -45,13 +44,18 @@ _ray19 = LooseVersion(ray.__version__) >= LooseVersion("1.9")
 import ray.train as rt  # noqa: E402
 from ray.train.trainer import Trainer  # noqa: E402
 
+logger = logging.getLogger(__name__)
+
+try:
+    from horovod.ray import RayExecutor
+except ImportError as e:
+    logger.warn(f"ImportError (ray.py) from horovod.ray import RayExecutor failed with error: \n\t{e}")
+    RayExecutor = None
+
 if _ray19:
     from ray.train.horovod import HorovodConfig
 else:
     from ray.train.backends.horovod import HorovodConfig
-
-
-logger = logging.getLogger(__name__)
 
 
 # TODO: deprecated v0.5
@@ -278,6 +282,10 @@ def legacy_train_fn(
 class RayLegacyTrainer(BaseTrainer):
     def __init__(self, horovod_kwargs, executable_kwargs):
         # TODO ray: make this more configurable by allowing YAML overrides of timeout_s, etc.
+        if RayExecutor is None:
+            logger.error("RayLegacyTrainer failed to initialize: RayExecutor is None."
+                         "Make sure horovod[ray] is installed.")
+            return
         setting = RayExecutor.create_settings(timeout_s=30)
 
         self.executor = RayExecutor(setting, **{**get_horovod_kwargs(), **horovod_kwargs})

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -2,6 +2,7 @@ import copy
 import datetime
 import glob
 import json
+import logging
 import os
 import shutil
 import threading
@@ -25,6 +26,8 @@ from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.fs_utils import has_remote_protocol
 from ludwig.utils.misc_utils import get_from_registry, hash_dict
 
+logger = logging.getLogger(__name__)
+
 try:
     import ray
     from ray import tune
@@ -37,7 +40,8 @@ try:
     from ray.util.queue import Queue as RayQueue
 
     from ludwig.backend.ray import RayBackend
-except ImportError:
+except ImportError as e:
+    logger.warn(f"ImportError (execution.py) failed to import ray with error: \n\t{e}")
     ray = None
     get_horovod_kwargs = None
 
@@ -296,7 +300,7 @@ class RayTuneExecutor(HyperoptExecutor):
         **kwargs,
     ) -> None:
         if ray is None:
-            raise ImportError("ray module is not installed. To " "install it,try running pip install ray")
+            raise ImportError("ray module is not installed. To install it, try running pip install ray")
         if not isinstance(hyperopt_sampler, RayTuneSampler):
             raise ValueError(
                 "Sampler {} is not compatible with RayTuneExecutor, "


### PR DESCRIPTION
1.  Ludwig was crashing if horovod is not installed.  Horovod should be optional - so this PR wraps the horovod import in a try/except.
2. Now logs a warning if ray imports fail, and prints the exception thrown - to make it easier to debug ray installations.