### PR TITLE
Fixes export.cli_export_torchscript functionality

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1451,6 +1451,19 @@ class LudwigModel:
         inference_module = InferenceModule(self.model, self.config, self.training_set_metadata)
         return torch.jit.script(inference_module)
 
+    def save_torchscript(self, save_path: str):
+        """Saves the Torchscript model to disk.
+
+        # Return
+        :return: `None`
+        """
+        self._check_initialization()
+        inference_module = self.to_torchscript()
+        print(inference_module.code)
+        inference_module.save(os.path.join(save_path, "inference_module.pt"))
+        # debugging: this raises an error
+        torch.jit.load(os.path.join(save_path, "inference_module.pt"))
+
     def _check_initialization(self):
         if self.model is None or self.config is None or self.training_set_metadata is None:
             raise ValueError("Model has not been trained or loaded")

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1452,17 +1452,9 @@ class LudwigModel:
         return torch.jit.script(inference_module)
 
     def save_torchscript(self, save_path: str):
-        """Saves the Torchscript model to disk.
-
-        # Return
-        :return: `None`
-        """
-        self._check_initialization()
+        """Saves the Torchscript model to disk."""
         inference_module = self.to_torchscript()
-        print(inference_module.code)
         inference_module.save(os.path.join(save_path, "inference_module.pt"))
-        # debugging: this raises an error
-        torch.jit.load(os.path.join(save_path, "inference_module.pt"))
 
     def _check_initialization(self):
         if self.model is None or self.config is None or self.training_set_metadata is None:

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -15,7 +15,6 @@
 import os
 import shutil
 import tempfile
-from unicodedata import category
 from unittest import mock
 
 import pytest
@@ -32,7 +31,6 @@ from tests.integration_tests.utils import (
     get_weights,
     run_api_experiment,
     sequence_feature,
-    text_feature,
 )
 
 

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -31,6 +31,7 @@ from tests.integration_tests.utils import (
     get_weights,
     run_api_experiment,
     sequence_feature,
+    text_feature,
 )
 
 
@@ -517,3 +518,33 @@ def test_api_callbacks_checkpoints_per_epoch(csv_filename, epochs, batch_size, n
 
     assert mock_callback.on_eval_end.call_count == total_checkpoints
     assert mock_callback.on_eval_start.call_count == total_checkpoints
+
+
+def test_api_save_torchscript(tmpdir):
+    """Tests successful saving and loading of model in TorchScript format."""
+    input_features = [
+        text_feature(
+            vocab_size=3,
+            preprocessing={
+                "tokenizer": "sentencepiece_tokenizer",
+            },
+        )
+    ]
+    output_features = [category_feature(vocab_size=5, reduce_input="sum")]
+
+    data_csv = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"))
+    val_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "validation.csv"))
+    test_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "test.csv"))
+
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        "combiner": {"type": "concat", "output_size": 14},
+    }
+    model = LudwigModel(config)
+    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv)
+    save_path = os.path.join(tmpdir, "torchscript")
+
+    os.makedirs(save_path, exist_ok=True)
+    model.save_torchscript(save_path)
+    torch.jit.load(os.path.join(save_path, "inference_module.pt"))

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -15,6 +15,7 @@
 import os
 import shutil
 import tempfile
+from unicodedata import category
 from unittest import mock
 
 import pytest
@@ -522,14 +523,7 @@ def test_api_callbacks_checkpoints_per_epoch(csv_filename, epochs, batch_size, n
 
 def test_api_save_torchscript(tmpdir):
     """Tests successful saving and loading of model in TorchScript format."""
-    input_features = [
-        text_feature(
-            vocab_size=3,
-            preprocessing={
-                "tokenizer": "sentencepiece_tokenizer",
-            },
-        )
-    ]
+    input_features = [category_feature(vocab_size=5)]
     output_features = [category_feature(vocab_size=5, reduce_input="sum")]
 
     data_csv = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"))

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -544,7 +544,8 @@ def test_api_save_torchscript(tmpdir):
     model = LudwigModel(config)
     model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv)
     save_path = os.path.join(tmpdir, "torchscript")
-
     os.makedirs(save_path, exist_ok=True)
+
     model.save_torchscript(save_path)
+
     torch.jit.load(os.path.join(save_path, "inference_module.pt"))

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -266,10 +266,8 @@ def test_torchscript_e2e(csv_filename, tmpdir):
     # Obtain predictions from Python model
     preds_dict, _ = ludwig_model.predict(dataset=training_data_csv_path, return_type=dict)
 
-    # Create, save, and load graph inference model (Torchscript) from trained Ludwig model.
-    save_path = os.path.join(tmpdir, "torchscript_model.pt")
-    ludwig_model.save_torchscript(save_path)
-    script_module = torch.jit.load(save_path)
+    # Create graph inference model (Torchscript) from trained Ludwig model.
+    script_module = ludwig_model.to_torchscript()
 
     def to_input(s: pd.Series) -> Union[List[str], torch.Tensor]:
         if s.dtype == "object":

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -266,8 +266,10 @@ def test_torchscript_e2e(csv_filename, tmpdir):
     # Obtain predictions from Python model
     preds_dict, _ = ludwig_model.predict(dataset=training_data_csv_path, return_type=dict)
 
-    # Create graph inference model (Torchscript) from trained Ludwig model.
-    script_module = ludwig_model.to_torchscript()
+    # Create, save, and load graph inference model (Torchscript) from trained Ludwig model.
+    save_path = os.path.join(tmpdir, "torchscript_model.pt")
+    ludwig_model.save_torchscript(save_path)
+    script_module = torch.jit.load(save_path)
 
     def to_input(s: pd.Series) -> Union[List[str], torch.Tensor]:
         if s.dtype == "object":


### PR DESCRIPTION
This PR fixes the `export.cli_export_torchscript` function. 

Prior to this PR, the `LudwigModel.save_torchscript` was called from `export.export_torchscript`, but the method did not exist:
https://github.com/ludwig-ai/ludwig/blob/aacabd3f5406701ecc336692c27c487ed043517c/ludwig/export.py#L47

This PR implements `LudwigModel.save_torchscript`, which creates an `InferenceModule`, converts it to Torchscript, and writes it to `output_path`.