### PR TITLE
Add checkpoints_per_epoch as an additional parameter to dictate the checkpoint-eval frequency.

### DIFF
--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -53,7 +53,7 @@ from ludwig.utils.horovod_utils import return_first
 from ludwig.utils.math_utils import exponential_decay, learning_rate_warmup, learning_rate_warmup_distributed
 from ludwig.utils.metric_utils import get_metric_names, TrainerMetric
 from ludwig.utils.misc_utils import set_random_seed
-from ludwig.utils.trainer_utils import get_new_progress_tracker, ProgressTracker
+from ludwig.utils.trainer_utils import get_new_progress_tracker, ProgressTracker, get_terminal_steps_per_checkpoint
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +101,7 @@ class Trainer(BaseTrainer):
         optimizer=None,
         epochs=100,
         steps_per_checkpoint=0,
+        checkpoints_per_epoch=0,
         regularization_lambda=0.0,
         regularization_type=None,
         learning_rate=0.001,
@@ -158,6 +159,10 @@ class Trainer(BaseTrainer):
         :param steps_per_checkpoint: How often the model is checkpointed. Also dictates maximum evaluation frequency.
                 0: Model is checkpointed after every epoch.
         :type steps_per_checkpoint: Integer
+        :param checkpoints_per_epoch: Number of checkpoints per epoch. For example, 2 -> checkpoints are written every
+                half of an epoch. Note that it is invalid to specify both non-zero steps_per_checkpoint and non-zero
+                checkpoints_per_epoch.
+        :type checkpoints_per_epoch: float
         :param learning_rate: Learning rate specified in configuration, represents how much to scale the gradients by.
                If 'auto', tune_learning_rate must be called before training to estimate the optimal learning rate.
         :type learning_rate: Float
@@ -262,6 +267,7 @@ class Trainer(BaseTrainer):
         self._validation_metric = validation_metric
         self.early_stop = early_stop
         self.steps_per_checkpoint = steps_per_checkpoint
+        self.checkpoints_per_epoch = checkpoints_per_epoch
         self.reduce_learning_rate_on_plateau = reduce_learning_rate_on_plateau
         self.reduce_learning_rate_on_plateau_patience = reduce_learning_rate_on_plateau_patience
         self.reduce_learning_rate_on_plateau_rate = reduce_learning_rate_on_plateau_rate
@@ -295,6 +301,14 @@ class Trainer(BaseTrainer):
         # Most optimizers require 'lr' parameter.  set_optimizer_learning_rate will update this during training.
         optimizer = {**optimizer, "lr": base_learning_rate}
         self.optimizer, self.clipper = create_optimizer_with_clipper(model, horovod=horovod, **optimizer)
+
+        # TODO(Justin): Move to config validation when that's ready.
+        if checkpoints_per_epoch != 0 and steps_per_checkpoint != 0:
+            raise ValueError(
+                "It is invalid to specify both trainer.checkpoints_per_epoch AND "
+                "trainer.steps_per_checkpoint. Please specify one or the other, or specify neither to checkpoint/eval "
+                "the model every epoch."
+            )
 
     def train_step(
         self, inputs: Dict[str, torch.Tensor], targets: Dict[str, torch.Tensor]
@@ -829,20 +843,17 @@ class Trainer(BaseTrainer):
             # ================ Training Loop ================
             total_steps = self.epochs * batcher.steps_per_epoch
 
-            # Check steps_per_checkpoint and adjust if needed.
-            if self.steps_per_checkpoint == 0 or self.steps_per_checkpoint > batcher.steps_per_epoch:
-                self.steps_per_checkpoint = batcher.steps_per_epoch
-                if self.is_coordinator():
-                    logger.info(
-                        f"Note: steps_per_checkpoint (was {self.steps_per_checkpoint}) is now set to the number of "
-                        f"steps per epoch: {batcher.steps_per_epoch}.\n"
-                    )
-
-            logger.info(
-                f"Training for {total_steps} step(s), approximately "
-                f"{int(total_steps / batcher.steps_per_epoch)} epoch(s)."
+            # Get the terminal steps per checkpoint.
+            terminal_steps_per_checkpoint = get_terminal_steps_per_checkpoint(
+                batcher.steps_per_epoch, self.steps_per_checkpoint, self.checkpoints_per_epoch, self.is_coordinator()
             )
-            logger.info(f"Starting with step {progress_tracker.steps}, epoch: {progress_tracker.epoch}")
+
+            if self.is_coordinator():
+                logger.info(
+                    f"Training for {total_steps} step(s), approximately "
+                    f"{int(total_steps / batcher.steps_per_epoch)} epoch(s)."
+                )
+                logger.info(f"Starting with step {progress_tracker.steps}, epoch: {progress_tracker.epoch}")
 
             progress_bar = None
             if self.is_coordinator():
@@ -884,6 +895,7 @@ class Trainer(BaseTrainer):
                     output_features,
                     metrics_names,
                     checkpoint_manager,
+                    terminal_steps_per_checkpoint,
                 )
 
                 # ================ Post Training Epoch ================
@@ -944,6 +956,7 @@ class Trainer(BaseTrainer):
         output_features,
         metrics_names,
         checkpoint_manager,
+        terminal_steps_per_checkpoint: int,
     ) -> bool:
         """Completes one epoch through the data."""
         while not batcher.last_batch():
@@ -1019,7 +1032,7 @@ class Trainer(BaseTrainer):
                     f"{psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB"
                 )
 
-            if progress_tracker.steps % self.steps_per_checkpoint == 0:
+            if progress_tracker.steps % terminal_steps_per_checkpoint == 0:
                 # Checkpoint the model.
                 if self.is_coordinator():
                     checkpoint_manager.save(progress_tracker.steps)

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -1,5 +1,5 @@
-from collections import OrderedDict
 import logging
+from collections import OrderedDict
 from typing import Dict, List
 
 from ludwig.constants import COMBINED, LOSS
@@ -142,11 +142,10 @@ class ProgressTracker:
         return log_metrics
 
 
-def get_terminal_steps_per_checkpoint(
+def get_final_steps_per_checkpoint(
     steps_per_epoch: int, steps_per_checkpoint: int = 0, checkpoints_per_epoch: float = 0, should_log: bool = False
 ):
-    """Returns the terminal steps per checkpoint to use for the training loop, given user+default inputs."""
-
+    """Returns the steps per checkpoint to use for the training loop, given user+default inputs."""
     if steps_per_checkpoint != 0 and checkpoints_per_epoch != 0:
         raise ValueError(
             "It is invalid to specify both checkpoints_per_epoch AND steps_per_checkpoint. Please specify one or the "

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import logging
 from typing import Dict, List
 
 from ludwig.constants import COMBINED, LOSS
@@ -139,3 +140,30 @@ class ProgressTracker:
                         log_metrics[f"{metrics_dict_name}.{feature_name}.{metric_name}"] = metrics_tuples[-1][-1]
 
         return log_metrics
+
+
+def get_terminal_steps_per_checkpoint(
+    steps_per_epoch: int, steps_per_checkpoint: int = 0, checkpoints_per_epoch: float = 0, should_log: bool = False
+):
+    """Returns the terminal steps per checkpoint to use for the training loop, given user+default inputs."""
+
+    if steps_per_checkpoint != 0 and checkpoints_per_epoch != 0:
+        raise ValueError(
+            "It is invalid to specify both checkpoints_per_epoch AND steps_per_checkpoint. Please specify one or the "
+            "other, or specify neither to checkpoint/eval the model every epoch."
+        )
+
+    # Set steps_per_checkpoint based on the checkpoints_per_epoch, if it was specified.
+    if checkpoints_per_epoch != 0:
+        steps_per_checkpoint = int(steps_per_epoch / checkpoints_per_epoch)
+
+    # Check steps_per_checkpoint and cap it at steps_per_epoch.
+    if steps_per_checkpoint == 0 or steps_per_checkpoint > steps_per_epoch:
+        steps_per_checkpoint = steps_per_epoch
+        if should_log:
+            logging.info(
+                f"Note: steps_per_checkpoint (was {steps_per_checkpoint}) is now set to the number of "
+                f"steps per epoch: {steps_per_epoch}.\n"
+            )
+
+    return steps_per_checkpoint

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -469,3 +469,51 @@ def test_api_callbacks(csv_filename, epochs, batch_size, num_examples, steps_per
 
     assert mock_callback.on_eval_end.call_count == total_checkpoints
     assert mock_callback.on_eval_start.call_count == total_checkpoints
+
+
+@pytest.mark.parametrize("epochs", [1, 2])
+@pytest.mark.parametrize("batch_size", [4, 8])
+@pytest.mark.parametrize("num_examples", [32, 64])
+@pytest.mark.parametrize("checkpoints_per_epoch", [1, 2, 4])
+def test_api_callbacks_checkpoints_per_epoch(csv_filename, epochs, batch_size, num_examples, checkpoints_per_epoch):
+    mock_callback = mock.Mock(wraps=Callback())
+
+    total_checkpoints = epochs * checkpoints_per_epoch
+    total_batches = epochs * (num_examples / batch_size)
+
+    with tempfile.TemporaryDirectory() as output_dir:
+        input_features = [sequence_feature(reduce_output="sum")]
+        output_features = [category_feature(vocab_size=5, reduce_input="sum")]
+
+        config = {
+            "input_features": input_features,
+            "output_features": output_features,
+            "combiner": {"type": "concat", "output_size": 14},
+            TRAINER: {"epochs": epochs, "batch_size": batch_size, "checkpoints_per_epoch": checkpoints_per_epoch},
+        }
+        model = LudwigModel(config, callbacks=[mock_callback])
+
+        data_csv = generate_data(
+            input_features, output_features, os.path.join(output_dir, csv_filename), num_examples=num_examples
+        )
+        val_csv = shutil.copyfile(data_csv, os.path.join(output_dir, "validation.csv"))
+        test_csv = shutil.copyfile(data_csv, os.path.join(output_dir, "test.csv"))
+
+        model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv)
+
+    assert mock_callback.on_epoch_start.call_count == epochs
+    assert mock_callback.on_epoch_end.call_count == epochs
+
+    assert mock_callback.should_early_stop.call_count == total_checkpoints
+
+    assert mock_callback.on_validation_start.call_count == total_checkpoints
+    assert mock_callback.on_validation_end.call_count == total_checkpoints
+
+    assert mock_callback.on_test_start.call_count == total_checkpoints
+    assert mock_callback.on_test_end.call_count == total_checkpoints
+
+    assert mock_callback.on_batch_start.call_count == total_batches
+    assert mock_callback.on_batch_end.call_count == total_batches
+
+    assert mock_callback.on_eval_end.call_count == total_checkpoints
+    assert mock_callback.on_eval_start.call_count == total_checkpoints

--- a/tests/ludwig/utils/test_trainer_utils.py
+++ b/tests/ludwig/utils/test_trainer_utils.py
@@ -65,23 +65,23 @@ def test_progress_tracker():
     }
 
 
-def test_get_terminal_steps_per_checkpoint():
+def test_get_final_steps_per_checkpoint():
     # steps_per_checkpoint and checkpoints_per_epoch cannot both be specified.
     with pytest.raises(Exception):
-        trainer_utils.get_terminal_steps_per_checkpoint(
+        trainer_utils.get_final_steps_per_checkpoint(
             steps_per_epoch=1024,
             steps_per_checkpoint=1,
             checkpoints_per_epoch=1,
         )
 
-    assert trainer_utils.get_terminal_steps_per_checkpoint(steps_per_epoch=1024, steps_per_checkpoint=100) == 100
-    assert trainer_utils.get_terminal_steps_per_checkpoint(steps_per_epoch=1024, steps_per_checkpoint=2048) == 1024
-    assert trainer_utils.get_terminal_steps_per_checkpoint(steps_per_epoch=1024, checkpoints_per_epoch=2) == 512
-    assert trainer_utils.get_terminal_steps_per_checkpoint(steps_per_epoch=1024, checkpoints_per_epoch=2.5) == 409
-    assert trainer_utils.get_terminal_steps_per_checkpoint(steps_per_epoch=1024, checkpoints_per_epoch=0.5) == 1024
-    assert trainer_utils.get_terminal_steps_per_checkpoint(steps_per_epoch=1024) == 1024
+    assert trainer_utils.get_final_steps_per_checkpoint(steps_per_epoch=1024, steps_per_checkpoint=100) == 100
+    assert trainer_utils.get_final_steps_per_checkpoint(steps_per_epoch=1024, steps_per_checkpoint=2048) == 1024
+    assert trainer_utils.get_final_steps_per_checkpoint(steps_per_epoch=1024, checkpoints_per_epoch=2) == 512
+    assert trainer_utils.get_final_steps_per_checkpoint(steps_per_epoch=1024, checkpoints_per_epoch=2.5) == 409
+    assert trainer_utils.get_final_steps_per_checkpoint(steps_per_epoch=1024, checkpoints_per_epoch=0.5) == 1024
+    assert trainer_utils.get_final_steps_per_checkpoint(steps_per_epoch=1024) == 1024
     assert (
-        trainer_utils.get_terminal_steps_per_checkpoint(
+        trainer_utils.get_final_steps_per_checkpoint(
             steps_per_epoch=1024, steps_per_checkpoint=0, checkpoints_per_epoch=0
         )
         == 1024

--- a/tests/ludwig/utils/test_trainer_utils.py
+++ b/tests/ludwig/utils/test_trainer_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ludwig.constants import COMBINED, LOSS
 from ludwig.features.category_feature import CategoryOutputFeature
 from ludwig.features.feature_utils import LudwigFeatureDict
@@ -61,3 +63,26 @@ def test_progress_tracker():
         "steps": 0,
         "validation_metrics.combined.loss": 0.2,
     }
+
+
+def test_get_terminal_steps_per_checkpoint():
+    # steps_per_checkpoint and checkpoints_per_epoch cannot both be specified.
+    with pytest.raises(Exception):
+        trainer_utils.get_terminal_steps_per_checkpoint(
+            steps_per_epoch=1024,
+            steps_per_checkpoint=1,
+            checkpoints_per_epoch=1,
+        )
+
+    assert trainer_utils.get_terminal_steps_per_checkpoint(steps_per_epoch=1024, steps_per_checkpoint=100) == 100
+    assert trainer_utils.get_terminal_steps_per_checkpoint(steps_per_epoch=1024, steps_per_checkpoint=2048) == 1024
+    assert trainer_utils.get_terminal_steps_per_checkpoint(steps_per_epoch=1024, checkpoints_per_epoch=2) == 512
+    assert trainer_utils.get_terminal_steps_per_checkpoint(steps_per_epoch=1024, checkpoints_per_epoch=2.5) == 409
+    assert trainer_utils.get_terminal_steps_per_checkpoint(steps_per_epoch=1024, checkpoints_per_epoch=0.5) == 1024
+    assert trainer_utils.get_terminal_steps_per_checkpoint(steps_per_epoch=1024) == 1024
+    assert (
+        trainer_utils.get_terminal_steps_per_checkpoint(
+            steps_per_epoch=1024, steps_per_checkpoint=0, checkpoints_per_epoch=0
+        )
+        == 1024
+    )


### PR DESCRIPTION
Internally, `trainer.checkpoints_per_epoch` is converted to `steps_per_checkpoint`, and the training loop saves checkpoints based on `steps_per_checkpoint`.

It's also possible to specify `trainer.steps_per_checkpoint` directly, so we've made it invalid to specify both `trainer.checkpoints_per_epoch` and `trainer.steps_per_checkpoint` simultaneously.

 The interaction between `trainer.checkpoints_per_epoch` and `trainer.steps_per_checkpoint` is fully described by this unit test:

```
def test_get_final_steps_per_checkpoint():
    # steps_per_checkpoint and checkpoints_per_epoch cannot both be specified.
    with pytest.raises(Exception):
        trainer_utils.get_final_steps_per_checkpoint(
            steps_per_epoch=1024,
            steps_per_checkpoint=1,
            checkpoints_per_epoch=1,
        )

    assert trainer_utils.get_final_steps_per_checkpoint(steps_per_epoch=1024, steps_per_checkpoint=100) == 100
    assert trainer_utils.get_final_steps_per_checkpoint(steps_per_epoch=1024, steps_per_checkpoint=2048) == 1024
    assert trainer_utils.get_final_steps_per_checkpoint(steps_per_epoch=1024, checkpoints_per_epoch=2) == 512
    assert trainer_utils.get_final_steps_per_checkpoint(steps_per_epoch=1024, checkpoints_per_epoch=2.5) == 409
    assert trainer_utils.get_final_steps_per_checkpoint(steps_per_epoch=1024, checkpoints_per_epoch=0.5) == 1024
    assert trainer_utils.get_final_steps_per_checkpoint(steps_per_epoch=1024) == 1024
    assert (
        trainer_utils.get_final_steps_per_checkpoint(
            steps_per_epoch=1024, steps_per_checkpoint=0, checkpoints_per_epoch=0
        )
        == 1024
    )
```