### PR TITLE
Fallback to training split during hyperopt if no validation set is present

### DIFF
--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -106,6 +106,9 @@ class HyperoptExecutor(ABC):
         if self._has_metric(train_stats, VALIDATION):
             logger.info("Returning metric score from training (validation) statistics")
             return self.get_metric_score_from_train_stats(train_stats, VALIDATION)
+        elif self._has_metric(train_stats, TRAINING):
+            logger.info("Returning metric score from training split statistics, " "as no validation was given")
+            return self.get_metric_score_from_train_stats(train_stats, TRAINING)
         else:
             raise RuntimeError("Unable to obtain metric score from missing training (validation) statistics")
 

--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -17,6 +17,7 @@ import logging
 import os.path
 
 import mlflow
+import pandas as pd
 import pytest
 import ray
 from mlflow.tracking import MlflowClient
@@ -118,9 +119,15 @@ def run_hyperopt_executor(
     csv_filename,
     validate_output_feature=False,
     validation_metric=None,
+    use_split=False,
 ):
     config = _get_config(sampler, executor)
     rel_path = generate_data(config["input_features"], config["output_features"], csv_filename)
+
+    if not use_split:
+        df = pd.read_csv(rel_path)
+        df["split"] = 0
+        df.to_csv(rel_path)
 
     config = merge_with_defaults(config)
 
@@ -165,7 +172,8 @@ def test_hyperopt_executor(sampler, executor, csv_filename):
 
 
 @pytest.mark.distributed
-def test_hyperopt_executor_with_metric(csv_filename):
+@pytest.mark.parametrize("use_split", [True, False], ids=["split", "no_split"])
+def test_hyperopt_executor_with_metric(use_split, csv_filename):
     with ray_start_4_cpus():
         run_hyperopt_executor(
             {"type": "ray", "num_samples": 2},
@@ -173,6 +181,7 @@ def test_hyperopt_executor_with_metric(csv_filename):
             csv_filename,
             validate_output_feature=True,
             validation_metric=ACCURACY,
+            use_split=use_split,
         )
 
 

--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -119,7 +119,7 @@ def run_hyperopt_executor(
     csv_filename,
     validate_output_feature=False,
     validation_metric=None,
-    use_split=False,
+    use_split=True,
 ):
     config = _get_config(sampler, executor)
     rel_path = generate_data(config["input_features"], config["output_features"], csv_filename)


### PR DESCRIPTION
In #1625 we removed reporting hyperopt metrics on the test set and instead always use the validation set. This makes sense, but will not work if the user pre-split their data to only have a training set. To support this scenario, this PR adds back the fallback behavior to use training set metrics, but retains the logic to skip test sets.