### PR TITLE
Tune train path for items observed using py-spy wrt text AutoML (Bert) on dbpedia

### DIFF
--- a/ludwig/automl/defaults/text/bert_config.yaml
+++ b/ludwig/automl/defaults/text/bert_config.yaml
@@ -2,10 +2,8 @@ hyperopt:
   # goal: maximize
   parameters:
     trainer.learning_rate:
-      type: float
-      lower: 0.00002
-      upper: 0.00005
-      space: loguniform
+      space: choice
+      categories: [0.00002, 0.00003, 0.00005]
     trainer.batch_size:
       space: choice
       categories: [8, 16, 32, 64, 128]

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -211,7 +211,7 @@ class ECD(LudwigModule):
             train_loss += loss
 
         # Add regularization loss
-        if regularization_type is not None:
+        if regularization_type is not None and regularization_lambda != 0:
             train_loss += reg_loss(self, regularization_type, l1=regularization_lambda, l2=regularization_lambda)
 
         return train_loss, of_train_losses

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -302,7 +302,7 @@ class Trainer(BaseTrainer):
         Returns:
             A tuple of the loss and a dictionary of metrics.
         """
-        self.optimizer.zero_grad()
+        self.optimizer.zero_grad(set_to_none=True)
 
         # Obtain model predictions and loss
         model_outputs = self.model((inputs, targets))

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -302,7 +302,7 @@ class Trainer(BaseTrainer):
         Returns:
             A tuple of the loss and a dictionary of metrics.
         """
-        self.optimizer.zero_grad(set_to_none=True)
+        self.optimizer.zero_grad()
 
         # Obtain model predictions and loss
         model_outputs = self.model((inputs, targets))

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -302,7 +302,10 @@ class Trainer(BaseTrainer):
         Returns:
             A tuple of the loss and a dictionary of metrics.
         """
-        self.optimizer.zero_grad()
+
+        # Change to self.optimizer.zero_grad(set_to_none=True) once all ludwig platform on pytorch 1.7 or greater
+        for param in self.model.parameters():
+            param.grad = None
 
         # Obtain model predictions and loss
         model_outputs = self.model((inputs, targets))

--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -113,14 +113,15 @@ def reg_loss(model: nn.Module, regularizer: str, l1: float = 0.01, l2: float = 0
         Regularization loss for the model (float).
     """
 
-    l1_reg = l1 * sum(torch.abs(p).sum() for p in model.parameters())
-    l2_reg = l2 * sum(torch.square(p).sum() for p in model.parameters())
-
     if regularizer == "l1":
+        l1_reg = l1 * sum(torch.abs(p).sum() for p in model.parameters())
         return l1_reg
     if regularizer == "l2":
+        l2_reg = l2 * sum(torch.square(p).sum() for p in model.parameters())
         return l2_reg
     if regularizer == "l1_l2":
+        l1_reg = l1 * sum(torch.abs(p).sum() for p in model.parameters())
+        l2_reg = l2 * sum(torch.square(p).sum() for p in model.parameters())
         return l1_reg + l2_reg
 
 


### PR DESCRIPTION
Items observed using py-spy for text AutoML (Bert) on dbpedia:

1) In reg_loss() in the current code, l1_reg and l2_reg are unconditionally computed, but both
    may not be used; it depends on the regularizer value (which is l2 by default).  The time to
    loop through the bert model parameters was non-trivial according to py-spy.  Updated the
    code to compute only the l1_reg and l2_reg values that will be consumed.
    
2) Additionally in reg_loss(), if 0 is passed in for lX, and the associated lX_reg value is to be computed,
    py-spy shows that the loop through the model parameters was still executed, which is uninteresting
    since the result is multiplied by 0, and regularization_lambda is 0 by default.  Updated the call site
    in train_loss to avoid calling reg_loss when regularization_lambda is 0.

3) Use set_to_none functionality for zero_grad, which py-spy had showed as taking non-trivial time,
    and can have good secondary effects as well (cited in pytorch tuning guide).  Note that I updated
    this PR to use the lower-level expression of this, because github testing showed failures otherwise.

With these changes (and limiting max_sequence_length), a dbpedia epoch actually completed in 2
hours (first time I have seen any dbpedia epoch complete), with good accuracy.

Bonus cleanup: specify learning rate as simple choice categories that match the values recommended
on the Google bert github page.
