### PR TITLE
Added dataset download CLI commands

### DIFF
--- a/ludwig/cli.py
+++ b/ludwig/cli.py
@@ -158,6 +158,11 @@ Available sub-commands:
 
         defaults.cli_render_config(sys.argv[2:])
 
+    def datasets(self):
+        from ludwig import datasets
+
+        datasets.cli(sys.argv[2:])
+
 
 def main():
     ludwig.contrib.preload(sys.argv)

--- a/ludwig/datasets/__init__.py
+++ b/ludwig/datasets/__init__.py
@@ -1,9 +1,21 @@
 import argparse
+import importlib
+import pkgutil
 from typing import List
 
+from ludwig import datasets
 from ludwig.datasets.registry import dataset_registry
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.utils.print_utils import print_ludwig
+
+
+def _import_submodules():
+    for _, name, _ in pkgutil.walk_packages(datasets.__path__):
+        full_name = datasets.__name__ + "." + name
+        importlib.import_module(full_name)
+
+
+_import_submodules()
 
 
 def list_datasets() -> List[str]:

--- a/ludwig/datasets/__init__.py
+++ b/ludwig/datasets/__init__.py
@@ -1,0 +1,45 @@
+import argparse
+
+import ludwig.datasets
+from ludwig.globals import LUDWIG_VERSION
+from ludwig.utils.print_utils import print_ludwig
+
+
+def download(dataset: str, output_dir: str = "."):
+    pass
+
+
+def cli(sys_argv):
+    parser = argparse.ArgumentParser(
+        description="This command downloads and lists Ludwig-ready datasets.",
+        prog="ludwig datasets",
+        usage="%(prog)s [options]",
+    )
+    sub_parsers = parser.add_subparsers(dest="command", help="download and list datasets")
+
+    parser_download = sub_parsers.add_parser("download", help="download a dataset")
+    parser_download.add_argument("dataset", help="dataset to download")
+    parser_download.add_argument(
+        "-o",
+        "--output_dir",
+        type=str,
+        default=".",
+        help="output directory to download into",
+        required=False,
+    )
+
+    sub_parsers.add_parser("list", help="list datasets")
+
+    args = parser.parse_args(sys_argv)
+    print_ludwig(f"Datasets {args.command}", LUDWIG_VERSION)
+
+    if args.command == "list":
+        import pkgutil
+
+        datasets = [ds.name for ds in pkgutil.iter_modules(ludwig.datasets.__path__) if ds.name != "mixins"]
+        for ds in datasets:
+            print(ds)
+    elif args.command == "download":
+        download(**vars(args))
+    else:
+        raise ValueError(f"Unrecognized command: {args.command}")

--- a/ludwig/datasets/__init__.py
+++ b/ludwig/datasets/__init__.py
@@ -22,6 +22,10 @@ def list_datasets() -> List[str]:
     return list(dataset_registry.keys())
 
 
+def describe_dataset(dataset: str) -> str:
+    return dataset_registry[dataset].__doc__
+
+
 def download_dataset(dataset: str, output_dir: str = "."):
     import importlib
 
@@ -49,6 +53,9 @@ def cli(sys_argv):
 
     sub_parsers.add_parser("list", help="list datasets")
 
+    parser_describe = sub_parsers.add_parser("describe", help="describe datasets")
+    parser_describe.add_argument("dataset", help="dataset to describe")
+
     args = parser.parse_args(sys_argv)
     print_ludwig(f"Datasets {args.command}", LUDWIG_VERSION)
 
@@ -56,6 +63,8 @@ def cli(sys_argv):
         datasets = list_datasets()
         for ds in datasets:
             print(ds)
+    elif args.command == "describe":
+        print(describe_dataset(args.dataset))
     elif args.command == "download":
         download_dataset(**vars(args))
     else:

--- a/ludwig/datasets/__init__.py
+++ b/ludwig/datasets/__init__.py
@@ -1,12 +1,19 @@
 import argparse
+from typing import List
 
-import ludwig.datasets
+from ludwig.datasets.registry import dataset_registry
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.utils.print_utils import print_ludwig
 
 
-def download(dataset: str, output_dir: str = "."):
-    pass
+def list_datasets() -> List[str]:
+    return list(dataset_registry.keys())
+
+
+def download_dataset(dataset: str, output_dir: str = "."):
+    import importlib
+
+    importlib.import_module(f"ludwig.datasets.{dataset}")
 
 
 def cli(sys_argv):
@@ -34,12 +41,10 @@ def cli(sys_argv):
     print_ludwig(f"Datasets {args.command}", LUDWIG_VERSION)
 
     if args.command == "list":
-        import pkgutil
-
-        datasets = [ds.name for ds in pkgutil.iter_modules(ludwig.datasets.__path__) if ds.name != "mixins"]
+        datasets = list_datasets()
         for ds in datasets:
             print(ds)
     elif args.command == "download":
-        download(**vars(args))
+        download_dataset(**vars(args))
     else:
         raise ValueError(f"Unrecognized command: {args.command}")

--- a/ludwig/datasets/adult_census_income/__init__.py
+++ b/ludwig/datasets/adult_census_income/__init__.py
@@ -20,6 +20,7 @@ import pandas as pd
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.fs_utils import makedirs, rename
 
 
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="adult_census_income")
 class AdultCensusIncome(UncompressedFileDownloadMixin, CSVLoadMixin, BaseDataset):
     """The Adult Census Income dataset.
 

--- a/ludwig/datasets/agnews/__init__.py
+++ b/ludwig/datasets/agnews/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
     return dataset.load(split=split)
 
 
+@register_dataset(name="agnews")
 class AGNews(UncompressedFileDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """The AGNews dataset."""
 

--- a/ludwig/datasets/allstate_claims_severity/__init__.py
+++ b/ludwig/datasets/allstate_claims_severity/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="allstate_claims_severity")
 class AllstateClaimsSeverity(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """Allstate Claims Severity.
 

--- a/ludwig/datasets/amazon_review_polarity/__init__.py
+++ b/ludwig/datasets/amazon_review_polarity/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import TarDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
     return dataset.load(split=split)
 
 
+@register_dataset(name="amazon_review_polarity")
 class AmazonPolarity(TarDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """
         The Amazon Reviews Polarity dataset

--- a/ludwig/datasets/amazon_reviews/__init__.py
+++ b/ludwig/datasets/amazon_reviews/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import TarDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
     return dataset.load(split=split)
 
 
+@register_dataset(name="amazon_reviews")
 class AmazonReviews(TarDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """
         The Amazon Reviews dataset

--- a/ludwig/datasets/ames_housing/__init__.py
+++ b/ludwig/datasets/ames_housing/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="ames_housing")
 class AmesHousing(CSVLoadMixin, MultifileJoinProcessMixin, KaggleDownloadMixin, BaseDataset):
     """The Ames Housing dataset.
 

--- a/ludwig/datasets/bnp_claims_management/__init__.py
+++ b/ludwig/datasets/bnp_claims_management/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="bnp_claims_management")
 class BNPClaimsManagement(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """The BNP Paribas Cardif Claims Management dataset.
 

--- a/ludwig/datasets/connect4/__init__.py
+++ b/ludwig/datasets/connect4/__init__.py
@@ -18,6 +18,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -25,6 +26,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="connect4")
 class Connect4(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """Connect-4 Game Dataset from Kaggle."""
 

--- a/ludwig/datasets/dbpedia/__init__.py
+++ b/ludwig/datasets/dbpedia/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import TarDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
     return dataset.load(split=split)
 
 
+@register_dataset(name="dbpedia")
 class DBPedia(TarDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """The DBPedia Ontology dataset.
 

--- a/ludwig/datasets/electricity/__init__.py
+++ b/ludwig/datasets/electricity/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="electricity")
 class Electricity(UncompressedFileDownloadMixin, IdentityProcessMixin, CSVLoadMixin, BaseDataset):
     """Electricity demand dataset. Half-hourly electricity demand in Victoria, Australia during 2014, along with
     Melbourne temperatures.

--- a/ludwig/datasets/ethos_binary/__init__.py
+++ b/ludwig/datasets/ethos_binary/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="ethos_binary")
 class EthosBinary(UncompressedFileDownloadMixin, IdentityProcessMixin, CSVLoadMixin, BaseDataset):
     """The Ethos Hate Speech Dataset.
 

--- a/ludwig/datasets/fever/__init__.py
+++ b/ludwig/datasets/fever/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="fever")
 class Fever(UncompressedFileDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """The Fever dataset.
 

--- a/ludwig/datasets/flickr8k/__init__.py
+++ b/ludwig/datasets/flickr8k/__init__.py
@@ -20,6 +20,7 @@ from collections import defaultdict
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import ZipDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.fs_utils import makedirs, rename
 
 
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="flickr8k")
 class Flickr8k(CSVLoadMixin, ZipDownloadMixin, BaseDataset):
     """The Flickr8k dataset.
 

--- a/ludwig/datasets/forest_cover/__init__.py
+++ b/ludwig/datasets/forest_cover/__init__.py
@@ -21,6 +21,7 @@ from sklearn.model_selection import train_test_split
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import GZipDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.fs_utils import makedirs, rename
 
 
@@ -29,6 +30,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, use_tabnet_split=True):
     return dataset.load(split=split)
 
 
+@register_dataset(name="forest_cover")
 class ForestCover(GZipDownloadMixin, CSVLoadMixin, BaseDataset):
     """The Forest Cover Type dataset.
 

--- a/ludwig/datasets/goemotions/__init__.py
+++ b/ludwig/datasets/goemotions/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="goemotions")
 class GoEmotions(UncompressedFileDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """The GoEmotions dataset.
 

--- a/ludwig/datasets/higgs/__init__.py
+++ b/ludwig/datasets/higgs/__init__.py
@@ -20,6 +20,7 @@ import pandas as pd
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import GZipDownloadMixin
 from ludwig.datasets.mixins.load import ParquetLoadMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.fs_utils import makedirs, rename
 
 
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, add_validation_set=False
     return dataset.load(split=split)
 
 
+@register_dataset(name="higgs")
 class Higgs(GZipDownloadMixin, ParquetLoadMixin, BaseDataset):
     """The Higgs Boson dataset.
 

--- a/ludwig/datasets/ieee_fraud/__init__.py
+++ b/ludwig/datasets/ieee_fraud/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.fs_utils import makedirs
 
 
@@ -29,6 +30,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="ieee_fraud")
 class IEEEFraud(CSVLoadMixin, MultifileJoinProcessMixin, KaggleDownloadMixin, BaseDataset):
     """The IEEE-CIS Fraud Detection Dataset https://www.kaggle.com/c/ieee-fraud-detection/overview."""
 

--- a/ludwig/datasets/insurance_lite/__init__.py
+++ b/ludwig/datasets/insurance_lite/__init__.py
@@ -20,6 +20,7 @@ import pandas as pd
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import KaggleDatasetDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.fs_utils import makedirs, rename
 
 
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="insurance_lite")
 class InsuranceLite(CSVLoadMixin, KaggleDatasetDownloadMixin, BaseDataset):
     """The InsuranceLite dataset.
 

--- a/ludwig/datasets/iris/__init__.py
+++ b/ludwig/datasets/iris/__init__.py
@@ -20,6 +20,7 @@ import pandas as pd
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.fs_utils import makedirs
 
 
@@ -30,6 +31,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="iris")
 class Iris(UncompressedFileDownloadMixin, CSVLoadMixin, BaseDataset):
     """The Iris dataset.
 

--- a/ludwig/datasets/irony/__init__.py
+++ b/ludwig/datasets/irony/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="irony")
 class Irony(UncompressedFileDownloadMixin, IdentityProcessMixin, CSVLoadMixin, BaseDataset):
     """The Reddit Irony dataset.
 

--- a/ludwig/datasets/kdd_appetency/__init__.py
+++ b/ludwig/datasets/kdd_appetency/__init__.py
@@ -15,6 +15,7 @@
 # ==============================================================================
 from ludwig.datasets.base_dataset import DEFAULT_CACHE_LOCATION
 from ludwig.datasets.kdd_dataset import KDDCup2009Dataset
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, include_test_download=False):
@@ -22,6 +23,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, include_test_download=Fa
     return dataset.load(split=split)
 
 
+@register_dataset(name="kdd_appetency")
 class KDDAppetency(KDDCup2009Dataset):
     """The KDD Cup 2009 Appetency dataset.
 

--- a/ludwig/datasets/kdd_churn/__init__.py
+++ b/ludwig/datasets/kdd_churn/__init__.py
@@ -31,6 +31,7 @@
 # ==============================================================================
 from ludwig.datasets.base_dataset import DEFAULT_CACHE_LOCATION
 from ludwig.datasets.kdd_dataset import KDDCup2009Dataset
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, include_test_download=False):
@@ -38,6 +39,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, include_test_download=Fa
     return dataset.load(split=split)
 
 
+@register_dataset(name="kdd_churn")
 class KDDChurn(KDDCup2009Dataset):
     """The KDD Cup 2009 Churn dataset.
 

--- a/ludwig/datasets/kdd_upselling/__init__.py
+++ b/ludwig/datasets/kdd_upselling/__init__.py
@@ -31,6 +31,7 @@
 # ==============================================================================
 from ludwig.datasets.base_dataset import DEFAULT_CACHE_LOCATION
 from ludwig.datasets.kdd_dataset import KDDCup2009Dataset
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, include_test_download=False):
@@ -38,6 +39,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, include_test_download=Fa
     return dataset.load(split=split)
 
 
+@register_dataset(name="kdd_upselling")
 class KDDUpselling(KDDCup2009Dataset):
     """The KDD Cup 2009 Upselling dataset.
 

--- a/ludwig/datasets/mercedes_benz_greener/__init__.py
+++ b/ludwig/datasets/mercedes_benz_greener/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="mercedes_benz_greener")
 class MercedesBenzGreener(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """The Mercedes-Benz Greener Manufacturing dataset.
 

--- a/ludwig/datasets/mnist/__init__.py
+++ b/ludwig/datasets/mnist/__init__.py
@@ -24,6 +24,7 @@ import torch
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import GZipDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.fs_utils import makedirs, rename
 
 NUM_LABELS = 10
@@ -34,6 +35,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="mnist")
 class Mnist(CSVLoadMixin, GZipDownloadMixin, BaseDataset):
     """The Mnist dataset.
 

--- a/ludwig/datasets/mushroom_edibility/__init__.py
+++ b/ludwig/datasets/mushroom_edibility/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="mushroom_edibility")
 class MushroomEdibility(UncompressedFileDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """The Mushroom Edibility dataset.
 

--- a/ludwig/datasets/naval/__init__.py
+++ b/ludwig/datasets/naval/__init__.py
@@ -20,6 +20,7 @@ import pandas as pd
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import ZipDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.fs_utils import makedirs, rename
 
 
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="naval")
 class Naval(ZipDownloadMixin, CSVLoadMixin, BaseDataset):
     """Condition Based Maintenance of Naval Propulsion Plants Data Set.
 

--- a/ludwig/datasets/numerai28pt6/__init__.py
+++ b/ludwig/datasets/numerai28pt6/__init__.py
@@ -18,6 +18,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -25,6 +26,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="numerai28pt6")
 class Numerai28pt6(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """Encrypted Stock Market Data from Numerai dataset from Kaggle."""
 

--- a/ludwig/datasets/ohsumed/__init__.py
+++ b/ludwig/datasets/ohsumed/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import ZipDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="ohsumed")
 class OhsuMed(ZipDownloadMixin, IdentityProcessMixin, CSVLoadMixin, BaseDataset):
     """The OhsuMed dataset.
 

--- a/ludwig/datasets/otto_group_product/__init__.py
+++ b/ludwig/datasets/otto_group_product/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="otto_group_product")
 class OttoGroupProduct(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """The Otto Group Product Classification Challenge https://www.kaggle.com/c/otto-group-product-classification-
     challenge/overview."""

--- a/ludwig/datasets/poker_hand/__init__.py
+++ b/ludwig/datasets/poker_hand/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
     return dataset.load(split=split)
 
 
+@register_dataset(name="poker_hand")
 class PokerHand(UncompressedFileDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """The Poker Hand dataset.
 

--- a/ludwig/datasets/porto_seguro_safe_driver/__init__.py
+++ b/ludwig/datasets/porto_seguro_safe_driver/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="porto_seguro_safe_driver")
 class PortoSeguroSafeDriver(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """Porto Seguro's Safe Driver Prediction.
 

--- a/ludwig/datasets/protein/__init__.py
+++ b/ludwig/datasets/protein/__init__.py
@@ -18,6 +18,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
@@ -25,6 +26,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="protein")
 class Protein(UncompressedFileDownloadMixin, IdentityProcessMixin, CSVLoadMixin, BaseDataset):
     """Physicochemical Properties of Protein Tertiary Structure Data Set.
 

--- a/ludwig/datasets/registry.py
+++ b/ludwig/datasets/registry.py
@@ -1,0 +1,27 @@
+#! /usr/bin/env python
+# Copyright (c) 2022 Predibase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from ludwig.utils.registry import Registry
+
+dataset_registry = Registry()
+
+
+def register_dataset(name: str):
+    def wrap(cls):
+        dataset_registry[name] = cls
+        return cls
+
+    return wrap

--- a/ludwig/datasets/reuters/__init__.py
+++ b/ludwig/datasets/reuters/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import ZipDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="reuters")
 class Reuters(ZipDownloadMixin, IdentityProcessMixin, CSVLoadMixin, BaseDataset):
     """The Reuters dataset.
 

--- a/ludwig/datasets/rossmann_store_sales/__init__.py
+++ b/ludwig/datasets/rossmann_store_sales/__init__.py
@@ -22,6 +22,7 @@ import pandas as pd
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.fs_utils import makedirs, rename
 
 
@@ -30,6 +31,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="rossmann_store_sales")
 class RossmannStoreSales(CSVLoadMixin, KaggleDownloadMixin, BaseDataset):
     """The Rossmann Store Sales dataset.
 

--- a/ludwig/datasets/santander_customer_satisfaction/__init__.py
+++ b/ludwig/datasets/santander_customer_satisfaction/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="santander_customer_satisfaction")
 class SantanderCustomerSatisfaction(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """Santander Customer Satisfaction Prediction.
 

--- a/ludwig/datasets/santander_customer_transaction/__init__.py
+++ b/ludwig/datasets/santander_customer_transaction/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="santander_customer_transaction")
 class SantanderCustomerTransaction(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """Santander Customer Transaction Prediction.
 

--- a/ludwig/datasets/santander_value_prediction/__init__.py
+++ b/ludwig/datasets/santander_value_prediction/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="santander_value_prediction")
 class SantanderValuePrediction(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """The Santander Value Prediction Challenge dataset.
 

--- a/ludwig/datasets/sarcos/__init__.py
+++ b/ludwig/datasets/sarcos/__init__.py
@@ -22,6 +22,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import BinaryFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.fs_utils import open_file
 
 
@@ -30,6 +31,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
     return dataset.load(split=split)
 
 
+@register_dataset(name="sarcos")
 class Sarcos(BinaryFileDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """The Sarcos dataset.
 

--- a/ludwig/datasets/sst2/__init__.py
+++ b/ludwig/datasets/sst2/__init__.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 from ludwig.datasets.base_dataset import DEFAULT_CACHE_LOCATION
+from ludwig.datasets.registry import register_dataset
 from ludwig.datasets.sst2.sst_utils import SST
 
 
@@ -33,6 +34,7 @@ def load(
     return dataset.load(split=split)
 
 
+@register_dataset(name="sst2")
 class SST2(SST):
     """The SST2 dataset.
 

--- a/ludwig/datasets/sst3/__init__.py
+++ b/ludwig/datasets/sst3/__init__.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 from ludwig.datasets.base_dataset import DEFAULT_CACHE_LOCATION
+from ludwig.datasets.registry import register_dataset
 from ludwig.datasets.sst2 import SST
 
 
@@ -22,6 +23,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, include_subtrees=False, 
     return dataset.load(split=split)
 
 
+@register_dataset(name="sst3")
 class SST3(SST):
     """The SST5 dataset.
 

--- a/ludwig/datasets/sst5/__init__.py
+++ b/ludwig/datasets/sst5/__init__.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 from ludwig.datasets.base_dataset import DEFAULT_CACHE_LOCATION
+from ludwig.datasets.registry import register_dataset
 from ludwig.datasets.sst2 import SST
 
 
@@ -22,6 +23,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, include_subtrees=False, 
     return dataset.load(split=split)
 
 
+@register_dataset(name="sst5")
 class SST5(SST):
     """The SST5 dataset.
 

--- a/ludwig/datasets/synthetic_fraud/__init__.py
+++ b/ludwig/datasets/synthetic_fraud/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="synthetic_fraud")
 class SyntheticFraud(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """The Synthetic Financial Datasets For Fraud Detection dataset.
 

--- a/ludwig/datasets/temperature/__init__.py
+++ b/ludwig/datasets/temperature/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_api_key=None):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="temperature")
 class Temperature(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """Hourly temperature dataset from Kaggle."""
 

--- a/ludwig/datasets/titanic/__init__.py
+++ b/ludwig/datasets/titanic/__init__.py
@@ -20,6 +20,7 @@ import pandas as pd
 from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.fs_utils import makedirs, rename
 
 
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="titanic")
 class Titanic(CSVLoadMixin, KaggleDownloadMixin, BaseDataset):
     """The Titanic dataset.
 

--- a/ludwig/datasets/walmart_recruiting/__init__.py
+++ b/ludwig/datasets/walmart_recruiting/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, kaggle_key=None):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False, kaggle_username=None, ka
     return dataset.load(split=split)
 
 
+@register_dataset(name="walmart_recruiting")
 class WalmartRecruiting(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """The Walmart Recruiting: Trip Type Classification https://www.kaggle.com/c/walmart-recruiting-trip-type-
     classification."""

--- a/ludwig/datasets/wmt15/__init__.py
+++ b/ludwig/datasets/wmt15/__init__.py
@@ -4,6 +4,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.kaggle import KaggleDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 from ludwig.utils.print_utils import print_boxed
 
 
@@ -16,6 +17,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, kaggle_username=None, kaggle_key=None
     return loaded_dataset
 
 
+@register_dataset(name="wmt15")
 class WMT15(CSVLoadMixin, IdentityProcessMixin, KaggleDownloadMixin, BaseDataset):
     """French/English parallel texts for training translation models. Over 22.5 million sentences in French and
     English.

--- a/ludwig/datasets/yahoo_answers/__init__.py
+++ b/ludwig/datasets/yahoo_answers/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import TarDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
     return dataset.load(split=split)
 
 
+@register_dataset(name="yahoo_answers")
 class YahooAnswers(TarDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """
         The Yahoo Answers dataset

--- a/ludwig/datasets/yelp_review_polarity/__init__.py
+++ b/ludwig/datasets/yelp_review_polarity/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import TarDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
     return dataset.load(split=split)
 
 
+@register_dataset(name="yelp_polarity")
 class YelpPolarity(TarDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """
         The Yelp Polarity dataset

--- a/ludwig/datasets/yelp_reviews/__init__.py
+++ b/ludwig/datasets/yelp_reviews/__init__.py
@@ -21,6 +21,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import TarDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import MultifileJoinProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
@@ -28,6 +29,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=True):
     return dataset.load(split=split)
 
 
+@register_dataset(name="yelp_reviews")
 class YelpReviews(TarDownloadMixin, MultifileJoinProcessMixin, CSVLoadMixin, BaseDataset):
     """
         The Yelp Reviews dataset

--- a/ludwig/datasets/yosemite/__init__.py
+++ b/ludwig/datasets/yosemite/__init__.py
@@ -17,6 +17,7 @@ from ludwig.datasets.base_dataset import BaseDataset, DEFAULT_CACHE_LOCATION
 from ludwig.datasets.mixins.download import UncompressedFileDownloadMixin
 from ludwig.datasets.mixins.load import CSVLoadMixin
 from ludwig.datasets.mixins.process import IdentityProcessMixin
+from ludwig.datasets.registry import register_dataset
 
 
 def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
@@ -24,6 +25,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False):
     return dataset.load(split=split)
 
 
+@register_dataset(name="yosemite")
 class Yosemite(UncompressedFileDownloadMixin, IdentityProcessMixin, CSVLoadMixin, BaseDataset):
     """Yosemite temperatures dataset.
 


### PR DESCRIPTION
Adds new commands for interacting with the dataset zoo:

- `ludwig datasets list` -> lists all available datasets to download
- `ludwig datasets describe [dataset]` -> prints class docstring for given dataset
- `ludwig datasets download [dataset] [-- output_dir "."]` -> downloads dataset to output_dir or CWD