### PR TITLE
Add file lock on training checkpoints to prevent race condition

### DIFF
--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -151,7 +151,6 @@ class MlflowCallback(Callback):
 
 
 def _log_mlflow_loop(q: queue.Queue):
-
     should_return = False
     while not should_return:
         elem = q.get()

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -80,11 +80,11 @@ class RayDataset(Dataset):
         if not fully_executed and not _ray112:
             raise ValueError(f"Cannot set fully_execute=False in ray {ray.__version__}")
 
-        ds = self.ds
         if fully_executed and _ray112:
-            ds = ds.fully_executed()
+            # set instance state so calls to __len__ will also use the fully_executed version
+            self.ds = self.ds.fully_executed()
 
-        pipe = ds.repeat()
+        pipe = self.ds.repeat()
         if shuffle:
             if _ray18:
                 pipe = pipe.random_shuffle_each_window()

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -897,106 +897,110 @@ class Trainer(BaseTrainer):
 
         set_random_seed(self.random_seed)
 
-        with training_set.initialize_batcher(
-            batch_size=self.batch_size,
-            should_shuffle=self.should_shuffle,
-            seed=self.random_seed,
-            horovod=self.horovod,
-        ) as batcher:
-            # ================ Training Loop ================
-            total_steps = self.epochs * batcher.steps_per_epoch
+        try:
+            with training_set.initialize_batcher(
+                batch_size=self.batch_size,
+                should_shuffle=self.should_shuffle,
+                seed=self.random_seed,
+                horovod=self.horovod,
+            ) as batcher:
+                # ================ Training Loop ================
+                total_steps = self.epochs * batcher.steps_per_epoch
 
-            # Get the terminal steps per checkpoint.
-            final_steps_per_checkpoint = get_final_steps_per_checkpoint(
-                batcher.steps_per_epoch, self.steps_per_checkpoint, self.checkpoints_per_epoch, self.is_coordinator()
-            )
-
-            if self.is_coordinator():
-                logger.info(
-                    f"Training for {total_steps} step(s), approximately "
-                    f"{int(total_steps / batcher.steps_per_epoch)} epoch(s)."
+                # Get the terminal steps per checkpoint.
+                final_steps_per_checkpoint = get_final_steps_per_checkpoint(
+                    batcher.steps_per_epoch,
+                    self.steps_per_checkpoint,
+                    self.checkpoints_per_epoch,
+                    self.is_coordinator(),
                 )
-                logger.info(f"Starting with step {progress_tracker.steps}, epoch: {progress_tracker.epoch}")
-
-            progress_bar = None
-            if self.is_coordinator():
-                progress_bar = tqdm(
-                    desc="Training",
-                    total=total_steps,
-                    file=sys.stdout,
-                    disable=is_progressbar_disabled(),
-                )
-
-            while progress_tracker.steps < total_steps:
-                # note that batch size may change over epochs
-                batcher.set_epoch(progress_tracker.epoch, progress_tracker.batch_size)
-
-                # epoch init
-                start_time = time.time()
-
-                # Reset the metrics at the start of the next epoch
-                self.model.train()  # Sets model to training mode.
-                self.model.reset_metrics()
-
-                self.callback(lambda c: c.on_epoch_start(self, progress_tracker, save_path))
-
-                # Trains over a full epoch of data.
-                should_break = self._train_loop(
-                    batcher,
-                    progress_tracker,
-                    save_path,
-                    train_summary_writer,
-                    progress_bar,
-                    training_set,
-                    validation_set,
-                    test_set,
-                    start_time,
-                    validation_summary_writer,
-                    test_summary_writer,
-                    model_weights_path,
-                    model_hyperparameters_path,
-                    output_features,
-                    metrics_names,
-                    checkpoint_manager,
-                    final_steps_per_checkpoint,
-                )
-
-                # ================ Post Training Epoch ================
-                progress_tracker.epoch += 1
-                self.callback(lambda c: c.on_epoch_end(self, progress_tracker, save_path))
 
                 if self.is_coordinator():
-                    # ========== Save training progress ==========
-                    logging.debug(
-                        f"Epoch {progress_tracker.epoch} took: "
-                        f"{time_utils.strdelta((time.time()- start_time) * 1000.0)}."
+                    logger.info(
+                        f"Training for {total_steps} step(s), approximately "
+                        f"{int(total_steps / batcher.steps_per_epoch)} epoch(s)."
                     )
-                    checkpoint_manager.save(progress_tracker.steps)
-                    progress_tracker.save(os.path.join(save_path, TRAINING_PROGRESS_TRACKER_FILE_NAME))
+                    logger.info(f"Starting with step {progress_tracker.steps}, epoch: {progress_tracker.epoch}")
 
-                # Early stop if needed.
-                if should_break:
-                    break
+                progress_bar = None
+                if self.is_coordinator():
+                    progress_bar = tqdm(
+                        desc="Training",
+                        total=total_steps,
+                        file=sys.stdout,
+                        disable=is_progressbar_disabled(),
+                    )
 
-        # ================ Finished Training ================
-        self.callback(
-            lambda c: c.on_trainer_train_teardown(self, progress_tracker, save_path, self.is_coordinator()),
-            coordinator_only=False,
-        )
+                while progress_tracker.steps < total_steps:
+                    # note that batch size may change over epochs
+                    batcher.set_epoch(progress_tracker.epoch, progress_tracker.batch_size)
 
-        if train_summary_writer is not None:
-            train_summary_writer.close()
-        if validation_summary_writer is not None:
-            validation_summary_writer.close()
-        if test_summary_writer is not None:
-            test_summary_writer.close()
+                    # epoch init
+                    start_time = time.time()
 
-        if self.is_coordinator():
-            checkpoint_manager.close()
+                    # Reset the metrics at the start of the next epoch
+                    self.model.train()  # Sets model to training mode.
+                    self.model.reset_metrics()
 
-        # Load the best weights from saved checkpoint
-        if self.is_coordinator() and not self.skip_save_model:
-            self.model.load_state_dict(torch.load(model_weights_path))
+                    self.callback(lambda c: c.on_epoch_start(self, progress_tracker, save_path))
+
+                    # Trains over a full epoch of data.
+                    should_break = self._train_loop(
+                        batcher,
+                        progress_tracker,
+                        save_path,
+                        train_summary_writer,
+                        progress_bar,
+                        training_set,
+                        validation_set,
+                        test_set,
+                        start_time,
+                        validation_summary_writer,
+                        test_summary_writer,
+                        model_weights_path,
+                        model_hyperparameters_path,
+                        output_features,
+                        metrics_names,
+                        checkpoint_manager,
+                        final_steps_per_checkpoint,
+                    )
+
+                    # ================ Post Training Epoch ================
+                    progress_tracker.epoch += 1
+                    self.callback(lambda c: c.on_epoch_end(self, progress_tracker, save_path))
+
+                    if self.is_coordinator():
+                        # ========== Save training progress ==========
+                        logging.debug(
+                            f"Epoch {progress_tracker.epoch} took: "
+                            f"{time_utils.strdelta((time.time()- start_time) * 1000.0)}."
+                        )
+                        checkpoint_manager.save(progress_tracker.steps)
+                        progress_tracker.save(os.path.join(save_path, TRAINING_PROGRESS_TRACKER_FILE_NAME))
+
+                    # Early stop if needed.
+                    if should_break:
+                        break
+        finally:
+            # ================ Finished Training ================
+            self.callback(
+                lambda c: c.on_trainer_train_teardown(self, progress_tracker, save_path, self.is_coordinator()),
+                coordinator_only=False,
+            )
+
+            if train_summary_writer is not None:
+                train_summary_writer.close()
+            if validation_summary_writer is not None:
+                validation_summary_writer.close()
+            if test_summary_writer is not None:
+                test_summary_writer.close()
+
+            if self.is_coordinator():
+                checkpoint_manager.close()
+
+            # Load the best weights from saved checkpoint
+            if self.is_coordinator() and not self.skip_save_model:
+                self.model.load_state_dict(torch.load(model_weights_path))
 
         return (
             self.model,

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -991,6 +991,9 @@ class Trainer(BaseTrainer):
         if test_summary_writer is not None:
             test_summary_writer.close()
 
+        if self.is_coordinator():
+            checkpoint_manager.close()
+
         # Load the best weights from saved checkpoint
         if self.is_coordinator() and not self.skip_save_model:
             self.model.load_state_dict(torch.load(model_weights_path))

--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -5,8 +5,10 @@ https://gist.github.com/kevinzakka/5d345421f7abefd5dbaf6a77f829e70a.
 import logging
 import os
 import os.path as osp
+import queue
 import re
 import signal
+import threading
 from glob import glob
 
 import numpy as np
@@ -36,6 +38,25 @@ def get_files(d, pattern, sort=True):
 
         files.sort(key=lambda x: int(filter_numeric(os.path.basename(x).split(".")[0])))
     return files
+
+
+def traim_checkpoints_loop(q: queue.Queue, directory: str, max_to_keep: int):
+    """Trim older checkpoints until `max_to_keep` remain."""
+    while True:
+        should_continue = q.get()
+        if should_continue is False:
+            return
+
+        # get a list of checkpoints in reverse
+        # chronological order
+        ckpts = get_files(directory, "*.ckpt")[::-1]
+
+        # remove until `max_to_keep` remain
+        num_remove = len(ckpts) - max_to_keep
+        while num_remove > 0:
+            ckpt_name = ckpts.pop()
+            os.remove(ckpt_name)
+            num_remove -= 1
 
 
 class Checkpoint:
@@ -135,6 +156,12 @@ class CheckpointManager:
         # already exist
         mkdir(self.directory)
 
+        self.queue = queue.Queue()
+        self.trim_thread = threading.Thread(
+            target=traim_checkpoints_loop, args=(self.queue, self.directory, self.max_to_keep)
+        )
+        self.trim_thread.start()
+
     def restore_or_initialize(self):
         """Restore items in checkpoint from the latest checkpoint file.
 
@@ -163,20 +190,11 @@ class CheckpointManager:
         save_path = osp.join(self.directory, f"{global_step:09d}.ckpt")
         self.checkpoint.save(save_path)
         self.latest_checkpoint = save_path
-        self._trim_checkpoints()
+        self.queue.put(True)
 
-    def _trim_checkpoints(self):
-        """Trim older checkpoints until `max_to_keep` remain."""
-        # get a list of checkpoints in reverse
-        # chronological order
-        ckpts = get_files(self.directory, "*.ckpt")[::-1]
-
-        # remove until `max_to_keep` remain
-        num_remove = len(ckpts) - self.max_to_keep
-        while num_remove > 0:
-            ckpt_name = ckpts.pop()
-            os.remove(ckpt_name)
-            num_remove -= 1
+    def close(self):
+        self.queue.put(False)
+        self.trim_thread.join()
 
     @staticmethod
     def load_latest_checkpoint(checkpoint, directory, device):

--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -14,6 +14,8 @@ from glob import glob
 import numpy as np
 import torch
 
+from ludwig.utils.fs_utils import file_lock
+
 
 def mkdir(s):
     """Create a directory if it doesn't already exist."""
@@ -47,16 +49,17 @@ def traim_checkpoints_loop(q: queue.Queue, directory: str, max_to_keep: int):
         if should_continue is False:
             return
 
-        # get a list of checkpoints in reverse
-        # chronological order
-        ckpts = get_files(directory, "*.ckpt")[::-1]
+        with file_lock(directory, lock_file=".lock"):
+            # get a list of checkpoints in reverse
+            # chronological order
+            ckpts = get_files(directory, "*.ckpt")[::-1]
 
-        # remove until `max_to_keep` remain
-        num_remove = len(ckpts) - max_to_keep
-        while num_remove > 0:
-            ckpt_name = ckpts.pop()
-            os.remove(ckpt_name)
-            num_remove -= 1
+            # remove until `max_to_keep` remain
+            num_remove = len(ckpts) - max_to_keep
+            while num_remove > 0:
+                ckpt_name = ckpts.pop()
+                os.remove(ckpt_name)
+                num_remove -= 1
 
 
 class Checkpoint:


### PR DESCRIPTION
The mlflow background thread to log artifacts can fail if it's attempting to copy checkpoints at the same time the `CheckpointManager` is attempting to remove old checkpoints. An error message like the following will be raised:

```
shutil.Error: [('/tmp/tmpyb40h3qc/training_checkpoints/tmp-862061404.ckpt', '/tmp/tmpscqa4cna/model/model/training_checkpoints/tmp-862061404.ckpt', "[Errno 2] No such file or directory: '/tmp/tmpyb40h3qc/training_checkpoints/tmp-862061404.ckpt'"), ('/tmp/tmpyb40h3qc/training_checkpoints/000000004.ckpt', '/tmp/tmpscqa4cna/model/model/training_checkpoints/000000004.ckpt', "[Errno 2] No such file or directory: '/tmp/tmpyb40h3qc/training_checkpoints/000000004.ckpt'")]
```

See: https://github.com/ludwig-ai/ludwig/runs/6050320675?check_suite_focus=true

Adding a `file_lock` around the checkpoints directory when the mlflow thread attempts to write should address the issue. Furthermore, we can move the checkpoint cleanup process into its own thread to avoid blocking the main thread on mlflow artifact logging.