### PR TITLE
Handle when progress_trainer.log_metrics() is called before any metrics are added.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -274,16 +274,16 @@ jobs:
   #         name: Unit Test Results (Python ${{ matrix.python-version }} gpu
   #         path: pytest.xml
 
-  # event_file:
-  #   name: "Event File"
-  #   runs-on: ubuntu-latest
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Upload
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: Event File
-  #         path: ${{ github.event_path }}
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: Event File
+          path: ${{ github.event_path }}
 
   # stop-runner:
   #   name: Stop self-hosted EC2 runner

--- a/ludwig/callbacks.py
+++ b/ludwig/callbacks.py
@@ -164,7 +164,7 @@ class Callback(ABC):
         :param trainer: The trainer instance.
         :type trainer: ludwig.models.trainer.Trainer
         :param progress_tracker: An object which tracks training progress.
-        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :type progress_tracker: ludwig.utils.trainer_utils.ProgressTracker
         :param is_coordinator: Is this trainer the coordinator.
         """
         pass
@@ -175,7 +175,7 @@ class Callback(ABC):
         :param trainer: The trainer instance.
         :type trainer: ludwig.models.trainer.Trainer
         :param progress_tracker: An object which tracks training progress.
-        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :type progress_tracker: ludwig.utils.trainer_utils.ProgressTracker
         :param save_path: The path to the directory model is saved in.
         """
         pass
@@ -186,7 +186,7 @@ class Callback(ABC):
         :param trainer: The trainer instance.
         :type trainer: ludwig.models.trainer.Trainer
         :param progress_tracker: An object which tracks training progress.
-        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :type progress_tracker: ludwig.utils.trainer_utils.ProgressTracker
         :param save_path: The path to the directory model is saved in.
         """
         pass
@@ -197,7 +197,7 @@ class Callback(ABC):
         :param trainer: The trainer instance.
         :type trainer: ludwig.models.trainer.Trainer
         :param progress_tracker: An object which tracks training progress.
-        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :type progress_tracker: ludwig.utils.trainer_utils.ProgressTracker
         :param save_path: The path to the directory model is saved in.
         """
         pass
@@ -208,7 +208,7 @@ class Callback(ABC):
         :param trainer: The trainer instance.
         :type trainer: ludwig.models.trainer.Trainer
         :param progress_tracker: An object which tracks training progress.
-        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :type progress_tracker: ludwig.utils.trainer_utils.ProgressTracker
         :param save_path: The path to the directory model is saved in.
         """
         pass
@@ -219,7 +219,7 @@ class Callback(ABC):
         :param trainer: The trainer instance.
         :type trainer: ludwig.models.trainer.Trainer
         :param progress_tracker: An object which tracks training progress.
-        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :type progress_tracker: ludwig.utils.trainer_utils.ProgressTracker
         :param save_path: The path to the directory model is saved in.
         """
         pass
@@ -230,7 +230,7 @@ class Callback(ABC):
         :param trainer: The trainer instance.
         :type trainer: ludwig.models.trainer.Trainer
         :param progress_tracker: An object which tracks training progress.
-        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :type progress_tracker: ludwig.utils.trainer_utils.ProgressTracker
         :param save_path: The path to the directory model is saved in.
         """
         pass
@@ -241,7 +241,7 @@ class Callback(ABC):
         :param trainer: The trainer instance.
         :type trainer: ludwig.models.trainer.Trainer
         :param progress_tracker: An object which tracks training progress.
-        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :type progress_tracker: ludwig.utils.trainer_utils.ProgressTracker
         :param save_path: The path to the directory model is saved in.
         """
         pass
@@ -252,7 +252,7 @@ class Callback(ABC):
         :param trainer: The trainer instance.
         :type trainer: ludwig.models.trainer.Trainer
         :param progress_tracker: An object which tracks training progress.
-        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :type progress_tracker: ludwig.utils.trainer_utils.ProgressTracker
         :param save_path: The path to the directory model is saved in.
         """
         pass
@@ -263,7 +263,7 @@ class Callback(ABC):
         :param trainer: The trainer instance.
         :type trainer: ludwig.models.trainer.Trainer
         :param progress_tracker: An object which tracks training progress.
-        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :type progress_tracker: ludwig.utils.trainer_utils.ProgressTracker
         :param save_path: The path to the directory model is saved in.
         """
         pass
@@ -274,7 +274,7 @@ class Callback(ABC):
         :param trainer: The trainer instance.
         :type trainer: ludwig.models.trainer.Trainer
         :param progress_tracker: An object which tracks training progress.
-        :type progress_tracker: ludwig.models.trainer.ProgressTracker
+        :type progress_tracker: ludwig.utils.trainer_utils.ProgressTracker
         :param save_path: The path to the directory model is saved in.
         """
         pass

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -86,11 +86,6 @@ class MlflowCallback(Callback):
 
         _log_model(save_path)
 
-    def on_epoch_end(self, trainer, progress_tracker, save_path):
-        mlflow.log_metrics(progress_tracker.log_metrics(), step=progress_tracker.steps)
-
-        _log_model(save_path)
-
     def on_trainer_train_teardown(self, trainer, progress_tracker, is_coordinator):
         if self.run is not None:
             mlflow.end_run()

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -86,6 +86,11 @@ class MlflowCallback(Callback):
 
         _log_model(save_path)
 
+    def on_epoch_end(self, trainer, progress_tracker, save_path):
+        mlflow.log_metrics(progress_tracker.log_metrics(), step=progress_tracker.steps)
+
+        _log_model(save_path)
+
     def on_trainer_train_teardown(self, trainer, progress_tracker, is_coordinator):
         if self.run is not None:
             mlflow.end_run()

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -53,7 +53,7 @@ from ludwig.utils.horovod_utils import return_first
 from ludwig.utils.math_utils import exponential_decay, learning_rate_warmup, learning_rate_warmup_distributed
 from ludwig.utils.metric_utils import get_metric_names, TrainerMetric
 from ludwig.utils.misc_utils import set_random_seed
-from ludwig.utils.trainer_utils import ProgressTracker
+from ludwig.utils.trainer_utils import get_new_progress_tracker, ProgressTracker
 
 logger = logging.getLogger(__name__)
 
@@ -812,27 +812,15 @@ class Trainer(BaseTrainer):
             if self.is_coordinator():
                 self.resume_weights_and_optimizer(training_checkpoints_path, checkpoint)
         else:
-            progress_tracker = ProgressTracker(
+            progress_tracker = get_new_progress_tracker(
                 batch_size=self.batch_size,
-                epoch=0,
-                steps=0,
-                last_improvement_steps=0,
-                last_learning_rate_reduction_steps=0,
-                last_increase_batch_size_steps=0,
                 learning_rate=self.base_learning_rate,
                 best_eval_metric=get_initial_validation_value(self.validation_metric),
                 best_reduce_learning_rate_eval_metric=get_initial_validation_value(
                     self.reduce_learning_rate_eval_metric
                 ),
-                last_reduce_learning_rate_eval_metric_improvement=0,
                 best_increase_batch_size_eval_metric=get_initial_validation_value(self.increase_batch_size_eval_metric),
-                last_increase_batch_size_eval_metric_improvement=0,
-                num_reductions_learning_rate=0,
-                num_increases_batch_size=0,
                 output_features=output_features,
-                last_improvement=0,
-                last_learning_rate_reduction=0,
-                last_increase_batch_size=0,
             )
 
         if self.horovod:

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -24,7 +24,7 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Tuple
 
 import numpy as np
 import psutil
@@ -48,12 +48,12 @@ from ludwig.modules.metric_modules import get_improved_fun, get_initial_validati
 from ludwig.modules.optimization_modules import create_optimizer_with_clipper
 from ludwig.utils import time_utils
 from ludwig.utils.checkpoint_utils import Checkpoint, CheckpointManager
-from ludwig.utils.data_utils import load_json, save_json
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.horovod_utils import return_first
 from ludwig.utils.math_utils import exponential_decay, learning_rate_warmup, learning_rate_warmup_distributed
-from ludwig.utils.metric_utils import TrainerMetric
+from ludwig.utils.metric_utils import get_metric_names, TrainerMetric
 from ludwig.utils.misc_utils import set_random_seed
+from ludwig.utils.trainer_utils import ProgressTracker
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +101,7 @@ class Trainer(BaseTrainer):
         optimizer=None,
         epochs=100,
         steps_per_checkpoint=0,
+        should_evaluate_train=False,
         regularization_lambda=0.0,
         regularization_type=None,
         learning_rate=0.001,
@@ -155,6 +156,11 @@ class Trainer(BaseTrainer):
         :type regularization_type: str
         :param epochs: Number of epochs the algorithm is intended to be run over
         :type epochs: Integer
+        :param steps_per_checkpoint: How often the model is checkpointed. Also dictates maximum evaluation frequency.
+                0: Model is checkpointed after every epoch.
+        :type steps_per_checkpoint: Integer
+        :param should_evaluate_train: Whether to run evaluation on the entire training set.
+        :type should_evaluate_train: Boolean
         :param learning_rate: Learning rate specified in configuration, represents how much to scale the gradients by.
                If 'auto', tune_learning_rate must be called before training to estimate the optimal learning rate.
         :type learning_rate: Float
@@ -259,6 +265,7 @@ class Trainer(BaseTrainer):
         self._validation_metric = validation_metric
         self.early_stop = early_stop
         self.steps_per_checkpoint = steps_per_checkpoint
+        self.should_evaluate_train = should_evaluate_train
         self.reduce_learning_rate_on_plateau = reduce_learning_rate_on_plateau
         self.reduce_learning_rate_on_plateau_patience = reduce_learning_rate_on_plateau_patience
         self.reduce_learning_rate_on_plateau_rate = reduce_learning_rate_on_plateau_rate
@@ -303,7 +310,8 @@ class Trainer(BaseTrainer):
             targets: A dictionary of target data, from feature name to tensor.
 
         Returns:
-            A tuple of the loss and a dictionary of metrics.
+            A tuple of the loss tensor and a dictionary of loss for every
+            output feature.
         """
         self.optimizer.zero_grad()
 
@@ -590,6 +598,8 @@ class Trainer(BaseTrainer):
         output_features,
         metrics_names,
         save_path,
+        loss: torch.Tensor,
+        all_losses: Dict[str, torch.Tensor],
     ) -> bool:
         """Runs evaluation over training, validation, and test sets.
 
@@ -615,15 +625,28 @@ class Trainer(BaseTrainer):
 
         # eval metrics on train
         self.eval_batch_size = max(self.eval_batch_size, progress_tracker.batch_size)
-        self.evaluation(
-            training_set, "train", progress_tracker.train_metrics, tables, self.eval_batch_size, progress_tracker
-        )
 
-        self.write_eval_summary(
-            summary_writer=train_summary_writer,
-            metrics=progress_tracker.train_metrics,
-            step=progress_tracker.steps,
-        )
+        if self.should_evaluate_train:
+            self.evaluation(
+                training_set, "train", progress_tracker.train_metrics, tables, self.eval_batch_size, progress_tracker
+            )
+
+            self.write_eval_summary(
+                summary_writer=train_summary_writer,
+                metrics=progress_tracker.train_metrics,
+                step=progress_tracker.steps,
+            )
+        else:
+            # Training set is not evaluated. Add loss to the progress tracker.
+            progress_tracker.train_metrics[COMBINED][LOSS].append(
+                TrainerMetric(epoch=progress_tracker.epoch, step=progress_tracker.steps, value=loss.item())
+            )
+            for output_feature_name, loss_tensor in all_losses.items():
+                progress_tracker.train_metrics[output_feature_name][LOSS].append(
+                    TrainerMetric(epoch=progress_tracker.epoch, step=progress_tracker.steps, value=loss_tensor.item())
+                )
+                tables[output_feature_name].append(["train", loss_tensor.item()])
+            tables[COMBINED].append(["train", loss.item()])
 
         if validation_set is not None:
             self.callback(lambda c: c.on_validation_start(self, progress_tracker, save_path))
@@ -711,7 +734,7 @@ class Trainer(BaseTrainer):
         if threading.current_thread() == threading.main_thread():
             signal.signal(signal.SIGINT, self.set_epochs_to_1_or_quit)
 
-        metrics_names = self.get_metrics_names(output_features)
+        metrics_names = get_metric_names(output_features)
 
         # check if validation_field is valid
         valid_validation_field = False
@@ -789,10 +812,6 @@ class Trainer(BaseTrainer):
             if self.is_coordinator():
                 self.resume_weights_and_optimizer(training_checkpoints_path, checkpoint)
         else:
-            train_metrics = self.initialize_trainer_metric_dict(output_features)
-            vali_metrics = self.initialize_trainer_metric_dict(output_features)
-            test_metrics = self.initialize_trainer_metric_dict(output_features)
-
             progress_tracker = ProgressTracker(
                 batch_size=self.batch_size,
                 epoch=0,
@@ -810,9 +829,7 @@ class Trainer(BaseTrainer):
                 last_increase_batch_size_eval_metric_improvement=0,
                 num_reductions_learning_rate=0,
                 num_increases_batch_size=0,
-                train_metrics=train_metrics,
-                vali_metrics=vali_metrics,
-                test_metrics=test_metrics,
+                output_features=output_features,
                 last_improvement=0,
                 last_learning_rate_reduction=0,
                 last_increase_batch_size=0,
@@ -1045,6 +1062,8 @@ class Trainer(BaseTrainer):
                     output_features,
                     metrics_names,
                     save_path,
+                    loss,
+                    all_losses,
                 )
                 if should_break:
                     return should_break
@@ -1277,28 +1296,6 @@ class Trainer(BaseTrainer):
         progress_tracker = ProgressTracker.load(training_progress_tracker_path)
         return progress_tracker
 
-    def initialize_trainer_metric_dict(self, output_features) -> Dict[str, Dict[str, List[TrainerMetric]]]:
-        """Returns a dict of dict of metrics, output_feature_name -> metric_name -> List[TrainerMetric]."""
-        metrics = OrderedDict()
-
-        for output_feature_name, output_feature in output_features.items():
-            metrics[output_feature_name] = OrderedDict()
-            for metric in output_feature.metric_functions:
-                metrics[output_feature_name][metric] = []
-
-        metrics[COMBINED] = {LOSS: []}
-        return metrics
-
-    def get_metrics_names(self, output_features):
-        metrics_names = {}
-        for output_feature_name, output_feature in output_features.items():
-            for metric in output_feature.metric_functions:
-                metrics = metrics_names.get(output_feature_name, [])
-                metrics.append(metric)
-                metrics_names[output_feature_name] = metrics
-        metrics_names[COMBINED] = [LOSS]
-        return metrics_names
-
     def resume_weights_and_optimizer(
         self,
         model_weights_progress_path: str,
@@ -1455,90 +1452,3 @@ class RemoteTrainer(Trainer):
         # Only return results from rank 0 to reduce network overhead
         self.train = return_first(self.train)
         self.train_online = return_first(self.train_online)
-
-
-class ProgressTracker:
-    def __init__(
-        self,
-        epoch,
-        batch_size,
-        steps,
-        last_improvement_steps,
-        last_learning_rate_reduction_steps,
-        last_increase_batch_size_steps,
-        best_eval_metric,
-        best_reduce_learning_rate_eval_metric,
-        last_reduce_learning_rate_eval_metric_improvement,
-        best_increase_batch_size_eval_metric,
-        last_increase_batch_size_eval_metric_improvement,
-        learning_rate,
-        num_reductions_learning_rate,
-        num_increases_batch_size,
-        train_metrics,
-        vali_metrics,
-        test_metrics,
-        last_improvement,
-        last_learning_rate_reduction,
-        last_increase_batch_size,
-    ):
-        """JSON-serializable holder object that stores information related to training progress.
-
-        [train/vali/test]_metrics is a nested dictionary of TrainerMetrics: feature_name -> metric_name ->
-        List[TrainerMetrics], with one entry per training checkpoint.
-
-        Note that when a model resumes training from a checkpoint, the progress tracker is deserialized from JSON, which
-        automatically converts TrainerMetrics namedtuples into regular (epoch, steps, value) tuples.
-        """
-        self.batch_size = batch_size
-        self.epoch = epoch
-        self.steps = steps
-        self.last_improvement_steps = last_improvement_steps
-        self.last_improvement = last_improvement
-        self.last_learning_rate_reduction_steps = last_learning_rate_reduction_steps
-        self.last_learning_rate_reduction = last_learning_rate_reduction
-        self.last_increase_batch_size_steps = last_increase_batch_size_steps
-        self.last_increase_batch_size = last_increase_batch_size
-        self.learning_rate = learning_rate
-        self.best_eval_metric = best_eval_metric
-        self.best_reduce_learning_rate_eval_metric = best_reduce_learning_rate_eval_metric
-        self.last_reduce_learning_rate_eval_metric_improvement = last_reduce_learning_rate_eval_metric_improvement
-        self.best_increase_batch_size_eval_metric = best_increase_batch_size_eval_metric
-        self.last_increase_batch_size_eval_metric_improvement = last_increase_batch_size_eval_metric_improvement
-        self.num_reductions_learning_rate = num_reductions_learning_rate
-        self.num_increases_batch_size = num_increases_batch_size
-        self.train_metrics = train_metrics
-        self.vali_metrics = vali_metrics
-        self.test_metrics = test_metrics
-
-    def save(self, filepath):
-        save_json(filepath, self.__dict__)
-
-    @staticmethod
-    def load(filepath):
-        loaded = load_json(filepath)
-        return ProgressTracker(**loaded)
-
-    def log_metrics(self):
-        log_metrics = {
-            "batch_size": self.batch_size,
-            "epoch": self.epoch,
-            "steps": self.steps,
-            "last_improvement_steps": self.last_improvement_steps,
-            "learning_rate": self.learning_rate,
-            "best_valid_metric": self.best_eval_metric,
-            "num_reductions_lr": self.num_reductions_learning_rate,
-            "num_increases_bs": self.num_increases_batch_size,
-        }
-        for metrics_dict_name in [
-            "train_metrics",
-            "vali_metrics",
-            "test_metrics",
-        ]:
-            metrics_dict = getattr(self, metrics_dict_name)
-            for feature_name in metrics_dict:
-                for metric_name, metrics_tuple in metrics_dict[feature_name].items():
-                    # For logging, get the latest metrics. The second "-1" indexes into the TrainerMetric namedtuple.
-                    # The last element of the TrainerMetric namedtuple is the actual metric value.
-                    log_metrics[f"{metrics_dict_name}.{feature_name}.{metric_name}"] = metrics_tuple[-1][-1]
-
-        return log_metrics

--- a/ludwig/utils/metric_utils.py
+++ b/ludwig/utils/metric_utils.py
@@ -5,6 +5,8 @@ import torch
 from torch import Tensor
 from torchmetrics.metric import Metric
 
+from ludwig.constants import COMBINED, LOSS
+
 
 def sequence_mask(lengths: Tensor, maxlen: Optional[int] = None, dtype=torch.bool) -> Tensor:
     """Implements tf.sequence_mask in torch.
@@ -84,3 +86,15 @@ def reduce_trainer_metrics_dict(
             for trainer_metric in trainer_metrics:
                 flattened_dict[feature_name][metric_name].append(trainer_metric[-1])
     return flattened_dict
+
+
+def get_metric_names(output_features: Dict[str, Dict]) -> Dict[str, List[str]]:
+    """Returns a dict of output_feature_name -> list of metric names."""
+    metrics_names = {}
+    for output_feature_name, output_feature in output_features.items():
+        for metric in output_feature.metric_functions:
+            metrics = metrics_names.get(output_feature_name, [])
+            metrics.append(metric)
+            metrics_names[output_feature_name] = metrics
+    metrics_names[COMBINED] = [LOSS]
+    return metrics_names

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -20,6 +20,39 @@ def initialize_trainer_metric_dict(output_features) -> Dict[str, Dict[str, List[
     return metrics
 
 
+def get_new_progress_tracker(
+    batch_size: int,
+    best_eval_metric: float,
+    best_reduce_learning_rate_eval_metric: float,
+    best_increase_batch_size_eval_metric: float,
+    learning_rate: float,
+    output_features: Dict[str, OutputFeature],
+):
+    """Returns a new instance of a ProgressTracker with empty metrics."""
+    return ProgressTracker(
+        epoch=0,
+        batch_size=batch_size,
+        steps=0,
+        last_improvement_steps=0,
+        last_learning_rate_reduction_steps=0,
+        last_increase_batch_size_steps=0,
+        best_eval_metric=best_eval_metric,
+        best_reduce_learning_rate_eval_metric=best_reduce_learning_rate_eval_metric,
+        last_reduce_learning_rate_eval_metric_improvement=0,
+        best_increase_batch_size_eval_metric=best_increase_batch_size_eval_metric,
+        last_increase_batch_size_eval_metric_improvement=0,
+        learning_rate=learning_rate,
+        num_reductions_learning_rate=0,
+        num_increases_batch_size=0,
+        train_metrics=initialize_trainer_metric_dict(output_features),
+        vali_metrics=initialize_trainer_metric_dict(output_features),
+        test_metrics=initialize_trainer_metric_dict(output_features),
+        last_improvement=0,
+        last_learning_rate_reduction=0,
+        last_increase_batch_size=0,
+    )
+
+
 class ProgressTracker:
     def __init__(
         self,
@@ -37,7 +70,9 @@ class ProgressTracker:
         learning_rate: float,
         num_reductions_learning_rate: int,
         num_increases_batch_size: int,
-        output_features: Dict[str, OutputFeature],
+        train_metrics: Dict[str, Dict[str, List[TrainerMetric]]],
+        vali_metrics: Dict[str, Dict[str, List[TrainerMetric]]],
+        test_metrics: Dict[str, Dict[str, List[TrainerMetric]]],
         last_improvement: int,
         last_learning_rate_reduction: int,
         last_increase_batch_size: int,
@@ -67,9 +102,9 @@ class ProgressTracker:
         self.last_increase_batch_size_eval_metric_improvement = last_increase_batch_size_eval_metric_improvement
         self.num_reductions_learning_rate = num_reductions_learning_rate
         self.num_increases_batch_size = num_increases_batch_size
-        self.train_metrics = initialize_trainer_metric_dict(output_features)
-        self.vali_metrics = initialize_trainer_metric_dict(output_features)
-        self.test_metrics = initialize_trainer_metric_dict(output_features)
+        self.train_metrics = train_metrics
+        self.vali_metrics = vali_metrics
+        self.test_metrics = test_metrics
 
     def save(self, filepath):
         save_json(filepath, self.__dict__)

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -1,0 +1,106 @@
+from collections import OrderedDict
+from typing import Dict, List
+
+from ludwig.constants import COMBINED, LOSS
+from ludwig.features.base_feature import OutputFeature
+from ludwig.utils.data_utils import load_json, save_json
+from ludwig.utils.metric_utils import TrainerMetric
+
+
+def initialize_trainer_metric_dict(output_features) -> Dict[str, Dict[str, List[TrainerMetric]]]:
+    """Returns a dict of dict of metrics, output_feature_name -> metric_name -> List[TrainerMetric]."""
+    metrics = OrderedDict()
+
+    for output_feature_name, output_feature in output_features.items():
+        metrics[output_feature_name] = OrderedDict()
+        for metric in output_feature.metric_functions:
+            metrics[output_feature_name][metric] = []
+
+    metrics[COMBINED] = {LOSS: []}
+    return metrics
+
+
+class ProgressTracker:
+    def __init__(
+        self,
+        epoch: int,
+        batch_size: int,
+        steps: int,
+        last_improvement_steps: int,
+        last_learning_rate_reduction_steps: int,
+        last_increase_batch_size_steps: int,
+        best_eval_metric: float,
+        best_reduce_learning_rate_eval_metric: float,
+        last_reduce_learning_rate_eval_metric_improvement: int,
+        best_increase_batch_size_eval_metric: float,
+        last_increase_batch_size_eval_metric_improvement: int,
+        learning_rate: float,
+        num_reductions_learning_rate: int,
+        num_increases_batch_size: int,
+        output_features: Dict[str, OutputFeature],
+        last_improvement: int,
+        last_learning_rate_reduction: int,
+        last_increase_batch_size: int,
+    ):
+        """JSON-serializable holder object that stores information related to training progress.
+
+        [train/vali/test]_metrics is a nested dictionary of TrainerMetrics: feature_name -> metric_name ->
+        List[TrainerMetrics], with one entry per training checkpoint.
+
+        Note that when a model resumes training from a checkpoint, the progress tracker is deserialized from JSON, which
+        automatically converts TrainerMetrics namedtuples into regular (epoch, steps, value) tuples.
+        """
+        self.batch_size = batch_size
+        self.epoch = epoch
+        self.steps = steps
+        self.last_improvement_steps = last_improvement_steps
+        self.last_improvement = last_improvement
+        self.last_learning_rate_reduction_steps = last_learning_rate_reduction_steps
+        self.last_learning_rate_reduction = last_learning_rate_reduction
+        self.last_increase_batch_size_steps = last_increase_batch_size_steps
+        self.last_increase_batch_size = last_increase_batch_size
+        self.learning_rate = learning_rate
+        self.best_eval_metric = best_eval_metric
+        self.best_reduce_learning_rate_eval_metric = best_reduce_learning_rate_eval_metric
+        self.last_reduce_learning_rate_eval_metric_improvement = last_reduce_learning_rate_eval_metric_improvement
+        self.best_increase_batch_size_eval_metric = best_increase_batch_size_eval_metric
+        self.last_increase_batch_size_eval_metric_improvement = last_increase_batch_size_eval_metric_improvement
+        self.num_reductions_learning_rate = num_reductions_learning_rate
+        self.num_increases_batch_size = num_increases_batch_size
+        self.train_metrics = initialize_trainer_metric_dict(output_features)
+        self.vali_metrics = initialize_trainer_metric_dict(output_features)
+        self.test_metrics = initialize_trainer_metric_dict(output_features)
+
+    def save(self, filepath):
+        save_json(filepath, self.__dict__)
+
+    @staticmethod
+    def load(filepath):
+        loaded = load_json(filepath)
+        return ProgressTracker(**loaded)
+
+    def log_metrics(self):
+        log_metrics = {
+            "batch_size": self.batch_size,
+            "epoch": self.epoch,
+            "steps": self.steps,
+            "last_improvement_steps": self.last_improvement_steps,
+            "learning_rate": self.learning_rate,
+            "best_valid_metric": self.best_eval_metric,
+            "num_reductions_lr": self.num_reductions_learning_rate,
+            "num_increases_bs": self.num_increases_batch_size,
+        }
+        for metrics_dict_name in [
+            "train_metrics",
+            "vali_metrics",
+            "test_metrics",
+        ]:
+            metrics_dict = getattr(self, metrics_dict_name)
+            for feature_name in metrics_dict:
+                for metric_name, metrics_tuples in metrics_dict[feature_name].items():
+                    if metrics_tuples:
+                        # For logging, get the latest metrics. The second "-1" indexes into the TrainerMetric
+                        # namedtuple. The last element of the TrainerMetric namedtuple is the actual metric value.
+                        log_metrics[f"{metrics_dict_name}.{feature_name}.{metric_name}"] = metrics_tuples[-1][-1]
+
+        return log_metrics

--- a/tests/integration_tests/test_visualization.py
+++ b/tests/integration_tests/test_visualization.py
@@ -124,7 +124,7 @@ def test_visualization_learning_curves_output_saved(csv_filename):
         figure_cnt = glob.glob(viz_pattern)
 
         assert 0 == result.returncode
-        assert 4 == len(figure_cnt)
+        assert 2 == len(figure_cnt)
 
 
 def test_visualization_confusion_matrix_output_saved(csv_filename):

--- a/tests/integration_tests/test_visualization_api.py
+++ b/tests/integration_tests/test_visualization_api.py
@@ -147,7 +147,7 @@ def test_learning_curves_vis_api(experiment_to_use):
                 [experiment.train_stats], output_feature_name=None, output_directory=tmpvizdir, file_format=viz_output
             )
             figure_cnt = glob.glob(vis_output_pattern_pdf)
-            assert 3 == len(figure_cnt)
+            assert 2 == len(figure_cnt)
 
 
 def test_compare_performance_vis_api(experiment_to_use):

--- a/tests/ludwig/utils/test_trainer_utils.py
+++ b/tests/ludwig/utils/test_trainer_utils.py
@@ -11,25 +11,13 @@ def test_progress_tracker_empty():
         {"name": "category_feature", "input_size": 10, "num_classes": 3}, {}
     )
 
-    progress_tracker = trainer_utils.ProgressTracker(
+    progress_tracker = trainer_utils.get_new_progress_tracker(
         batch_size=5,
-        epoch=0,
-        steps=0,
-        last_improvement_steps=0,
-        last_learning_rate_reduction_steps=0,
-        last_increase_batch_size_steps=0,
-        learning_rate=0.01,
         best_eval_metric=0,
         best_reduce_learning_rate_eval_metric=0,
-        last_reduce_learning_rate_eval_metric_improvement=0,
         best_increase_batch_size_eval_metric=0,
-        last_increase_batch_size_eval_metric_improvement=0,
-        num_reductions_learning_rate=0,
-        num_increases_batch_size=0,
+        learning_rate=0.01,
         output_features=output_features,
-        last_improvement=0,
-        last_learning_rate_reduction=0,
-        last_increase_batch_size=0,
     )
 
     assert progress_tracker.log_metrics() == {
@@ -50,25 +38,13 @@ def test_progress_tracker():
         {"name": "category_feature", "input_size": 10, "num_classes": 3}, {}
     )
 
-    progress_tracker = trainer_utils.ProgressTracker(
+    progress_tracker = trainer_utils.get_new_progress_tracker(
         batch_size=5,
-        epoch=0,
-        steps=0,
-        last_improvement_steps=0,
-        last_learning_rate_reduction_steps=0,
-        last_increase_batch_size_steps=0,
-        learning_rate=0.01,
         best_eval_metric=0,
         best_reduce_learning_rate_eval_metric=0,
-        last_reduce_learning_rate_eval_metric_improvement=0,
         best_increase_batch_size_eval_metric=0,
-        last_increase_batch_size_eval_metric_improvement=0,
-        num_reductions_learning_rate=0,
-        num_increases_batch_size=0,
+        learning_rate=0.01,
         output_features=output_features,
-        last_improvement=0,
-        last_learning_rate_reduction=0,
-        last_increase_batch_size=0,
     )
 
     progress_tracker.vali_metrics[COMBINED][LOSS].append(TrainerMetric(epoch=1, step=10, value=0.1))

--- a/tests/ludwig/utils/test_trainer_utils.py
+++ b/tests/ludwig/utils/test_trainer_utils.py
@@ -1,0 +1,87 @@
+from ludwig.constants import COMBINED, LOSS
+from ludwig.features.category_feature import CategoryOutputFeature
+from ludwig.features.feature_utils import LudwigFeatureDict
+from ludwig.utils import trainer_utils
+from ludwig.utils.metric_utils import TrainerMetric
+
+
+def test_progress_tracker_empty():
+    output_features = LudwigFeatureDict()
+    output_features["category_feature"] = CategoryOutputFeature(
+        {"name": "category_feature", "input_size": 10, "num_classes": 3}, {}
+    )
+
+    progress_tracker = trainer_utils.ProgressTracker(
+        batch_size=5,
+        epoch=0,
+        steps=0,
+        last_improvement_steps=0,
+        last_learning_rate_reduction_steps=0,
+        last_increase_batch_size_steps=0,
+        learning_rate=0.01,
+        best_eval_metric=0,
+        best_reduce_learning_rate_eval_metric=0,
+        last_reduce_learning_rate_eval_metric_improvement=0,
+        best_increase_batch_size_eval_metric=0,
+        last_increase_batch_size_eval_metric_improvement=0,
+        num_reductions_learning_rate=0,
+        num_increases_batch_size=0,
+        output_features=output_features,
+        last_improvement=0,
+        last_learning_rate_reduction=0,
+        last_increase_batch_size=0,
+    )
+
+    assert progress_tracker.log_metrics() == {
+        "batch_size": 5,
+        "best_valid_metric": 0,
+        "epoch": 0,
+        "last_improvement_steps": 0,
+        "learning_rate": 0.01,
+        "num_increases_bs": 0,
+        "num_reductions_lr": 0,
+        "steps": 0,
+    }
+
+
+def test_progress_tracker():
+    output_features = LudwigFeatureDict()
+    output_features["category_feature"] = CategoryOutputFeature(
+        {"name": "category_feature", "input_size": 10, "num_classes": 3}, {}
+    )
+
+    progress_tracker = trainer_utils.ProgressTracker(
+        batch_size=5,
+        epoch=0,
+        steps=0,
+        last_improvement_steps=0,
+        last_learning_rate_reduction_steps=0,
+        last_increase_batch_size_steps=0,
+        learning_rate=0.01,
+        best_eval_metric=0,
+        best_reduce_learning_rate_eval_metric=0,
+        last_reduce_learning_rate_eval_metric_improvement=0,
+        best_increase_batch_size_eval_metric=0,
+        last_increase_batch_size_eval_metric_improvement=0,
+        num_reductions_learning_rate=0,
+        num_increases_batch_size=0,
+        output_features=output_features,
+        last_improvement=0,
+        last_learning_rate_reduction=0,
+        last_increase_batch_size=0,
+    )
+
+    progress_tracker.vali_metrics[COMBINED][LOSS].append(TrainerMetric(epoch=1, step=10, value=0.1))
+    progress_tracker.vali_metrics[COMBINED][LOSS].append(TrainerMetric(epoch=1, step=20, value=0.2))
+
+    assert progress_tracker.log_metrics() == {
+        "batch_size": 5,
+        "best_valid_metric": 0,
+        "epoch": 0,
+        "last_improvement_steps": 0,
+        "learning_rate": 0.01,
+        "num_increases_bs": 0,
+        "num_reductions_lr": 0,
+        "steps": 0,
+        "vali_metrics.combined.loss": 0.2,
+    }


### PR DESCRIPTION
Other changes:
- Refactor and move ProgressTracker to `trainer_utils`, and add unit tests.
- Introduce a new trainer parameter, `should_evaluate_train` that dictates whether to run evaluation on the entire training set. Default False.
