### PR TITLE
Adds heuristic for deciding number of image channels

### DIFF
--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -334,9 +334,16 @@ class ImageFeatureMixin(BaseFeatureMixin):
             user_specified_num_channels = False
             if preprocessing_parameters[INFER_IMAGE_DIMENSIONS]:
                 user_specified_num_channels = True
-                # Use the maximum num_channels found across all sampled images. torchvision has built-in support for
-                # upsampling images.
-                num_channels = max(num_channels_in_image(x) for x in inferred_sample)
+                channels_in_sample = np.array([num_channels_in_image(x) for x in inferred_sample])
+                if sum(channels_in_sample == 1) > len(inferred_sample) / 2:
+                    # If the majority of images in sample are 1 channel, use 1.
+                    num_channels = 1
+                elif sum(channels_in_sample == 4) > len(inferred_sample) / 2:
+                    # If the majority of images in sample are 4 channel, use 4.
+                    num_channels = 4
+                else:
+                    # Default case: use 3 channels.
+                    num_channels = 3
             elif first_image is not None:
                 num_channels = num_channels_in_image(first_image)
             else:

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -358,7 +358,7 @@ class ImageFeatureMixin(BaseFeatureMixin):
                 if num_channels == max(channel_frequency, key=channel_frequency.get):
                     logging.info(
                         f"Using {num_channels} channels because it is the majority in sample. If an image with"
-                        f" a different depth is read, will attempt to convert it to {num_channels} channels."
+                        f" a different depth is read, will attempt to convert to {num_channels} channels."
                     )
                 else:
                     logging.info(f"Defaulting to {num_channels} channels.")

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -338,6 +338,9 @@ class ImageFeatureMixin(BaseFeatureMixin):
                 if sum(channels_in_sample == 1) > len(inferred_sample) / 2:
                     # If the majority of images in sample are 1 channel, use 1.
                     num_channels = 1
+                elif sum(channels_in_sample == 2) > len(inferred_sample) / 2:
+                    # If the majority of images in sample are 2 channel, use 2.
+                    num_channels = 2
                 elif sum(channels_in_sample == 4) > len(inferred_sample) / 2:
                     # If the majority of images in sample are 4 channel, use 4.
                     num_channels = 4

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -85,7 +85,7 @@ def str2bool(v: str, fallback_true_label=None) -> bool:
     if v_str in BOOL_FALSE_STRS:
         return False
     if fallback_true_label is None:
-        raise ValueError(f"Cannot automatically map value {v} to a boolean and no `fallback_true_label` specified.")
+        raise ValueError(f"Cannot automatically map value {v} to a boolean and no `fallback_true_label` specified")
     return v == fallback_true_label
 
 


### PR DESCRIPTION
Addresses issue 1940: [Twitter bots dataset fails to load most images because 4 channels not supported for JPEG](https://github.com/ludwig-ai/ludwig/issues/1940)

When inferring number of channels for an image dataset, my assumption is that 3 channels is the most common use case.

This PR changes the behavior to use:

1 channel if the majority of samples are 1 channel
2 channel if the majority of samples are 2 channel
4 channel if the majority are 4 channel
3 otherwise

Also added logging to explain channel inference.  Sample output (twitter bots):
```
Inferring num_channels from the first 100 images for column profile_image_path.
  images with 1 channels: 4
  images with 3 channels: 88
  images with 4 channels: 8
Using 3 channels because it is the majority in sample. If an image with a different depth is read, will attempt to convert to 3 channels.
To explicitly set the number of channels, define num_channels in the preprocessing dictionary of the image input feature config.
```