### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,12 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         test-markers: ["not distributed", "distributed"]
         include:
-          - python-version: 3.6
-            pytorch-version: 1.10.2
-            torchscript-version: 1.10.2
           - python-version: 3.7
             pytorch-version: 1.10.2
             torchscript-version: 1.10.2

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     license="Apache 2.0",
     keywords="ludwig deep learning deep_learning machine machine_learning natural language processing computer vision",
     packages=find_packages(exclude=["contrib", "docs", "tests"]),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     include_package_data=True,
     package_data={"ludwig": ["etc/*", "examples/*.py"]},
     install_requires=requirements,


### PR DESCRIPTION
Python 3.6 has reached EOL. As discussed during the community meeting, we'll be dropping Python 3.6 from the v0.5 release on.