### PR TITLE
Unpin dask[dataframe] and fix error reading unreachable image urls

### DIFF
--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -153,15 +153,13 @@ def read_image_from_str(img: str, num_channels: Optional[int] = None) -> torch.T
             return read_image(img, mode=ImageReadMode.RGB_ALPHA)
         else:
             return read_image(img)
-    except HTTPError as e:
+    except Exception as e:
         upgraded = upgrade_http(img)
         if upgraded:
             logger.info(f"reading image url {img} failed due to {e}. upgrading to https and retrying")
-            return read_image(upgraded)
-        logger.info(f"reading image url {img} failed due to {e} and cannot be upgraded to https")
+            return read_image_from_str(upgraded, num_channels)
+        logger.info(f"reading image url {img} failed due to {e}")
         return None
-    except Exception as e:
-        logger.info(f"reading image url {img} failed with error: ", e)
 
 
 def pad(

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -20,7 +20,6 @@ import sys
 from collections.abc import Iterable
 from io import BytesIO
 from typing import BinaryIO, List, Optional, TextIO, Tuple, Union
-from urllib.error import HTTPError
 
 import numpy as np
 import torch

--- a/requirements_dask.txt
+++ b/requirements_dask.txt
@@ -1,2 +1,2 @@
-dask[dataframe]<2021.3.1  # https://github.com/ray-project/ray/issues/14992
+dask[dataframe]
 pyarrow>=2.0.0


### PR DESCRIPTION
- Original issue with ray has been resolved so can unpin dask.
- in `tf-legacy`, trying to read from an unreachable url would cause an `HTTPError`. In torch, this is a `RuntimeError`, so change catch statement in `read_image_from_str`