### PR TITLE
Fixed issues with mlflow when training on remote workers

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -490,13 +490,6 @@ class LudwigModel:
                 callbacks=train_callbacks,
                 random_seed=random_seed,
             ) as trainer:
-                for callback in self.callbacks:
-                    callback.on_train_start(
-                        model=self.model,
-                        config=self.config,
-                        config_fp=self.config_fp,
-                    )
-
                 # auto tune batch size
                 if self.config[TRAINER][BATCH_SIZE] == AUTO or self.config[TRAINER][EVAL_BATCH_SIZE] == AUTO:
                     # TODO (ASN): add support for substitute_with_max parameter
@@ -523,6 +516,13 @@ class LudwigModel:
                     print_boxed("TRAINING")
                     if not skip_save_model:
                         self.save_config(model_dir)
+
+                for callback in self.callbacks:
+                    callback.on_train_start(
+                        model=self.model,
+                        config=self.config,
+                        config_fp=self.config_fp,
+                    )
 
                 try:
                     train_stats = trainer.train(

--- a/ludwig/callbacks.py
+++ b/ludwig/callbacks.py
@@ -79,11 +79,11 @@ class Callback(ABC):
     def on_train_end(self, output_directory):
         pass
 
-    def on_trainer_train_setup(self, trainer, save_path):
+    def on_trainer_train_setup(self, trainer, save_path, is_coordinator):
         """Called in EVERY trainer (rank) before training starts."""
         pass
 
-    def on_trainer_train_teardown(self, trainer, progress_tracker):
+    def on_trainer_train_teardown(self, trainer, progress_tracker, is_coordinator):
         """Called in EVERY trainer (rank) after training completes."""
         pass
 

--- a/ludwig/contribs/mlflow/model.py
+++ b/ludwig/contribs/mlflow/model.py
@@ -294,7 +294,7 @@ def log_saved_model(lpath):
 
 
 class _CopyModel:
-    """Get model data with requiring us to read the model weights into memory."""
+    """Get model data without requiring us to read the model weights into memory."""
 
     def __init__(self, lpath):
         self.lpath = lpath

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -487,7 +487,7 @@ class RayTuneExecutor(HyperoptExecutor):
                 # sync client has to be recreated to avoid issues with serialization
                 return tune_executor._get_sync_client_and_remote_checkpoint_dir(trial_dir)
 
-            def on_trainer_train_setup(self, trainer, save_path):
+            def on_trainer_train_setup(self, trainer, save_path, is_coordinator):
                 if is_using_ray_backend and checkpoint_dir and trial_location != ray.util.get_node_ip_address():
                     save_path = Path(save_path)
 

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -9,7 +9,7 @@ from mlflow.tracking import MlflowClient
 from ludwig.api import LudwigModel
 from ludwig.constants import TRAINER
 from ludwig.contribs import MlflowCallback
-from tests.integration_tests.utils import category_feature, generate_data, sequence_feature
+from tests.integration_tests.utils import category_feature, FakeRemoteBackend, generate_data, sequence_feature
 
 
 def test_mlflow_callback(tmpdir):
@@ -40,7 +40,7 @@ def test_mlflow_callback(tmpdir):
     exp_name = "mlflow_test"
     callback = MlflowCallback()
 
-    model = LudwigModel(config, callbacks=[callback])
+    model = LudwigModel(config, callbacks=[callback], backend=FakeRemoteBackend())
     model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv, experiment_name=exp_name)
     expected_df, _ = model.predict(test_csv)
 

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -35,6 +35,7 @@ from ludwig.constants import COLUMN, NAME, PROC_COLUMN, TRAINER, VECTOR
 from ludwig.data.dataset_synthesizer import build_synthetic_dataset, DATETIME_FORMATS
 from ludwig.experiment import experiment_cli
 from ludwig.features.feature_utils import compute_feature_hash
+from ludwig.models.trainer import Trainer
 from ludwig.utils.data_utils import read_csv, replace_file_extension
 
 logger = logging.getLogger(__name__)
@@ -70,6 +71,22 @@ class LocalTestBackend(LocalBackend):
     @property
     def supports_multiprocessing(self):
         return False
+
+
+# Simulates running training on a separate node from the driver process
+class FakeRemoteBackend(LocalBackend):
+    def create_trainer(self, **kwargs):
+        return FakeRemoteTrainer(**kwargs)
+
+    @property
+    def supports_multiprocessing(self):
+        return False
+
+
+class FakeRemoteTrainer(Trainer):
+    def train(self, *args, save_path="model", **kwargs):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            return super().train(*args, save_path=tmpdir, **kwargs)
 
 
 def parse_flag_from_env(key, default=False):


### PR DESCRIPTION
Because the driver process and workers may not share a common filesystem, some files that were assumed to be available to both were missing. These changes make it so the appropriate files are either recreated or used in the context in which they are available.