### PR TITLE
Use explicit date dtype if provided in automl config

### DIFF
--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -21,7 +21,7 @@ from dataclasses_json import dataclass_json, LetterCase
 
 from ludwig.automl.data_source import DataframeSource, DataSource
 from ludwig.automl.utils import _ray_init, FieldConfig, FieldInfo, FieldMetadata, get_available_resources
-from ludwig.constants import BINARY, CATEGORY, IMAGE, NUMBER, TEXT
+from ludwig.constants import BINARY, CATEGORY, IMAGE, NUMBER, TEXT, DATE
 from ludwig.utils import strings_utils
 from ludwig.utils.data_utils import load_dataset, load_yaml
 from ludwig.utils.defaults import default_random_seed
@@ -308,6 +308,9 @@ def infer_type(field: FieldInfo, missing_value_percent: float, row_count: int) -
     # Return
     :return: (str) feature type
     """
+    if field.dtype == DATE:
+        return DATE
+
     num_distinct_values = field.num_distinct_values
     if num_distinct_values == 0:
         return CATEGORY

--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -21,7 +21,7 @@ from dataclasses_json import dataclass_json, LetterCase
 
 from ludwig.automl.data_source import DataframeSource, DataSource
 from ludwig.automl.utils import _ray_init, FieldConfig, FieldInfo, FieldMetadata, get_available_resources
-from ludwig.constants import BINARY, CATEGORY, IMAGE, NUMBER, TEXT, DATE
+from ludwig.constants import BINARY, CATEGORY, DATE, IMAGE, NUMBER, TEXT
 from ludwig.utils import strings_utils
 from ludwig.utils.data_utils import load_dataset, load_yaml
 from ludwig.utils.defaults import default_random_seed

--- a/tests/ludwig/automl/test_base_config.py
+++ b/tests/ludwig/automl/test_base_config.py
@@ -51,7 +51,7 @@ def test_infer_type(num_distinct_values, distinct_values, img_values, missing_va
     assert infer_type(field, missing_vals, ROW_COUNT) == expected
 
 
-def test_infer_type_explicit_date(num_distinct_values, distinct_values, img_values, missing_vals, expected):
+def test_infer_type_explicit_date():
     field = FieldInfo(
         name="foo",
         distinct_values=["1", "2"],

--- a/tests/ludwig/automl/test_base_config.py
+++ b/tests/ludwig/automl/test_base_config.py
@@ -4,7 +4,7 @@ import pytest
 
 from ludwig.automl.base_config import infer_type, should_exclude
 from ludwig.automl.utils import FieldInfo
-from ludwig.constants import BINARY, CATEGORY, IMAGE, NUMBER, TEXT, DATE
+from ludwig.constants import BINARY, CATEGORY, DATE, IMAGE, NUMBER, TEXT
 from ludwig.data.dataset_synthesizer import generate_string
 
 ROW_COUNT = 100

--- a/tests/ludwig/automl/test_base_config.py
+++ b/tests/ludwig/automl/test_base_config.py
@@ -51,44 +51,15 @@ def test_infer_type(num_distinct_values, distinct_values, img_values, missing_va
     assert infer_type(field, missing_vals, ROW_COUNT) == expected
 
 
-@pytest.mark.parametrize(
-    "num_distinct_values,distinct_values,img_values,missing_vals,expected",
-    [
-        # Random numbers.
-        (ROW_COUNT, [str(random.random()) for _ in range(ROW_COUNT)], 0, 0.0, NUMBER),
-        # Random numbers with NaNs.
-        (ROW_COUNT, [str(random.random()) for _ in range(ROW_COUNT - 1)] + ["NaN"], 0, 0.0, NUMBER),
-        # Finite list of numbers.
-        (10, ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"], 0, 0.0, CATEGORY),
-        (2, ["1.5", "3.7"], 0, 0.1, NUMBER),
-        (2, ["1.5", "3.7", "nan"], 0, 0.1, NUMBER),
-        # Bool-like values.
-        (2, ["0", "1"], 0, 0.0, BINARY),
-        # Mostly bool-like values.
-        (3, ["0", "1", "True"], 0, 0.0, CATEGORY),
-        # Finite list of strings.
-        (2, ["human", "bot"], 0, 0.0, CATEGORY),
-        (10, [generate_string(5) for _ in range(10)], 0, 0.0, CATEGORY),
-        (40, [generate_string(5) for _ in range(40)], 0, 0.0, CATEGORY),
-        # Mostly random strings.
-        (90, [generate_string(5) for _ in range(90)], 0, 0.0, TEXT),
-        # Mostly random strings with capped distinct values.
-        (90, [generate_string(5) for _ in range(10)], 0, 0.0, TEXT),
-        # All random strings.
-        (ROW_COUNT, [generate_string(5) for _ in range(ROW_COUNT)], 0, 0.0, TEXT),
-        # Images.
-        (ROW_COUNT, [], ROW_COUNT, 0.0, IMAGE),
-    ],
-)
 def test_infer_type_explicit_date(num_distinct_values, distinct_values, img_values, missing_vals, expected):
     field = FieldInfo(
         name="foo",
+        distinct_values=["1", "2"],
+        num_distinct_values=2,
         dtype=DATE,
-        num_distinct_values=num_distinct_values,
-        distinct_values=distinct_values,
-        image_values=img_values,
     )
-    assert infer_type(field, missing_vals, ROW_COUNT) == DATE
+    assert infer_type(field, 0, ROW_COUNT) == DATE
+
 
 @pytest.mark.parametrize(
     "idx,num_distinct_values,dtype,name,expected",


### PR DESCRIPTION
if FieldInfo contains explicit dtype=DATE, we should honor it instead of inferring it as text. It's difficult to infer dates organically since they can be both string timestamps and unix epoch seconds.

In general, maybe we should be honoring user supplied field dtypes if they match ludwig's types