### PR TITLE
Add callbacks for on_eval_start and on_eval_end

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -364,7 +364,7 @@ class LudwigModel:
             train_callbacks = self.callbacks
             if upload_fn is not None:
                 # Upload output files (checkpoints, etc.) to remote storage at the end of
-                # each epoch, in case of failure in the middle of training.
+                # each epoch and evaluation, in case of failure in the middle of training.
                 class UploadOnEpochEndCallback(Callback):
                     def on_eval_end(self, trainer, progress_tracker, save_path):
                         upload_fn()

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -366,6 +366,9 @@ class LudwigModel:
                 # Upload output files (checkpoints, etc.) to remote storage at the end of
                 # each epoch, in case of failure in the middle of training.
                 class UploadOnEpochEndCallback(Callback):
+                    def on_eval_end(self, trainer, progress_tracker, save_path):
+                        upload_fn()
+
                     def on_epoch_end(self, trainer, progress_tracker, save_path):
                         upload_fn()
 

--- a/ludwig/callbacks.py
+++ b/ludwig/callbacks.py
@@ -191,6 +191,28 @@ class Callback(ABC):
         """
         pass
 
+    def on_eval_start(self, trainer, progress_tracker, save_path: str):
+        """Called on coordinator at the start of evaluation.
+
+        :param trainer: The trainer instance.
+        :type trainer: ludwig.models.trainer.Trainer
+        :param progress_tracker: An object which tracks training progress.
+        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :param save_path: The path to the directory model is saved in.
+        """
+        pass
+
+    def on_eval_end(self, trainer, progress_tracker, save_path: str):
+        """Called on coordinator at the end of evaluation.
+
+        :param trainer: The trainer instance.
+        :type trainer: ludwig.models.trainer.Trainer
+        :param progress_tracker: An object which tracks training progress.
+        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :param save_path: The path to the directory model is saved in.
+        """
+        pass
+
     def on_epoch_start(self, trainer, progress_tracker, save_path: str):
         """Called on coordinator only before the start of each epoch.
 

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -81,6 +81,11 @@ class MlflowCallback(Callback):
         if not os.path.exists(model_hyperparameters_path):
             save_json(model_hyperparameters_path, self.config)
 
+    def on_eval_end(self, trainer, progress_tracker, save_path):
+        mlflow.log_metrics(progress_tracker.log_metrics(), step=progress_tracker.steps)
+
+        _log_model(save_path)
+
     def on_epoch_end(self, trainer, progress_tracker, save_path):
         mlflow.log_metrics(progress_tracker.log_metrics(), step=progress_tracker.steps)
 

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -870,7 +870,8 @@ class Trainer(BaseTrainer):
                 self.model.train()  # Sets model to training mode.
                 self.model.reset_metrics()
 
-                self.callback(lambda c: c.on_epoch_start(self, progress_tracker, save_path))
+                if self.is_coordinator():
+                    self.callback(lambda c: c.on_epoch_start(self, progress_tracker, save_path))
 
                 # Trains over a full epoch of data.
                 should_break = self._train_loop(
@@ -894,6 +895,7 @@ class Trainer(BaseTrainer):
 
                 # ================ Post Training Epoch ================
                 progress_tracker.epoch += 1
+
                 if self.is_coordinator():
                     self.callback(lambda c: c.on_epoch_end(self, progress_tracker, save_path))
 

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -422,12 +422,16 @@ def test_api_skip_parameters_evaluate(
         )
 
 
-def test_api_callbacks(csv_filename):
+@pytest.mark.parametrize("epochs", [1, 2])
+@pytest.mark.parametrize("batch_size", [4, 8])
+@pytest.mark.parametrize("num_examples", [16, 32])
+@pytest.mark.parametrize("steps_per_checkpoint", [1, 2])
+def test_api_callbacks(csv_filename, epochs, batch_size, num_examples, steps_per_checkpoint):
     mock_callback = mock.Mock(wraps=Callback())
 
-    epochs = 2
-    batch_size = 8
-    num_examples = 32
+    steps_per_epoch = num_examples / batch_size
+    total_checkpoints = (steps_per_epoch / steps_per_checkpoint) * epochs
+    total_batches = epochs * (num_examples / batch_size)
 
     with tempfile.TemporaryDirectory() as output_dir:
         input_features = [sequence_feature(reduce_output="sum")]
@@ -437,7 +441,7 @@ def test_api_callbacks(csv_filename):
             "input_features": input_features,
             "output_features": output_features,
             "combiner": {"type": "concat", "output_size": 14},
-            TRAINER: {"epochs": epochs, "batch_size": batch_size},
+            TRAINER: {"epochs": epochs, "batch_size": batch_size, "steps_per_checkpoint": steps_per_checkpoint},
         }
         model = LudwigModel(config, callbacks=[mock_callback])
 
@@ -452,13 +456,16 @@ def test_api_callbacks(csv_filename):
     assert mock_callback.on_epoch_start.call_count == epochs
     assert mock_callback.on_epoch_end.call_count == epochs
 
-    assert mock_callback.should_early_stop.call_count == epochs
+    assert mock_callback.should_early_stop.call_count == total_checkpoints
 
-    assert mock_callback.on_validation_start.call_count == epochs
-    assert mock_callback.on_validation_end.call_count == epochs
+    assert mock_callback.on_validation_start.call_count == total_checkpoints
+    assert mock_callback.on_validation_end.call_count == total_checkpoints
 
-    assert mock_callback.on_test_start.call_count == epochs
-    assert mock_callback.on_test_end.call_count == epochs
+    assert mock_callback.on_test_start.call_count == total_checkpoints
+    assert mock_callback.on_test_end.call_count == total_checkpoints
 
-    assert mock_callback.on_batch_start.call_count == epochs * (num_examples / batch_size)
-    assert mock_callback.on_batch_end.call_count == epochs * (num_examples / batch_size)
+    assert mock_callback.on_batch_start.call_count == total_batches
+    assert mock_callback.on_batch_end.call_count == total_batches
+
+    assert mock_callback.on_eval_end.call_count == total_checkpoints
+    assert mock_callback.on_eval_start.call_count == total_checkpoints


### PR DESCRIPTION
- Add callbacks for on_eval_start and on_eval_end.
- Parameterize callback unit tests to cover step-based training.
- Copy existing `on_epoch_end` callbacks to `on_eval_end` callbacks.