### PR TITLE
Address issues when AutoML tune_for_memory parameter set true

### DIFF
--- a/ludwig/automl/auto_tune_config.py
+++ b/ludwig/automl/auto_tune_config.py
@@ -92,7 +92,7 @@ def compute_memory_usage(config, training_set_metadata) -> int:
     batch_size = config[TRAINING][BATCH_SIZE]
     for tnsr in model_tensors:
         total_size += tnsr[1].numpy().size * batch_size
-    total_bytes = total_size * 32  # assumes 32-bit precision
+    total_bytes = total_size * 4  # assumes 32-bit precision = 4 bytes
     return total_bytes
 
 
@@ -145,7 +145,7 @@ def memory_tune_config(config, dataset):
             param_space = modified_hyperparam_search_space[param]["space"]
             if param_space == "choice":
                 if len(modified_hyperparam_search_space[param]['categories']) > 2 and \
-                        modified_hyperparam_search_space[param]['categories'][-2] > min_value:
+                        modified_hyperparam_search_space[param]['categories'][-2] >= min_value:
                     modified_hyperparam_search_space[param][
                         'categories'] = modified_hyperparam_search_space[param]['categories'][:-1]
                 else:

--- a/ludwig/automl/auto_tune_config.py
+++ b/ludwig/automl/auto_tune_config.py
@@ -121,12 +121,16 @@ def memory_tune_config(config, dataset):
     training_set_metadata = get_trainingset_metadata(raw_config, dataset)
     modified_hyperparam_search_space = copy.deepcopy(
         raw_config[HYPEROPT]['parameters'])
-    params_to_modify = RANKED_MODIFIABLE_PARAM_LIST[get_model_name(raw_config)]
-    param_list = list(params_to_modify.keys())
     current_param_values = {}
-    max_memory = get_machine_memory()
+    param_list = []
+    model_name = get_model_name(raw_config)
+    if model_name in RANKED_MODIFIABLE_PARAM_LIST:
+        params_to_modify = RANKED_MODIFIABLE_PARAM_LIST[model_name]
+        if len(params_to_modify.keys()) > 0:
+            param_list = list(params_to_modify.keys())
+            max_memory = get_machine_memory()
 
-    while param_list is not None and len(param_list) > 0:
+    while param_list:
         # compute memory utilization
         current_param_values = get_new_params(
             current_param_values, modified_hyperparam_search_space, params_to_modify)

--- a/ludwig/automl/auto_tune_config.py
+++ b/ludwig/automl/auto_tune_config.py
@@ -60,7 +60,7 @@ def get_machine_memory():
         @ray.remote(num_gpus=1)
         def get_remote_gpu():
             gpus = GPUtil.getGPUs()
-            total_mem_mb = gpus[0].memory_total
+            total_mem_mb = gpus[0].memoryTotal
             return total_mem_mb * BYTES_PER_MiB
 
         @ray.remote(num_cpus=1)
@@ -76,7 +76,7 @@ def get_machine_memory():
             machine_mem = ray.get(get_remote_cpu.remote())
     else:  # not using ray cluster
         if GPUtil.getGPUs():
-            machine_mem = GPUtil.getGPUs()[0].memory_total * BYTES_PER_MiB
+            machine_mem = GPUtil.getGPUs()[0].memoryTotal * BYTES_PER_MiB
         else:
             machine_mem = psutil.virtual_memory().total
 
@@ -107,10 +107,11 @@ def sub_new_params(config: dict, new_param_vals: dict):
 
 def get_new_params(current_param_values, hyperparam_search_space, params_to_modify):
     for param, _ in params_to_modify.items():
-        if hyperparam_search_space[param][SPACE] == "choice":
-            current_param_values[param] = hyperparam_search_space[param]['categories'][-1]
-        else:
-            current_param_values[param] = hyperparam_search_space[param]['upper']
+        if param in hyperparam_search_space:
+            if hyperparam_search_space[param][SPACE] == "choice":
+                current_param_values[param] = hyperparam_search_space[param]['categories'][-1]
+            else:
+                current_param_values[param] = hyperparam_search_space[param]['upper']
     return current_param_values
 
 
@@ -125,7 +126,7 @@ def memory_tune_config(config, dataset):
     current_param_values = {}
     max_memory = get_machine_memory()
 
-    while param_list is not None:
+    while param_list is not None and len(param_list) > 0:
         # compute memory utilization
         current_param_values = get_new_params(
             current_param_values, modified_hyperparam_search_space, params_to_modify)


### PR DESCRIPTION
Previous AutoML validation testing has been done with its tune_for_memory parameter set to false.

Running AutoML validation workloads with tune_for_memory set true exposed several
minor but blocking problems that are addressed in this PR.  Will cross-port to master.