### PR TITLE
Squeeze extra dimensions explicitly when preparing input symbols for the next time step.

### DIFF
--- a/ludwig/decoders/sequence_decoders.py
+++ b/ludwig/decoders/sequence_decoders.py
@@ -103,13 +103,9 @@ class LSTMDecoder(nn.Module):
             - hidden_state: [batch_size, hidden_size] tensor with the hidden state for the next time step.
             - cell_state: [batch_size, hidden_size] tensor with the cell state for the next time step.
         """
-        print(f"incoming hidden_state.size(): {hidden_state.size()}")
-        print(f"incoming cell_state.size(): {cell_state.size()}")
-        print(f"incoming input.size(): {input.size()}")
         # Unsqueeze predicted tokens.
         input = input.unsqueeze(1).to(torch.int)
         output = self.embedding(input)
-        print(f"incoming output.size(): {output.size()}")
         output, (hidden_state, cell_state) = self.lstm(output, (hidden_state, cell_state))
         output_logits = self.out(output)
         return output_logits, hidden_state, cell_state
@@ -176,7 +172,8 @@ class SequenceRNNDecoder(nn.Module):
             # TODO: Use a configurable ratio for how often to use teacher forcing during training.
             if target is None:
                 _, topi = decoder_output.topk(1)
-                decoder_input = topi.squeeze().detach()  # detach from history as input
+                # Squeeze out multilayer and vocabulary dimensions.
+                decoder_input = topi.squeeze(1).squeeze(1).detach()  # detach from history as input
             else:
                 # Teacher forcing.
                 decoder_input = target[:, di]
@@ -244,7 +241,8 @@ class SequenceLSTMDecoder(nn.Module):
             # TODO: Use a configurable ratio for how often to use teacher forcing during training.
             if target is None:
                 _, topi = decoder_output.topk(1)
-                decoder_input = topi.squeeze().detach()  # detach from history as input
+                # Squeeze out multilayer and vocabulary dimensions.
+                decoder_input = topi.squeeze(1).squeeze(1).detach()  # detach from history as input
             else:
                 # Teacher forcing.
                 decoder_input = target[:, di]

--- a/tests/ludwig/decoders/test_sequence_decoder.py
+++ b/tests/ludwig/decoders/test_sequence_decoder.py
@@ -13,10 +13,10 @@ from ludwig.decoders.sequence_decoders import (
 
 @pytest.mark.parametrize("cell_type", ["rnn", "gru"])
 @pytest.mark.parametrize("num_layers", [1, 2])
-def test_rnn_decoder(cell_type, num_layers):
+@pytest.mark.parametrize("batch_size", [20, 1])
+def test_rnn_decoder(cell_type, num_layers, batch_size):
     hidden_size = 256
     vocab_size = 50
-    batch_size = 20
 
     input = torch.randint(vocab_size, size=(batch_size,))
     initial_hidden = torch.zeros(num_layers, batch_size, hidden_size)
@@ -30,10 +30,10 @@ def test_rnn_decoder(cell_type, num_layers):
 
 
 @pytest.mark.parametrize("num_layers", [1, 2])
-def test_lstm_decoder(num_layers):
+@pytest.mark.parametrize("batch_size", [20, 1])
+def test_lstm_decoder(num_layers, batch_size):
     hidden_size = 256
     vocab_size = 50
-    batch_size = 20
 
     input = torch.randint(vocab_size, size=(batch_size,))
     initial_hidden = torch.zeros(num_layers, batch_size, hidden_size)
@@ -50,10 +50,10 @@ def test_lstm_decoder(num_layers):
 
 @pytest.mark.parametrize("cell_type", ["rnn", "gru"])
 @pytest.mark.parametrize("num_layers", [1, 2])
-def test_sequence_rnn_decoder(cell_type, num_layers):
+@pytest.mark.parametrize("batch_size", [20, 1])
+def test_sequence_rnn_decoder(cell_type, num_layers, batch_size):
     hidden_size = 256
     vocab_size = 50
-    batch_size = 20
     max_sequence_length = 10
 
     combiner_outputs = {HIDDEN: torch.rand([batch_size, hidden_size])}
@@ -67,10 +67,10 @@ def test_sequence_rnn_decoder(cell_type, num_layers):
 
 
 @pytest.mark.parametrize("num_layers", [1, 2])
-def test_sequence_lstm_decoder(num_layers):
+@pytest.mark.parametrize("batch_size", [20, 1])
+def test_sequence_lstm_decoder(num_layers, batch_size):
     hidden_size = 256
     vocab_size = 50
-    batch_size = 20
     max_sequence_length = 10
 
     combiner_outputs = {HIDDEN: torch.rand([batch_size, hidden_size])}
@@ -83,10 +83,10 @@ def test_sequence_lstm_decoder(num_layers):
 
 @pytest.mark.parametrize("cell_type", ["rnn", "gru", "lstm"])
 @pytest.mark.parametrize("num_layers", [1, 2])
-def test_sequence_generator_decoder(cell_type, num_layers):
+@pytest.mark.parametrize("batch_size", [20, 1])
+def test_sequence_generator_decoder(cell_type, num_layers, batch_size):
     hidden_size = 256
     vocab_size = 50
-    batch_size = 20
     max_sequence_length = 10
 
     combiner_outputs = {HIDDEN: torch.rand([batch_size, hidden_size])}


### PR DESCRIPTION
From [torch.squeeze](https://pytorch.org/docs/stable/generated/torch.squeeze.html): 

> If the tensor has a batch dimension of size 1, then squeeze(input) will also remove the batch dimension, which can lead to unexpected errors.

When the `batch_size = 1`, we would pass in a 0-dim tensor as the next time step. This causes an error: `IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)`.

The solution is to explicitly squeeze out the extra multi-layer and vocabulary dimensions with `tensor.squeeze(1).squeeze(1)` instead of `tensor.squeeze()` which squeezes `[batch_size, 1, 1]` -> `[]`.