### PR TITLE
Fixes FileExistsError thrown after training on windows completes

### DIFF
--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -6,6 +6,7 @@ import logging
 import os
 import os.path as osp
 import signal
+import re
 from glob import glob
 
 import numpy as np
@@ -29,7 +30,9 @@ def get_files(d, pattern, sort=True):
     files = glob(osp.join(d, pattern))
     files = [f for f in files if osp.isfile(f)]
     if sort:
-        files.sort(key=lambda x: int(os.path.basename(x).split(".")[0]))
+        def filter_nonnumeric(s):
+            return re.sub("[^0-9]", "", s)
+        files.sort(key=lambda x: int(filter_nonnumeric(os.path.basename(x).split(".")[0])))
     return files
 
 

--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -25,14 +25,14 @@ def get_files(d, pattern, sort=True):
     Args:
       d (str): The path to the directory.
       pattern (str): The wildcard to filter files with.
-      sort (bool): Whether to sort the returned list.
+      sort (bool): Whether to sort the returned list. Assumes filenames contain a number value to sort by (tmp-001).
     """
     files = glob(osp.join(d, pattern))
     files = [f for f in files if osp.isfile(f)]
     if sort:
-        def filter_nonnumeric(s):
+        def filter_numeric(s):
             return re.sub("[^0-9]", "", s)
-        files.sort(key=lambda x: int(filter_nonnumeric(os.path.basename(x).split(".")[0])))
+        files.sort(key=lambda x: int(filter_numeric(os.path.basename(x).split(".")[0])))
     return files
 
 

--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -30,8 +30,10 @@ def get_files(d, pattern, sort=True):
     files = glob(osp.join(d, pattern))
     files = [f for f in files if osp.isfile(f)]
     if sort:
+
         def filter_numeric(s):
             return re.sub("[^0-9]", "", s)
+
         files.sort(key=lambda x: int(filter_numeric(os.path.basename(x).split(".")[0])))
     return files
 

--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -95,7 +95,11 @@ class Checkpoint:
         # rename is an atomic operation in python
         # it is POSIX compliant according to docs
         # https://docs.python.org/3/library/os.html#os.rename
-        os.rename(tmp_path, save_path)
+        try:
+            os.rename(tmp_path, save_path)
+        except FileExistsError:
+            # On UNIX filesystems, os.rename will silently replace. On @indows it will throw an exception.
+            logging.debug(f"Checkpoint at {save_path} already exists.")
         logging.debug(f"Saved checkpoint at {save_path}.")
 
         # restore SIGINT handler

--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -95,14 +95,10 @@ class Checkpoint:
         save_dir = osp.dirname(save_path)
         tmp_path = osp.join(save_dir, f"tmp-{np.random.randint(1e9)}.ckpt")
         torch.save(state, tmp_path)
-        # rename is an atomic operation in python
+        # replace is an atomic operation in python
         # it is POSIX compliant according to docs
-        # https://docs.python.org/3/library/os.html#os.rename
-        try:
-            os.rename(tmp_path, save_path)
-        except FileExistsError:
-            # On UNIX filesystems, os.rename will silently replace. On @indows it will throw an exception.
-            logging.debug(f"Checkpoint at {save_path} already exists.")
+        # https://docs.python.org/3/library/os.html#os.replace
+        os.replace(tmp_path, save_path)
         logging.debug(f"Saved checkpoint at {save_path}.")
 
         # restore SIGINT handler


### PR DESCRIPTION
os.replace added in python 3.3, and (I think) this is the semantics we want here, rather than os.rename

Also strips non-numeric characters from filename in get_files before casting to int.