### PR TITLE
Added annotations to spread Dask data loading across Ray workers

### DIFF
--- a/ludwig/data/dataframe/dask.py
+++ b/ludwig/data/dataframe/dask.py
@@ -59,7 +59,9 @@ class DaskEngine(DataFrameEngine):
         return data
 
     def persist(self, data):
-        return data.persist() if self._persist else data
+        # No graph optimizations to prevent dropping custom annotations
+        # https://github.com/dask/dask/issues/7036
+        return data.persist(optimize_graph=False) if self._persist else data
 
     def concat(self, dfs):
         return self.df_lib.multi.concat(dfs)

--- a/ludwig/features/number_feature.py
+++ b/ludwig/features/number_feature.py
@@ -270,7 +270,7 @@ class NumberFeatureMixin(BaseFeatureMixin):
     ):
         def normalize(series: pd.Series) -> pd.Series:
             numeric_transformer = get_transformer(metadata[feature_config[NAME]], preprocessing_parameters)
-            series.update(numeric_transformer.transform(series.values))
+            series.copy().update(numeric_transformer.transform(series.values))
             return series
 
         input_series = input_df[feature_config[COLUMN]].astype(np.float32)

--- a/ludwig/features/number_feature.py
+++ b/ludwig/features/number_feature.py
@@ -269,8 +269,9 @@ class NumberFeatureMixin(BaseFeatureMixin):
         skip_save_processed_input,
     ):
         def normalize(series: pd.Series) -> pd.Series:
+            series = series.copy()
             numeric_transformer = get_transformer(metadata[feature_config[NAME]], preprocessing_parameters)
-            series.copy().update(numeric_transformer.transform(series.values))
+            series.update(numeric_transformer.transform(series.values))
             return series
 
         input_series = input_df[feature_config[COLUMN]].astype(np.float32)

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -35,6 +35,7 @@ from ludwig.utils.fs_utils import download_h5, open_file, upload_h5
 from ludwig.utils.misc_utils import get_from_registry
 
 try:
+    import dask
     import dask.dataframe as dd
 
     DASK_DF_FORMATS = {dd.core.DataFrame}
@@ -107,6 +108,19 @@ def load_csv(data_fp):
     return data
 
 
+# Decorator used to encourage Dask on Ray to spread out data loading across workers
+def spread(fn):
+    def wrapped_fn(*args, **kwargs):
+        if dd is None:
+            return fn(*args, **kwargs)
+
+        with dask.annotate(ray_remote_args=dict(scheduling_strategy="SPREAD")):
+            return fn(*args, **kwargs)
+
+    return wrapped_fn
+
+
+@spread
 def read_xsv(data_fp, df_lib=PANDAS_DF, separator=",", header=0, nrows=None, skiprows=None):
     """Helper method to read a csv file. Wraps around pd.read_csv to handle some exceptions. Can extend to cover
     cases as necessary.
@@ -145,6 +159,7 @@ read_csv = functools.partial(read_xsv, separator=",")
 read_tsv = functools.partial(read_xsv, separator="\t")
 
 
+@spread
 def read_json(data_fp, df_lib, normalize=False):
     if normalize:
         return df_lib.json_normalize(load_json(data_fp))
@@ -152,10 +167,12 @@ def read_json(data_fp, df_lib, normalize=False):
         return df_lib.read_json(data_fp)
 
 
+@spread
 def read_jsonl(data_fp, df_lib):
     return df_lib.read_json(data_fp, lines=True)
 
 
+@spread
 def read_excel(data_fp, df_lib):
     fp_split = os.path.splitext(data_fp)
     if fp_split[1] == ".xls":
@@ -165,42 +182,52 @@ def read_excel(data_fp, df_lib):
     return df_lib.read_excel(data_fp, engine=excel_engine)
 
 
+@spread
 def read_parquet(data_fp, df_lib):
     return df_lib.read_parquet(data_fp)
 
 
+@spread
 def read_pickle(data_fp, df_lib):
     return df_lib.read_pickle(data_fp)
 
 
+@spread
 def read_fwf(data_fp, df_lib):
     return df_lib.read_fwf(data_fp)
 
 
+@spread
 def read_feather(data_fp, df_lib):
     return df_lib.read_feather(data_fp)
 
 
+@spread
 def read_html(data_fp, df_lib):
     return df_lib.read_html(data_fp)[0]
 
 
+@spread
 def read_orc(data_fp, df_lib):
     return df_lib.read_orc(data_fp)
 
 
+@spread
 def read_sas(data_fp, df_lib):
     return df_lib.read_sas(data_fp)
 
 
+@spread
 def read_spss(data_fp, df_lib):
     return df_lib.read_spss(data_fp)
 
 
+@spread
 def read_stata(data_fp, df_lib):
     return df_lib.read_stata(data_fp)
 
 
+@spread
 def read_hdf5(data_fp, **kwargs):
     return load_hdf5(data_fp, clean_cols=True)
 


### PR DESCRIPTION
By default, Dask on Ray will try to place workers on the head node instead of spreading the across the cluster.

This is the new API to address the issue described here: https://docs.ray.io/en/latest/data/dask-on-ray.html#best-practice-for-large-scale-workloads.

cc @clarkzinzow