### PR TITLE
Pin Ray GPU docker image to include GPU fix

### DIFF
--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM rayproject/ray:1.11.0-py37-cu111
+FROM rayproject/ray:06d444-py37-cu111
 
 RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y \
     build-essential \

--- a/requirements_ray.txt
+++ b/requirements_ray.txt
@@ -1,4 +1,4 @@
-ray[default,tune]>=1.8.0,!=1.10
+ray[default,data,serve,tune]>=1.8.0,!=1.10
 pickle5; python_version <= '3.7'
 tensorboardX<2.3
 GPUtil


### PR DESCRIPTION
Uses commit SHA corresponding to this commit: https://github.com/ray-project/ray/pull/22482

This is because 1.11 did not include this essential fix for GPU training with PyTorch, so we will pin to this version until 1.12.