### PR TITLE
Address missing batch_size specification if autoML is used for text dataset

### DIFF
--- a/ludwig/automl/defaults/text/bert_config.yaml
+++ b/ludwig/automl/defaults/text/bert_config.yaml
@@ -6,3 +6,6 @@ hyperopt:
       lower: 0.00002
       upper: 0.00005
       space: loguniform
+    training.batch_size:
+      space: choice
+      categories: [8, 16, 32, 64, 128]

--- a/ludwig/datasets/sst2/__init__.py
+++ b/ludwig/datasets/sst2/__init__.py
@@ -22,7 +22,7 @@ def load(cache_dir=DEFAULT_CACHE_LOCATION, split=False,
          include_subtrees=False, convert_parentheses=True, 
          remove_duplicates=False):
     dataset = SST2(cache_dir=cache_dir, include_subtrees=include_subtrees,
-                   convert_parentheses=onvert_parentheses, 
+                   convert_parentheses=convert_parentheses,
                    remove_duplicates=remove_duplicates)
     return dataset.load(split=split)
 


### PR DESCRIPTION
If AutoML is run on a dataset that is characterized as text (currently defined as having 3 or fewer fields),
bert is used as the input encoder and the tabnet config is not used.  The bert config missed specifying
training batch_size, which is expected to be specified, since the AutoML default training batch_size is set to auto.

This change set adds training batch_size to the bert config, with the value range set to reflect bert's high memory use.

This change was validated by running AutoML on the sst2 dataset on tf-legacy.
I can cross-port this change to master and retest there.

Bonus fix: Address typo in sst2 dataset processing.