### PR TITLE
Removes version constraint for torchmetrics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ marshmallow
 marshmallow-jsonschema
 marshmallow-dataclass
 tensorboard
-torchmetrics>=0.6.0,<0.7
+torchmetrics
 torchinfo
 filelock
 


### PR DESCRIPTION
Unpins torchmetrics. Issues related to #1686 seem to have been fixed in versions >0.7.0.