### PR TITLE
Update tune_for_memory code

### DIFF
--- a/ludwig/automl/auto_tune_config.py
+++ b/ludwig/automl/auto_tune_config.py
@@ -14,10 +14,11 @@ except ImportError:
     )
 
 from ludwig.api import LudwigModel
-from ludwig.automl.utils import get_available_resources, get_model_name
+from ludwig.automl.utils import get_model_name
 from ludwig.data.preprocessing import preprocess_for_training
 from ludwig.features.feature_registries import update_config_with_metadata
 from ludwig.utils.defaults import merge_with_defaults
+from ludwig.utils.tf_utils import initialize_tensorflow
 from ludwig.constants import COMBINER, HYPEROPT, BATCH_SIZE, TRAINING, TYPE, PREPROCESSING, SPACE
 
 # maps variable search space that can be modified to minimum permissible value for the range
@@ -54,46 +55,21 @@ def get_trainingset_metadata(config, dataset):
     return training_set_metadata
 
 
-def get_machine_memory():
-
-    if ray.is_initialized():  # using ray cluster
-        @ray.remote(num_gpus=1)
-        def get_remote_gpu():
-            gpus = GPUtil.getGPUs()
-            total_mem_mb = gpus[0].memoryTotal
-            return total_mem_mb * BYTES_PER_MiB
-
-        @ray.remote(num_cpus=1)
-        def get_remote_cpu():
-            total_mem = psutil.virtual_memory().total
-            return total_mem
-
-        resources = get_available_resources()  # check if cluster has GPUS
-
-        if resources['gpu'] > 0:
-            machine_mem = ray.get(get_remote_gpu.remote())
-        else:
-            machine_mem = ray.get(get_remote_cpu.remote())
-    else:  # not using ray cluster
-        if GPUtil.getGPUs():
-            machine_mem = GPUtil.getGPUs()[0].memoryTotal * BYTES_PER_MiB
-        else:
-            machine_mem = psutil.virtual_memory().total
-
+# Note: if run in Ray Cluster, this method is run remote with gpu resources requested if available
+def _get_machine_memory():
+    if GPUtil.getGPUs():
+        machine_mem = GPUtil.getGPUs()[0].memoryTotal * BYTES_PER_MiB
+    else:
+        machine_mem = psutil.virtual_memory().total
     return machine_mem
 
 
 def compute_memory_usage(config, training_set_metadata) -> int:
     update_config_with_metadata(config, training_set_metadata)
     lm = LudwigModel.create_model(config)
-    lm.get_connected_model()
-    model_tensors = lm.collect_weights()
-    total_size = 0
+    model_size = lm.get_model_size()
     batch_size = config[TRAINING][BATCH_SIZE]
-    for tnsr in model_tensors:
-        total_size += tnsr[1].numpy().size * batch_size
-    total_bytes = total_size * 4  # assumes 32-bit precision = 4 bytes
-    return total_bytes
+    return model_size * batch_size
 
 
 def sub_new_params(config: dict, new_param_vals: dict):
@@ -115,6 +91,7 @@ def get_new_params(current_param_values, hyperparam_search_space, params_to_modi
     return current_param_values
 
 
+# Note: if run in Ray Cluster, this method is run remote with gpu resources requested if available
 def memory_tune_config(config, dataset):
     fits_in_memory = False
     raw_config = merge_with_defaults(config)
@@ -128,7 +105,8 @@ def memory_tune_config(config, dataset):
         params_to_modify = RANKED_MODIFIABLE_PARAM_LIST[model_name]
         if len(params_to_modify.keys()) > 0:
             param_list = list(params_to_modify.keys())
-            max_memory = get_machine_memory()
+            max_memory = _get_machine_memory()
+            initialize_tensorflow()
 
     while param_list:
         # compute memory utilization

--- a/ludwig/automl/auto_tune_config.py
+++ b/ludwig/automl/auto_tune_config.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 from collections import OrderedDict
 
 import psutil
@@ -21,6 +22,8 @@ from ludwig.utils.defaults import merge_with_defaults
 from ludwig.utils.tf_utils import initialize_tensorflow
 from ludwig.constants import COMBINER, HYPEROPT, BATCH_SIZE, TRAINING, TYPE, PREPROCESSING, SPACE
 
+logger = logging.getLogger(__name__)
+
 # maps variable search space that can be modified to minimum permissible value for the range
 RANKED_MODIFIABLE_PARAM_LIST = {
     'tabnet': OrderedDict({
@@ -41,10 +44,15 @@ RANKED_MODIFIABLE_PARAM_LIST = {
         'combiner.num_layers': 4,
         'combiner.num_fc_layers': 1,
     }),
+    'text': OrderedDict({ # for single input feature text models e.g. bert and its variants
+        'training.batch_size': 8,
+    }),
 }
 
 
 BYTES_PER_MiB = 1048576
+BYTES_PER_WEIGHT = 4  # assumes 32-bit precision = 4 bytes
+BYTES_OPTIMIZER_PER_WEIGHT = 8 # for optimizer m and v vectors
 
 
 def get_trainingset_metadata(config, dataset):
@@ -67,9 +75,9 @@ def _get_machine_memory():
 def compute_memory_usage(config, training_set_metadata) -> int:
     update_config_with_metadata(config, training_set_metadata)
     lm = LudwigModel.create_model(config)
-    model_size = lm.get_model_size()
+    model_size = lm.get_model_size() # number of parameters in model
     batch_size = config[TRAINING][BATCH_SIZE]
-    return model_size * batch_size
+    return model_size * (BYTES_PER_WEIGHT + BYTES_OPTIMIZER_PER_WEIGHT) * batch_size
 
 
 def sub_new_params(config: dict, new_param_vals: dict):
@@ -100,9 +108,13 @@ def memory_tune_config(config, dataset):
         raw_config[HYPEROPT]['parameters'])
     current_param_values = {}
     param_list = []
-    model_name = get_model_name(raw_config)
-    if model_name in RANKED_MODIFIABLE_PARAM_LIST:
-        params_to_modify = RANKED_MODIFIABLE_PARAM_LIST[model_name]
+    if ('input_features' in config and len(config['input_features']) == 1 and
+            'type' in config['input_features'][0] and config['input_features'][0]['type'] == 'text'):
+        model_type = 'text'
+    else:
+        model_type = get_model_name(raw_config)
+    if model_type in RANKED_MODIFIABLE_PARAM_LIST:
+        params_to_modify = RANKED_MODIFIABLE_PARAM_LIST[model_type]
         if len(params_to_modify.keys()) > 0:
             param_list = list(params_to_modify.keys())
             max_memory = _get_machine_memory()
@@ -113,7 +125,9 @@ def memory_tune_config(config, dataset):
         current_param_values = get_new_params(
             current_param_values, modified_hyperparam_search_space, params_to_modify)
         temp_config = sub_new_params(raw_config, current_param_values)
-        if compute_memory_usage(temp_config, training_set_metadata) < max_memory:
+        mem_use = compute_memory_usage(temp_config, training_set_metadata)
+        logger.info('Checking model mem use {} against memory size {}'.format(mem_use, max_memory))
+        if mem_use <= max_memory:
             fits_in_memory = True
             break
         # check if we have exhausted tuning of current param (e.g. we can no longer reduce the param value)
@@ -122,7 +136,7 @@ def memory_tune_config(config, dataset):
         if param in modified_hyperparam_search_space.keys():
             param_space = modified_hyperparam_search_space[param]["space"]
             if param_space == "choice":
-                if len(modified_hyperparam_search_space[param]['categories']) > 2 and \
+                if len(modified_hyperparam_search_space[param]['categories']) >= 2 and \
                         modified_hyperparam_search_space[param]['categories'][-2] >= min_value:
                     modified_hyperparam_search_space[param][
                         'categories'] = modified_hyperparam_search_space[param]['categories'][:-1]

--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -155,7 +155,7 @@ def create_auto_config(
         if ray.is_initialized():
             resources = get_available_resources()  # check if cluster has GPUS
             if resources["gpu"] > 0:
-                model_config, fits_in_memory = ray.get(ray.remote(num_gpus=1,num_cpus=1)(
+                model_config, fits_in_memory = ray.get(ray.remote(num_gpus=1,num_cpus=1,max_calls=1)(
                     memory_tune_config
                 ).remote(model_config, dataset))
             else:

--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -21,7 +21,7 @@ import copy
 from ludwig.api import LudwigModel
 from ludwig.automl.base_config import _create_default_config, DatasetInfo, get_dataset_info, _get_reference_configs, infer_type
 from ludwig.automl.auto_tune_config import memory_tune_config
-from ludwig.automl.utils import _add_transfer_config, _ray_init, get_model_name
+from ludwig.automl.utils import _add_transfer_config, _ray_init, get_available_resources, get_model_name
 from ludwig.constants import COMBINER, TYPE, HYPEROPT, NUMERICAL
 from ludwig.contrib import add_contrib_callback_args
 from ludwig.globals import LUDWIG_VERSION
@@ -153,11 +153,22 @@ def create_auto_config(
     )
     if tune_for_memory:
         if ray.is_initialized():
-            model_config, _ = ray.get(ray.remote(num_cpus=1)(
-                memory_tune_config
-            ).remote(model_config, dataset))
+            resources = get_available_resources()  # check if cluster has GPUS
+            if resources["gpu"] > 0:
+                model_config, fits_in_memory = ray.get(ray.remote(num_gpus=1,num_cpus=1)(
+                    memory_tune_config
+                ).remote(model_config, dataset))
+            else:
+                model_config, fits_in_memory = ray.get(ray.remote(num_cpus=1)(
+                    memory_tune_config
+                ).remote(model_config, dataset))
         else:
-            model_config, _ = memory_tune_config(model_config, dataset)
+            model_config, fits_in_memory = memory_tune_config(model_config, dataset)
+        if not fits_in_memory:
+            warnings.warn(
+                "AutoML with tune_for_memory set True estimates model will not fit in memory. "
+                "Consider setting AutoML user_config to further reduce model memory footprint. "
+            )
     return model_config
 
 

--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -166,8 +166,8 @@ def create_auto_config(
             model_config, fits_in_memory = memory_tune_config(model_config, dataset)
         if not fits_in_memory:
             warnings.warn(
-                "AutoML with tune_for_memory set True estimates model will not fit in memory. "
-                "Consider setting AutoML user_config to further reduce model memory footprint. "
+                "AutoML with tune_for_memory enabled did not return estimation that model will fit in memory. "
+                "If out-of-memory occurs, consider setting AutoML user_config to reduce model memory footprint. "
             )
     return model_config
 

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -91,6 +91,14 @@ class ECD(tf.keras.Model):
         outputs = self.call(inputs)
         return tf.keras.Model(inputs=inputs, outputs=outputs)
 
+    def get_model_size(self) -> int:
+        model_tensors = self.collect_weights()
+        total_size = 0
+        for tnsr in model_tensors:
+            total_size += tnsr[1].numpy().size
+        total_bytes = total_size * 4  # assumes 32-bit precision = 4 bytes
+        return total_bytes
+
     def save_savedmodel(self, save_path):
         keras_model = self.get_connected_model(training=False)
         keras_model.save(save_path)

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -91,13 +91,13 @@ class ECD(tf.keras.Model):
         outputs = self.call(inputs)
         return tf.keras.Model(inputs=inputs, outputs=outputs)
 
+    # Return total number of parameters in model
     def get_model_size(self) -> int:
         model_tensors = self.collect_weights()
         total_size = 0
         for tnsr in model_tensors:
             total_size += tnsr[1].numpy().size
-        total_bytes = total_size * 4  # assumes 32-bit precision = 4 bytes
-        return total_bytes
+        return total_size
 
     def save_savedmodel(self, save_path):
         keras_model = self.get_connected_model(training=False)


### PR DESCRIPTION
Update tune_for_memory code [crossporting to master]:

    Include optimizer memory use per model weight in model memory use estimation.
    Support lower minimum batch size for text models.
    Add logging of estimated model size and machine memory.
    Issue a warning if the model configuration has not been estimated to fit in memory.
    Restructure the code to make the get_model_size functionality a method in the ECD class.
    Simplify memory_tune_config path and allow it to setup gpu options as expected by ludwig.

Details on last item above:
   
    Currently, when tune_for_memory is set True for Ludwig AutoML running against a Ray cluster,
    a Ray remote call to memory_tune_config is invoked with num_cpus=1. That method in turn
    engenders an additional Ray remote call via get_machine_memory, with either num_gpus=1 or
    num_cpus=1, depending on whether the ray cluster resources include gpu or not.
   
    This PR updates this path so that the Ray remote call to memory_tune_config is invoked with
    num_cpus=1, optionally also including num_gpus=1 if ray cluster resources include gpu. This
    not only simplifies this code path, it also provides gpu-visibility across memory_tune_config,
    allowing the gpu initialization code (initialize_tensorflow) to be called to set up the gpus
    as ludwig expects and hence avoid their getting set up with the default gpu configuration,
    which can cause later ludwig gpu setup to fail, with the message "Intra op parallelism cannot
    be modified after initialization." when run across a multi-node ray cluster. 
 
Tested on Ray cluster on various ludwig text datasets.
