### PR TITLE
Fix callbacks integration test by mocking should_early_stop callbacks.

### DIFF
--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -423,6 +423,7 @@ def test_api_skip_parameters_evaluate(
 
 def test_api_callbacks(csv_filename):
     mock_callback = mock.Mock()
+    mock_callback.should_early_stop.return_value = False
 
     epochs = 2
     batch_size = 8
@@ -450,6 +451,8 @@ def test_api_callbacks(csv_filename):
 
     assert mock_callback.on_epoch_start.call_count == epochs
     assert mock_callback.on_epoch_end.call_count == epochs
+
+    assert mock_callback.should_early_stop.call_count == epochs
 
     assert mock_callback.on_validation_start.call_count == epochs
     assert mock_callback.on_validation_end.call_count == epochs


### PR DESCRIPTION
`mock.should_early_stop()` evaluates to `True` in the early stopping callback checks in the trainer.

```
for callback in self.callbacks:
    if callback.should_early_stop(self, progress_tracker, self.is_coordinator()):
        early_stop_bool = True
        break
```