### PR TITLE
Additional tuning for Text AutoML using Bert

### DIFF
--- a/ludwig/automl/auto_tune_config.py
+++ b/ludwig/automl/auto_tune_config.py
@@ -44,7 +44,7 @@ RANKED_MODIFIABLE_PARAM_LIST = {
     ),
     "text": OrderedDict(  # for single input feature text models e.g. bert and its variants
         {
-            "trainer.batch_size": 8,
+            "trainer.batch_size": 16,
         }
     ),
 }
@@ -119,7 +119,7 @@ def memory_tune_config(config, dataset):
         current_param_values = get_new_params(current_param_values, modified_hyperparam_search_space, params_to_modify)
         temp_config = sub_new_params(raw_config, current_param_values)
         mem_use = compute_memory_usage(temp_config, training_set_metadata)
-        logging.info(f"Checking model mem use {mem_use} against memory size {max_memory}")
+        logging.info(f"Checking model estimated mem use {mem_use} against memory size {max_memory}")
         if mem_use <= max_memory:
             fits_in_memory = True
             break

--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -278,6 +278,7 @@ def _train(
         model_name=model_name,
         random_seed=random_seed,
         backend="local",
+        skip_save_log=True, # avoid per-step log overhead by default
         **kwargs,
     )
     return hyperopt_results

--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -278,7 +278,7 @@ def _train(
         model_name=model_name,
         random_seed=random_seed,
         backend="local",
-        skip_save_log=True, # avoid per-step log overhead by default
+        skip_save_log=True,  # avoid per-step log overhead by default
         **kwargs,
     )
     return hyperopt_results

--- a/ludwig/automl/defaults/text/bert_config.yaml
+++ b/ludwig/automl/defaults/text/bert_config.yaml
@@ -1,9 +1,14 @@
+trainer:
+  learning_rate_warmup_epochs: 0
+  optimizer:
+    type: adamw
+
 hyperopt:
   # goal: maximize
   parameters:
     trainer.learning_rate:
       space: choice
-      categories: [0.00002, 0.00003, 0.00005]
+      categories: [0.00002, 0.00003]
     trainer.batch_size:
       space: choice
-      categories: [8, 16, 32, 64, 128]
+      categories: [16, 32, 64]

--- a/ludwig/modules/optimization_modules.py
+++ b/ludwig/modules/optimization_modules.py
@@ -25,6 +25,7 @@ optimizers_registry = {
     "gd": torch.optim.SGD,
     "gradient_descent": torch.optim.SGD,
     "adam": torch.optim.Adam,
+    "adamw": torch.optim.AdamW,
     "adadelta": torch.optim.Adadelta,
     "adagrad": torch.optim.Adagrad,
     "adamax": torch.optim.Adamax,

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -103,6 +103,10 @@ default_optimizer_params_registry = {
         # 'epsilon': 1e-08
         "eps": 1e-08,
     },
+    "adamw": {
+        "betas": (0.9, 0.999),
+        "eps": 1e-08,
+    },
     "adadelta": {
         "rho": 0.95,
         "eps": 1e-08


### PR DESCRIPTION
Additional tuning for Text AutoML using Bert:
- Reduce Text AutoML batch size range, based on results from recent runs and from the LBT paper.
- Set skip_save_log to True for AutoML, given its non-trivial per-step overhead reported by py-spy.
- Add AdamW to Ludwig.  Set Text AutoML default optimizer to AdamW, often used to fine-tune Bert, with citations to https://arxiv.org/abs/1711.05101.

Tested on 2 hour Text AutoML runs of sst2, sst3, sst5, agnews, dbpedia.