### PR TITLE
Manually upgrade black to mitigate black initialization error caused by click.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         name: Format code


### PR DESCRIPTION
Black is Incompatible with click 8.1.0 (ImportError: cannot import name '_unicodefun' from 'click')

from https://github.com/psf/black/issues/2964

Issue raised by @jimthompson5802 