### PR TITLE
Mlflow: move artifact logging to a background thread

### DIFF
--- a/ludwig/callbacks.py
+++ b/ludwig/callbacks.py
@@ -158,13 +158,14 @@ class Callback(ABC):
         """
         pass
 
-    def on_trainer_train_teardown(self, trainer, progress_tracker, is_coordinator: bool):
+    def on_trainer_train_teardown(self, trainer, progress_tracker, save_path: str, is_coordinator: bool):
         """Called in every trainer (distributed or local) after training completes.
 
         :param trainer: The trainer instance.
         :type trainer: ludwig.models.trainer.Trainer
         :param progress_tracker: An object which tracks training progress.
         :type progress_tracker: ludwig.utils.trainer_utils.ProgressTracker
+        :param save_path: The path to the directory model is saved in.
         :param is_coordinator: Is this trainer the coordinator.
         """
         pass

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -137,7 +137,8 @@ class MlflowCallback(Callback):
 
 
 def _log_mlflow_loop(q: queue.Queue):
-    while True:
+    should_return = False
+    while not should_return:
         elem = q.get()
         log_metrics, steps, save_path, should_return = elem
         mlflow.log_metrics(log_metrics, step=steps)
@@ -148,9 +149,6 @@ def _log_mlflow_loop(q: queue.Queue):
             continue
 
         _log_model(save_path)
-
-        if should_return:
-            return
 
 
 def _log_artifacts(output_directory):

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import queue
+import threading
 from distutils.version import LooseVersion
 from typing import Any, Dict
 
@@ -30,6 +32,8 @@ class MlflowCallback(Callback):
         self.tracking_uri = tracking_uri
         self.training_set_metadata = None
         self.config = None
+        self.save_queue = None
+        self.save_thread = None
         if tracking_uri:
             mlflow.set_tracking_uri(tracking_uri)
 
@@ -82,17 +86,18 @@ class MlflowCallback(Callback):
         if not os.path.exists(model_hyperparameters_path):
             save_json(model_hyperparameters_path, self.config)
 
+        self.save_queue = queue.Queue()
+        self.save_thread = threading.Thread(target=_log_mlflow_loop, args=(self.save_queue,))
+        self.save_thread.start()
+
     def on_eval_end(self, trainer, progress_tracker, save_path):
-        mlflow.log_metrics(progress_tracker.log_metrics(), step=progress_tracker.steps)
+        self.save_queue.put((progress_tracker.log_metrics(), progress_tracker.steps, save_path, False))
 
-        _log_model(save_path)
+    def on_trainer_train_teardown(self, trainer, progress_tracker, save_path, is_coordinator):
+        if is_coordinator:
+            self.save_queue.put((progress_tracker.log_metrics(), progress_tracker.steps, save_path, True))
+            self.save_thread.join()
 
-    def on_epoch_end(self, trainer, progress_tracker, save_path):
-        mlflow.log_metrics(progress_tracker.log_metrics(), step=progress_tracker.steps)
-
-        _log_model(save_path)
-
-    def on_trainer_train_teardown(self, trainer, progress_tracker, is_coordinator):
         if self.run is not None:
             mlflow.end_run()
 
@@ -129,6 +134,23 @@ class MlflowCallback(Callback):
         if self.run and not self.run_ended:
             mlflow.end_run()
             self.run = mlflow.start_run(run_id=self.run.info.run_id, experiment_id=self.run.info.experiment_id)
+
+
+def _log_mlflow_loop(q: queue.Queue):
+    while True:
+        elem = q.get()
+        log_metrics, steps, save_path, should_return = elem
+        mlflow.log_metrics(log_metrics, step=steps)
+
+        if not q.empty():
+            # in other words, don't bother saving the model artifacts
+            # if we're about to do it again
+            continue
+
+        _log_model(save_path)
+
+        if should_return:
+            return
 
 
 def _log_artifacts(output_directory):

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -73,8 +73,12 @@ class RayDataset(Dataset):
         #     return df
         # self.ds = self.ds.map_batches(to_tensors, batch_format="pandas")
 
-    def pipeline(self, shuffle=True) -> DatasetPipeline:
-        pipe = self.ds.repeat()
+    def pipeline(self, shuffle=True, fully_executed=True) -> DatasetPipeline:
+        ds = self.ds
+        if fully_executed:
+            ds = ds.fully_executed()
+
+        pipe = ds.repeat()
         if shuffle:
             if _ray18:
                 pipe = pipe.random_shuffle_each_window()

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -40,6 +40,9 @@ from ludwig.utils.types import DataFrame
 
 _ray18 = LooseVersion(ray.__version__) >= LooseVersion("1.8")
 _ray111 = LooseVersion(ray.__version__) >= LooseVersion("1.11")
+_ray112 = LooseVersion(ray.__version__) >= LooseVersion("1.12")
+
+
 _SCALAR_TYPES = {BINARY, CATEGORY, NUMBER}
 
 
@@ -74,8 +77,11 @@ class RayDataset(Dataset):
         # self.ds = self.ds.map_batches(to_tensors, batch_format="pandas")
 
     def pipeline(self, shuffle=True, fully_executed=True) -> DatasetPipeline:
+        if not fully_executed and not _ray112:
+            raise ValueError(f"Cannot set fully_execute=False in ray {ray.__version__}")
+
         ds = self.ds
-        if fully_executed:
+        if fully_executed and _ray112:
             ds = ds.fully_executed()
 
         pipe = ds.repeat()

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -980,7 +980,8 @@ class Trainer(BaseTrainer):
 
         # ================ Finished Training ================
         self.callback(
-            lambda c: c.on_trainer_train_teardown(self, progress_tracker, self.is_coordinator()), coordinator_only=False
+            lambda c: c.on_trainer_train_teardown(self, progress_tracker, save_path, self.is_coordinator()),
+            coordinator_only=False,
         )
 
         if train_summary_writer is not None:

--- a/tests/integration_tests/test_trainer.py
+++ b/tests/integration_tests/test_trainer.py
@@ -95,7 +95,7 @@ def run_scale_lr(config, data_csv, num_workers, outdir):
         def __init__(self):
             self.lr = None
 
-        def on_trainer_train_teardown(self, trainer, progress_tracker, is_coordinator: bool):
+        def on_trainer_train_teardown(self, trainer, progress_tracker, save_path, is_coordinator: bool):
             for g in trainer.optimizer.param_groups:
                 self.lr = g["lr"]
 


### PR DESCRIPTION
Also enables RayDatasets [fully_executed](https://docs.ray.io/en/master/data/package-ref.html#ray.data.Dataset.fully_executed) mode by default to bring the full dataset into cluster memory. This is to work around performance issues when training with small datasets. To enable reading from disk each epoch, we can set a param in the backend config:

```
backend:
    type: ray
    loader:
        fully_executed: false
```