### PR TITLE
FIX: Failure to perform number normalization under evaluate() method

### DIFF
--- a/ludwig/features/number_feature.py
+++ b/ludwig/features/number_feature.py
@@ -269,10 +269,14 @@ class NumberFeatureMixin(BaseFeatureMixin):
         skip_save_processed_input,
     ):
         def normalize(series: pd.Series) -> pd.Series:
-            series = series.copy()
+            # retrieve request numeric transformer
             numeric_transformer = get_transformer(metadata[feature_config[NAME]], preprocessing_parameters)
-            series.update(numeric_transformer.transform(series.values))
-            return series
+
+            # transform input numeric values with specified transformer
+            transformed_values = numeric_transformer.transform(series.values)
+
+            # return transformed values with same index values as original series.
+            return pd.Series(transformed_values, index=series.index)
 
         input_series = input_df[feature_config[COLUMN]].astype(np.float32)
         proc_df[feature_config[PROC_COLUMN]] = backend.df_engine.map_partitions(input_series, normalize)


### PR DESCRIPTION
Fix Issue #1911 

With this fix, predicted probablites are now not all 1.0 or 0.0.

```
>> evaluate api from in-memory api trained model
                         income_probabilities income_predictions  income_probabilities_ <=50K  \
0   [0.40296435356140137, 0.5970356464385986]               >50K                     0.402964   
1    [0.7000786066055298, 0.2999213933944702]              <=50K                     0.700079   
2    [0.7115788757801056, 0.2884211242198944]              <=50K                     0.711579   
3   [0.9771468658000231, 0.02285313419997692]              <=50K                     0.977147   
4  [0.9722735546529293, 0.027726445347070694]              <=50K                     0.972274   
   income_probabilities_ >50K  income_probability  
0                    0.597036            0.597036  
1                    0.299921            0.700079  
2                    0.288421            0.711579  
3                    0.022853            0.977147  
4                    0.027726            0.972274 

```
