### PR TITLE
Deletes requirements_[audio|image|text].txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,11 @@ scikit-learn
 tqdm
 torch==1.9.1 ; platform_system == "Windows"  # https://github.com/pytorch/pytorch/issues/65473
 torch>=1.10.0 ; platform_system != "Windows"
+torchtext
+torchvision==0.10.1 ; platform_system == "Windows"  # https://github.com/pytorch/pytorch/issues/65473
+torchvision>=0.10.1 ; platform_system != "Windows"
+transformers>=4.10.1
+spacy>=2.3
 PyYAML>=3.12
 absl-py
 kaggle

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ tensorboard
 torchmetrics
 torchinfo
 filelock
+psutil
 
 # new data format support
 xlwt            # excel

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,12 @@ scikit-learn
 tqdm
 torch==1.9.1 ; platform_system == "Windows"  # https://github.com/pytorch/pytorch/issues/65473
 torch>=1.10.0 ; platform_system != "Windows"
+torchaudio>=0.9.0
 torchtext
 torchvision==0.10.1 ; platform_system == "Windows"  # https://github.com/pytorch/pytorch/issues/65473
 torchvision>=0.10.1 ; platform_system != "Windows"
 transformers>=4.10.1
+soundfile
 spacy>=2.3
 PyYAML>=3.12
 absl-py

--- a/requirements_audio.txt
+++ b/requirements_audio.txt
@@ -1,2 +1,0 @@
-soundfile
-torchaudio>=0.9.0

--- a/requirements_image.txt
+++ b/requirements_image.txt
@@ -1,3 +1,0 @@
-torchvision==0.10.1 ; platform_system == "Windows"  # https://github.com/pytorch/pytorch/issues/65473
-torchvision>=0.10.1 ; platform_system != "Windows"
-transformers>=4.10.1

--- a/requirements_text.txt
+++ b/requirements_text.txt
@@ -1,4 +1,0 @@
-spacy>=2.3
-transformers>=4.10.1
-sentencepiece
-torchtext

--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,8 @@ extra_requirements = {}
 with open(path.join(here, "requirements_audio.txt"), encoding="utf-8") as f:
     extra_requirements["audio"] = [line.strip() for line in f if line]
 
-with open(path.join(here, "requirements_image.txt"), encoding="utf-8") as f:
-    extra_requirements["image"] = [line.strip() for line in f if line]
-
 with open(path.join(here, "requirements_serve.txt"), encoding="utf-8") as f:
     extra_requirements["serve"] = [line.strip() for line in f if line]
-
-with open(path.join(here, "requirements_text.txt"), encoding="utf-8") as f:
-    extra_requirements["text"] = [line.strip() for line in f if line]
 
 with open(path.join(here, "requirements_viz.txt"), encoding="utf-8") as f:
     extra_requirements["viz"] = [line.strip() for line in f if line]

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,6 @@ with open(path.join(here, "requirements.txt"), encoding="utf-8") as f:
 
 extra_requirements = {}
 
-with open(path.join(here, "requirements_audio.txt"), encoding="utf-8") as f:
-    extra_requirements["audio"] = [line.strip() for line in f if line]
-
 with open(path.join(here, "requirements_serve.txt"), encoding="utf-8") as f:
     extra_requirements["serve"] = [line.strip() for line in f if line]
 


### PR DESCRIPTION
Broadly, this PR (1) deletes `requirements_audio.txt`, `requirements_image.txt` and `requirements_text.txt`, (2) adds dependencies in those files to `requirements.txt`.

The primary way I tested this PR was by (1) creating a new virtual environment, (2) `pip install -e .`, then ran the text classification CLI [tutorial](http://127.0.0.1:8000/ludwig-docs/examples/text_classification/) from the 0.5 docs for a couple of epochs.

It is possible that this PR may cause downstream issues that I am not entirely familiar with, so please look through this PR carefully. Small details I want to highlight:

1. Removed `sentencepiece` as a dependency. I couldn't find it being used anywhere in the repository. If users are interested in using a sentencepiece tokenizer, we recently added `torchtext`-based implementation (#1887) (requires `torch>=1.11.0` and `torchtext>=0.12.0`).
2. Added `psutil` as a dependency. I attempted to train a model using a fresh install `pip install -e .` and ran into a `ModuleNotFoundError` for this module.

I could see this affecting tutorials and/or existing documentation, as well as potentially any automated installation workflows used in production. Please take a look and confirm.