### PR TITLE
Nit: don't end ValueError message with punctuation if its going to be caught and logged.

### DIFF
--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -84,7 +84,7 @@ def str2bool(v: str, fallback_true_label=None) -> bool:
     if v_str in BOOL_FALSE_STRS:
         return False
     if fallback_true_label is None:
-        raise ValueError(f"Cannot automatically map value {v} to a boolean and no `fallback_true_label` specified.")
+        raise ValueError(f"Cannot automatically map value {v} to a boolean and no `fallback_true_label` specified")
     return v == fallback_true_label
 
 

--- a/tests/integration_tests/test_validation_metrics.py
+++ b/tests/integration_tests/test_validation_metrics.py
@@ -101,6 +101,6 @@ def test_validation_invalid_metric(test_case: TestCase, csv_filename: str):
     # this should generate ValueError Exception
     try:
         test_validation_metrics(test_case, csv_filename)
-        raise RuntimeError("test_validation_metrics() should have raised ValueError " "but did not.")
+        raise RuntimeError("test_validation_metrics() should have raised ValueError but did not")
     except ValueError:
         pass


### PR DESCRIPTION
Results in double ..

Yes, I made a PR for this one thing.

```
Binary feature account_type has at least 1 unconventional boolean value:
Cannot automatically map value bot to a boolean and no `fallback_true_label` specified..
```
