### PR TITLE
Move hash_dict into data_util to use NumpyEncoder to handle float32

### DIFF
--- a/ludwig/data/cache/util.py
+++ b/ludwig/data/cache/util.py
@@ -1,7 +1,7 @@
 import ludwig
 from ludwig.constants import NAME, PREPROCESSING, TYPE
 from ludwig.data.cache.types import CacheableDataset
-from ludwig.utils.misc_utils import hash_dict
+from ludwig.utils.data_utils import hash_dict
 
 
 def calculate_checksum(original_dataset: CacheableDataset, config: dict):

--- a/ludwig/features/feature_utils.py
+++ b/ludwig/features/feature_utils.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 
 from ludwig.constants import NAME, PREPROCESSING, SEQUENCE, TEXT, TIMESERIES
-from ludwig.utils.misc_utils import hash_dict
+from ludwig.utils.data_utils import hash_dict
 from ludwig.utils.strings_utils import tokenizer_registry, UNKNOWN_SYMBOL
 
 SEQUENCE_TYPES = {SEQUENCE, TEXT, TIMESERIES}

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -22,10 +22,10 @@ from ludwig.hyperopt.sampling import HyperoptSampler, RayTuneSampler
 from ludwig.hyperopt.utils import load_json_values
 from ludwig.modules.metric_modules import get_best_function
 from ludwig.utils import metric_utils
-from ludwig.utils.data_utils import NumpyEncoder
+from ludwig.utils.data_utils import hash_dict, NumpyEncoder
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.fs_utils import has_remote_protocol
-from ludwig.utils.misc_utils import get_from_registry, hash_dict
+from ludwig.utils.misc_utils import get_from_registry
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import base64
 import collections.abc
 import csv
 import functools
+import hashlib
 import json
 import logging
 import os.path
@@ -23,7 +25,7 @@ import pickle
 import random
 import re
 from itertools import islice
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -271,6 +273,14 @@ def load_json(data_fp):
 def save_json(data_fp, data, sort_keys=True, indent=4):
     with open_file(data_fp, "w") as output_file:
         json.dump(data, output_file, cls=NumpyEncoder, sort_keys=sort_keys, indent=indent)
+
+
+def hash_dict(d: dict, max_length: Union[int, None] = 6) -> bytes:
+    s = json.dumps(d, cls=NumpyEncoder, sort_keys=True, ensure_ascii=True)
+    h = hashlib.md5(s.encode())
+    d = h.digest()
+    b = base64.b64encode(d, altchars=b"__")
+    return b[:max_length]
 
 
 def to_json_dict(d):

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -13,15 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import base64
 import copy
-import hashlib
-import json
 import os
 import random
 from collections import OrderedDict
 from collections.abc import Mapping
-from typing import Union
 
 import numpy
 import torch
@@ -122,14 +118,6 @@ def get_file_names(output_directory):
     model_dir = os.path.join(output_directory, "model")
 
     return description_fn, training_stats_fn, model_dir
-
-
-def hash_dict(d: dict, max_length: Union[int, None] = 6) -> bytes:
-    s = json.dumps(d, sort_keys=True, ensure_ascii=True)
-    h = hashlib.md5(s.encode())
-    d = h.digest()
-    b = base64.b64encode(d, altchars=b"__")
-    return b[:max_length]
 
 
 def get_combined_features(config):

--- a/tests/ludwig/utils/test_data_utils.py
+++ b/tests/ludwig/utils/test_data_utils.py
@@ -16,7 +16,7 @@ import dask.dataframe as dd
 import pandas as pd
 
 from ludwig.data.cache.types import CacheableDataframe
-from ludwig.utils.data_utils import add_sequence_feature_column, figure_data_format_dataset, get_abs_path
+from ludwig.utils.data_utils import add_sequence_feature_column, figure_data_format_dataset, get_abs_path, hash_dict
 
 
 def test_add_sequence_feature_column():
@@ -86,3 +86,9 @@ def test_figure_data_format_dataset():
         )
         == dd.core.DataFrame
     )
+
+
+def test_hash_dict_numpy_types():
+    df = pd.DataFrame([{"text": "t", "int": 1, "float": 0.1, "bool": True}])
+    d = df.to_dict()
+    assert hash_dict(d) == b"OCq5a6"

--- a/tests/ludwig/utils/test_data_utils.py
+++ b/tests/ludwig/utils/test_data_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 import dask.dataframe as dd
+import numpy as np
 import pandas as pd
 
 from ludwig.data.cache.types import CacheableDataframe
@@ -89,6 +90,5 @@ def test_figure_data_format_dataset():
 
 
 def test_hash_dict_numpy_types():
-    df = pd.DataFrame([{"text": "t", "int": 1, "float": 0.1, "bool": True}])
-    d = df.to_dict()
-    assert hash_dict(d) == b"OCq5a6"
+    d = {"float32": np.float32(1)}
+    assert hash_dict(d) == b"uqtgWB"


### PR DESCRIPTION
Closes #1889

The `calculate_checksum` method calls [hash_dict](https://github.com/ludwig-ai/ludwig/blob/master/ludwig/utils/misc_utils.py#L127-L132) which calls `json.dumps` without using NumpyEncoder.  This PR moves this method into the `data_utils.py` class (required to avoid circular reference)

* Added test method to convert pandas df with different types (string, int, float, bool) to dict and calc checksum.