### PR TITLE
Fix issue 1875 learning curve keyerror with training only statistics

### DIFF
--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1241,7 +1241,7 @@ def learning_curves(
 
                 validation_stats = []
                 for learning_stats in train_stats_per_model_list:
-                    if VALIDATION in learning_stats and len(learning_stats[VALIDATION]) > 0:
+                    if VALIDATION in learning_stats and output_feature_name in learning_stats[VALIDATION]:
                         validation_stats.append(learning_stats[VALIDATION][output_feature_name][metric])
                     else:
                         validation_stats.append(None)

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1241,7 +1241,7 @@ def learning_curves(
 
                 validation_stats = []
                 for learning_stats in train_stats_per_model_list:
-                    if VALIDATION in learning_stats:
+                    if VALIDATION in learning_stats and len(learning_stats[VALIDATION]) > 0:
                         validation_stats.append(learning_stats[VALIDATION][output_feature_name][metric])
                     else:
                         validation_stats.append(None)

--- a/tests/integration_tests/test_visualization_api.py
+++ b/tests/integration_tests/test_visualization_api.py
@@ -23,8 +23,7 @@ import pytest
 
 from ludwig import visualize
 from ludwig.api import LudwigModel
-from ludwig.constants import NAME, PREDICTIONS, PROBABILITIES, PROBABILITY, SPLIT, TRAINER, \
-    TEST, TRAINING, VALIDATION
+from ludwig.constants import NAME, PREDICTIONS, PROBABILITIES, PROBABILITY, SPLIT, TEST, TRAINER, TRAINING, VALIDATION
 from ludwig.data.preprocessing import get_split
 from ludwig.utils.data_utils import read_csv, split_dataset_ttv
 from tests.integration_tests.utils import (
@@ -132,7 +131,7 @@ def obtain_df_splits(data_csv):
     return test_df, train_df, val_df
 
 
-@pytest.mark.parametrize('training_only', [True, False])
+@pytest.mark.parametrize("training_only", [True, False])
 def test_learning_curves_vis_api(experiment_to_use, training_only):
     """Ensure pdf and png figures can be saved via visualization API call.
 
@@ -146,11 +145,7 @@ def test_learning_curves_vis_api(experiment_to_use, training_only):
     if training_only:
         # ensure plot works with only training metrics
         # Handle situation in Issue #1875
-        train_stats = {
-            TEST: {},
-            TRAINING: train_stats[TRAINING],
-            VALIDATION: {}
-        }
+        train_stats = {TEST: {}, TRAINING: train_stats[TRAINING], VALIDATION: {}}
     with TemporaryDirectory() as tmpvizdir:
         for viz_output in viz_outputs:
             vis_output_pattern_pdf = tmpvizdir + f"/*.{viz_output}"

--- a/tests/integration_tests/test_visualization_api.py
+++ b/tests/integration_tests/test_visualization_api.py
@@ -23,7 +23,8 @@ import pytest
 
 from ludwig import visualize
 from ludwig.api import LudwigModel
-from ludwig.constants import NAME, PREDICTIONS, PROBABILITIES, PROBABILITY, SPLIT, TRAINER
+from ludwig.constants import NAME, PREDICTIONS, PROBABILITIES, PROBABILITY, SPLIT, TRAINER, \
+    TEST, TRAINING, VALIDATION
 from ludwig.data.preprocessing import get_split
 from ludwig.utils.data_utils import read_csv, split_dataset_ttv
 from tests.integration_tests.utils import (
@@ -131,7 +132,8 @@ def obtain_df_splits(data_csv):
     return test_df, train_df, val_df
 
 
-def test_learning_curves_vis_api(experiment_to_use):
+@pytest.mark.parametrize('training_only', [True, False])
+def test_learning_curves_vis_api(experiment_to_use, training_only):
     """Ensure pdf and png figures can be saved via visualization API call.
 
     :param experiment_to_use: Object containing trained model and results to
@@ -140,11 +142,20 @@ def test_learning_curves_vis_api(experiment_to_use):
     """
     experiment = experiment_to_use
     viz_outputs = ("pdf", "png")
+    train_stats = experiment.train_stats
+    if training_only:
+        # ensure plot works with only training metrics
+        # Handle situation in Issue #1875
+        train_stats = {
+            TEST: {},
+            TRAINING: train_stats[TRAINING],
+            VALIDATION: {}
+        }
     with TemporaryDirectory() as tmpvizdir:
         for viz_output in viz_outputs:
             vis_output_pattern_pdf = tmpvizdir + f"/*.{viz_output}"
             visualize.learning_curves(
-                [experiment.train_stats], output_feature_name=None, output_directory=tmpvizdir, file_format=viz_output
+                [train_stats], output_feature_name=None, output_directory=tmpvizdir, file_format=viz_output
             )
             figure_cnt = glob.glob(vis_output_pattern_pdf)
             assert 3 == len(figure_cnt)


### PR DESCRIPTION
# Code Pull Requests

Fix #1875 

Summary of changes:
* updated  `visualize.py` to handle use correctly detect when validation metrics are not present in training_statistics
* updated unit test to test the situation that caused issue #1875 

Output from updated unit test:
```
root@0b8156dfe700:/opt/project/sandbox/pytest_area# pytest -v /opt/project/tests/integration_tests/test_visualization_api.py::test_learning_curves_vis_api
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.8.13, pytest-7.1.1, pluggy-1.0.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /opt/project, configfile: pytest.ini
plugins: timeout-2.1.0, xdist-2.5.0, pycharm-0.7.0, forked-1.4.0, cov-3.0.0, anyio-3.5.0
collected 2 items

../../tests/integration_tests/test_visualization_api.py::test_learning_curves_vis_api[True] PASSED                                                                                   [ 50%]
../../tests/integration_tests/test_visualization_api.py::test_learning_curves_vis_api[False] PASSED                                                                                  [100%]

```