### PR TITLE
fix: Updated fs_utils to get valid windows path from url

### DIFF
--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -18,6 +18,7 @@ import contextlib
 import os
 import pathlib
 import tempfile
+from urllib.parse import unquote, urlparse
 
 import fsspec
 import h5py
@@ -27,6 +28,10 @@ from fsspec.core import split_protocol
 
 def get_fs_and_path(url):
     protocol, path = split_protocol(url)
+    # Parse the url to get only the escaped url path
+    path = unquote(urlparse(path).path)
+    # Create a windows compatible path from url path
+    path = os.fspath(pathlib.PurePosixPath(path))
     fs = fsspec.filesystem(protocol)
     return fs, path
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 markers =
     distributed: mark a test as a distributed test.
+    filesystem: mark to test operating system systems.
     slow: mark test as slow.

--- a/tests/ludwig/utils/test_fs_utils.py
+++ b/tests/ludwig/utils/test_fs_utils.py
@@ -1,17 +1,3 @@
-# Copyright (c) 2019 Uber Technologies, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==============================================================================
 import logging
 import os
 import platform

--- a/tests/ludwig/utils/test_fs_utils.py
+++ b/tests/ludwig/utils/test_fs_utils.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2019 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import os
+import tempfile
+
+from ludwig.utils.fs_utils import get_fs_and_path
+
+
+def assert_and_create_file(url, expected_path):
+    _, path = get_fs_and_path(url)
+    assert path == expected_path, f"Expected path {expected_path}"
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, path)
+            os.makedirs(os.path.dirname(file_path))
+            with open(file_path, "w"):
+                assert True
+    except OSError as exc:
+        # OSError if file exists or is invalid
+        assert False, f"OS exception {exc}"
+
+
+def test_get_fs_and_path_simple():
+    assert_and_create_file("http://a/b.jpg", os.path.join("a", "b.jpg"))
+
+
+def test_get_fs_and_path_query_string():
+    assert_and_create_file("http://a/b.jpg?c=d", os.path.join("a", "b.jpg"))
+
+
+def test_get_fs_and_path_decode():
+    assert_and_create_file("http://a//b%20c.jpg", os.path.join("a", "b c.jpg"))
+
+
+def test_get_fs_and_path_unicode():
+    assert_and_create_file("http://a/æ.jpg", "a/æ.jpg")


### PR DESCRIPTION
Resolves #1802 which was having an issue writing to a windows file path after calling `get_fs_and_path`

```
File I:\Anaconda\envs\ludwig5\lib\site-packages\ludwig\utils\fs_utils.py:133, in open_file(url, *args, **kwargs)
    [130](file:///i%3A/Anaconda/envs/ludwig5/lib/site-packages/ludwig/utils/fs_utils.py?line=129) @contextlib.contextmanager
    [131](file:///i%3A/Anaconda/envs/ludwig5/lib/site-packages/ludwig/utils/fs_utils.py?line=130) def open_file(url, *args, **kwargs):
    [132](file:///i%3A/Anaconda/envs/ludwig5/lib/site-packages/ludwig/utils/fs_utils.py?line=131)     fs, path = get_fs_and_path(url)
--> [133](file:///i%3A/Anaconda/envs/ludwig5/lib/site-packages/ludwig/utils/fs_utils.py?line=132)     with fs.open(path, *args, **kwargs) as f:
    [134](file:///i%3A/Anaconda/envs/ludwig5/lib/site-packages/ludwig/utils/fs_utils.py?line=133)         yield f
```

The `fs_utils.get_fs_and_path` method that calls `fsspec.split_protocol` which does to support conversion to windows paths [windows paths](https://github.com/fsspec/filesystem_spec/blob/master/fsspec/core.py#L518).

Updated this method to parse the url path, and decode any url escaping before using [pathlib.PurePosixPath](https://docs.python.org/3/library/pathlib.html) to convert the url into relative os path.