### PR TITLE
Fixed preprocessing to always return series, not arrays

### DIFF
--- a/ludwig/data/dataframe/base.py
+++ b/ludwig/data/dataframe/base.py
@@ -43,6 +43,10 @@ class DataFrameEngine(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def map_partitions(self, series, map_fn, meta=None):
+        raise NotImplementedError()
+
+    @abstractmethod
     def apply_objects(self, series, map_fn, meta=None):
         raise NotImplementedError()
 

--- a/ludwig/data/dataframe/dask.py
+++ b/ludwig/data/dataframe/dask.py
@@ -72,6 +72,10 @@ class DaskEngine(DataFrameEngine):
         meta = meta or ("data", "object")
         return series.map(map_fn, meta=meta)
 
+    def map_partitions(self, series, map_fn, meta=None):
+        meta = meta or ("data", "object")
+        return series.map_partitions(map_fn, meta=meta)
+
     def apply_objects(self, df, apply_fn, meta=None):
         meta = meta or ("data", "object")
         return df.apply(apply_fn, axis=1, meta=meta)

--- a/ludwig/data/dataframe/pandas.py
+++ b/ludwig/data/dataframe/pandas.py
@@ -42,6 +42,9 @@ class PandasEngine(DataFrameEngine):
     def map_objects(self, series, map_fn, meta=None):
         return series.map(map_fn)
 
+    def map_partitions(self, series, map_fn, meta=None):
+        return map_fn(series)
+
     def apply_objects(self, df, apply_fn, meta=None):
         return df.apply(apply_fn, axis=1)
 

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -193,7 +193,7 @@ class BinaryFeatureMixin(BaseFeatureMixin):
                 # No predefined mapping from string to bool, so compute it directly
                 column = column.map(strings_utils.str2bool)
 
-        proc_df[feature_config[PROC_COLUMN]] = column.astype(np.bool_).values
+        proc_df[feature_config[PROC_COLUMN]] = column.astype(np.bool_)
         return proc_df
 
 

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -188,7 +188,7 @@ class BinaryFeatureMixin(BaseFeatureMixin):
         if column.dtype == object:
             metadata = metadata[feature_config[NAME]]
             if "str2bool" in metadata:
-                column = column.map(lambda x: metadata["str2bool"][x])
+                column = column.map(lambda x: metadata["str2bool"][str(x)])
             else:
                 # No predefined mapping from string to bool, so compute it directly
                 column = column.map(strings_utils.str2bool)

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -267,12 +267,13 @@ class NumericalFeatureMixin(BaseFeatureMixin):
         backend,
         skip_save_processed_input,
     ):
-        proc_df[feature_config[PROC_COLUMN]] = input_df[feature_config[COLUMN]].astype(np.float32).values
+        proc_df[feature_config[PROC_COLUMN]] = input_df[feature_config[COLUMN]]
+        values = input_df[feature_config[COLUMN]].astype(np.float32).values
 
         # normalize data as required
         numeric_transformer = get_transformer(metadata[feature_config[NAME]], preprocessing_parameters)
 
-        proc_df[feature_config[PROC_COLUMN]] = numeric_transformer.transform(proc_df[feature_config[PROC_COLUMN]])
+        proc_df[feature_config[PROC_COLUMN]].update(numeric_transformer.transform(values))
 
         return proc_df
 

--- a/ludwig/features/numerical_feature.py
+++ b/ludwig/features/numerical_feature.py
@@ -18,6 +18,7 @@ import random
 from typing import Any, Dict, List, Union
 
 import numpy as np
+import pandas as pd
 import torch
 from torch import nn
 
@@ -267,13 +268,13 @@ class NumericalFeatureMixin(BaseFeatureMixin):
         backend,
         skip_save_processed_input,
     ):
-        proc_df[feature_config[PROC_COLUMN]] = input_df[feature_config[COLUMN]]
-        values = input_df[feature_config[COLUMN]].astype(np.float32).values
+        def normalize(series: pd.Series) -> pd.Series:
+            numeric_transformer = get_transformer(metadata[feature_config[NAME]], preprocessing_parameters)
+            series.update(numeric_transformer.transform(series.values))
+            return series
 
-        # normalize data as required
-        numeric_transformer = get_transformer(metadata[feature_config[NAME]], preprocessing_parameters)
-
-        proc_df[feature_config[PROC_COLUMN]].update(numeric_transformer.transform(values))
+        input_series = input_df[feature_config[COLUMN]].astype(np.float32)
+        proc_df[feature_config[PROC_COLUMN]] = backend.df_engine.map_partitions(input_series, normalize)
 
         return proc_df
 

--- a/tests/integration_tests/test_missing_value_strategy.py
+++ b/tests/integration_tests/test_missing_value_strategy.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 
 from ludwig.api import LudwigModel
+from ludwig.constants import DROP_ROW, PREPROCESSING
 from tests.integration_tests.utils import (
     binary_feature,
     category_feature,
@@ -66,19 +67,19 @@ def test_missing_value_prediction(csv_filename):
 def test_missing_values_drop_rows(csv_filename, tmpdir):
     data_csv_path = os.path.join(tmpdir, csv_filename)
 
-    # Configure features to be tested:
+    kwargs = {PREPROCESSING: {"missing_value_strategy": DROP_ROW}}
     input_features = [
         numerical_feature(),
         binary_feature(),
         category_feature(vocab_size=3),
     ]
     output_features = [
-        binary_feature(),
-        numerical_feature(),
-        category_feature(vocab_size=3),
-        sequence_feature(vocab_size=3),
-        text_feature(vocab_size=3),
-        set_feature(vocab_size=3),
+        binary_feature(**kwargs),
+        numerical_feature(**kwargs),
+        category_feature(vocab_size=3, **kwargs),
+        sequence_feature(vocab_size=3, **kwargs),
+        text_feature(vocab_size=3, **kwargs),
+        set_feature(vocab_size=3, **kwargs),
         vector_feature(),
     ]
     backend = LocalTestBackend()


### PR DESCRIPTION
Previous behavior was problematic in cases where missing rows were dropped, as converting from a series to an array using `.values` drops the index, which is necessary for re-alignment when we reform the DataFrame at the end of preprocessing.