### PR TITLE
Fixed train resume logic from checkpoints

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -318,7 +318,7 @@ class LudwigModel:
         :param skip_save_processed_input: (bool, default: `False`) if input
             dataset is provided it is preprocessed and cached by saving an HDF5
             and JSON files to avoid running the preprocessing again. If this
-            parameter is `False`, the HDF5 and JSON file are not saved.
+            parameter is `False`, the HDF5 and JSON file are saved.
         :param output_directory: (str, default: `'results'`) the directory that
             will contain the training statistics, TensorBoard logs, the saved
             model and the training progress files.
@@ -490,7 +490,7 @@ class LudwigModel:
             with self.backend.create_trainer(
                 model=self.model,
                 config=config,
-                resume=model_resume_path is not None,
+                resume=not(model_resume_path is None and experiment_name is None),
                 skip_save_model=skip_save_model,
                 skip_save_progress=skip_save_progress,
                 skip_save_log=skip_save_log,

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -490,7 +490,7 @@ class LudwigModel:
             with self.backend.create_trainer(
                 model=self.model,
                 config=config,
-                resume=not(model_resume_path is None and experiment_name is None),
+                resume=not (model_resume_path is None and experiment_name is None),
                 skip_save_model=skip_save_model,
                 skip_save_progress=skip_save_progress,
                 skip_save_log=skip_save_log,

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -931,11 +931,8 @@ class Trainer(BaseTrainer):
             batch_size=self.batch_size,
             learning_rate=self.base_learning_rate,
             best_eval_metric=get_initial_validation_value(self.validation_metric),
-            best_reduce_learning_rate_eval_metric=get_initial_validation_value(
-                self.reduce_learning_rate_eval_metric
-            ),
-            best_increase_batch_size_eval_metric=get_initial_validation_value(
-                self.increase_batch_size_eval_metric),
+            best_reduce_learning_rate_eval_metric=get_initial_validation_value(self.reduce_learning_rate_eval_metric),
+            best_increase_batch_size_eval_metric=get_initial_validation_value(self.increase_batch_size_eval_metric),
             output_features=output_features,
         )
         if self.resume:

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -27,6 +27,7 @@ from ludwig.utils.fs_utils import find_non_existing_dir_by_adding_suffix
 
 BASE_PATH = "/ludwig/output"
 
+
 def set_random_seed(random_seed):
     os.environ["PYTHONHASHSEED"] = str(random_seed)
     random.seed(random_seed)

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -25,6 +25,7 @@ import torch
 from ludwig.constants import PROC_COLUMN
 from ludwig.utils.fs_utils import find_non_existing_dir_by_adding_suffix
 
+BASE_PATH = "/ludwig/output"
 
 def set_random_seed(random_seed):
     os.environ["PYTHONHASHSEED"] = str(random_seed)
@@ -106,9 +107,11 @@ def get_class_attributes(c):
     return {i for i in dir(c) if not callable(getattr(c, i)) and not i.startswith("_")}
 
 
-def get_output_directory(output_directory, experiment_name, model_name="run"):
+def get_output_directory(output_directory, experiment_name, model_name="run", create_unique_output_dir=False):
     base_dir_name = os.path.join(output_directory, experiment_name + ("_" if model_name else "") + (model_name or ""))
-    return os.path.abspath(find_non_existing_dir_by_adding_suffix(base_dir_name))
+    non_existing_dir = find_non_existing_dir_by_adding_suffix(base_dir_name)
+    abs_path = os.path.join(BASE_PATH, non_existing_dir)
+    return abs_path
 
 
 def get_file_names(output_directory):


### PR DESCRIPTION
# Code Pull Requests

This change fixes the logic to resume training from checkpoint in case only an experiment name and model id are provided, without an explicit resume path. We look for checkpoint in the `output_dir` determined solely by those 2 inputs.

Issue https://github.com/predibase/predibase/issues/468

Tested on Ray backend:
```
Stage 0: : 4it [00:25,  7.31s/it] pid=62271) 
(BaseWorkerMixin pid=61908) Note: steps_per_checkpoint (was 11) is now set to the number of steps per epoch: 11.
(BaseWorkerMixin pid=61908) 
(BaseWorkerMixin pid=61908) Training for 1100 step(s), approximately 100 epoch(s).
(BaseWorkerMixin pid=61908) Starting with step 297, epoch: 26
```