### PR TITLE
Adds min dask version, also check if `dask.annotate` is available

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -111,7 +111,7 @@ def load_csv(data_fp):
 # Decorator used to encourage Dask on Ray to spread out data loading across workers
 def spread(fn):
     def wrapped_fn(*args, **kwargs):
-        if dd is None:
+        if dd is None or not hasattr(dask, "annotate"):
             return fn(*args, **kwargs)
 
         with dask.annotate(ray_remote_args=dict(scheduling_strategy="SPREAD")):

--- a/requirements_dask.txt
+++ b/requirements_dask.txt
@@ -1,2 +1,2 @@
-dask[dataframe]<2022.1.1
+dask[dataframe]>2021.3.1,<2022.1.1
 pyarrow>=2.0.0


### PR DESCRIPTION
The check is to fix this error when running Ludwig in Colab environment:

```
Using full raw dataset, no hdf5 and json file with the same name have been found
Building dataset (it may take a while)
Traceback (most recent call last):
  File "/usr/local/bin/ludwig", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/dist-packages/ludwig/cli.py", line 158, in main
    CLI()
  File "/usr/local/lib/python3.7/dist-packages/ludwig/cli.py", line 63, in __init__
    getattr(self, args.command)()
  File "/usr/local/lib/python3.7/dist-packages/ludwig/cli.py", line 68, in train
    train.cli(sys.argv[2:])
  File "/usr/local/lib/python3.7/dist-packages/ludwig/train.py", line 387, in cli
    train_cli(**vars(args))
  File "/usr/local/lib/python3.7/dist-packages/ludwig/train.py", line 198, in train_cli
    random_seed=random_seed,
  File "/usr/local/lib/python3.7/dist-packages/ludwig/api.py", line 441, in train
    **kwargs,
  File "/usr/local/lib/python3.7/dist-packages/ludwig/api.py", line 1267, in preprocess
    callbacks=self.callbacks,
  File "/usr/local/lib/python3.7/dist-packages/ludwig/data/preprocessing.py", line 1515, in preprocess_for_training
    callbacks=callbacks,
  File "/usr/local/lib/python3.7/dist-packages/ludwig/data/preprocessing.py", line 286, in preprocess_for_training
    callbacks=callbacks,
  File "/usr/local/lib/python3.7/dist-packages/ludwig/data/preprocessing.py", line 1578, in _preprocess_file_for_training
    dataset_df = read_fn(dataset, backend.df_engine.df_lib)
  File "/usr/local/lib/python3.7/dist-packages/ludwig/utils/data_utils.py", line 117, in wrapped_fn
    with dask.annotate(ray_remote_args=dict(scheduling_strategy="SPREAD")):
AttributeError: module 'dask' has no attribute 'annotate'
```

The min dask version is to ensure that a new enough dask version is installed if `ludwig[dask]` specifically installed.