### PR TITLE
Clean invalid characters from class names when using categorical class to generate file names

### DIFF
--- a/ludwig/data/postprocessing.py
+++ b/ludwig/data/postprocessing.py
@@ -20,6 +20,7 @@ import numpy as np
 from ludwig.backend import LOCAL_BACKEND
 from ludwig.utils.data_utils import DATAFRAME_FORMATS, DICT_FORMATS, to_numpy_dataset
 from ludwig.utils.misc_utils import get_from_registry
+from ludwig.utils.strings_utils import make_safe_filename
 
 
 def postprocess(
@@ -59,9 +60,8 @@ def _save_as_numpy(predictions, output_directory, saved_keys):
     numpy_predictions = to_numpy_dataset(predictions)
     for k, v in numpy_predictions.items():
         k = k.replace("<", "[").replace(">", "]")  # Replace <UNK> and <PAD> with [UNK], [PAD]
-        k = k.replace("/", "_").replace("\\", "_")  # Replace / or \ with _
         if k not in saved_keys:
-            np.save(npy_filename.format(k), v)
+            np.save(npy_filename.format(make_safe_filename(k)), v)
             saved_keys.add(k)
 
 

--- a/ludwig/data/postprocessing.py
+++ b/ludwig/data/postprocessing.py
@@ -58,8 +58,9 @@ def _save_as_numpy(predictions, output_directory, saved_keys):
     npy_filename = os.path.join(output_directory, "{}.npy")
     numpy_predictions = to_numpy_dataset(predictions)
     for k, v in numpy_predictions.items():
+        k = k.replace("<", "[").replace(">", "]")  # Replace <UNK> and <PAD> with [UNK], [PAD]
+        k = k.replace("/", "_").replace("\\", "_")  # Replace / or \ with _
         if k not in saved_keys:
-            k = k.replace("<", "[").replace(">", "]")  # Replace <UNK> and <PAD>
             np.save(npy_filename.format(k), v)
             saved_keys.add(k)
 

--- a/ludwig/datasets/agnews/__init__.py
+++ b/ludwig/datasets/agnews/__init__.py
@@ -47,7 +47,7 @@ class AGNews(UncompressedFileDownloadMixin, MultifileJoinProcessMixin, CSVLoadMi
         super().process_downloaded_dataset(header=None)
         processed_df = pd.read_csv(os.path.join(self.processed_dataset_path, self.csv_filename))
         # Maps class_index to class name.
-        class_names = ["", "world", "sports", "business", "sci/tech"]
+        class_names = ["", "world", "sports", "business", "sci_tech"]
         # Adds new column 'class' by mapping class indexes to strings.
         processed_df["class"] = processed_df.class_index.apply(lambda i: class_names[i])
         processed_df.to_csv(os.path.join(self.processed_dataset_path, self.csv_filename), index=False)

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -306,7 +306,6 @@ def save_prediction_outputs(
         postprocessed_dict = convert_to_dict(postprocessed_output, output_features)
         csv_filename = os.path.join(output_directory, "{}_{}.csv")
         for output_field, outputs in postprocessed_dict.items():
-            output_field = make_safe_filename(output_field)
             for output_name, values in outputs.items():
                 save_csv(csv_filename.format(output_field, make_safe_filename(output_name)), values)
 

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -307,8 +307,8 @@ def save_prediction_outputs(
         csv_filename = os.path.join(output_directory, "{}_{}.csv")
         for output_field, outputs in postprocessed_dict.items():
             output_field = make_safe_filename(output_field)
-            for output_type, values in outputs.items():
-                save_csv(csv_filename.format(output_field, output_type), values)
+            for output_name, values in outputs.items():
+                save_csv(csv_filename.format(output_field, make_safe_filename(output_name)), values)
 
 
 def save_evaluation_stats(test_stats, output_directory):

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -24,6 +24,7 @@ from ludwig.models.ecd import ECD
 from ludwig.utils.data_utils import flatten_df, from_numpy_dataset, save_csv, save_json
 from ludwig.utils.horovod_utils import initialize_horovod, return_first
 from ludwig.utils.print_utils import repr_ordered_dict
+from ludwig.utils.strings_utils import make_safe_filename
 from ludwig.utils.torch_utils import initialize_pytorch
 
 EXCLUDE_PRED_SET = {LOGITS, LAST_HIDDEN}
@@ -305,6 +306,7 @@ def save_prediction_outputs(
         postprocessed_dict = convert_to_dict(postprocessed_output, output_features)
         csv_filename = os.path.join(output_directory, "{}_{}.csv")
         for output_field, outputs in postprocessed_dict.items():
+            output_field = make_safe_filename(output_field)
             for output_type, values in outputs.items():
                 save_csv(csv_filename.format(output_field, output_type), values)
 


### PR DESCRIPTION
Using `/` in class names is bad practice.

Also, the code shouldn't crash if someone happens to do it.

This PR uses `ludwig.utils.string_utils.safe_file_name` when generating output files based on categorical class names. 
 Also changes AG news class`sci/tech` to `sci_tech`.

The "sci/tech" class in AG's news was causing crashes in `ludwig evaluate`.


