### PR TITLE
Extending os.matrix to support `windows-latest`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9]
         test-markers: ["not distributed", "distributed"]
         include:
@@ -92,6 +92,7 @@ jobs:
         shell: bash
 
       - name: Install Neuropod backend
+        if: runner.os == 'linux'
         run: |
           sudo mkdir -p "$NEUROPOD_BASE_DIR"
           curl -L https://github.com/uber/neuropod/releases/download/v${{ env.NEUROPOD_VERISON }}/libneuropod-cpu-linux-v${{ env.NEUROPOD_VERISON }}-torchscript-${{ env.TORCHSCRIPT_VERISON }}-backend.tar.gz | sudo tar -xz -C "$NEUROPOD_BASE_DIR"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install dependencies
         env:
-          HOROVOD_WITH_PYTORCH: 1
+          HOROVOD_WITHOUT_PYTORCH: 1
           HOROVOD_WITHOUT_MPI: 1
           HOROVOD_WITHOUT_TENSORFLOW: 1
           HOROVOD_WITHOUT_MXNET: 1
@@ -99,6 +99,7 @@ jobs:
         shell: bash
 
       - name: Reinstall Horovod if necessary
+        if: runner.os == 'linux'
         env:
           HOROVOD_WITH_PYTORCH: 1
           HOROVOD_WITHOUT_MPI: 1


### PR DESCRIPTION
The github action for pytest currently only runs on linux os which may be failing to catch errors in the windows environment as related to git issue #1802.  This PR is created to surface any such errors, and also to identifier libraries of dependencies that may not be fully functional in non-linux environments.

The neuropod library is excluded as it is not supported, and tests are [skipped](https://github.com/ludwig-ai/ludwig/blob/master/tests/integration_tests/test_neuropod.py#L37) for windows.