### PR TITLE
Adds Torchscript-compatible image transforms

### DIFF
--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -163,22 +163,20 @@ def read_image_from_str(img: str, num_channels: Optional[int] = None) -> torch.T
 
 def pad(
     img: torch.Tensor,
-    size: Union[int, Tuple[int, int]],
+    new_size: Union[int, Tuple[int, int]],
 ) -> torch.Tensor:
     """torchscript-compatible implementation of pad.
 
     Args:
         img (torch.Tensor): image with shape [..., height, width] to pad
-        size (Union[int, Tuple[int, int]]): size to pad to. If int, resizes to square image of that size.
+        new_size (Union[int, Tuple[int, int]]): size to pad to. If int, resizes to square image of that size.
 
     Returns:
         torch.Tensor: padded image of size [..., size[0], size[1]] or [..., size, size] if size is int.
     """
-    new_size = to_tensor_pair(size)
-
-    old_size = torch.tensor(img.shape[-2:])
-
-    pad_size = (new_size - old_size) / 2
+    new_size = to_tuple(new_size)
+    old_size = img.shape[-2:]
+    pad_size = (torch.tensor(new_size) - torch.tensor(old_size)) / 2
     padding = torch.cat((torch.floor(pad_size), torch.ceil(pad_size)))
     padding[padding < 0] = 0
     padding = [int(x) for x in padding]
@@ -187,7 +185,7 @@ def pad(
 
 def crop(
     img: torch.Tensor,
-    size: Union[int, Tuple[int, int]],
+    new_size: Union[int, Tuple[int, int]],
 ) -> torch.Tensor:
     """torchscript-compatible implementation of crop.
 
@@ -198,8 +196,7 @@ def crop(
     Returns:
         torch.Tensor: cropped image of size [..., size[0], size[1]] or [..., size, size] if size is int.
     """
-    new_size = to_tensor_pair(size)
-
+    new_size = to_tuple(new_size)
     return F.center_crop(img, output_size=new_size)
 
 
@@ -208,13 +205,12 @@ def crop_or_pad(img: torch.Tensor, new_size: Union[int, Tuple[int, int]]):
 
     Args:
         img (torch.Tensor): image with shape [..., height, width] to resize
-        size (Union[int, Tuple[int, int]]): size to resize to. If int, resizes to square image of that size.
+        new_size (Union[int, Tuple[int, int]]): size to resize to. If int, resizes to square image of that size.
 
     Returns:
         torch.Tensor: resized image of size [..., size[0], size[1]] or [..., size, size] if size is int.
     """
-    new_size = to_tensor_pair(new_size)
-
+    new_size = to_tuple(new_size)
     if list(new_size) == list(img.shape[-2:]):
         return img
     img = pad(img, new_size)
@@ -239,8 +235,7 @@ def resize_image(
     Returns:
         torch.Tensor: resized image of size [..., size[0], size[1]] or [..., size, size] if size is int.
     """
-    new_size = to_tensor_pair(new_size)
-
+    new_size = to_tuple(new_size)
     if list(img.shape[-2:]) != list(new_size):
         if resize_method == crop_or_pad_constant:
             return crop_or_pad(img, new_size)
@@ -266,7 +261,7 @@ def num_channels_in_image(img: torch.Tensor):
         return img.shape[0]
 
 
-def to_tensor_pair(v: Union[int, Tuple[int, int]]) -> Tuple[int, int]:
+def to_tuple(v: Union[int, Tuple[int, int]]) -> Tuple[int, int]:
     """Converts int or tuple to tuple of ints."""
     if torch.jit.isinstance(v, int):
         return v, v

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -174,10 +174,8 @@ def pad(
     Returns:
         torch.Tensor: padded image of size [..., size[0], size[1]] or [..., size, size] if size is int.
     """
-    if torch.jit.isinstance(size, int):
-        new_size = torch.tensor((size, size))
-    else:
-        new_size = torch.tensor(size)
+    new_size = to_tensor_pair(size)
+
     old_size = torch.tensor(img.shape[-2:])
 
     pad_size = (new_size - old_size) / 2
@@ -200,10 +198,8 @@ def crop(
     Returns:
         torch.Tensor: cropped image of size [..., size[0], size[1]] or [..., size, size] if size is int.
     """
-    if torch.jit.isinstance(size, int):
-        new_size = (size, size)
-    else:
-        new_size = size
+    new_size = to_tensor_pair(size)
+
     return F.center_crop(img, output_size=new_size)
 
 
@@ -217,10 +213,7 @@ def crop_or_pad(img: torch.Tensor, new_size: Union[int, Tuple[int, int]]):
     Returns:
         torch.Tensor: resized image of size [..., size[0], size[1]] or [..., size, size] if size is int.
     """
-    if torch.jit.isinstance(new_size, int):
-        new_size = (new_size, new_size)
-    else:
-        new_size = new_size
+    new_size = to_tensor_pair(new_size)
 
     if list(new_size) == list(img.shape[-2:]):
         return img
@@ -246,10 +239,7 @@ def resize_image(
     Returns:
         torch.Tensor: resized image of size [..., size[0], size[1]] or [..., size, size] if size is int.
     """
-    if torch.jit.isinstance(new_size, int):
-        new_size = (new_size, new_size)
-    else:
-        new_size = new_size
+    new_size = to_tensor_pair(new_size)
 
     if list(img.shape[-2:]) != list(new_size):
         if resize_method == crop_or_pad_constant:
@@ -274,6 +264,14 @@ def num_channels_in_image(img: torch.Tensor):
         return 1
     else:
         return img.shape[0]
+
+
+def to_tensor_pair(v: Union[int, Tuple[int, int]]) -> Tuple[int, int]:
+    """Converts int or tuple to tuple of ints."""
+    if torch.jit.isinstance(v, int):
+        return v, v
+    else:
+        return v
 
 
 def to_np_tuple(prop: Union[int, Iterable]) -> np.ndarray:

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -165,6 +165,15 @@ def pad(
     img: torch.Tensor,
     size: Union[int, Tuple[int, int]],
 ) -> torch.Tensor:
+    """torchscript-compatible implementation of pad.
+
+    Args:
+        img (torch.Tensor): image with shape [..., height, width] to pad
+        size (Union[int, Tuple[int, int]]): size to pad to. If int, resizes to square image of that size.
+
+    Returns:
+        torch.Tensor: padded image of size [..., size[0], size[1]] or [..., size, size] if size is int.
+    """
     if torch.jit.isinstance(size, int):
         new_size = torch.tensor((size, size))
     else:
@@ -182,6 +191,15 @@ def crop(
     img: torch.Tensor,
     size: Union[int, Tuple[int, int]],
 ) -> torch.Tensor:
+    """torchscript-compatible implementation of crop.
+
+    Args:
+        img (torch.Tensor): image with shape [..., height, width] to crop
+        size (Union[int, Tuple[int, int]]): size to crop to. If int, crops to square image of that size.
+
+    Returns:
+        torch.Tensor: cropped image of size [..., size[0], size[1]] or [..., size, size] if size is int.
+    """
     if torch.jit.isinstance(size, int):
         new_size = (size, size)
     else:
@@ -190,11 +208,14 @@ def crop(
 
 
 def crop_or_pad(img: torch.Tensor, new_size: Union[int, Tuple[int, int]]):
-    """torchscript-compatible implementation of resize with constants.CROP_OR_PAD.
+    """torchscript-compatible implementation of resize using constants.CROP_OR_PAD.
 
     Args:
         img (torch.Tensor): image with shape [..., height, width] to resize
-        size (Union[int, Tuple[int, int]]): size to pad to. If int, resizes to square image of that size.
+        size (Union[int, Tuple[int, int]]): size to resize to. If int, resizes to square image of that size.
+
+    Returns:
+        torch.Tensor: resized image of size [..., size[0], size[1]] or [..., size, size] if size is int.
     """
     if torch.jit.isinstance(new_size, int):
         new_size = (new_size, new_size)
@@ -219,7 +240,11 @@ def resize_image(
 
     Args:
         img (torch.Tensor): image with shape [..., height, width] to resize
-        size (Union[int, Tuple[int, int]]): size to pad to. If int, resizes to square image of that size.
+        new_size (Union[int, Tuple[int, int]]): size to resize to. If int, resizes to square image of that size.
+        resize_method (str): method to use for resizing. Either constants.CROP_OR_PAD or constants.INTERPOLATE.
+
+    Returns:
+        torch.Tensor: resized image of size [..., size[0], size[1]] or [..., size, size] if size is int.
     """
     if torch.jit.isinstance(new_size, int):
         new_size = (new_size, new_size)
@@ -236,10 +261,12 @@ def resize_image(
 
 
 def grayscale(img: torch.Tensor) -> torch.Tensor:
+    """Grayscales RGB image."""
     return F.rgb_to_grayscale(img)
 
 
 def num_channels_in_image(img: torch.Tensor):
+    """Returns number of channels in image."""
     if img is None or img.ndim < 2:
         raise ValueError("Invalid image data")
 
@@ -278,7 +305,6 @@ def get_img_output_shape(
 
     Currently supported for Conv2D, MaxPool2D and AvgPool2d ops.
     """
-
     if padding == "same":
         return (img_height, img_width)
     elif padding == "valid":

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -239,19 +239,6 @@ def grayscale(img: torch.Tensor) -> torch.Tensor:
     return F.rgb_to_grayscale(img)
 
 
-def normalize(image: torch.Tensor) -> torch.Tensor:
-    """
-    Normalize pixel values to be between 0 and 1.
-
-    Args:
-        image: Image tensor.
-
-    Returns:
-        Normalized image tensor.
-    """
-    return image.type(torch.float32) / 255.0
-
-
 def num_channels_in_image(img: torch.Tensor):
     if img is None or img.ndim < 2:
         raise ValueError("Invalid image data")

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -239,6 +239,19 @@ def grayscale(img: torch.Tensor) -> torch.Tensor:
     return F.rgb_to_grayscale(img)
 
 
+def normalize(image: torch.Tensor) -> torch.Tensor:
+    """
+    Normalize pixel values to be between 0 and 1.
+
+    Args:
+        image: Image tensor.
+
+    Returns:
+        Normalized image tensor.
+    """
+    return image.type(torch.float32) / 255.0
+
+
 def num_channels_in_image(img: torch.Tensor):
     if img is None or img.ndim < 2:
         raise ValueError("Invalid image data")

--- a/tests/ludwig/utils/test_image_utils.py
+++ b/tests/ludwig/utils/test_image_utils.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import Callable
+
 import pytest
 import torch
 
 from ludwig.utils.image_utils import crop, crop_or_pad, grayscale, num_channels_in_image, pad, resize_image
 
 
+@pytest.mark.parametrize("pad_fn", [pad, torch.jit.script(pad)])
 @pytest.mark.parametrize(
     "img,size,padded_img",
     [
@@ -81,11 +84,12 @@ from ludwig.utils.image_utils import crop, crop_or_pad, grayscale, num_channels_
         )
     ],
 )
-def test_pad(img: torch.Tensor, size: int, padded_img: torch.Tensor):
-    output_img = pad(img, size)
+def test_pad(pad_fn: Callable, img: torch.Tensor, size: int, padded_img: torch.Tensor):
+    output_img = pad_fn(img, size)
     assert torch.equal(output_img, padded_img)
 
 
+@pytest.mark.parametrize("crop_fn", [crop, torch.jit.script(crop)])
 @pytest.mark.parametrize(
     "img,size,cropped_img",
     [
@@ -96,11 +100,12 @@ def test_pad(img: torch.Tensor, size: int, padded_img: torch.Tensor):
         )
     ],
 )
-def test_crop(img: torch.Tensor, size: int, cropped_img: torch.Tensor):
-    output_img = crop(img, size)
+def test_crop(crop_fn: Callable, img: torch.Tensor, size: int, cropped_img: torch.Tensor):
+    output_img = crop_fn(img, size)
     assert torch.equal(output_img, cropped_img)
 
 
+@pytest.mark.parametrize("crop_or_pad_fn", [crop_or_pad, torch.jit.script(crop_or_pad)])
 @pytest.mark.parametrize(
     "img,new_size,expected_img",
     [
@@ -169,11 +174,12 @@ def test_crop(img: torch.Tensor, size: int, cropped_img: torch.Tensor):
         ),
     ],
 )
-def test_crop_or_pad(img: torch.Tensor, new_size: int, expected_img: torch.Tensor):
-    output_image = crop_or_pad(img, new_size)
+def test_crop_or_pad(crop_or_pad_fn: Callable, img: torch.Tensor, new_size: int, expected_img: torch.Tensor):
+    output_image = crop_or_pad_fn(img, new_size)
     assert torch.equal(output_image, expected_img)
 
 
+@pytest.mark.parametrize("resize_image_fn", [resize_image, torch.jit.script(resize_image)])
 @pytest.mark.parametrize(
     "img,new_size,resize_method,expected_img",
     [
@@ -191,17 +197,20 @@ def test_crop_or_pad(img: torch.Tensor, new_size: int, expected_img: torch.Tenso
         ),
     ],
 )
-def test_resize_image(img: torch.Tensor, new_size: int, resize_method: str, expected_img: torch.Tensor):
-    output_img = resize_image(img, new_size, resize_method)
+def test_resize_image(
+    resize_image_fn: Callable, img: torch.Tensor, new_size: int, resize_method: str, expected_img: torch.Tensor
+):
+    output_img = resize_image_fn(img, new_size, resize_method)
     assert torch.equal(output_img, expected_img)
 
 
+@pytest.mark.parametrize("grayscale_fn", [grayscale, torch.jit.script(grayscale)])
 @pytest.mark.parametrize(
     "input_img,grayscale_img",
     [(torch.arange(12).reshape(3, 2, 2).type(torch.int), torch.Tensor([[[3, 4], [5, 6]]]).type(torch.int))],
 )
-def test_grayscale(input_img: torch.Tensor, grayscale_img: torch.Tensor):
-    output_img = grayscale(input_img)
+def test_grayscale(grayscale_fn: Callable, input_img: torch.Tensor, grayscale_img: torch.Tensor):
+    output_img = grayscale_fn(input_img)
     assert torch.equal(output_img, grayscale_img)
 
 

--- a/tests/ludwig/utils/test_image_utils.py
+++ b/tests/ludwig/utils/test_image_utils.py
@@ -17,7 +17,7 @@ from typing import Callable
 import pytest
 import torch
 
-from ludwig.utils.image_utils import crop, crop_or_pad, grayscale, normalize, num_channels_in_image, pad, resize_image
+from ludwig.utils.image_utils import crop, crop_or_pad, grayscale, num_channels_in_image, pad, resize_image
 
 
 @pytest.mark.parametrize("pad_fn", [pad, torch.jit.script(pad)])
@@ -212,26 +212,6 @@ def test_resize_image(
 def test_grayscale(grayscale_fn: Callable, input_img: torch.Tensor, grayscale_img: torch.Tensor):
     output_img = grayscale_fn(input_img)
     assert torch.equal(output_img, grayscale_img)
-
-
-@pytest.mark.parametrize("normalize_fn", [normalize, torch.jit.script(normalize)])
-def test_normalize(normalize_fn: Callable):
-    input_img = torch.tensor(
-        [
-            [255, 51, 0],
-            [0, 51, 255],
-        ]
-    )
-    expected_img = torch.tensor(
-        [
-            [1.0, 0.2, 0.0],
-            [0.0, 0.2, 1.0],
-        ]
-    )
-
-    output_img = normalize_fn(input_img)
-
-    assert torch.allclose(output_img, expected_img)
 
 
 def test_num_channels_in_image():

--- a/tests/ludwig/utils/test_image_utils.py
+++ b/tests/ludwig/utils/test_image_utils.py
@@ -17,7 +17,7 @@ from typing import Callable
 import pytest
 import torch
 
-from ludwig.utils.image_utils import crop, crop_or_pad, grayscale, num_channels_in_image, pad, resize_image
+from ludwig.utils.image_utils import crop, crop_or_pad, grayscale, normalize, num_channels_in_image, pad, resize_image
 
 
 @pytest.mark.parametrize("pad_fn", [pad, torch.jit.script(pad)])
@@ -212,6 +212,26 @@ def test_resize_image(
 def test_grayscale(grayscale_fn: Callable, input_img: torch.Tensor, grayscale_img: torch.Tensor):
     output_img = grayscale_fn(input_img)
     assert torch.equal(output_img, grayscale_img)
+
+
+@pytest.mark.parametrize("normalize_fn", [normalize, torch.jit.script(normalize)])
+def test_normalize(normalize_fn: Callable):
+    input_img = torch.tensor(
+        [
+            [255, 51, 0],
+            [0, 51, 255],
+        ]
+    )
+    expected_img = torch.tensor(
+        [
+            [1.0, 0.2, 0.0],
+            [0.0, 0.2, 1.0],
+        ]
+    )
+
+    output_img = normalize_fn(input_img)
+
+    assert torch.allclose(output_img, expected_img)
 
 
 def test_num_channels_in_image():


### PR DESCRIPTION
This PR adapts many of the image preprocessing functions in `image_utils.py` (namely, `crop`, `pad`, `crop_or_pad`, and `resize_image`) in order to make them torchscript-compatible. Namely, it (1) removes their dependency on Numpy, (2) enforces stricter typing throughout, and (3) brings constants into local scope in the case of `resize_image`.

Note: this PR assumes `torchvision` is a part of the minimal Ludwig installation because `try` blocks and `import` statements are not permitted in torchscript code. Concretely, I've removed the `torchvision` checks in `resize_image` and `grayscale`– however, those checks are not currently doing anything in any case because `import torchvision.transforms.functional as F` is currently already located at the top of the file. **That said, we still probably should NOT merge this in until we reach a resolution for #1914.**