### PR TITLE
Added distributed evaluation on Ray

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,11 +28,11 @@ jobs:
           - python-version: 3.7
             pytorch-version: 1.10.2
             torchscript-version: 1.10.2
-            ray-version: 1.9.2
+            ray-version: 1.11.0
           - python-version: 3.8
             pytorch-version: 1.11.0
             torchscript-version: 1.10.2
-            ray-version: 1.11.0
+            ray-version: 1.12.0
           - python-version: 3.9
             pytorch-version: nightly
             torchscript-version: 1.10.2

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -785,7 +785,7 @@ class LudwigModel:
         dataset: Union[str, dict, pd.DataFrame] = None,
         data_format: str = None,
         split: str = FULL,
-        batch_size: int = 128,
+        batch_size: Optional[int] = None,
         skip_save_unprocessed_output: bool = True,
         skip_save_predictions: bool = True,
         skip_save_eval_stats: bool = True,
@@ -811,8 +811,8 @@ class LudwigModel:
         :param: split: (str, default= `'full'`): if the input dataset contains
             a split column, this parameter indicates which split of the data
             to use. Possible values are `'full'`, `'training'`, `'validation'`, `'test'`.
-        :param batch_size: (int, default: 128) size of batch to use when making
-            predictions.
+        :param batch_size: (int, default: None) size of batch to use when making
+            predictions. Defaults to model config eval_batch_size
         :param skip_save_unprocessed_output: (bool, default: `True`) if this
             parameter is `False`, predictions and their probabilities are saved
             in both raw unprocessed numpy files containing tensors and as
@@ -857,6 +857,10 @@ class LudwigModel:
             backend=self.backend,
             callbacks=self.callbacks,
         )
+
+        # Fallback to use eval_batch_size or batch_size if not provided
+        if batch_size is None:
+            batch_size = self.config[TRAINER][EVAL_BATCH_SIZE] or self.config[TRAINER][BATCH_SIZE]
 
         logger.debug("Predicting")
         with self.backend.create_predictor(self.model, batch_size=batch_size) as predictor:

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -569,6 +569,7 @@ class RayBackend(RemoteTrainingMixin, Backend):
     def create_trainer(self, model: ECD, **kwargs):
         executable_kwargs = {**kwargs, **self._pytorch_kwargs}
         if not self._use_legacy:
+            # Deep copy to workaround https://github.com/ray-project/ray/issues/24139
             return RayTrainerV2(
                 model,
                 copy.deepcopy(self._horovod_kwargs),

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -38,8 +38,6 @@ from ludwig.utils.fs_utils import get_fs_and_path
 from ludwig.utils.misc_utils import get_proc_features
 from ludwig.utils.types import DataFrame
 
-_ray18 = LooseVersion(ray.__version__) >= LooseVersion("1.8")
-_ray111 = LooseVersion(ray.__version__) >= LooseVersion("1.11")
 _ray112 = LooseVersion(ray.__version__) >= LooseVersion("1.12")
 
 
@@ -47,9 +45,6 @@ _SCALAR_TYPES = {BINARY, CATEGORY, NUMBER}
 
 
 def read_remote_parquet(path: str):
-    if not _ray111:
-        return read_parquet(path)
-
     fs, path = get_fs_and_path(path)
     return read_parquet(path, filesystem=PyFileSystem(FSSpecHandler(fs)))
 
@@ -86,10 +81,7 @@ class RayDataset(Dataset):
 
         pipe = self.ds.repeat()
         if shuffle:
-            if _ray18:
-                pipe = pipe.random_shuffle_each_window()
-            else:
-                pipe = pipe.random_shuffle()
+            pipe = pipe.random_shuffle_each_window()
         return pipe
 
     @contextlib.contextmanager

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -22,10 +22,9 @@ from ludwig.globals import (
 )
 from ludwig.models.ecd import ECD
 from ludwig.utils.data_utils import flatten_df, from_numpy_dataset, save_csv, save_json
-from ludwig.utils.horovod_utils import initialize_horovod, return_first
+from ludwig.utils.horovod_utils import return_first
 from ludwig.utils.print_utils import repr_ordered_dict
 from ludwig.utils.strings_utils import make_safe_filename
-from ludwig.utils.torch_utils import initialize_pytorch
 
 EXCLUDE_PRED_SET = {LOGITS, LAST_HIDDEN}
 SKIP_EVAL_METRICS = {"confusion_matrix", "roc_curve"}
@@ -264,11 +263,7 @@ class Predictor(BasePredictor):
 
 class RemotePredictor(Predictor):
     def __init__(self, model: ECD, gpus=None, gpu_memory_limit=None, allow_parallel_threads=True, **kwargs):
-        horovod = initialize_horovod()
-        initialize_pytorch(
-            gpus=gpus, gpu_memory_limit=gpu_memory_limit, allow_parallel_threads=allow_parallel_threads, horovod=horovod
-        )
-        super().__init__(model, horovod=horovod, **kwargs)
+        super().__init__(model, **kwargs)
 
         # Only return results from rank 0 to reduce network overhead
         self.batch_predict = return_first(self.batch_predict)

--- a/requirements_distributed.txt
+++ b/requirements_distributed.txt
@@ -4,7 +4,7 @@ pyarrow>=2.0.0
 # requirements for horovod
 horovod[pytorch]>=0.24.0
 # requirements for ray
-ray[default,data,serve,tune]>=1.9.2,!=1.10
+ray[default,data,serve,tune]>=1.11.0
 pickle5; python_version <= '3.7'
 tensorboardX<2.3
 GPUtil

--- a/requirements_distributed.txt
+++ b/requirements_distributed.txt
@@ -10,4 +10,4 @@ tensorboardX<2.3
 GPUtil
 tblib
 awscli
-modin[ray]; python_version >= '3.7'
+modin[ray]

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -91,7 +91,7 @@ def run_api_experiment(config, data_parquet, backend_config):
         assert not kwargs.get("use_gpu"), kwargs
 
     # Train on Parquet
-    model = train_with_backend(backend_config, config, dataset=data_parquet, evaluate=False)
+    model = train_with_backend(backend_config, config, dataset=data_parquet, evaluate=True)
 
     assert isinstance(model.backend, RayBackend)
     if isinstance(model.backend.df_engine, DaskEngine):

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 import contextlib
 import os
-import sys
 import tempfile
 
 import numpy as np
@@ -91,7 +90,7 @@ def run_api_experiment(config, data_parquet, backend_config):
         assert not kwargs.get("use_gpu"), kwargs
 
     # Train on Parquet
-    model = train_with_backend(backend_config, config, dataset=data_parquet, evaluate=True)
+    model = train_with_backend(backend_config, config, dataset=data_parquet, evaluate=True, predict=False)
 
     assert isinstance(model.backend, RayBackend)
     if isinstance(model.backend.df_engine, DaskEngine):
@@ -102,7 +101,7 @@ def run_split_api_experiment(config, data_parquet, backend_config):
     train_fname, val_fname, test_fname = split(data_parquet)
 
     # Train
-    train_with_backend(backend_config, config, training_set=train_fname, evaluate=False, predict=False)
+    train_with_backend(backend_config, config, training_set=train_fname, evaluate=False, predict=True)
 
     # Train + Validation
     train_with_backend(
@@ -176,9 +175,6 @@ def run_test_parquet(
 @pytest.mark.parametrize("df_engine", ["dask", "modin"])
 @pytest.mark.distributed
 def test_ray_tabular(df_engine):
-    if df_engine == "modin" and sys.version_info < (3, 7):
-        pytest.skip("Modin is not supported with Python 3.6 at this time")
-
     input_features = [
         sequence_feature(reduce_output="sum"),
         category_feature(vocab_size=2, reduce_input="sum"),

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -27,6 +27,7 @@ from distutils.util import strtobool
 from typing import List
 
 import cloudpickle
+import numpy as np
 import pandas as pd
 import ray
 import torch
@@ -617,10 +618,36 @@ def train_with_backend(
             assert preds is not None
 
         if evaluate:
-            eval_stats, eval_preds, _ = model.evaluate(dataset=dataset, collect_overall_stats=False)
-            print(eval_stats)
-            print(eval_preds)
+            eval_stats, eval_preds, _ = model.evaluate(
+                dataset=dataset, collect_overall_stats=False, collect_predictions=True
+            )
             assert eval_preds is not None
+
+            # Test that eval_stats are approx equal when using local backend
+            with tempfile.TemporaryDirectory() as tmpdir:
+                model.save(tmpdir)
+                local_model = LudwigModel.load(tmpdir, backend=LocalTestBackend())
+                local_eval_stats, _, _ = local_model.evaluate(
+                    dataset=dataset, collect_overall_stats=False, collect_predictions=False
+                )
+
+                # Filter out metrics that are not being aggregated correctly for now
+                # TODO(travis): https://github.com/ludwig-ai/ludwig/issues/1956
+                def filter(stats):
+                    return {
+                        k: {
+                            metric_name: value
+                            for metric_name, value in v.items()
+                            if metric_name not in {"loss", "root_mean_squared_percentage_error"}
+                        }
+                        for k, v in stats.items()
+                    }
+
+                for (k1, v1), (k2, v2) in zip(filter(eval_stats).items(), filter(local_eval_stats).items()):
+                    assert k1 == k2
+                    for (name1, metric1), (name2, metric2) in zip(v1.items(), v2.items()):
+                        assert name1 == name2
+                        assert np.isclose(metric1, metric2)
 
         return model
     finally:

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -647,7 +647,7 @@ def train_with_backend(
                     assert k1 == k2
                     for (name1, metric1), (name2, metric2) in zip(v1.items(), v2.items()):
                         assert name1 == name2
-                        assert np.isclose(metric1, metric2)
+                        assert np.isclose(metric1, metric2), f"metric {name1}: {metric1} != {metric2}"
 
         return model
     finally:

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -647,7 +647,7 @@ def train_with_backend(
                     assert k1 == k2
                     for (name1, metric1), (name2, metric2) in zip(v1.items(), v2.items()):
                         assert name1 == name2
-                        assert np.isclose(metric1, metric2), f"metric {name1}: {metric1} != {metric2}"
+                        assert np.isclose(metric1, metric2, rtol=1e-04), f"metric {name1}: {metric1} != {metric2}"
 
         return model
     finally:

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -617,7 +617,9 @@ def train_with_backend(
             assert preds is not None
 
         if evaluate:
-            _, eval_preds, _ = model.evaluate(dataset=dataset)
+            eval_stats, eval_preds, _ = model.evaluate(dataset=dataset, collect_overall_stats=False)
+            print(eval_stats)
+            print(eval_preds)
             assert eval_preds is not None
 
         return model


### PR DESCRIPTION
Also adds tests to ensure approximate equivalent between distributed and local eval metrics computation.

Also uncovered a few issues:

#1956
https://github.com/ray-project/ray/issues/24139

For some reason, Ray 1.9.2 produces different results for metric aggregations, which may be related to some data loading bugs we uncovered in older versions of Ray Datasets. As such, we are also dropping support for Ray < 1.11 in this PR.