### PR TITLE
Add backwards compatibility for text models trained with legacy vocabulary levels.

### DIFF
--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -163,7 +163,8 @@ class TextFeatureMixin(BaseFeatureMixin):
 
     @staticmethod
     def feature_data(column, metadata, preprocessing_parameters, backend):
-        # TODO(1891): Remove backward compatibility once all models have been retrained.
+        # TODO(1891): Remove backward compatibility hack once all models have been retrained with Ludwig after
+        # https://github.com/ludwig-ai/ludwig/pull/1859.
         prefix = ""
         padding_symbol_metadata_key = "padding_symbol"
         unknown_symbol_metadata_key = "unknown_symbol"

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -163,16 +163,25 @@ class TextFeatureMixin(BaseFeatureMixin):
 
     @staticmethod
     def feature_data(column, metadata, preprocessing_parameters, backend):
+        # TODO(1891): Remove backward compatibility once all models have been retrained.
+        prefix = ""
+        padding_symbol_metadata_key = "padding_symbol"
+        unknown_symbol_metadata_key = "unknown_symbol"
+        if "str2idx" not in metadata:
+            prefix = "word_"
+            padding_symbol_metadata_key = "word_pad_symbol"
+            # unknown_symbol_metadata_key = "word_unk_symbol"
+
         return build_sequence_matrix(
             sequences=column,
-            inverse_vocabulary=metadata["str2idx"],
-            tokenizer_type=preprocessing_parameters["tokenizer"],
-            length_limit=metadata["max_sequence_length"],
-            padding_symbol=metadata["padding_symbol"],
+            inverse_vocabulary=metadata[f"{prefix}str2idx"],
+            tokenizer_type=preprocessing_parameters[f"{prefix}tokenizer"],
+            length_limit=metadata[f"{prefix}max_sequence_length"],
+            padding_symbol=metadata[padding_symbol_metadata_key],
             padding=preprocessing_parameters["padding"],
-            unknown_symbol=metadata["unknown_symbol"],
+            unknown_symbol=metadata[unknown_symbol_metadata_key],
             lowercase=preprocessing_parameters["lowercase"],
-            tokenizer_vocab_file=preprocessing_parameters["vocab_file"],
+            tokenizer_vocab_file=preprocessing_parameters[f"{prefix}vocab_file"],
             pretrained_model_name_or_path=preprocessing_parameters["pretrained_model_name_or_path"],
             processor=backend.df_engine,
         )

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -170,7 +170,7 @@ class TextFeatureMixin(BaseFeatureMixin):
         if "str2idx" not in metadata:
             prefix = "word_"
             padding_symbol_metadata_key = "word_pad_symbol"
-            # unknown_symbol_metadata_key = "word_unk_symbol"
+            unknown_symbol_metadata_key = "word_unk_symbol"
 
         return build_sequence_matrix(
             sequences=column,

--- a/tests/ludwig/features/test_text_feature.py
+++ b/tests/ludwig/features/test_text_feature.py
@@ -1,0 +1,103 @@
+import pandas as pd
+
+from ludwig.backend import LocalBackend
+from ludwig.features import text_feature
+
+
+def test_backwards_compatibility():
+    # Tests that legacy level-based metadata keys are supported.
+    metadata = {
+        "SibSp": {
+            "char_idx2str": ["<EOS>", "<SOS>", "<PAD>", "<UNK>", "0", "1", "2", "4", "3", "8", "5"],
+            "char_max_sequence_length": 3,
+            "char_pad_idx": 2,
+            "char_pad_symbol": "<PAD>",
+            "char_str2freq": {
+                "0": 608,
+                "1": 209,
+                "2": 28,
+                "3": 16,
+                "4": 18,
+                "5": 5,
+                "8": 7,
+                "<EOS>": 0,
+                "<PAD>": 0,
+                "<SOS>": 0,
+                "<UNK>": 0,
+            },
+            "char_str2idx": {
+                "0": 4,
+                "1": 5,
+                "2": 6,
+                "3": 8,
+                "4": 7,
+                "5": 10,
+                "8": 9,
+                "<EOS>": 0,
+                "<PAD>": 2,
+                "<SOS>": 1,
+                "<UNK>": 3,
+            },
+            "char_unk_symbol": "<UNK>",
+            "char_vocab_size": 11,
+            "preprocessing": {
+                "char_most_common": 70,
+                "char_sequence_length_limit": 1024,
+                "char_tokenizer": "characters",
+                "char_vocab_file": None,
+                "computed_fill_value": "<UNK>",
+                "fill_value": "<UNK>",
+                "lowercase": True,
+                "missing_value_strategy": "fill_with_const",
+                "padding": "right",
+                "padding_symbol": "<PAD>",
+                "pretrained_model_name_or_path": None,
+                "unknown_symbol": "<UNK>",
+                "word_most_common": 20000,
+                "word_sequence_length_limit": 256,
+                "word_tokenizer": "space_punct",
+                "word_vocab_file": None,
+            },
+            "word_idx2str": ["<EOS>", "<SOS>", "<PAD>", "<UNK>", "0", "1", "2", "4", "3", "8", "5"],
+            "word_max_sequence_length": 3,
+            "word_pad_idx": 2,
+            "word_pad_symbol": "<PAD>",
+            "word_str2freq": {
+                "0": 608,
+                "1": 209,
+                "2": 28,
+                "3": 16,
+                "4": 18,
+                "5": 5,
+                "8": 7,
+                "<EOS>": 0,
+                "<PAD>": 0,
+                "<SOS>": 0,
+                "<UNK>": 0,
+            },
+            "word_str2idx": {
+                "0": 4,
+                "1": 5,
+                "2": 6,
+                "3": 8,
+                "4": 7,
+                "5": 10,
+                "8": 9,
+                "<EOS>": 0,
+                "<PAD>": 2,
+                "<SOS>": 1,
+                "<UNK>": 3,
+            },
+            "word_unk_symbol": "<UNK>",
+            "word_vocab_size": 11,
+        }
+    }
+
+    column = pd.core.series.Series(["hello world", "hello world"])
+
+    feature_data = text_feature.TextInputFeature.feature_data(
+        column, metadata["SibSp"], metadata["SibSp"]["preprocessing"], LocalBackend()
+    )
+
+    assert list(feature_data[0]) == [1, 3, 3]
+    assert list(feature_data[1]) == [1, 3, 3]


### PR DESCRIPTION
Vocabulary levels for text features was removed in: https://github.com/ludwig-ai/ludwig/pull/1859/files.

This breaks older models that use old level-dependent metadata key names.

This adds some tech debt by checking for the old keys before a hard lookup with new keys in the feature metadata. This extra check can and should be removed once all models are trained on releases that include https://github.com/ludwig-ai/ludwig/pull/1859/files