### PR TITLE
Upgrade tf from 2.5.2 to 2.7.0.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.7, 3.8, 3.9 ]
         test-markers: [ "not distributed", "distributed" ]
         include:
           - python-version: 3.7

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,12 +29,12 @@ jobs:
         python-version: [ 3.6, 3.7, 3.8 ]
         test-markers: [ "not distributed", "distributed" ]
         include:
-          - python-version: 3.6
-            tensorflow-version: 2.3.1
           - python-version: 3.7
             tensorflow-version: 2.5.0
           - python-version: 3.8
-            tensorflow-version: 2.5.0
+            tensorflow-version: 2.7.0
+          - python-version: 3.9
+            tensorflow-version: 2.7.0
     env:
       TENSORFLOW: ${{ matrix.tensorflow-version }}
       MARKERS: ${{ matrix.test-markers }}

--- a/docker/ludwig-dev/Dockerfile
+++ b/docker/ludwig-dev/Dockerfile
@@ -11,7 +11,7 @@
 #
 
 
-FROM tensorflow/tensorflow:2.4.0-gpu
+FROM tensorflow/tensorflow:2.7.0-gpu
 
 RUN apt-get -y update && apt-get -y install \
     git \

--- a/docker/ludwig-dev/Dockerfile
+++ b/docker/ludwig-dev/Dockerfile
@@ -17,9 +17,9 @@ RUN apt-get -y update && apt-get -y install \
     git \
     libsndfile1 \
     cmake \
-    libcudnn7=7.6.5.32-1+cuda10.1 \
-    libnccl2=2.7.8-1+cuda10.1 \
-    libnccl-dev=2.7.8-1+cuda10.1
+    libcudnn8=8.1.1.33-1+cuda11.2 \
+    libnccl2=2.8.4-1+cuda11.2 \
+    libnccl-dev=2.8.4-1+cuda11.2
 
 WORKDIR /ludwig
 

--- a/docker/ludwig-gpu/Dockerfile
+++ b/docker/ludwig-gpu/Dockerfile
@@ -15,9 +15,8 @@ RUN apt-get -y update && apt-get -y install \
     git \
     libsndfile1 \
     cmake \
-    libcudnn8=8.1.1.33-1+cuda11.2 \
-    libnccl2=2.8.4-1+cuda11.2 \
-    libnccl-dev=2.8.4-1+cuda11.2
+    libcudnn8 \
+    libnccl2
 
 WORKDIR /ludwig
 

--- a/docker/ludwig-gpu/Dockerfile
+++ b/docker/ludwig-gpu/Dockerfile
@@ -15,8 +15,9 @@ RUN apt-get -y update && apt-get -y install \
     git \
     libsndfile1 \
     cmake \
-    libcudnn8 \
-    libnccl2
+    libcudnn8=8.1.1.33-1+cuda11.2 \
+    libnccl2=2.8.4-1+cuda11.2 \
+    libnccl-dev=2.8.4-1+cuda11.2
 
 WORKDIR /ludwig
 

--- a/docker/ludwig-gpu/Dockerfile
+++ b/docker/ludwig-gpu/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM tensorflow/tensorflow:2.4.1-gpu
+FROM tensorflow/tensorflow:2.7.0-gpu
 
 RUN apt-get -y update && apt-get -y install \
     git \

--- a/docker/ludwig-gpu/Dockerfile
+++ b/docker/ludwig-gpu/Dockerfile
@@ -15,9 +15,9 @@ RUN apt-get -y update && apt-get -y install \
     git \
     libsndfile1 \
     cmake \
-    libcudnn7=7.6.5.32-1+cuda10.1 \
-    libnccl2=2.7.8-1+cuda10.1 \
-    libnccl-dev=2.7.8-1+cuda10.1
+    libcudnn8=8.1.1.33-1+cuda11.2 \
+    libnccl2=2.8.4-1+cuda11.2 \
+    libnccl-dev=2.8.4-1+cuda11.2
 
 WORKDIR /ludwig
 

--- a/docker/ludwig/Dockerfile
+++ b/docker/ludwig/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM tensorflow/tensorflow:2.4.1
+FROM tensorflow/tensorflow:2.7.0
 
 RUN apt-get -y update && apt-get -y install \
     git \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scipy>=0.18
 tabulate>=0.7
 scikit-learn<1.0
 tqdm
-tensorflow>=2.3.1,<=2.7.0
+tensorflow>=2.3.1,<2.8
 tensorflow-addons==0.15.0
 PyYAML>=3.12
 absl-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ tabulate>=0.7
 scikit-learn<1.0
 tqdm
 tensorflow>=2.3.1,<=2.7.0
-tensorflow-addons==0.13.0
+tensorflow-addons==0.15.0
 PyYAML>=3.12
 absl-py
 kaggle

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scipy>=0.18
 tabulate>=0.7
 scikit-learn<1.0
 tqdm
-tensorflow>=2.3.1,<2.6.0
+tensorflow>=2.3.1,<=2.7.0
 tensorflow-addons==0.13.0
 PyYAML>=3.12
 absl-py

--- a/requirements_serve.txt
+++ b/requirements_serve.txt
@@ -2,5 +2,5 @@ uvicorn
 fastapi
 pydantic
 python-multipart
-neuropod ; platform_system != "Windows"
+neuropod ; platform_system != "Windows" and python_version < 3.9
 imageio

--- a/requirements_serve.txt
+++ b/requirements_serve.txt
@@ -2,5 +2,5 @@ uvicorn
 fastapi
 pydantic
 python-multipart
-neuropod ; platform_system != "Windows" and python_version < 3.9
+neuropod ; platform_system != "Windows" and python_version < '3.9'
 imageio

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -196,7 +196,7 @@ def test_export_savedmodel_cli(csv_filename):
                     )
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 9))
+@pytest.mark.skipif(sys.version_info >= (3, 9), reason="neuropod requires python3.8 or lower.")
 @pytest.mark.distributed
 def test_export_neuropod_cli(csv_filename):
     """Test exporting Ludwig model to neuropod format."""

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -198,7 +198,7 @@ def test_export_savedmodel_cli(csv_filename):
 
 
 @pytest.mark.distributed
-@pytest.mark.skipIf(LooseVersion(platform.python_version()) >= LooseVersion('3.8'))
+@pytest.mark.skipIf(LooseVersion(platform.python_version()) == LooseVersion('3.9'))
 def test_export_neuropod_cli(csv_filename):
     """Test exporting Ludwig model to neuropod format."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -198,7 +198,7 @@ def test_export_savedmodel_cli(csv_filename):
 
 
 @pytest.mark.distributed
-@pytest.mark.skipIf(LooseVersion(platform.python_version()) == LooseVersion('3.9'))
+@pytest.mark.skipIf(LooseVersion(platform.python_version()) >= LooseVersion('3.9'))
 def test_export_neuropod_cli(csv_filename):
     """Test exporting Ludwig model to neuropod format."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from distutils.version import LooseVersion
 import os
 import os.path
 import re
-import platform
 import shutil
 import subprocess
+import sys
 import tempfile
 from io import StringIO
 
@@ -197,8 +196,8 @@ def test_export_savedmodel_cli(csv_filename):
                     )
 
 
+@pytest.mark.skipIf(sys.version_info >= (3, 9))
 @pytest.mark.distributed
-@pytest.mark.skipIf(LooseVersion(platform.python_version()) >= LooseVersion('3.9'))
 def test_export_neuropod_cli(csv_filename):
     """Test exporting Ludwig model to neuropod format."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from distutils.version import LooseVersion
 import os
 import os.path
 import re
+import platform
 import shutil
 import subprocess
 import tempfile
@@ -196,6 +198,7 @@ def test_export_savedmodel_cli(csv_filename):
 
 
 @pytest.mark.distributed
+@pytest.mark.skipIf(LooseVersion(platform.python_version()) >= LooseVersion('3.8'))
 def test_export_neuropod_cli(csv_filename):
     """Test exporting Ludwig model to neuropod format."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -196,7 +196,7 @@ def test_export_savedmodel_cli(csv_filename):
                     )
 
 
-@pytest.mark.skipIf(sys.version_info >= (3, 9))
+@pytest.mark.skipif(sys.version_info >= (3, 9))
 @pytest.mark.distributed
 def test_export_neuropod_cli(csv_filename):
     """Test exporting Ludwig model to neuropod format."""

--- a/tests/integration_tests/test_neuropod.py
+++ b/tests/integration_tests/test_neuropod.py
@@ -17,6 +17,7 @@ from distutils.version import LooseVersion
 import itertools
 import os
 import platform
+import pytest
 import shutil
 import tempfile
 

--- a/tests/integration_tests/test_neuropod.py
+++ b/tests/integration_tests/test_neuropod.py
@@ -36,7 +36,7 @@ from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import sequence_feature
 
 
-@pytest.mark.skipIf(LooseVersion(platform.python_version()) >= LooseVersion('3.8'))
+@pytest.mark.skipIf(LooseVersion(platform.python_version()) == LooseVersion('3.9'))
 def test_neuropod(csv_filename):
     #######
     # Setup

--- a/tests/integration_tests/test_neuropod.py
+++ b/tests/integration_tests/test_neuropod.py
@@ -13,12 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from distutils.version import LooseVersion
 import itertools
 import os
-import platform
 import pytest
 import shutil
+import sys
 import tempfile
 
 import numpy as np
@@ -36,7 +35,7 @@ from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import sequence_feature
 
 
-@pytest.mark.skipIf(LooseVersion(platform.python_version()) >= LooseVersion('3.9'))
+@pytest.mark.skipIf(sys.version_info >= (3, 9))
 def test_neuropod(csv_filename):
     #######
     # Setup

--- a/tests/integration_tests/test_neuropod.py
+++ b/tests/integration_tests/test_neuropod.py
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from distutils.version import LooseVersion
 import itertools
 import os
+import platform
 import shutil
 import tempfile
 
@@ -33,6 +35,7 @@ from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import sequence_feature
 
 
+@pytest.mark.skipIf(LooseVersion(platform.python_version()) >= LooseVersion('3.8'))
 def test_neuropod(csv_filename):
     #######
     # Setup

--- a/tests/integration_tests/test_neuropod.py
+++ b/tests/integration_tests/test_neuropod.py
@@ -46,7 +46,7 @@ from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import sequence_feature
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 9))
+@pytest.mark.skipif(sys.version_info >= (3, 9), reason="neuropod requires python3.8 or lower.")
 def test_neuropod(csv_filename):
     #######
     # Setup

--- a/tests/integration_tests/test_neuropod.py
+++ b/tests/integration_tests/test_neuropod.py
@@ -36,7 +36,7 @@ from tests.integration_tests.utils import generate_data
 from tests.integration_tests.utils import sequence_feature
 
 
-@pytest.mark.skipIf(LooseVersion(platform.python_version()) == LooseVersion('3.9'))
+@pytest.mark.skipIf(LooseVersion(platform.python_version()) >= LooseVersion('3.9'))
 def test_neuropod(csv_filename):
     #######
     # Setup


### PR DESCRIPTION
## Updated github workflows to check python 3.7-3.9 (instead of 3.6-3.8)

Neuropod doesn't yet support python 3.9, so I've added pytest skip annotations for relevant tests contingent on the python version.

## Updated requirements.txt files

Added a condition to requirements_serve.txt to install neuropod only if the python version is < 3.9.

## Updated docker GPU images

Docker builds for ludwig GPU images for upgrading tensorflow to 2.7.0 were failing due to incompatible versions of cuDNN and CUDA. Tensorflow's docker linux builds only work for certain versions of cuDNN and CUDA. A table of supported versions is here: https://www.tensorflow.org/install/source#gpu

What's unclear is how the coarse `cuDNN` and `CUDA` versions map to actual library versions that we need to reference in the Dockerfile. For instance, tensorflow 2.5.2 uses the same cuDNN (8.1) and CUDA (11.2) coarse versions as tensorflow 2.7.0, yet `libcudnn7=7.6.5.32-1+cuda10.1` installs fine from the `tensorflow:2.5.2-gpu` docker image, but not from `tensorflow:2.7.0-gpu`.

To find good versions, per @tgaddair 's recommendation, I referred to [Horovod's docker composition test](https://github.com/horovod/horovod/blob/master/docker-compose.test.yml#L167), though even there it was a small amount of guesswork mapping the declared versions, i.e. `CUDNN_VERSION: 8.1.1.33-1+cuda11.2` to Dockerfile library versions, i.e. `libcudnn7=8.1.1.33-1+cuda11.2` -> `libcudnn8=8.1.1.33-1+cuda11.2`.

To verify the package versions, I tried manually running the apt install commands in a tensorflow 2.7.0 container:

> docker run -it tensorflow/tensorflow:2.7.0-gpu /bin/bash
> apt install libcudnn7=7.6.5.32-1+cuda10.1 --> error (same as github)
> apt install libcudnn7=8.6.5.32-1+cuda10.1 --> error (no such package)
> apt install libcudnn8=8.6.5.32-1+cuda10.1 --> works

Not specifying a version also works in the container:

> apt install libcudnn8 --> works

However, going versionless in ludwig's Dockerfile fails on github's workflow. Ludwig's horovod+tensorflow+gpu dockerimage seems to need specific versions for these drivers. @tgaddair, can you confirm this is expected?

To further verify that the new package versions install compatibly with the new tensorflow 2.7.0-based ludwig docker image, I ran:

`docker build -t ludwig-tf-legacy-gpu docker/ludwig-gpu`

This fails at the last step because there doesn't seem to be visibility of the `setup.py` file, but the first several steps of `apt-get install` for the CUDA/NCCL libraries passes.