### PR TITLE
Update Ludwig README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ configuration system.
   you need to start training deep learning models. Ludwig uses declared features to compose a deep learning model
   accordingly.
 
-- [Training, Prediction, and Evaluation](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/command_line_interface)
+- [Training, Prediction, and Evaluation from the command line](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/command_line_interface)
 
   Simple commands can be used to train models and predict new data.
 
@@ -55,32 +55,6 @@ configuration system.
   ludwig predict --model_path results/experiment_run/model --dataset test.csv
   ludwig eval --model_path results/experiment_run/model --dataset test.csv
   ```
-
-- [Distributed Training](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/distributed_training)
-
-  Train models in a distributed setting using [Horovod](https://github.com/horovod/horovod), which allows training on a
-  single machine with multiple GPUs or multiple machines with multiple GPUs.
-
-- [Serving](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/serving)
-
-  Serve models using FastAPI.
-
-  ```
-  ludwig serve --model_path ./results/experiment_run/model
-  curl http://0.0.0.0:8000/predict -X POST -F "movie_title=Friends With Money" -F "content_rating=R" -F "genres=Art House & International, Comedy, Drama" -F "runtime=88.0" -F "top_critic=TRUE" -F "review_content=The cast is terrific, the movie isn't."
-  ```
-
-- [Hyperparameter optimization](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/hyperopt)
-
-  Run hyperparameter optimization locally or using [Ray Tune](https://docs.ray.io/en/latest/tune/index.html).
-
-  ```sh
-  ludwig hyperopt --config config.yaml --dataset data.csv
-  ```
-
-- [AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl)
-
-  Ludwig AutoML takes a dataset, the target column, and a time budget, and returns a trained Ludwig model.
 
 - [Programmatic API](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/api/LudwigModel)
 
@@ -113,6 +87,32 @@ configuration system.
   # obtain predictions
   predictions = model.predict(data)
   ```
+
+- [Distributed Training](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/distributed_training)
+
+  Train models in a distributed setting using [Horovod](https://github.com/horovod/horovod), which allows training on a
+  single machine with multiple GPUs or multiple machines with multiple GPUs.
+
+- [Serving](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/serving)
+
+  Serve models using FastAPI.
+
+  ```
+  ludwig serve --model_path ./results/experiment_run/model
+  curl http://0.0.0.0:8000/predict -X POST -F "movie_title=Friends With Money" -F "content_rating=R" -F "genres=Art House & International, Comedy, Drama" -F "runtime=88.0" -F "top_critic=TRUE" -F "review_content=The cast is terrific, the movie isn't."
+  ```
+
+- [Hyperparameter optimization](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/hyperopt)
+
+  Run hyperparameter optimization locally or using [Ray Tune](https://docs.ray.io/en/latest/tune/index.html).
+
+  ```sh
+  ludwig hyperopt --config config.yaml --dataset data.csv
+  ```
+
+- [AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl)
+
+  Ludwig AutoML takes a dataset, the target column, and a time budget, and returns a trained Ludwig model.
 
 - [Third-Party Integrations](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/integrations)
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Ludwig takes care of the engineering complexity of deep learning out of the box,
 
 Data preprocessing, hyperparameter optimization, device management, and distributed training for newly registered `torch.nn.Module` models come completely free.
 
-## Easily build your benachmarks
+## Easily build your benchmarks
 
 Creating a state-of-the-art baseline and comapring it with a new model  is a simple config change.
 
@@ -293,7 +293,7 @@ Ludwig also natively integrates with pre-trained models, such as the ones availa
 ludwig train --dataset sst5 -–config_str “{input_features: [{name: sentence, type: text, encoder: bert}], output_features: [{name: label, type: category}]}”
 ```
 
-## Low-code interface for autoML
+## Low-code interface for AutoML
 
 [Ludwig AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl/) allows users to obtain trained models by providing just a dataset, the target column, and a time budget.
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ or take a look at end-to-end [Examples](https://ludwig-ai.github.io/ludwig-docs/
 Install from PyPi. Be aware that Ludwig requires Python 3.7+.
 
 ```
-> pip install ludwig
+pip install ludwig
 ```
 
 ## Step 2: Define a configuration

--- a/README.md
+++ b/README.md
@@ -18,21 +18,33 @@ Translated in [🇰🇷 Korean](README_KR.md)/
 
 # What is Ludwig?
 
-Ludwig is a data-driven declarative ML framework that makes it easy to define deep learning pipelines for many types of tasks using a simple and flexible data-driven configuration system. It was open sourced by Uber and is hosted by the Linux Foundation AI & Data.
+Ludwig is an open-source [declarative Machine Learning framework](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/what_is_ludwig/#why-declarative-machine-learning-systems)
+that makes it easy to define deep learning pipelines for many types of tasks using a simple and flexible data-driven
+configuration system. Ludwig was open sourced by Uber and is hosted by the Linux Foundation AI & Data.
 
-A data-driven configuration system allows users to define their deep learning pipeline by providing a list of inputs and outputs with their data type. The data type determines how inputs and outputs are preprocessed, encoded, decoded and which metrics and losses to use. Ludwig will assemble and train a deep learning model based on the combination of data types for many machine learning tasks.
+A data-driven configuration system allows users to define their deep learning pipeline by providing a list of inputs and
+outputs with their data type. The data type determines how inputs and outputs are preprocessed, encoded, decoded and
+which metrics and losses to use. Ludwig will assemble and train a deep learning model based on the combination of data
+types for many machine learning tasks.
 
 ![img](https://raw.githubusercontent.com/ludwig-ai/ludwig-docs/ludwig05/docs/images/ludwig_legos.gif)
 
-Configurations are simple and flexible, enabling deep control of every aspect of the end-to-end pipeline; from experimenting with different training recipes, exploring state-of-the-art model architectures, to scaling up to large out-of-memory datasets and multi-node clusters, and finally serving the best model in production -- all can be achieved through small configuration changes.
+Configurations are simple and flexible, enabling deep control of every aspect of the end-to-end pipeline; from
+experimenting with different training recipes, exploring state-of-the-art model architectures, to scaling up to large
+out-of-memory datasets and multi-node clusters, and finally serving the best model in production -- all can be achieved
+through small configuration changes.
 
-Finally, the use of abstract interfaces throughout the codebase makes it easy for users to extend Ludwig by adding new models, metrics, losses, preprocessing functions and register them to make them available immediately in the configuration system.
+Finally, the use of abstract interfaces throughout the codebase makes it easy for users to extend Ludwig by adding new
+models, metrics, losses, preprocessing functions and register them to make them available immediately in the
+configuration system.
 
 # Main Features
 
 - [Data-Driven configuration system](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/how_ludwig_works)
 
-  A config YAML file that describes the schema of your data (input features, output features, and their types) is all you need to start training deep learning models. Ludwig uses declared features to compose a deep learning model accordingly.
+  A config YAML file that describes the schema of your data (input features, output features, and their types) is all
+  you need to start training deep learning models. Ludwig uses declared features to compose a deep learning model
+  accordingly.
 
 - [Training, Prediction, and Evaluation](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/command_line_interface)
 
@@ -46,7 +58,8 @@ Finally, the use of abstract interfaces throughout the codebase makes it easy fo
 
 - [Distributed Training](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/distributed_training)
 
-  Train models in a distributed setting using [Horovod](https://github.com/horovod/horovod), which allows training on a single machine with multiple GPUs or multiple machines with multiple GPUs.
+  Train models in a distributed setting using [Horovod](https://github.com/horovod/horovod), which allows training on a
+  single machine with multiple GPUs or multiple machines with multiple GPUs.
 
 - [Serving](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/serving)
 
@@ -59,7 +72,11 @@ Finally, the use of abstract interfaces throughout the codebase makes it easy fo
 
 - [Hyperparameter optimization](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/hyperopt)
 
-  Ludwig supports hyperparameter optimization using Ray Tune or a local executor.
+  Run hyperparameter optimization locally or using [Ray Tune](https://docs.ray.io/en/latest/tune/index.html).
+
+  ```sh
+  ludwig hyperopt --config config.yaml --dataset data.csv
+  ```
 
 - [AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl)
 
@@ -171,7 +188,7 @@ trainer:
   optimizer:
     type: adamw
     beat1: 0.9
-  learning_rate: 0.0001
+  learning_rate: 0.001
 
 backend:
   type: ray
@@ -193,7 +210,7 @@ hyperopt:
       lower: 1
       upper: 5
     trainer.learning_rate:
-      values: [0.01, 0.003, 0,001]
+      values: [0.01, 0.003, 0.001]
 ```
 
 For details on what can be configured, check out [Ludwig Configuration](https://ludwig-ai.github.io/ludwig-docs/latest/configuration/)
@@ -227,22 +244,9 @@ ludwig visualize --visualization compare_performance --test_statistics path/to/t
 
 For the full set of visualization see the [Visualization Guide](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/visualizations).
 
-## Step 6: Hyperopt, serving, and more
+## Step 6: Happy modeling!
 
-Run hyperparameter optimization locally or using [Ray Tune](https://docs.ray.io/en/latest/tune/index.html).
-
-```sh
-ludwig hyperopt --config config.yaml --dataset data.csv
-```
-
-Serve models using [FastAPI](https://fastapi.tiangolo.com/).
-
-```sh
-ludwig serve --model_path ./results/experiment_run/model
-curl http://0.0.0.0:8000/predict -X POST -F "sentence=Former president Barack Obama"
-```
-
-Try applying Ludwig to your data! [Reach out](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ)
+Try applying Ludwig to your data. [Reach out](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ)
 if you have any questions.
 
 # Advantages

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ preprocessing data, and setting up pipelines for (distributed) training, evaluat
 Ludwig takes care of the engineering complexity of deep learning out of the box, enabling research scientists to focus
 on building models at the highest level of abstraction.
 
-Without Ludwig, if you had a great idea for a novel architecture for image classification, you would implement your new
-model as a PyTorch module.
+Let's say that you have a great idea for a novel architecture for image classification with a change specific to how
+images are encoded. You would implement your new model as a PyTorch module.
 
 ```python
 import torch.nn as nn
@@ -175,7 +175,8 @@ a training-checkpoint-eval loop, post-process logits tensors into predictions, a
 these steps elongate model development time and introduce potential sources of error.
 
 Instead of implementing all of this from scratch, research scientists can implement new models as PyTorch Modules in
-Ludwig directly to take advantage of all of the engineering conveniences that Ludwig offers.
+Ludwig directly to take advantage of all of the engineering conveniences that Ludwig offers. Since your modeling idea
+applies specifically to image encoding, then only the encoder needs to be implemented.
 
 ```python
 import torch
@@ -184,7 +185,7 @@ from ludwig.encoders.base import Encoder
 
 
 @register("my_encoder", IMAGE)
-class MyImageClassificationModel(Encoder):
+class MyImageEncoder(Encoder):
     def __init__(self, hyperparameter_1, hyperparameter_2):
         # ...
         pass

--- a/README.md
+++ b/README.md
@@ -301,21 +301,25 @@ Ludwig supports exporting models to efficient Torschscript bundles.
 ludwig export_torchscript -–model_path=/path/to/model
 ```
 
-# Examples
+# Tutorials
 
 - [Text Classification](https://ludwig-ai.github.io/ludwig-docs/latest/examples/text_classification)
+- [Tabular Data Classification](https://ludwig-ai.github.io/ludwig-docs/latest/examples/adult_census_income)
+- [Image Classification](https://ludwig-ai.github.io/ludwig-docs/latest/examples/mnist)
+- [Multimodal Classification](https://ludwig-ai.github.io/ludwig-docs/latest/examples/multimodal_classification)
+
+# Example Use Cases
+
 - [Named Entity Recognition Tagging](https://ludwig-ai.github.io/ludwig-docs/latest/examples/ner_tagging)
 - [Natural Language Understanding](https://ludwig-ai.github.io/ludwig-docs/latest/examples/nlu)
 - [Machine Translation](https://ludwig-ai.github.io/ludwig-docs/latest/examples/machine_translation)
 - [Chit-Chat Dialogue Modeling through seq2seq](https://ludwig-ai.github.io/ludwig-docs/latest/examples/seq2seq)
 - [Sentiment Analysis](https://ludwig-ai.github.io/ludwig-docs/latest/examples/sentiment_analysis)
-- [Image Classification](https://ludwig-ai.github.io/ludwig-docs/latest/examples/image_classification)
-- [Image Classification (MNIST)](https://ludwig-ai.github.io/ludwig-docs/latest/examples/mnist)
-- [Visual Question Answering](https://ludwig-ai.github.io/ludwig-docs/latest/examples/visual_qa)
 - [One-shot Learning with Siamese Networks](https://ludwig-ai.github.io/ludwig-docs/latest/examples/oneshot)
-- [Speaker Verification](https://ludwig-ai.github.io/ludwig-docs/latest/examples/speaker_verification)
+- [Visual Question Answering](https://ludwig-ai.github.io/ludwig-docs/latest/examples/visual_qa)
 - [Spoken Digit Speech Recognition](https://ludwig-ai.github.io/ludwig-docs/latest/examples/speech_recognition)
-- [Binary Classification (titanic)](https://ludwig-ai.github.io/ludwig-docs/latest/examples/titanic)
+- [Speaker Verification](https://ludwig-ai.github.io/ludwig-docs/latest/examples/speaker_verification)
+- [Binary Classification (Titanic)](https://ludwig-ai.github.io/ludwig-docs/latest/examples/titanic)
 - [Timeseries forecasting](https://ludwig-ai.github.io/ludwig-docs/latest/examples/forecasting)
 - [Timeseries forecasting (Weather)](https://ludwig-ai.github.io/ludwig-docs/latest/examples/weather)
 - [Movie rating prediction](https://ludwig-ai.github.io/ludwig-docs/latest/examples/movie_ratings)

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ Finally, the use of abstract interfaces throughout the codebase makes it easy fo
 
 - [Serving](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/serving)
 
-  ```
   Serve models using FastAPI.
-  ```
 
-  > ludwig serve --model_path ./results/experiment_run/model
-  > curl http://0.0.0.0:8000/predict -X POST -F "movie_title=Friends With Money" -F "content_rating=R" -F "genres=Art House & International, Comedy, Drama" -F "runtime=88.0" -F "top_critic=TRUE" -F "review_content=The cast is terrific, the movie isn't."
+  ```
+  ludwig serve --model_path ./results/experiment_run/model
+  curl http://0.0.0.0:8000/predict -X POST -F "movie_title=Friends With Money" -F "content_rating=R" -F "genres=Art House & International, Comedy, Drama" -F "runtime=88.0" -F "top_critic=TRUE" -F "review_content=The cast is terrific, the movie isn't."
+  ```
 
 - [Hyperparameter optimization](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/hyperopt)
 

--- a/README.md
+++ b/README.md
@@ -113,34 +113,45 @@ Ludwig is a profound utility for research scientists, data scientists, and machi
 
 **Minimal machine learning boilerplate**
 
+```
 Ludwig takes care of the engineering complexity of deep learning out of the box, enabling research scientists to focus on building models at the highest level of abstraction.
 
 Data preprocessing, hyperparameter optimization, device management, and distributed training for newly registered `torch.nn.Module` models come completely free.
+```
 
 **Compare models against existing SOTA models**
 
+```
 Comparing the new model against existing published and implemented models is a simple config change.
+```
 
 **Easily apply new architectures to multiple problems and datasets**
 
+```
 Apply new models across the extensive set of tasks and datasets that Ludwig supports. Ludwig includes a [full benchmarking toolkit](https://arxiv.org/abs/2111.04260) accessible to any user, for running experiments with multiple models across multiple datasets with just a simple configuration.
+```
 
 **Highly configurable data preprocessing, modeling, and metrics**
 
+```
 Any and all aspects of the model architecture, training loop, hyperparameter search, and backend infrastructure can be modified as additional fields in the declarative configuration to customize the pipeline to meet your requirements.
 
 For details on what can be configured, check out [Ludwig Configuration](https://ludwig-ai.github.io/ludwig-docs/latest/configuration/) docs.
+```
 
 **Low-code interface for state-of-the-art models, including pre-trained Huggingface Transformers**
 
+````
 Ludwig also natively integrates with pre-trained models, such as the ones available in [Huggingface Transformers](https://huggingface.co/docs/transformers/index). Users can choose from a vast collection of state-of-the-art pre-trained PyTorch models to use without needing to write any code at all. For example, training a BERT-based sentiment analysis model with Ludwig is as simple as:
 
 ```
 ludwig train --dataset sst5 -–config_str “{input_features: [{name: sentence, type: text, encoder: bert}], output_features: [{name: label, type: category}]}”
 ```
+````
 
 **Low-code Interface for AutoML**
 
+````
 [Ludwig AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl/) allows users to obtain trained models by providing just a dataset, the target column, and a time budget. It’s as simple as that!
 
 ```
@@ -148,9 +159,11 @@ auto_train_results = ludwig.automl.auto_train(
     dataset=my_dataset_df, target=target_column_name, time_limit_s=7200, tune_for_memory=False
 )
 ```
+````
 
 **Easy Productionisation**
 
+````
 Ludwig makes it easy to serve deep learning models, including on GPUs. Launch a REST API for your trained Ludwig model.
 
 ```
@@ -162,6 +175,7 @@ Ludwig supports exporting models to efficient Torschscript bundles.
 ```
 ludwig export_torchscript -–model_path=/path/to/model
 ```
+````
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -111,57 +111,57 @@ Finally, the use of abstract interfaces throughout the codebase makes it easy fo
 
 Ludwig is a profound utility for research scientists, data scientists, and machine learning engineers.
 
-- Minimal machine learning boilerplate
+**Minimal machine learning boilerplate**
 
-  Ludwig takes care of the engineering complexity of deep learning out of the box, enabling research scientists to focus on building models at the highest level of abstraction.
+Ludwig takes care of the engineering complexity of deep learning out of the box, enabling research scientists to focus on building models at the highest level of abstraction.
 
-  Data preprocessing, hyperparameter optimization, device management, and distributed training for newly registered `torch.nn.Module` models come completely free.
+Data preprocessing, hyperparameter optimization, device management, and distributed training for newly registered `torch.nn.Module` models come completely free.
 
-- Compare models against existing SOTA models
+**Compare models against existing SOTA models**
 
-  Comparing the new model against existing published and implemented models is a simple config change.
+Comparing the new model against existing published and implemented models is a simple config change.
 
-- Easily apply new architectures to multiple problems and datasets
+**Easily apply new architectures to multiple problems and datasets**
 
-  Apply new models across the extensive set of tasks and datasets that Ludwig supports. Ludwig includes a [full benchmarking toolkit](https://arxiv.org/abs/2111.04260) accessible to any user, for running experiments with multiple models across multiple datasets with just a simple configuration.
+Apply new models across the extensive set of tasks and datasets that Ludwig supports. Ludwig includes a [full benchmarking toolkit](https://arxiv.org/abs/2111.04260) accessible to any user, for running experiments with multiple models across multiple datasets with just a simple configuration.
 
-- Highly configurable data preprocessing, modeling, and metrics
+**Highly configurable data preprocessing, modeling, and metrics**
 
-  Any and all aspects of the model architecture, training loop, hyperparameter search, and backend infrastructure can be modified as additional fields in the declarative configuration to customize the pipeline to meet your requirements.
+Any and all aspects of the model architecture, training loop, hyperparameter search, and backend infrastructure can be modified as additional fields in the declarative configuration to customize the pipeline to meet your requirements.
 
-  For details on what can be configured, check out [Ludwig Configuration](https://ludwig-ai.github.io/ludwig-docs/latest/configuration/) docs.
+For details on what can be configured, check out [Ludwig Configuration](https://ludwig-ai.github.io/ludwig-docs/latest/configuration/) docs.
 
-- Low-code interface for state-of-the-art models, including pre-trained Huggingface Transformers
+**Low-code interface for state-of-the-art models, including pre-trained Huggingface Transformers**
 
-  Ludwig also natively integrates with pre-trained models, such as the ones available in [Huggingface Transformers](https://huggingface.co/docs/transformers/index). Users can choose from a vast collection of state-of-the-art pre-trained PyTorch models to use without needing to write any code at all. For example, training a BERT-based sentiment analysis model with Ludwig is as simple as:
+Ludwig also natively integrates with pre-trained models, such as the ones available in [Huggingface Transformers](https://huggingface.co/docs/transformers/index). Users can choose from a vast collection of state-of-the-art pre-trained PyTorch models to use without needing to write any code at all. For example, training a BERT-based sentiment analysis model with Ludwig is as simple as:
 
-  ```
-  ludwig train --dataset sst5 -–config_str “{input_features: [{name: sentence, type: text, encoder: bert}], output_features: [{name: label, type: category}]}”
-  ```
+```
+ludwig train --dataset sst5 -–config_str “{input_features: [{name: sentence, type: text, encoder: bert}], output_features: [{name: label, type: category}]}”
+```
 
-- Low-code Interface for AutoML
+**Low-code Interface for AutoML**
 
-  [Ludwig AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl/) allows users to obtain trained models by providing just a dataset, the target column, and a time budget. It’s as simple as that!
+[Ludwig AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl/) allows users to obtain trained models by providing just a dataset, the target column, and a time budget. It’s as simple as that!
 
-  ```
-  auto_train_results = ludwig.automl.auto_train(
-      dataset=my_dataset_df, target=target_column_name, time_limit_s=7200, tune_for_memory=False
-  )
-  ```
+```
+auto_train_results = ludwig.automl.auto_train(
+    dataset=my_dataset_df, target=target_column_name, time_limit_s=7200, tune_for_memory=False
+)
+```
 
-- Easy Productionisation
+**Easy Productionisation**
 
-  Ludwig makes it easy to serve deep learning models, including on GPUs. Launch a REST API for your trained Ludwig model.
+Ludwig makes it easy to serve deep learning models, including on GPUs. Launch a REST API for your trained Ludwig model.
 
-  ```
-  ludwig serve --model_path=/path/to/model
-  ```
+```
+ludwig serve --model_path=/path/to/model
+```
 
-  Ludwig supports exporting models to efficient Torschscript bundles.
+Ludwig supports exporting models to efficient Torschscript bundles.
 
-  ```
-  ludwig export_torchscript -–model_path=/path/to/model
-  ```
+```
+ludwig export_torchscript -–model_path=/path/to/model
+```
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ ludwig export_torchscript -–model_path=/path/to/model
 
 # More Information
 
-[Full official documentation](https://ludwig-ai.github.io/ludwig-docs/)
+[Full official documentation](https://ludwig-ai.github.io/ludwig-docs/).
 
 Read our publications on [Ludwig](https://arxiv.org/pdf/1909.07930.pdf), [declarative ML](https://arxiv.org/pdf/2107.08148.pdf), and [Ludwig’s SoTA benchmarks](https://openreview.net/pdf?id=hwjnu6qW7E4).
 

--- a/README.md
+++ b/README.md
@@ -111,47 +111,36 @@ Finally, the use of abstract interfaces throughout the codebase makes it easy fo
 
 Ludwig is a profound utility for research scientists, data scientists, and machine learning engineers.
 
-**Minimal machine learning boilerplate**
+## Minimal machine learning boilerplate
 
-```
 Ludwig takes care of the engineering complexity of deep learning out of the box, enabling research scientists to focus on building models at the highest level of abstraction.
 
 Data preprocessing, hyperparameter optimization, device management, and distributed training for newly registered `torch.nn.Module` models come completely free.
-```
 
-**Compare models against existing SOTA models**
+## Compare models against existing SOTA models
 
-```
 Comparing the new model against existing published and implemented models is a simple config change.
-```
 
-**Easily apply new architectures to multiple problems and datasets**
+## Easily apply new architectures to multiple problems and datasets
 
-```
 Apply new models across the extensive set of tasks and datasets that Ludwig supports. Ludwig includes a [full benchmarking toolkit](https://arxiv.org/abs/2111.04260) accessible to any user, for running experiments with multiple models across multiple datasets with just a simple configuration.
-```
 
-**Highly configurable data preprocessing, modeling, and metrics**
+## Highly configurable data preprocessing, modeling, and metrics
 
-```
 Any and all aspects of the model architecture, training loop, hyperparameter search, and backend infrastructure can be modified as additional fields in the declarative configuration to customize the pipeline to meet your requirements.
 
 For details on what can be configured, check out [Ludwig Configuration](https://ludwig-ai.github.io/ludwig-docs/latest/configuration/) docs.
-```
 
-**Low-code interface for state-of-the-art models, including pre-trained Huggingface Transformers**
+## Low-code interface for state-of-the-art models, including pre-trained Huggingface Transformers
 
-````
 Ludwig also natively integrates with pre-trained models, such as the ones available in [Huggingface Transformers](https://huggingface.co/docs/transformers/index). Users can choose from a vast collection of state-of-the-art pre-trained PyTorch models to use without needing to write any code at all. For example, training a BERT-based sentiment analysis model with Ludwig is as simple as:
 
 ```
 ludwig train --dataset sst5 -–config_str “{input_features: [{name: sentence, type: text, encoder: bert}], output_features: [{name: label, type: category}]}”
 ```
-````
 
-**Low-code Interface for AutoML**
+## Low-code Interface for AutoML
 
-````
 [Ludwig AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl/) allows users to obtain trained models by providing just a dataset, the target column, and a time budget. It’s as simple as that!
 
 ```
@@ -159,11 +148,9 @@ auto_train_results = ludwig.automl.auto_train(
     dataset=my_dataset_df, target=target_column_name, time_limit_s=7200, tune_for_memory=False
 )
 ```
-````
 
-**Easy Productionisation**
+## Easy Productionisation
 
-````
 Ludwig makes it easy to serve deep learning models, including on GPUs. Launch a REST API for your trained Ludwig model.
 
 ```
@@ -175,7 +162,6 @@ Ludwig supports exporting models to efficient Torschscript bundles.
 ```
 ludwig export_torchscript -–model_path=/path/to/model
 ```
-````
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Translated in [🇰🇷Korean](README_KR.md)
 
 # What is Ludwig?
 
-Ludwig is an open-source [declarative Machine Learning framework](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/what_is_ludwig/#why-declarative-machine-learning-systems)
+Ludwig is an open-source [declarative machine learning framework](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/what_is_ludwig/#why-declarative-machine-learning-systems)
 that makes it easy to define deep learning pipelines for many types of tasks using a simple and flexible data-driven
 configuration system. Ludwig was open sourced by Uber and is hosted by the Linux Foundation AI & Data.
 
@@ -66,7 +66,7 @@ configuration system.
     ...
   ```
 
-- [Training, Prediction, and Evaluation from the command line](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/command_line_interface)
+- [Training, prediction, and evaluation from the command line](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/command_line_interface)
 
   Simple commands can be used to train models and predict new data.
 
@@ -99,7 +99,7 @@ configuration system.
   predictions = model.predict(data)
   ```
 
-- [Distributed Training](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/distributed_training)
+- [Distributed training](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/distributed_training)
 
   Train models in a distributed setting using [Horovod](https://github.com/horovod/horovod), which allows training on a
   single machine with multiple GPUs or multiple machines with multiple GPUs.
@@ -125,7 +125,7 @@ configuration system.
 
   Ludwig AutoML takes a dataset, the target column, and a time budget, and returns a trained Ludwig model.
 
-- [Third-Party Integrations](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/integrations)
+- [Third-Party integrations](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/integrations)
 
   Ludwig provides an extendable interface to integrate with third-party systems for tracking experiments. Third-party
   integrations exist for Comet ML, Weights & Biases, WhyLabs and MLFlow.
@@ -293,7 +293,7 @@ Ludwig also natively integrates with pre-trained models, such as the ones availa
 ludwig train --dataset sst5 -–config_str “{input_features: [{name: sentence, type: text, encoder: bert}], output_features: [{name: label, type: category}]}”
 ```
 
-## Low-code Interface for AutoML
+## Low-code interface for autoML
 
 [Ludwig AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl/) allows users to obtain trained models by providing just a dataset, the target column, and a time budget.
 
@@ -301,7 +301,7 @@ ludwig train --dataset sst5 -–config_str “{input_features: [{name: sentence,
 auto_train_results = ludwig.automl.auto_train(dataset=my_dataset_df, target=target_column_name, time_limit_s=7200)
 ```
 
-## Easy Productionisation
+## Easy productionisation
 
 Ludwig makes it easy to serve deep learning models, including on GPUs. Launch a REST API for your trained Ludwig model.
 

--- a/README.md
+++ b/README.md
@@ -18,475 +18,186 @@ Translated in [🇰🇷 Korean](README_KR.md)/
 
 # What is Ludwig?
 
-Ludwig is a data-driven declarative ML framework hosted by the LF AI & Data Foundation that makes it easy to define
-deep learning pipelines for many types of tasks with a simple and flexible data-driven configuration system.
+Ludwig is a data-driven declarative ML framework that makes it easy to define deep learning pipelines for many types of tasks using a simple and flexible data-driven configuration system. It was open sourced by Uber and is hosted by the Linux Foundation AI & Data.
+
+A data-driven configuration system allows users to define their deep learning pipeline by providing a list of inputs and outputs with their data type. The data type determines how inputs and outputs are preprocessed, encoded, decoded and which metrics and losses to use. Ludwig will assemble and train a deep learning model based on the combination of data types for many machine learning tasks.
 
 ![img](https://raw.githubusercontent.com/ludwig-ai/ludwig-docs/ludwig05/docs/images/ludwig_legos.gif)
 
-Ludwig supports many different combinations of input and output types that solve many different machine learning tasks.
+Configurations are simple and flexible, enabling deep control of every aspect of the end-to-end pipeline; from experimenting with different training recipes, exploring state-of-the-art model architectures, to scaling up to large out-of-memory datasets and multi-node clusters, and finally serving the best model in production -- all can be achieved through small configuration changes.
 
-Ludwig supports users in their machine learning projects end-to-end; from experimenting with different training recipes,
-exploring state-of-the-art model architectures, to scaling up to large out-of-memory datasets and multi-node clusters,
-and finally serving the best model in production.
+Finally, the use of abstract interfaces throughout the codebase makes it easy for users to extend Ludwig by adding new models, metrics, losses, preprocessing functions and register them to make them available immediately in the configuration system.
 
-# Getting started
+# Main Features
 
-Check out the official [getting started guide](https://ludwig-ai.github.io/ludwig-docs/latest/getting_started/).
+- [Data-Driven configuration system](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/how_ludwig_works)
 
-# How to Use Ludwig
+  A config YAML file that describes the schema of your data (input features, output features, and their types) is all you need to start training deep learning models. Ludwig uses declared features to compose a deep learning model accordingly.
 
-Create a config that describes the schema of your data.
+- [Training, Prediction, and Evaluation](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/command_line_interface)
 
-```yaml
-input_features:
-    -
-        name: Pclass
-        type: category
-    -
-        name: Sex
-        type: category
-    -
-        name: Age
-        type: number
-        preprocessing:
-            missing_value_strategy: fill_with_mean
-    -
-        name: SibSp
-        type: number
-    -
-        name: Parch
-        type: number
-    -
-        name: Fare
-        type: number
-        preprocessing:
-            missing_value_strategy: fill_with_mean
-    -
-        name: Embarked
-        type: category
+  Simple commands can be used to train models and predict new data.
 
-output_features:
-    -
-        name: Survived
-        type: binary
-```
+  ```
+  ludwig train --config config.yaml --dataset data.csv
+  ludwig predict --model_path results/experiment_run/model --dataset test.csv
+  ludwig eval --model_path results/experiment_run/model --dataset test.csv
+  ```
 
-Simple commands can be used to train models and predict new data.
+- [Distributed Training](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/distributed_training)
 
-```sh
-ludwig train --config config.yaml --dataset data.csv
-ludwig predict --model_path results/experiment_run/model --dataset test.csv
-```
+  Train models in a distributed setting using [Horovod](https://github.com/horovod/horovod), which allows training on a single machine with multiple GPUs or multiple machines with multiple GPUs.
 
-A programmatic API is also available to use Ludwig from Python.
+- [Serving](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/serving)
 
-```python
-from ludwig.api import LudwigModel
-import pandas as pd
+  ```
+  Serve models using FastAPI.
+  ```
 
-# train a model
-config = {
-    "input_features": [
-        {"name": "Pclass", "type": "category"},
-        {"name": "Sex", "type": "category"},
-        {"name": "Age", "type": "number", "preprocessing": {"missing_value_strategy": "fill_with_mean"}},
-        {"name": "SibSp", "type": "number"},
-        {"name": "Parch", "type": "number"},
-        {"name": "Fare", "type": "number", "preprocessing": {"missing_value_strategy": "fill_with_mean"}},
-        {"name": "Embarked", "type": "category"},
-    ],
-    "output_features": [{"name": "Survived", "type": "binary"}],
-}
-model = LudwigModel(config)
-data = pd.read_csv("data.csv")
-train_stats, _, model_dir = model.train(data)
+  > ludwig serve --model_path ./results/experiment_run/model
+  > curl http://0.0.0.0:8000/predict -X POST -F "movie_title=Friends With Money" -F "content_rating=R" -F "genres=Art House & International, Comedy, Drama" -F "runtime=88.0" -F "top_critic=TRUE" -F "review_content=The cast is terrific, the movie isn't."
 
-# or load a model
-model = LudwigModel.load(model_dir)
+- [Hyperparameter optimization](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/hyperopt)
 
-# obtain predictions
-predictions = model.predict(data)
-```
+  Ludwig supports hyperparameter optimization using Ray Tune or a local executor.
 
-A suite of visualization tools allows you to analyze models' training and test performance and to compare them.
+- [AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl)
 
-```sh
-ludwig visualize --visualization compare_performance --test_statistics path/to/test_statistics_model_1.json path/to/test_statistics_model_2.json
-```
+  Ludwig AutoML takes a dataset, the target column, and a time budget, and returns a trained Ludwig model.
 
-![img](https://raw.githubusercontent.com/ludwig-ai/ludwig-docs/ludwig05/docs/images/compare_performance.png)
+- [Programmatic API](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/api/LudwigModel)
 
-Run hyperparameter optimization locally or using Ray Tune.
+  Ludwig also provides a simple programmatic API for all of the functionality described above and more.
 
-```sh
-ludwig hyperopt --config rotten_tomatoes.yaml --dataset rotten_tomatoes.csv
-```
+  ```python
+  from ludwig.api import LudwigModel
+  import pandas as pd
 
-Serve models using [FastAPI](https://fastapi.tiangolo.com/).
+  # train a model
+  config = {
+      "input_features": [
+          {"name": "Pclass", "type": "category"},
+          {"name": "Sex", "type": "category"},
+          {"name": "Age", "type": "number", "preprocessing": {"missing_value_strategy": "fill_with_mean"}},
+          {"name": "SibSp", "type": "number"},
+          {"name": "Parch", "type": "number"},
+          {"name": "Fare", "type": "number", "preprocessing": {"missing_value_strategy": "fill_with_mean"}},
+          {"name": "Embarked", "type": "category"},
+      ],
+      "output_features": [{"name": "Survived", "type": "binary"}],
+  }
+  model = LudwigModel(config)
+  data = pd.read_csv("data.csv")
+  train_stats, _, model_dir = model.train(data)
 
-```sh
-ludwig serve --model_path ./results/experiment_run/model
-curl http://0.0.0.0:8000/predict -X POST -F "movie_title=Friends With Money" -F "content_rating=R" -F "genres=Art House & International, Comedy, Drama" -F "runtime=88.0" -F "top_critic=TRUE" -F "review_content=The cast is terrific, the movie isn't."
-```
+  # or load a model
+  model = LudwigModel.load(model_dir)
 
-To learn more about [How Ludwig Works](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/how_ludwig_works/),
-check out the official [Ludwig Docs](https://ludwig-ai.github.io/ludwig-docs/) for our guide on [how to get started](https://ludwig-ai.github.io/ludwig-docs/latest/getting_started/), or read our publications on [Ludwig](https://arxiv.org/pdf/1909.07930.pdf), [declarative ML](https://arxiv.org/pdf/2107.08148.pdf), and [Ludwig’s SoTA benchmarks](https://openreview.net/pdf?id=hwjnu6qW7E4).
+  # obtain predictions
+  predictions = model.predict(data)
+  ```
+
+- [Third-Party Integrations](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/integrations)
+
+  Ludwig provides an extendable interface to integrate with third-party systems for tracking experiments. Third-party integrations exist for Comet ML, Weights & Biases, WhyLabs and MLFlow.
+
+- [Extensibility](https://ludwig-ai.github.io/ludwig-docs/latest/developer_guide)
+
+  Ludwig is built from the ground up with extensibility in mind. It is easy to add new data types by implementing clear, well-documented abstract classes that define functions to preprocess, encode, and decode data.
+
+  Furthermore, new `torch nn.Module` models can be easily added by them to a registry. This encourages reuse and sharing new models with the community. Refer to the [Developer Guide](https://ludwig-ai.github.io/ludwig-docs/latest/developer_guide) for further details.
+
+# Advantages
+
+Ludwig is a profound utility for research scientists, data scientists, and machine learning engineers.
+
+- Minimal machine learning boilerplate
+
+  Ludwig takes care of the engineering complexity of deep learning out of the box, enabling research scientists to focus on building models at the highest level of abstraction.
+
+  Data preprocessing, hyperparameter optimization, device management, and distributed training for newly registered `torch.nn.Module` models come completely free.
+
+- Compare models against existing SOTA models
+
+  Comparing the new model against existing published and implemented models is a simple config change.
+
+- Easily apply new architectures to multiple problems and datasets
+
+  Apply new models across the extensive set of tasks and datasets that Ludwig supports. Ludwig includes a [full benchmarking toolkit](https://arxiv.org/abs/2111.04260) accessible to any user, for running experiments with multiple models across multiple datasets with just a simple configuration.
+
+- Highly configurable data preprocessing, modeling, and metrics
+
+  Any and all aspects of the model architecture, training loop, hyperparameter search, and backend infrastructure can be modified as additional fields in the declarative configuration to customize the pipeline to meet your requirements.
+
+  For details on what can be configured, check out [Ludwig Configuration](https://ludwig-ai.github.io/ludwig-docs/latest/configuration/) docs.
+
+- Low-code interface for state-of-the-art models, including pre-trained Huggingface Transformers
+
+  Ludwig also natively integrates with pre-trained models, such as the ones available in [Huggingface Transformers](https://huggingface.co/docs/transformers/index). Users can choose from a vast collection of state-of-the-art pre-trained PyTorch models to use without needing to write any code at all. For example, training a BERT-based sentiment analysis model with Ludwig is as simple as:
+
+  ```
+  ludwig train --dataset sst5 -–config_str “{input_features: [{name: sentence, type: text, encoder: bert}], output_features: [{name: label, type: category}]}”
+  ```
+
+- Low-code Interface for AutoML
+
+  [Ludwig AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl/) allows users to obtain trained models by providing just a dataset, the target column, and a time budget. It’s as simple as that!
+
+  ```
+  auto_train_results = ludwig.automl.auto_train(
+      dataset=my_dataset_df, target=target_column_name, time_limit_s=7200, tune_for_memory=False
+  )
+  ```
+
+- Easy Productionisation
+
+  Ludwig makes it easy to serve deep learning models, including on GPUs. Launch a REST API for your trained Ludwig model.
+
+  ```
+  ludwig serve --model_path=/path/to/model
+  ```
+
+  Ludwig supports exporting models to efficient Torschscript bundles.
+
+  ```
+  ludwig export_torchscript -–model_path=/path/to/model
+  ```
+
+# Examples
+
+- [Text Classification](https://ludwig-ai.github.io/ludwig-docs/latest/examples/text_classification)
+- [Named Entity Recognition Tagging](https://ludwig-ai.github.io/ludwig-docs/latest/examples/ner_tagging)
+- [Natural Language Understanding](https://ludwig-ai.github.io/ludwig-docs/latest/examples/nlu)
+- [Machine Translation](https://ludwig-ai.github.io/ludwig-docs/latest/examples/machine_translation)
+- [Chit-Chat Dialogue Modeling through seq2seq](https://ludwig-ai.github.io/ludwig-docs/latest/examples/seq2seq)
+- [Sentiment Analysis](https://ludwig-ai.github.io/ludwig-docs/latest/examples/sentiment_analysis)
+- [Image Classification](https://ludwig-ai.github.io/ludwig-docs/latest/examples/image_classification)
+- [Image Classification (MNIST)](https://ludwig-ai.github.io/ludwig-docs/latest/examples/mnist)
+- [Visual Question Answering](https://ludwig-ai.github.io/ludwig-docs/latest/examples/visual_qa)
+- [One-shot Learning with Siamese Networks](https://ludwig-ai.github.io/ludwig-docs/latest/examples/oneshot)
+- [Speaker Verification](https://ludwig-ai.github.io/ludwig-docs/latest/examples/speaker_verification)
+- [Spoken Digit Speech Recognition](https://ludwig-ai.github.io/ludwig-docs/latest/examples/speech_recognition)
+- [Binary Classification (titanic)](https://ludwig-ai.github.io/ludwig-docs/latest/examples/titanic)
+- [Timeseries forecasting](https://ludwig-ai.github.io/ludwig-docs/latest/examples/forecasting)
+- [Timeseries forecasting (Weather)](https://ludwig-ai.github.io/ludwig-docs/latest/examples/weather)
+- [Movie rating prediction](https://ludwig-ai.github.io/ludwig-docs/latest/examples/movie_ratings)
+- [Multi-label classification](https://ludwig-ai.github.io/ludwig-docs/latest/examples/multi_label)
+- [Multi-Task Learning](https://ludwig-ai.github.io/ludwig-docs/latest/examples/multi_task)
+- [Simple Regression: Fuel Efficiency Prediction](https://ludwig-ai.github.io/ludwig-docs/latest/examples/fuel_efficiency)
+- [Fraud Detection](https://ludwig-ai.github.io/ludwig-docs/latest/examples/fraud)
+
+# More Information
+
+[Full official documentation](https://ludwig-ai.github.io/ludwig-docs/)
+
+Read our publications on [Ludwig](https://arxiv.org/pdf/1909.07930.pdf), [declarative ML](https://arxiv.org/pdf/2107.08148.pdf), and [Ludwig’s SoTA benchmarks](https://openreview.net/pdf?id=hwjnu6qW7E4).
+
+Learn more about [how Ludwig works](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/how_ludwig_works/), [how to get started](https://ludwig-ai.github.io/ludwig-docs/latest/getting_started/), and work through more [examples](https://ludwig-ai.github.io/ludwig-docs/latest/examples).
 
 If you are interested in contributing, have questions, comments, or thoughts to share, or if you just want to be in the
 know, please consider [joining the Ludwig Slack](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ) and follow us on [Twitter](https://twitter.com/ludwig_ai)!
 
-# Why Ludwig?
-
-Ludwig is a profound utility for research scientists, data scientists, and machine learning engineers.
-
-## Minimal Machine Learning Boilerplate
-
-PyTorch and Tensorflow are popular libraries for deep learning research scientists who develop new training algorithms,
-design and develop new model architectures, and run experiments with them.
-
-However, experimenting with a new architecture often requires a formidable amount of code for scalably loading and
-preprocessing data, and setting up pipelines for (distributed) training, evaluation, and hyperparameter optimization.
-
-Ludwig takes care of the engineering complexity of deep learning out of the box, enabling research scientists to focus
-on building models at the highest level of abstraction.
-
-Let's say that you have a great idea for a novel architecture for image classification with a change specific to how
-images are encoded. You would implement your new model as a PyTorch module.
-
-```python
-import torch.nn as nn
-
-
-class MyImageClassificationModel(nn.Module):
-    def __init__(self, hyperparameter_1, hyperparameter_2):
-        # ...
-        pass
-
-    def forward(inputs):  # Image tensors
-        # Encode image tensors.
-        # ...
-
-        # "Boilerplate" decoding code: reduce dimension to logits over num_classes.
-        return outputs  # Output tensors
-```
-
-However, this is rather incomplete – we'll also need to figure out how to read images from disk with torchvision, write
-a training-checkpoint-eval loop, post-process logits tensors into predictions, and compute metrics over predictions. All
-these steps elongate model development time and introduce potential sources of error.
-
-Instead of implementing all of this from scratch, research scientists can implement new models as PyTorch Modules in
-Ludwig directly to take advantage of all of the engineering conveniences that Ludwig offers. Since your modeling idea
-applies specifically to image encoding, then only the encoder needs to be implemented.
-
-```python
-import torch
-from ludwig.constants import IMAGE
-from ludwig.encoders.base import Encoder
-
-
-@register("my_encoder", IMAGE)
-class MyImageEncoder(Encoder):
-    def __init__(self, hyperparameter_1, hyperparameter_2):
-        # ...
-        pass
-
-    def forward(inputs):  # Preprocessed image tensors.
-        # ...
-        return outputs  # Dimension reduction, loss, and softmax handled by existing decoders.
-
-    @property
-    def input_shape() -> torch.Size:
-        """Returns size of the input tensor without the batch dimension."""
-        pass
-
-    @property
-    def output_shape() -> torch.Size:
-        """Returns size of the output tensor without the batch dimension."""
-        pass
-```
-
-The new encoder `my_encoder` can immediately be used in a new Ludwig configuration by just setting
-`encoder: my_encoder`. Ludwig will take care of the rest of the pipeline for you!
-
-## Seamless Benchmarking and Testing on Multiple Problems and Datasets
-
-Benchmarking the new model against existing published and implemented models is a simple config change.
-
-baseline_config.yaml
-
-```yaml
-input_features:
-name: image_path
-type: image
-encoder: resnet
-layers: 50
-output_features:
-name: class
-type: category
-```
-
-```sh
-ludwig experiment -–config baseline_config.yaml -–dataset my_dataset.csv
-```
-
-my_new_encoder_config.yaml
-
-```yaml
-input_features:
-name: image_path
-type: image
-encoder: my_encoder
-hyperparameter_1: #
-hyperparameter_2: #
-output_features:
-name: class
-type: category
-```
-
-```sh
-ludwig experiment -–config my_new_encoder_config.yaml -–dataset my_dataset.csv
-```
-
-Now you can run exactly the same configuration as before, which guarantees exactly the same preprocessing, training and
-evaluation is performed, to easily compare the performance of your new encoder, with new hyperparameters that can be set
-directly in the config.
-
-## Immediate integration with hyperparameter optimization on Ray Tune
-
-Registered models and their constructor parameters can be used immediately alongside other Ludwig building blocks like
-hyperparameter optimization.
-
-```yaml
-input_features:
--
-    name: image_path
-    type: image
-    encoder: my_encoder
-    hyperparameter_1: #
-    hyperparameter_2: #
-output_features:
--
-    name: class
-    type: category
-hyperopt:
-  parameters:
-    image_path.hyperparameter_1:
-      values: [10, 100, 1000]
-    image_path.hyperparameter_2:
-      low: 0.1
-      high: 0.5
-```
-
-## Broadening to Multiple Problems and Datasets
-
-Registered models can be subsequently applied across the extensive set of tasks and datasets that Ludwig supports.
-Ludwig includes a [full benchmarking toolkit](https://arxiv.org/abs/2111.04260) accessible to any user, for running
-experiments with multiple models across multiple datasets with just a simple configuration.
-
-For more information on how to add your dataset or model to Ludwig, check out the [Developer Guide](https://ludwig-ai.github.io/ludwig-docs/latest/developer_guide) and the [Ludwig Dataset Zoo](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/datasets/dataset_zoo/).
-
-## Low-code interface for state-of-the-art models, including pre-trained Huggingface Transformers
-
-Ludwig strives to bring state of the art performance for any ML task without needing to write hundreds of lines of code.
-
-Ludwig provides robust implementations of common architectures like CNNs, RNNs, Transformers, TabNet, MLP-Mixer.
-
-Models can be trained from scratch, but Ludwig also natively integrates with pre-trained models, such as the ones
-available in [Huggingface Transformers](https://huggingface.co/docs/transformers/index). Users can choose from a vast
-collection of state-of-the-art pre-trained PyTorch models to use without needing to write any code at all. For example,
-training a BERT-based sentiment analysis model with Ludwig is as simple as:
-
-```sh
-ludwig train -–dataset sst5 -–config_str “{input_features: [{name: sentence, type: text, encoder: bert}], output_features: [{name: label, type: category}]}”
-```
-
-## Low-code Interface for AutoML
-
-[Ludwig AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl/) allows users to obtain trained models
-by providing just a dataset, the target column, and a time budget. It’s as simple as that!
-
-```python
-auto_train_results = ludwig.automl.auto_train(
-    dataset=my_dataset_df, target=target_column_name, time_limit_s=7200, tune_for_memory=False
-)
-```
-
-## Highly Configurable Data Preprocessing, Modeling, and Metrics
-
-Any and all aspects of the model architecture, training loop, hyperparameter search, and backend infrastructure can be
-modified as additional fields in the declarative configuration to customize the pipeline to meet your requirements.
-
-```yaml
-input_features:
--
-  name: title
-  type: text
-  encoder: rnn
-  cell: lstm
-  num_layers: 2
-  state_size: 128
-  preprocessing:
-    tokenizer: space_punct
--
-  name: author
-  type: category
-  embedding_size: 128
-  preprocessing:
-    most_common: 10000
--
-  name: description
-  type: text
-  encoder: bert
--
-  name: cover
-  type: image
-  encoder: resnet
-  num_layers: 18
-
-output_features:
--
-  name: genre
-  type: set
--
-  name: price
-  type: number
-  preprocessing:
-    normalization: zscore
-
-trainer:
-  epochs: 50
-  batch_size: 256
-  optimizer:
-    type: adam
-    beat1: 0.9
-  learning_rate: 0.001
-
-backend:
-  type: local
-  cache_format: parquet
-
-hyperopt:
-  metric: f1
-  sampler: random
-  parameters:
-    title.num_layers:
-      lower: 1
-      upper: 5
-    training.learning_rate:
-      values: [0.01, 0.003, 0,001]
-```
-
-For details on what can be configured, check out
-[Ludwig Configuration](https://ludwig-ai.github.io/ludwig-docs/latest/configuration/) docs. If a model, loss, evaluation
-metric, preprocessing function or other parts of the pipeline are not already available, the modularity of the
-underlying architecture allows users to very easily extend Ludwig’s capabilities by implementing simple abstract
-interfaces, as described in the [Developer Guide](https://ludwig-ai.github.io/ludwig-docs/latest/developer_guide/).
-
-## Effortless Device Management and Distributed Training
-
-PyTorch provides great performance for training with one or multiple GPUs, including in our own benchmarks. However,
-setting up GPU training in PyTorch adds the overhead of moving models, data, labels, and metrics to the right device.
-Even for a single GPU, this overhead can be substantial for some types of advanced models, like we have experienced when
-porting our TabNet implementation. The overhead is greater for distributed training on multiple GPUs, and even more so
-when training on multiple nodes each with multiple GPUs.
-
-Ludwig v0.5 brings effortless scaling to the PyTorch ecosystem. Training models on a single GPU, multiple GPUs, or
-multiple nodes is as easy as setting a flag in the Ludwig configuration. The two code snippets below show examples of
-using GPUs in PyTorch and Ludwig.
-
-```python
-import torch
-import torch.nn as nn
-
-
-inputs, labels = data
-
-# create model
-class Model(nn.Module):
-    def __init__(self):
-        # ...
-        pass
-
-    def forward(self, x):
-        # Must manually move all new tensors to GPU.
-        if torch.cuda.is_available():
-            mask = torch.ones(x, device="cuda")
-        # ...
-
-
-# move model and data to the correct device
-model = Model()
-if torch.cuda.is_available():
-    model = model.to("cuda")
-    inputs = inputs.to("cuda")
-    labels = labels.to("cuda")
-```
-
-In Ludwig, a GPU is used by default if it is available. However, explicitly setting GPU training is as easy as setting a
-single parameter in the config.
-
-```yaml
-backend:
-    trainer:
-        use_gpu: true
-```
-
-Setting up distributed training on multiple GPUs or multiple nodes using [Horovod](https://github.com/horovod/horovod)
-is a similarly trivial configuration change specifying the number of GPU workers.
-
-```yaml
-backend:
-    trainer:
-        use_gpu: true
-        num_workers: 4  # Distributed training with 4 GPUs
-```
-
-## Easy Productionisation
-
-Bringing machine learning models to fruition in production is usually a lengthy and complicated process. Ludwig provides a few paths to make the life of machine learning engineers responsible for deployment easier.
-
-With [Ludwig Serving](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/serving/), Ludwig makes it easy to serve
-deep learning models, including on GPUs. Use `ludwig serve` to launch a REST API for your trained Ludwig model.
-
-```
-ludwig serve --model_path=/path/to/model
-
-curl http://0.0.0.0:8000/predict -X POST -F 'english_text=words to be translated'
-```
-
-For highly efficient deployments it’s often critical to minimize the overhead caused by the python runtime. Ludwig
-supports exporting models to efficient Torschscript bundles.
-
-```
-ludwig export_torchscript -–model_path=/path/to/model
-```
-
-# Ludwig Principles
-
-The core design principles baked into the toolbox are:
-
-- No coding required: no coding skills are required to train a model, use it for obtaining predictions, and serving.
-- Generalizability: a datatype-based approach to deep learning model design makes the tool usable across many different use cases.
-- Flexibility: experienced users have extensive control over model building and training, while newcomers will find it easy to use.
-- Extensibility: Easily add new model architecture and new feature datatypes.
-- Understandability: Compelling visualizations to understand their performance and compare their predictions.
-- Open Source: Apache License 2.0
-
-<p><img src="https://raw.githubusercontent.com/lfai/artwork/master/lfaidata-assets/lfaidata/horizontal/color/lfaidata-horizontal-color.png" alt="LF AI & Data logo" width="200"/></p>
-
-Ludwig is hosted by the Linux Foundation as part of the [LF AI & Data Foundation](https://lfaidata.foundation/). For
-details about who's involved and how Ludwig fits into the larger open source AI landscape,
-read the Linux Foundation [announcement](https://lfaidata.foundation/blog/2020/12/17/ludwig-joins-lf-ai--data-as-new-incubation-project/).
-
-## Full documentation
-
-You can find the full documentation [here](https://ludwig-ai.github.io/ludwig-docs/).
-
-## License
-
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fuber%2Fludwig.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fuber%2Fludwig?ref=badge_large)
-
-## Getting Involved
+# Getting Involved
 
 - [Slack](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ)
 - [Twitter](https://twitter.com/ludwig_ai)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 </div>
 
-Translated in [🇰🇷 Korean](README_KR.md)/
+Translated in [🇰🇷Korean](README_KR.md)
 
 # What is Ludwig?
 
@@ -46,11 +46,31 @@ configuration system.
   you need to start training deep learning models. Ludwig uses declared features to compose a deep learning model
   accordingly.
 
+  ```yaml
+  input_features:
+    - name: data_column_1
+      type: number
+    - name: data_column_2
+      type: category
+    - name: data_column_3
+      type: text
+    - name: data_column_4
+      type: image
+    ...
+
+  output_features:
+    - name: data_column_5
+      type: number
+    - name: data_column_6
+      type: category
+    ...
+  ```
+
 - [Training, Prediction, and Evaluation from the command line](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/command_line_interface)
 
   Simple commands can be used to train models and predict new data.
 
-  ```
+  ```shell
   ludwig train --config config.yaml --dataset data.csv
   ludwig predict --model_path results/experiment_run/model --dataset test.csv
   ludwig eval --model_path results/experiment_run/model --dataset test.csv
@@ -62,20 +82,11 @@ configuration system.
 
   ```python
   from ludwig.api import LudwigModel
-  import pandas as pd
 
   # train a model
   config = {
-      "input_features": [
-          {"name": "Pclass", "type": "category"},
-          {"name": "Sex", "type": "category"},
-          {"name": "Age", "type": "number", "preprocessing": {"missing_value_strategy": "fill_with_mean"}},
-          {"name": "SibSp", "type": "number"},
-          {"name": "Parch", "type": "number"},
-          {"name": "Fare", "type": "number", "preprocessing": {"missing_value_strategy": "fill_with_mean"}},
-          {"name": "Embarked", "type": "category"},
-      ],
-      "output_features": [{"name": "Survived", "type": "binary"}],
+      "input_features": [...],
+      "output_features": [...],
   }
   model = LudwigModel(config)
   data = pd.read_csv("data.csv")
@@ -97,7 +108,7 @@ configuration system.
 
   Serve models using FastAPI.
 
-  ```
+  ```shell
   ludwig serve --model_path ./results/experiment_run/model
   curl http://0.0.0.0:8000/predict -X POST -F "movie_title=Friends With Money" -F "content_rating=R" -F "genres=Art House & International, Comedy, Drama" -F "runtime=88.0" -F "top_critic=TRUE" -F "review_content=The cast is terrific, the movie isn't."
   ```
@@ -106,7 +117,7 @@ configuration system.
 
   Run hyperparameter optimization locally or using [Ray Tune](https://docs.ray.io/en/latest/tune/index.html).
 
-  ```sh
+  ```shell
   ludwig hyperopt --config config.yaml --dataset data.csv
   ```
 
@@ -137,7 +148,7 @@ or take a look at end-to-end [Examples](https://ludwig-ai.github.io/ludwig-docs/
 
 Install from PyPi. Be aware that Ludwig requires Python 3.7+.
 
-```
+```shell
 pip install ludwig
 ```
 
@@ -174,17 +185,18 @@ to customize the pipeline to meet your requirements.
 input_features:
 - name: sentence
   type: text
-  encoder: t5
+  encoder: transformer
+  layers: 6
+  embedding_size: 512
 
 output_features:
 - name: class
   type: category
-  preprocessing:
-    most_common: 10000
+  loss: cross_entropy
 
 trainer:
   epochs: 50
-  batch_size: 256
+  batch_size: 64
   optimizer:
     type: adamw
     beat1: 0.9
@@ -220,7 +232,7 @@ docs.
 
 Simple commands can be used to train models and predict new data.
 
-```sh
+```shell
 ludwig train --config config.yaml --dataset data.csv
 ```
 
@@ -228,7 +240,7 @@ ludwig train --config config.yaml --dataset data.csv
 
 The training process will produce a model that can be used for evaluating on and obtaining predictions for new data.
 
-```sh
+```shell
 ludwig predict –model path/to/trained/model –dataset heldout.csv
 ludwig evaluate –model path/to/trained/model –dataset heldout.csv
 ```
@@ -238,7 +250,7 @@ ludwig evaluate –model path/to/trained/model –dataset heldout.csv
 Ludwig provides a suite of visualization tools allows you to analyze models' training and test performance and to
 compare them.
 
-```
+```shell
 ludwig visualize --visualization compare_performance --test_statistics path/to/test_statistics_model_1.json path/to/test_statistics_model_2.json
 ```
 
@@ -259,9 +271,9 @@ Ludwig takes care of the engineering complexity of deep learning out of the box,
 
 Data preprocessing, hyperparameter optimization, device management, and distributed training for newly registered `torch.nn.Module` models come completely free.
 
-## Compare models against existing SOTA models
+## Easily build your benachmarks
 
-Comparing the new model against existing published and implemented models is a simple config change.
+Creating a state-of-the-art baseline and comapring it with a new model  is a simple config change.
 
 ## Easily apply new architectures to multiple problems and datasets
 
@@ -277,31 +289,29 @@ For details on what can be configured, check out [Ludwig Configuration](https://
 
 Ludwig also natively integrates with pre-trained models, such as the ones available in [Huggingface Transformers](https://huggingface.co/docs/transformers/index). Users can choose from a vast collection of state-of-the-art pre-trained PyTorch models to use without needing to write any code at all. For example, training a BERT-based sentiment analysis model with Ludwig is as simple as:
 
-```
+```shell
 ludwig train --dataset sst5 -–config_str “{input_features: [{name: sentence, type: text, encoder: bert}], output_features: [{name: label, type: category}]}”
 ```
 
 ## Low-code Interface for AutoML
 
-[Ludwig AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl/) allows users to obtain trained models by providing just a dataset, the target column, and a time budget. It’s as simple as that!
+[Ludwig AutoML](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/automl/) allows users to obtain trained models by providing just a dataset, the target column, and a time budget.
 
-```
-auto_train_results = ludwig.automl.auto_train(
-    dataset=my_dataset_df, target=target_column_name, time_limit_s=7200, tune_for_memory=False
-)
+```python
+auto_train_results = ludwig.automl.auto_train(dataset=my_dataset_df, target=target_column_name, time_limit_s=7200)
 ```
 
 ## Easy Productionisation
 
 Ludwig makes it easy to serve deep learning models, including on GPUs. Launch a REST API for your trained Ludwig model.
 
-```
+```shell
 ludwig serve --model_path=/path/to/model
 ```
 
 Ludwig supports exporting models to efficient Torschscript bundles.
 
-```
+```shell
 ludwig export_torchscript -–model_path=/path/to/model
 ```
 


### PR DESCRIPTION
The README has a larger focus on the unique value that Ludwig brings, with ample pointers to official docs for diving deeper into specific functionalities.

To see the README visually (which may be easier to review), look at the branch directly: https://github.com/ludwig-ai/ludwig/tree/readme