### PR TITLE
Fixes number input feature to have torchscript-compatible numeric_transformer classes

### DIFF
--- a/ludwig/features/number_feature.py
+++ b/ludwig/features/number_feature.py
@@ -52,25 +52,19 @@ logger = logging.getLogger(__name__)
 class ZScoreTransformer(nn.Module):
     def __init__(self, mean: float = None, std: float = None, **kwargs: dict):
         super().__init__()
-        self.mu = mean
-        self.sigma = std
+        self.mu = float(mean)
+        self.sigma = float(std)
 
     def transform(self, x: np.ndarray) -> np.ndarray:
-        return self._transform(x)
-
-    def inverse_transform(self, x: np.ndarray) -> np.ndarray:
-        return self._inverse_transform(x)
-
-    def transform_inference(self, x: torch.Tensor) -> torch.Tensor:
-        return self._transform(x)
-
-    def inverse_transform_inference(self, x: torch.Tensor) -> torch.Tensor:
-        return self._inverse_transform(x)
-
-    def _transform(self, x: Union[np.ndarray, torch.Tensor]) -> torch.Tensor:
         return (x - self.mu) / self.sigma
 
-    def _inverse_transform(self, x: Union[np.ndarray, torch.Tensor]) -> torch.Tensor:
+    def inverse_transform(self, x: np.ndarray) -> np.ndarray:
+        return x * self.sigma + self.mu
+
+    def transform_inference(self, x: torch.Tensor) -> torch.Tensor:
+        return (x - self.mu) / self.sigma
+
+    def inverse_transform_inference(self, x: torch.Tensor) -> torch.Tensor:
         return x * self.sigma + self.mu
 
     @staticmethod
@@ -85,26 +79,22 @@ class ZScoreTransformer(nn.Module):
 class MinMaxTransformer(nn.Module):
     def __init__(self, min: float = None, max: float = None, **kwargs: dict):
         super().__init__()
-        self.min_value = min
-        self.max_value = max
-        self.range = None if min is None or max is None else max - min
+        self.min_value = float(min)
+        self.max_value = float(max)
+        self.range = float(None if min is None or max is None else max - min)
 
     def transform(self, x: np.ndarray) -> np.ndarray:
-        return self._transform(x)
-
-    def inverse_transform(self, x: np.ndarray) -> np.ndarray:
-        return self._inverse_transform(x)
-
-    def transform_inference(self, x: torch.Tensor) -> torch.Tensor:
-        return self._transform(x)
-
-    def inverse_transform_inference(self, x: torch.Tensor) -> torch.Tensor:
-        return self._inverse_transform(x)
-
-    def _transform(self, x: Union[np.ndarray, torch.Tensor]):
         return (x - self.min_value) / self.range
 
-    def _inverse_transform(self, x: Union[np.ndarray, torch.Tensor]):
+    def inverse_transform(self, x: np.ndarray) -> np.ndarray:
+        if self.range is None:
+            raise ValueError("Numeric transformer needs to be instantiated with " "min and max values.")
+        return x * self.range + self.min_value
+
+    def transform_inference(self, x: torch.Tensor) -> torch.Tensor:
+        return (x - self.min_value) / self.range
+
+    def inverse_transform_inference(self, x: torch.Tensor) -> torch.Tensor:
         if self.range is None:
             raise ValueError("Numeric transformer needs to be instantiated with " "min and max values.")
         return x * self.range + self.min_value

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -27,6 +27,7 @@ import torchtext
 from ludwig.api import LudwigModel
 from ludwig.constants import LOGITS, NAME, PREDICTIONS, PROBABILITIES, TRAINER
 from ludwig.data.preprocessing import preprocess_for_prediction
+from ludwig.features.number_feature import numeric_transformation_registry
 from ludwig.globals import TRAIN_SET_METADATA_FILE_NAME
 from ludwig.utils import image_utils, output_feature_utils
 from ludwig.utils.tokenizers import TORCHSCRIPT_ENABLED_TOKENIZERS
@@ -207,6 +208,10 @@ def test_torchscript_e2e(csv_filename, tmpdir):
 
     # Configure features to be tested:
     bin_str_feature = binary_feature()
+    transformed_number_features = [
+        number_feature(preprocessing={"normalization": numeric_transformer})
+        for numeric_transformer in numeric_transformation_registry.keys()
+    ]
     torchscript_enabled_text_features = [
         text_feature(vocab_size=3, preprocessing={"tokenizer": tokenizer})
         for tokenizer in TORCHSCRIPT_ENABLED_TOKENIZERS
@@ -214,7 +219,7 @@ def test_torchscript_e2e(csv_filename, tmpdir):
     input_features = [
         bin_str_feature,
         binary_feature(),
-        number_feature(),
+        *transformed_number_features,
         category_feature(vocab_size=3),
         image_feature(image_dest_folder),
         *torchscript_enabled_text_features


### PR DESCRIPTION
The number input feature class allows for various numerical normalizations. Some of these normalizations had the type hint `Union[np.ndarray, torch.Tensor]`, which torchscript did not recognize. This PR makes these normalizations torchscript-compatible and adds regression tests.