### PR TITLE
Fix handling of binary columns to always be interpreted as bool during batching

### DIFF
--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -237,6 +237,9 @@ class RayDatasetBatcher(Batcher):
                 # do not convert scalar columns: https://github.com/ray-project/ray/issues/20825
                 if features[c][TYPE] not in _SCALAR_TYPES:
                     df[c] = df[c].astype(TensorDtype())
+                elif features[c][TYPE] == BINARY:
+                    # TODO(travis): figure out why Ray is converting these into object types by default
+                    df[c] = df[c].astype(np.bool_)
             return df
 
         return to_tensors

--- a/ludwig/data/dataset_synthesizer.py
+++ b/ludwig/data/dataset_synthesizer.py
@@ -206,8 +206,9 @@ def generate_number(feature):
 
 
 def generate_binary(feature):
+    choices = feature.get("bool2str", [False, True])
     p = feature["prob"] if "prob" in feature else 0.5
-    return np.random.choice([True, False], p=[p, 1 - p])
+    return np.random.choice(choices, p=[1 - p, p])
 
 
 def generate_sequence(feature):

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -239,6 +239,9 @@ class DataFramePreprocessor(DataFormatPreprocessor):
 
     @staticmethod
     def preprocess_for_prediction(dataset, features, preprocessing_params, training_set_metadata, backend, callbacks):
+        if isinstance(dataset, pd.DataFrame):
+            dataset = backend.df_engine.from_pandas(dataset)
+
         dataset, training_set_metadata = build_dataset(
             dataset,
             features,

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -181,7 +181,7 @@ class BinaryFeatureMixin(BaseFeatureMixin):
         proc_df: Dict[str, DataFrame],
         metadata: Dict[str, Any],
         preprocessing_parameters: Dict[str, Any],
-        backend,  # Union[Backend, str]
+        backend,
         skip_save_processed_input: bool,
     ) -> None:
         column = input_df[feature_config[COLUMN]]
@@ -189,10 +189,10 @@ class BinaryFeatureMixin(BaseFeatureMixin):
         if column.dtype == object:
             metadata = metadata[feature_config[NAME]]
             if "str2bool" in metadata:
-                column = column.map(lambda x: metadata["str2bool"][str(x)])
+                column = backend.df_engine.map_objects(column, lambda x: metadata["str2bool"][str(x)])
             else:
                 # No predefined mapping from string to bool, so compute it directly
-                column = column.map(strings_utils.str2bool)
+                column = backend.df_engine.map_objects(column, strings_utils.str2bool)
 
         proc_df[feature_config[PROC_COLUMN]] = column.astype(np.bool_)
         return proc_df

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -191,6 +191,7 @@ def test_ray_tabular(df_engine):
         date_feature(),
     ]
     output_features = [
+        binary_feature(bool2str=["No", "Yes"]),
         binary_feature(),
         number_feature(normalization="zscore"),
     ]


### PR DESCRIPTION
This is a temp workaround for some strange behavior we're seeing with the latest unreleased version of Ray Datasets.