### PR TITLE
Renames torchtext tokenizers

### DIFF
--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -30,9 +30,9 @@ SPACE_PUNCTUATION_REGEX = re.compile(r"\w+|[^\w\s]")
 COMMA_REGEX = re.compile(r"\s*,\s*")
 UNDERSCORE_REGEX = re.compile(r"\s*_\s*")
 TORCHTEXT_TOKENIZERS = {
-    "sentencepiece_tokenizer",
-    "clip_tokenizer",
-    "gpt2bpe_tokenizer",
+    "sentencepiece",
+    "clip",
+    "gpt2bpe",
 }  # requires torchtext>=0.12.0
 TORCHSCRIPT_ENABLED_TOKENIZERS = {"space", *TORCHTEXT_TOKENIZERS}
 
@@ -948,9 +948,9 @@ try:
 
         tokenizer_registry.update(
             {
-                "sentencepiece_tokenizer": SentencePieceTokenizer,
-                "clip_tokenizer": CLIPTokenizer,
-                "gpt2bpe_tokenizer": GPT2BPETokenizer,
+                "sentencepiece": SentencePieceTokenizer,
+                "clip": CLIPTokenizer,
+                "gpt2bpe": GPT2BPETokenizer,
             }
         )
 

--- a/tests/ludwig/features/test_sequence_features.py
+++ b/tests/ludwig/features/test_sequence_features.py
@@ -148,7 +148,7 @@ def test_text_preproc_module_sentencepiece_tokenizer():
     metadata = {
         "preprocessing": {
             "lowercase": True,
-            "tokenizer": "sentencepiece_tokenizer",
+            "tokenizer": "sentencepiece",
             "unknown_symbol": "<UNK>",
             "padding_symbol": "<PAD>",
         },
@@ -182,7 +182,7 @@ def test_text_preproc_module_clip_tokenizer():
     metadata = {
         "preprocessing": {
             "lowercase": True,
-            "tokenizer": "clip_tokenizer",
+            "tokenizer": "clip",
             "unknown_symbol": "<UNK>",
             "padding_symbol": "<PAD>",
         },
@@ -214,7 +214,7 @@ def test_text_preproc_module_gpt2bpe_tokenizer():
     metadata = {
         "preprocessing": {
             "lowercase": True,
-            "tokenizer": "gpt2bpe_tokenizer",
+            "tokenizer": "gpt2bpe",
             "unknown_symbol": "<UNK>",
             "padding_symbol": "<PAD>",
         },


### PR DESCRIPTION
This PR renames the torchtext tokenizers to follow the convention of the other tokenizers by removing the "_tokenizer" suffix from each.