### PR TITLE
Do not install pickle5 when using python >= 3.8

### DIFF
--- a/requirements_ray.txt
+++ b/requirements_ray.txt
@@ -1,5 +1,5 @@
 ray[default,tune]>=1.8.0,<1.10
-pickle5
+pickle5; python_version <= '3.7'
 tensorboardX<2.3
 GPUtil
 tblib


### PR DESCRIPTION
See: https://github.com/ray-project/ray/issues/22562