### PR TITLE
Backwards compatibility for deprecated eval_batch_size=0

### DIFF
--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -28,6 +28,7 @@ from ludwig.constants import (
     COLUMN,
     COMBINED,
     DROP_ROW,
+    EVAL_BATCH_SIZE,
     HYPEROPT,
     LOSS,
     NAME,
@@ -168,6 +169,15 @@ def _upgrade_deprecated_fields(config: Dict[str, Any]):
                 )
                 hparams["trainer." + k[len(substr) :]] = v
                 del hparams[k]
+
+    if TRAINER in config:
+        trainer = config[TRAINER]
+        eval_batch_size = trainer.get(EVAL_BATCH_SIZE)
+        if eval_batch_size == 0:
+            warnings.warn(
+                "`trainer.eval_batch_size` value `0` changed to `None`, will be unsupported in v0.6", DeprecationWarning
+            )
+            trainer[EVAL_BATCH_SIZE] = None
 
 
 def _perform_sanity_checks(config):

--- a/tests/ludwig/utils/test_defaults.py
+++ b/tests/ludwig/utils/test_defaults.py
@@ -2,7 +2,17 @@ import copy
 
 import pytest
 
-from ludwig.constants import CATEGORY, DROP_ROW, FILL_WITH_MODE, HYPEROPT, NUMBER, PREPROCESSING, TRAINER, TYPE
+from ludwig.constants import (
+    CATEGORY,
+    DROP_ROW,
+    EVAL_BATCH_SIZE,
+    FILL_WITH_MODE,
+    HYPEROPT,
+    NUMBER,
+    PREPROCESSING,
+    TRAINER,
+    TYPE,
+)
 from ludwig.data.preprocessing import merge_preprocessing
 from ludwig.utils.defaults import default_training_params, merge_with_defaults
 from tests.integration_tests.utils import (
@@ -115,6 +125,7 @@ def test_deprecated_field_aliases():
         "output_features": [{"name": "num_out", "type": "number"}],
         "training": {
             "epochs": 2,
+            "eval_batch_size": 0,
         },
         "hyperopt": {
             "parameters": {
@@ -135,6 +146,7 @@ def test_deprecated_field_aliases():
 
     assert "training" not in merged_config
     assert merged_config[TRAINER]["epochs"] == 2
+    assert merged_config[TRAINER][EVAL_BATCH_SIZE] is None
 
     hparams = merged_config[HYPEROPT]["parameters"]
     assert "training.learning_rate" not in hparams

--- a/tests/ludwig/utils/test_validate_config_combiner.py
+++ b/tests/ludwig/utils/test_validate_config_combiner.py
@@ -6,7 +6,8 @@ from ludwig.utils.schema import validate_config
 from tests.integration_tests.utils import binary_feature, category_feature, number_feature
 
 
-def test_config_tabnet():
+@pytest.mark.parametrize("eval_batch_size", [500000, None])
+def test_config_tabnet(eval_batch_size):
     config = {
         "input_features": [
             category_feature(vocab_size=2, reduce_input="sum"),
@@ -27,7 +28,7 @@ def test_config_tabnet():
         },
         TRAINER: {
             "batch_size": 16384,
-            "eval_batch_size": 500000,
+            "eval_batch_size": eval_batch_size,
             "epochs": 1000,
             "early_stop": 20,
             "learning_rate": 0.02,


### PR DESCRIPTION
This will be removed in v0.6.