### PR TITLE
Use percentage cutoff of distinct values to assign categorical type instead of an arbitrary number of values.

### DIFF
--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -40,7 +40,8 @@ combiner_defaults = {
 
 encoder_defaults = {"text": {"bert": os.path.join(CONFIG_DIR, "text/bert_config.yaml")}}
 
-SMALL_DISTINCT_COUNT = 20
+# The highest percentage of distinct values that we might still assign a CATEGORY type.
+CATEGORY_TYPE_DISTINCT_VALUE_PERCENTAGE_CUTOFF = 0.5
 
 # Set >= SMALL_DISTINCT_COUNT & >= MAX_DISTINCT_BOOL_PERMUTATIONS
 MAX_DISTINCT_VALUES_TO_RETURN = 100
@@ -267,7 +268,7 @@ def get_field_metadata(
     metadata = []
     for idx, field in enumerate(fields):
         missing_value_percent = 1 - float(field.nonnull_values) / row_count
-        dtype = infer_type(field, missing_value_percent)
+        dtype = infer_type(field, missing_value_percent, row_count)
         metadata.append(
             FieldMetadata(
                 name=field.name,
@@ -295,15 +296,13 @@ def get_field_metadata(
     return metadata
 
 
-def infer_type(
-    field: FieldInfo,
-    missing_value_percent: float,
-) -> str:
+def infer_type(field: FieldInfo, missing_value_percent: float, row_count: int) -> str:
     """Perform type inference on field.
 
     # Inputs
     :param field: (FieldInfo) object describing field
     :param missing_value_percent: (float) percent of missing values in the column
+    :param row_count: (int) total number of entries in original dataset
 
     # Return
     :return: (str) feature type
@@ -320,14 +319,12 @@ def infer_type(
     if field.image_values >= 3:
         return IMAGE
 
-    # Use CATEGORY if there are a small number of distinct values if they are either not all numerical or if they
-    # comprise of a perfectly sequential list of integers that suggests the values represent categories.
-    if num_distinct_values < SMALL_DISTINCT_COUNT and (
+    # Use CATEGORY if there are a relatively small number of distinct values if they are either not all numerical or if
+    # they comprise of a perfectly sequential list of integers that suggests the values represent categories.
+    if num_distinct_values < row_count * CATEGORY_TYPE_DISTINCT_VALUE_PERCENTAGE_CUTOFF and (
         (not strings_utils.are_all_numericals(distinct_values))
         or strings_utils.are_sequential_integers(distinct_values)
     ):
-        # TODO (tgaddair): come up with something better than this, maybe attempt to fit to Gaussian
-        # NOTE (ASN): edge case -- there are less than SMALL_DISTINCT_COUNT samples in dataset
         return CATEGORY
 
     # Use numerical if all of the distinct values are numerical.

--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -45,7 +45,7 @@ encoder_defaults = {"text": {"bert": os.path.join(CONFIG_DIR, "text/bert_config.
 CATEGORY_TYPE_DISTINCT_VALUE_PERCENTAGE_CUTOFF = 0.5
 
 # Cap for number of distinct values to return.
-MAX_DISTINCT_VALUES_TO_RETURN = 10000
+MAX_DISTINCT_VALUES_TO_RETURN = 10
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL)
@@ -321,18 +321,13 @@ def infer_type(field: FieldInfo, missing_value_percent: float, row_count: int) -
         return IMAGE
 
     # Use CATEGORY if:
-    # - The number of distinct values is less than absolute cap of number of distinct values to return.
     # - The number of distinct values is significantly less than the total number of examples.
     # - The distinct values are not all numerical.
     # - The distinct values are all numerical but comprise of a perfectly sequential list of integers that suggests the
     #   values represent categories.
-    if (
-        num_distinct_values < MAX_DISTINCT_VALUES_TO_RETURN
-        and num_distinct_values < row_count * CATEGORY_TYPE_DISTINCT_VALUE_PERCENTAGE_CUTOFF
-        and (
-            (not strings_utils.are_all_numericals(distinct_values))
-            or strings_utils.are_sequential_integers(distinct_values)
-        )
+    if num_distinct_values < row_count * CATEGORY_TYPE_DISTINCT_VALUE_PERCENTAGE_CUTOFF and (
+        (not strings_utils.are_all_numericals(distinct_values))
+        or strings_utils.are_sequential_integers(distinct_values)
     ):
         return CATEGORY
 

--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -40,7 +40,8 @@ combiner_defaults = {
 
 encoder_defaults = {"text": {"bert": os.path.join(CONFIG_DIR, "text/bert_config.yaml")}}
 
-# The highest percentage of distinct values that we might still assign a CATEGORY type.
+# For a given feature, the highest percentage of distinct values out of the total number of rows that we might still
+# assign the CATEGORY type.
 CATEGORY_TYPE_DISTINCT_VALUE_PERCENTAGE_CUTOFF = 0.5
 
 # Cap for number of distinct values to return.

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -31,8 +31,6 @@ from ludwig.utils.types import DataFrame
 
 BOOL_TRUE_STRS = {"yes", "y", "true", "t", "1", "1.0"}
 BOOL_FALSE_STRS = {"no", "n", "false", "f", "0", "0.0"}
-# Update the following if BOOL_TRUE_STRS or BOOL_FALSE_STRS changes
-MAX_DISTINCT_BOOL_PERMUTATIONS = 70
 
 # Special symbols.
 STOP_SYMBOL = "<EOS>"

--- a/tests/ludwig/automl/test_base_config.py
+++ b/tests/ludwig/automl/test_base_config.py
@@ -29,7 +29,10 @@ TARGET_NAME = "target"
         # Finite list of strings.
         (2, ["human", "bot"], 0, 0.0, CATEGORY),
         (10, [generate_string(5) for _ in range(10)], 0, 0.0, CATEGORY),
-        # Random strings.
+        (40, [generate_string(5) for _ in range(40)], 0, 0.0, CATEGORY),
+        # Mostly random strings.
+        (90, [generate_string(5) for _ in range(90)], 0, 0.0, TEXT),
+        # All random strings.
         (ROW_COUNT, [generate_string(5) for _ in range(ROW_COUNT)], 0, 0.0, TEXT),
         # Images.
         (ROW_COUNT, [], ROW_COUNT, 0.0, IMAGE),
@@ -43,7 +46,7 @@ def test_infer_type(num_distinct_values, distinct_values, img_values, missing_va
         distinct_values=distinct_values,
         image_values=img_values,
     )
-    assert infer_type(field, missing_vals) == expected
+    assert infer_type(field, missing_vals, ROW_COUNT) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/ludwig/automl/test_base_config.py
+++ b/tests/ludwig/automl/test_base_config.py
@@ -32,6 +32,8 @@ TARGET_NAME = "target"
         (40, [generate_string(5) for _ in range(40)], 0, 0.0, CATEGORY),
         # Mostly random strings.
         (90, [generate_string(5) for _ in range(90)], 0, 0.0, TEXT),
+        # Mostly random strings with capped distinct values.
+        (90, [generate_string(5) for _ in range(10)], 0, 0.0, TEXT),
         # All random strings.
         (ROW_COUNT, [generate_string(5) for _ in range(ROW_COUNT)], 0, 0.0, TEXT),
         # Images.


### PR DESCRIPTION
Verified that this change fixes typing assignment discrepancies for KDD and Mercedes Benz.