### PR TITLE
Fix python 3 compatibility issues

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import collections
+import collections.abc
 import csv
 import functools
 import json
@@ -209,7 +209,7 @@ def save_csv(data_fp, data):
     with open_file(data_fp, "w", encoding="utf-8") as csv_file:
         writer = csv.writer(csv_file)
         for row in data:
-            if not isinstance(row, collections.Iterable) or isinstance(row, str):
+            if not isinstance(row, collections.abc.Iterable) or isinstance(row, str):
                 row = [row]
             writer.writerow(row)
 
@@ -265,7 +265,7 @@ def flatten_dict(d, parent_key="", sep="."):
     for k, v in d.items():
         new_key = parent_key + sep + k if parent_key else k
 
-        if isinstance(v, collections.MutableMapping):
+        if isinstance(v, collections.abc.MutableMapping):
             items.extend(flatten_dict(v, new_key, sep=sep).items())
         elif isinstance(v, list):
             list_mapping = {str(i): item for i, item in enumerate(v)}

--- a/ludwig/utils/time_utils.py
+++ b/ludwig/utils/time_utils.py
@@ -26,14 +26,14 @@ class WithTimer:
         self.quiet = quiet
 
     def elapsed(self):
-        return time.time() - self.wall, time.clock() - self.proc
+        return time.time() - self.wall, time.process_time() - self.proc
 
     def enter(self):
         """Manually trigger enter."""
         self.__enter__()
 
     def __enter__(self):
-        self.proc = time.clock()
+        self.proc = time.process_time()
         self.wall = time.time()
         return self
 
@@ -48,7 +48,7 @@ class Timer:
         self.reset()
 
     def reset(self):
-        self._proc = time.clock()
+        self._proc = time.process_time()
         self._wall = time.time()
 
     def elapsed(self):
@@ -61,7 +61,7 @@ class Timer:
         return time.time() - self._wall
 
     def proc(self):
-        return time.clock() - self._proc
+        return time.process_time() - self._proc
 
     def tic(self):
         """Like Matlab tic/toc for wall time and processor time."""


### PR DESCRIPTION
# Code Pull Requests

* `time.clock` was removed in https://github.com/python/cpython/pull/13270.
* Import ABC from `collections` was deprecated and removed in Python 3.10. Use `collections.abc` .