### PR TITLE
Add validation split to AG news dataset in preprocessing

### DIFF
--- a/ludwig/datasets/agnews/__init__.py
+++ b/ludwig/datasets/agnews/__init__.py
@@ -56,5 +56,5 @@ class AGNews(UncompressedFileDownloadMixin, MultifileJoinProcessMixin, CSVLoadMi
         for ci in range(1, 5):
             # For each class, reassign the first val_set_n rows of the training set to validation set.
             train_rows = processed_df[(processed_df.split == 0) & (processed_df.class_index == ci)].index
-            processed_df.split.loc[train_rows[:val_set_n]] = 1
+            processed_df.loc[train_rows[:val_set_n], "split"] = 1
         processed_df.to_csv(os.path.join(self.processed_dataset_path, self.csv_filename), index=False)

--- a/ludwig/datasets/agnews/__init__.py
+++ b/ludwig/datasets/agnews/__init__.py
@@ -50,4 +50,11 @@ class AGNews(UncompressedFileDownloadMixin, MultifileJoinProcessMixin, CSVLoadMi
         class_names = ["", "world", "sports", "business", "sci_tech"]
         # Adds new column 'class' by mapping class indexes to strings.
         processed_df["class"] = processed_df.class_index.apply(lambda i: class_names[i])
+        # Agnews has no validation split, only train and test (0, 2). For convenience, we'll designate the first 5% of
+        # each class from the training set as the validation set.
+        val_set_n = int((len(processed_df) * 0.05) // len(class_names))  # rows from each class in validation set.
+        for ci in range(1, 5):
+            # For each class, reassign the first val_set_n rows of the training set to validation set.
+            train_rows = processed_df[(processed_df.split == 0) & (processed_df.class_index == ci)].index
+            processed_df.split.loc[train_rows[:val_set_n]] = 1
         processed_df.to_csv(os.path.join(self.processed_dataset_path, self.csv_filename), index=False)


### PR DESCRIPTION
The AG news dataset only have train and test splits (split 0, 2).

To make this work more smoothly with Ludwig, designates a portion of the train set as a validation set in preprocessing.

train/test/val counts:
```
0    114899
2      7599
1      5100
```