### PR TITLE
Changed --config_file to --config

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can use the following config:
 and start the training typing the following command in your console:
 
 ```
-ludwig train --dataset path/to/file.csv --config "{input_features: [{name: doc_text, type: text}], output_features: [{name: class, type: category}]}"
+ludwig train --dataset path/to/file.csv --config_str "{input_features: [{name: doc_text, type: text}], output_features: [{name: class, type: category}]}"
 ```
 
 where `path/to/file.csv` is the path to a UTF-8 encoded CSV file containing the dataset in the previous table (many other data formats are supported).

--- a/README_KR.md
+++ b/README_KR.md
@@ -140,7 +140,7 @@ Config 파일은 인코더와 디코더가 사용할 각 열에 저장된 데이
 그리고 사용자의 콘솔 창에서 다음의 명령을 입력하여 학습을 시작합니다:
 
 ```
-ludwig train --dataset path/to/file.csv --config "{input_features: [{name: doc_text, type: text}], output_features: [{name: class, type: category}]}"
+ludwig train --dataset path/to/file.csv --config_str "{input_features: [{name: doc_text, type: text}], output_features: [{name: class, type: category}]}"
 ```
 
 위의 명령어에서 `path/to/file.csv`부분은 위의 표(이외에 많은 데이터 타입이 지원됩니다)에서 UTF-8로 인코딩 되어 있는 dataset파일을 포함하는 경로입니다.

--- a/examples/kfold_cv/k-fold_cv_classification.sh
+++ b/examples/kfold_cv/k-fold_cv_classification.sh
@@ -9,7 +9,7 @@ python prepare_classification_data_set.py
 # Run 5-fold cross validation
 #
 ludwig experiment \
-  --config_file config.yaml \
+  --config config.yaml \
   --dataset data/train.csv \
   --output_directory results \
   --logging_level 'error' \

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -388,14 +388,17 @@ def cli(sys_argv):
     # ----------------
     config = parser.add_mutually_exclusive_group(required=True)
     config.add_argument(
-        "-c", "--config", type=load_config_from_str, help="JSON or YAML serialized string of the model configuration"
-    )
-    config.add_argument(
-        "-cf",
-        "--config_file",
-        dest="config",
+        "-c",
+        "--config",
         type=load_yaml,
         help="Path to the YAML file containing the model configuration",
+    )
+    config.add_argument(
+        "-cs",
+        "--config_str",
+        dest="config",
+        type=load_config_from_str,
+        help="JSON or YAML serialized string of the model configuration",
     )
 
     parser.add_argument("-mlp", "--model_load_path", help="path of a pretrained model to load as initialization")

--- a/ludwig/hyperopt_cli.py
+++ b/ludwig/hyperopt_cli.py
@@ -280,14 +280,17 @@ def cli(sys_argv):
     # ----------------
     config = parser.add_mutually_exclusive_group(required=True)
     config.add_argument(
-        "-c", "--config", type=load_config_from_str, help="JSON or YAML serialized string of the model configuration"
-    )
-    config.add_argument(
-        "-cf",
-        "--config_file",
-        dest="config",
+        "-c",
+        "--config",
         type=load_yaml,
         help="Path to the YAML file containing the model configuration",
+    )
+    config.add_argument(
+        "-cs",
+        "--config_str",
+        dest="config",
+        type=load_config_from_str,
+        help="JSON or YAML serialized string of the model configuration",
     )
 
     parser.add_argument(

--- a/ludwig/preprocess.py
+++ b/ludwig/preprocess.py
@@ -219,19 +219,19 @@ def cli(sys_argv):
     preprocessing_def.add_argument(
         "-pc",
         "--preprocessing_config",
-        type=yaml.safe_load,
-        help="preproceesing config. "
+        dest="preprocessing_config",
+        type=load_yaml,
+        help="YAML file describing the preprocessing. "
+        "Ignores --preprocessing_config."
         "Uses the same format of config, "
         "but ignores encoder specific parameters, "
         "decoder specific paramters, combiner and training parameters",
     )
     preprocessing_def.add_argument(
-        "-pcf",
-        "--preprocessing_config_file",
-        dest="preprocessing_config",
-        type=load_yaml,
-        help="YAML file describing the preprocessing. "
-        "Ignores --preprocessing_config."
+        "-pcs",
+        "--preprocessing_config_str",
+        type=yaml.safe_load,
+        help="preproceesing config. "
         "Uses the same format of config, "
         "but ignores encoder specific parameters, "
         "decoder specific paramters, combiner and training parameters",

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -268,14 +268,17 @@ def cli(sys_argv):
     # ----------------
     config = parser.add_mutually_exclusive_group(required=True)
     config.add_argument(
-        "-c", "--config", type=load_config_from_str, help="JSON or YAML serialized string of the model configuration"
-    )
-    config.add_argument(
-        "-cf",
-        "--config_file",
-        dest="config",
+        "-c",
+        "--config",
         type=load_yaml,
         help="Path to the YAML file containing the model configuration",
+    )
+    config.add_argument(
+        "-cs",
+        "--config_str",
+        dest="config",
+        type=load_config_from_str,
+        help="JSON or YAML serialized string of the model configuration",
     )
 
     parser.add_argument("-mlp", "--model_load_path", help="path of a pretrained model to load as initialization")

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -37,7 +37,7 @@ from ludwig.contrib import add_contrib_callback_args
 from ludwig.features.feature_registries import base_type_registry, input_type_registry, output_type_registry
 from ludwig.features.feature_utils import compute_feature_hash
 from ludwig.globals import LUDWIG_VERSION
-from ludwig.utils.data_utils import load_config_from_str
+from ludwig.utils.data_utils import load_config_from_str, load_yaml
 from ludwig.utils.misc_utils import get_from_registry, merge_dict, set_default_value
 from ludwig.utils.print_utils import print_ludwig
 
@@ -299,8 +299,15 @@ def cli_render_config(sys_argv):
     parser.add_argument(
         "-c",
         "--config",
+        type=load_yaml,
+        help="Path to the YAML file containing the model configuration",
+    )
+    parser.add_argument(
+        "-cs",
+        "--config_str",
+        dest="config",
         type=load_config_from_str,
-        help="input user YAML config path",
+        help="JSON or YAML serialized string of the model configuration",
     )
     parser.add_argument(
         "-o",

--- a/requirements_hyperopt.txt
+++ b/requirements_hyperopt.txt
@@ -1,4 +1,4 @@
 bayesmark>=0.0.7
 pySOT
 hyperopt
-ray[tune]
+ray[default,tune]>=1.8.0,<1.10

--- a/requirements_ray.txt
+++ b/requirements_ray.txt
@@ -1,4 +1,4 @@
-ray[default,tune]>=1.8.0
+ray[default,tune]>=1.8.0,<1.10
 pickle5
 tensorboardX<2.3
 GPUtil

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -141,7 +141,7 @@ def test_train_cli_horovod(csv_filename):
         _run_ludwig_horovod(
             "train",
             dataset=dataset_filename,
-            config_file=config_filename,
+            config=config_filename,
             output_directory=tmpdir,
             experiment_name="horovod_experiment",
         )
@@ -150,7 +150,7 @@ def test_train_cli_horovod(csv_filename):
         _run_ludwig_horovod(
             "train",
             dataset=dataset_filename,
-            config_file=config_filename,
+            config=config_filename,
             output_directory=tmpdir,
             model_load_path=os.path.join(tmpdir, "horovod_experiment_run", "model"),
         )
@@ -166,7 +166,7 @@ def test_export_savedmodel_cli(csv_filename):
         _run_ludwig("train", dataset=dataset_filename, config=config_filename, output_directory=tmpdir)
         _run_ludwig(
             "export_savedmodel",
-            model_path=os.path.join(tmpdir, "experiment_run", "model"),
+            model=os.path.join(tmpdir, "experiment_run", "model"),
             output_path=os.path.join(tmpdir, "savedmodel"),
         )
 
@@ -181,7 +181,7 @@ def test_export_neuropod_cli(csv_filename):
         _run_ludwig("train", dataset=dataset_filename, config=config_filename, output_directory=tmpdir)
         _run_ludwig(
             "export_neuropod",
-            model_path=os.path.join(tmpdir, "experiment_run", "model"),
+            model=os.path.join(tmpdir, "experiment_run", "model"),
             output_path=os.path.join(tmpdir, "neuropod"),
         )
 
@@ -205,7 +205,7 @@ def test_predict_cli(csv_filename):
         _run_ludwig(
             "predict",
             dataset=dataset_filename,
-            model_path=os.path.join(tmpdir, "experiment_run", "model"),
+            model=os.path.join(tmpdir, "experiment_run", "model"),
             output_directory=os.path.join(tmpdir, "predictions"),
         )
 
@@ -220,7 +220,7 @@ def test_evaluate_cli(csv_filename):
         _run_ludwig(
             "evaluate",
             dataset=dataset_filename,
-            model_path=os.path.join(tmpdir, "experiment_run", "model"),
+            model=os.path.join(tmpdir, "experiment_run", "model"),
             output_directory=os.path.join(tmpdir, "predictions"),
         )
 
@@ -257,7 +257,7 @@ def test_collect_summary_activations_weights_cli(csv_filename):
         config_filename = os.path.join(tmpdir, "config.yaml")
         dataset_filename = _prepare_data(csv_filename, config_filename)
         _run_ludwig("train", dataset=dataset_filename, config=config_filename, output_directory=tmpdir)
-        completed_process = _run_ludwig("collect_summary", model_path=os.path.join(tmpdir, "experiment_run", "model"))
+        completed_process = _run_ludwig("collect_summary", model=os.path.join(tmpdir, "experiment_run", "model"))
         stdout = completed_process.stdout.decode("utf-8")
 
         assert "Modules" in stdout
@@ -298,4 +298,4 @@ def test_preprocess_cli(csv_filename):
     with tempfile.TemporaryDirectory() as tmpdir:
         config_filename = os.path.join(tmpdir, "config.yaml")
         dataset_filename = _prepare_data(csv_filename, config_filename)
-        _run_ludwig("preprocess", dataset=dataset_filename, preprocessing_config_file=config_filename)
+        _run_ludwig("preprocess", dataset=dataset_filename, preprocessing_config=config_filename)

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -111,7 +111,7 @@ def test_train_cli_dataset(csv_filename):
     with tempfile.TemporaryDirectory() as tmpdir:
         config_filename = os.path.join(tmpdir, "config.yaml")
         dataset_filename = _prepare_data(csv_filename, config_filename)
-        _run_ludwig("train", dataset=dataset_filename, config_file=config_filename, output_directory=tmpdir)
+        _run_ludwig("train", dataset=dataset_filename, config=config_filename, output_directory=tmpdir)
 
 
 @pytest.mark.distributed
@@ -127,7 +127,7 @@ def test_train_cli_training_set(csv_filename):
             training_set=dataset_filename,
             validation_set=validation_filename,
             test_set=test_filename,
-            config_file=config_filename,
+            config=config_filename,
             output_directory=tmpdir,
         )
 
@@ -163,7 +163,7 @@ def test_export_savedmodel_cli(csv_filename):
     with tempfile.TemporaryDirectory() as tmpdir:
         config_filename = os.path.join(tmpdir, "config.yaml")
         dataset_filename = _prepare_data(csv_filename, config_filename)
-        _run_ludwig("train", dataset=dataset_filename, config_file=config_filename, output_directory=tmpdir)
+        _run_ludwig("train", dataset=dataset_filename, config=config_filename, output_directory=tmpdir)
         _run_ludwig(
             "export_savedmodel",
             model_path=os.path.join(tmpdir, "experiment_run", "model"),
@@ -178,7 +178,7 @@ def test_export_neuropod_cli(csv_filename):
     with tempfile.TemporaryDirectory() as tmpdir:
         config_filename = os.path.join(tmpdir, "config.yaml")
         dataset_filename = _prepare_data(csv_filename, config_filename)
-        _run_ludwig("train", dataset=dataset_filename, config_file=config_filename, output_directory=tmpdir)
+        _run_ludwig("train", dataset=dataset_filename, config=config_filename, output_directory=tmpdir)
         _run_ludwig(
             "export_neuropod",
             model_path=os.path.join(tmpdir, "experiment_run", "model"),
@@ -192,7 +192,7 @@ def test_experiment_cli(csv_filename):
     with tempfile.TemporaryDirectory() as tmpdir:
         config_filename = os.path.join(tmpdir, "config.yaml")
         dataset_filename = _prepare_data(csv_filename, config_filename)
-        _run_ludwig("experiment", dataset=dataset_filename, config_file=config_filename, output_directory=tmpdir)
+        _run_ludwig("experiment", dataset=dataset_filename, config=config_filename, output_directory=tmpdir)
 
 
 @pytest.mark.distributed
@@ -201,7 +201,7 @@ def test_predict_cli(csv_filename):
     with tempfile.TemporaryDirectory() as tmpdir:
         config_filename = os.path.join(tmpdir, "config.yaml")
         dataset_filename = _prepare_data(csv_filename, config_filename)
-        _run_ludwig("train", dataset=dataset_filename, config_file=config_filename, output_directory=tmpdir)
+        _run_ludwig("train", dataset=dataset_filename, config=config_filename, output_directory=tmpdir)
         _run_ludwig(
             "predict",
             dataset=dataset_filename,
@@ -216,7 +216,7 @@ def test_evaluate_cli(csv_filename):
     with tempfile.TemporaryDirectory() as tmpdir:
         config_filename = os.path.join(tmpdir, "config.yaml")
         dataset_filename = _prepare_data(csv_filename, config_filename)
-        _run_ludwig("train", dataset=dataset_filename, config_file=config_filename, output_directory=tmpdir)
+        _run_ludwig("train", dataset=dataset_filename, config=config_filename, output_directory=tmpdir)
         _run_ludwig(
             "evaluate",
             dataset=dataset_filename,
@@ -231,7 +231,7 @@ def test_hyperopt_cli(csv_filename):
     with tempfile.TemporaryDirectory() as tmpdir:
         config_filename = os.path.join(tmpdir, "config.yaml")
         dataset_filename = _prepare_hyperopt_data(csv_filename, config_filename)
-        _run_ludwig("hyperopt", dataset=dataset_filename, config_file=config_filename, output_directory=tmpdir)
+        _run_ludwig("hyperopt", dataset=dataset_filename, config=config_filename, output_directory=tmpdir)
 
 
 @pytest.mark.distributed
@@ -240,7 +240,7 @@ def test_visualize_cli(csv_filename):
     with tempfile.TemporaryDirectory() as tmpdir:
         config_filename = os.path.join(tmpdir, "config.yaml")
         dataset_filename = _prepare_data(csv_filename, config_filename)
-        _run_ludwig("train", dataset=dataset_filename, config_file=config_filename, output_directory=tmpdir)
+        _run_ludwig("train", dataset=dataset_filename, config=config_filename, output_directory=tmpdir)
         _run_ludwig(
             "visualize",
             visualization="learning_curves",
@@ -256,7 +256,7 @@ def test_collect_summary_activations_weights_cli(csv_filename):
     with tempfile.TemporaryDirectory() as tmpdir:
         config_filename = os.path.join(tmpdir, "config.yaml")
         dataset_filename = _prepare_data(csv_filename, config_filename)
-        _run_ludwig("train", dataset=dataset_filename, config_file=config_filename, output_directory=tmpdir)
+        _run_ludwig("train", dataset=dataset_filename, config=config_filename, output_directory=tmpdir)
         completed_process = _run_ludwig("collect_summary", model_path=os.path.join(tmpdir, "experiment_run", "model"))
         stdout = completed_process.stdout.decode("utf-8")
 

--- a/tests/integration_tests/test_kfold_cv.py
+++ b/tests/integration_tests/test_kfold_cv.py
@@ -133,7 +133,7 @@ def test_kfold_cv_cli(features_to_use: FeaturesToUse):
 
 @pytest.mark.distributed
 def test_kfold_cv_api_from_file():
-    # k-fold_cross_validate api with config_file
+    # k-fold_cross_validate api with config file
     num_folds = 3
 
     # setup temporary directory to run test


### PR DESCRIPTION
Reasoning here is that for most real applications of Ludwig, it's not practical to pass the config as a JSON string, so the most common usage (a YAML file) should be the simpler and more intuitive form of the parameter.