### PR TITLE
Change early_stop to be the number of consecutive rounds of evaluation.

### DIFF
--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -166,8 +166,8 @@ class TrainerConfig(schema.BaseMarshmallowConfig):
         default=5,
         min=-1,
         description=(
-            "How many epochs without any improvement in the `validation_metric` triggers the algorithm to stop. Can be "
-            "set to -1, which disables `early_stop`."
+            "Number of consecutive rounds of evaluation without any improvement on the `validation_metric` that "
+            "triggers training to stop. Can be set to -1, which disables early stopping entirely."
         ),
     )
 
@@ -706,6 +706,7 @@ class Trainer(BaseTrainer):
         save_path,
         loss: torch.Tensor,
         all_losses: Dict[str, torch.Tensor],
+        early_stopping_steps: int,
     ) -> bool:
         """Runs evaluation over training, validation, and test sets.
 
@@ -823,7 +824,7 @@ class Trainer(BaseTrainer):
                 self.increase_batch_size_on_plateau_max,
                 self.increase_batch_size_eval_metric,
                 self.increase_batch_size_eval_split,
-                self.early_stop,
+                early_stopping_steps,
                 self.skip_save_model,
             )
         else:
@@ -970,6 +971,8 @@ class Trainer(BaseTrainer):
                     self.is_coordinator(),
                 )
 
+                early_stopping_steps = final_steps_per_checkpoint * self.early_stop
+
                 if self.is_coordinator():
                     logger.info(
                         f"Training for {total_steps} step(s), approximately "
@@ -1018,6 +1021,7 @@ class Trainer(BaseTrainer):
                         metrics_names,
                         checkpoint_manager,
                         final_steps_per_checkpoint,
+                        early_stopping_steps,
                     )
 
                     # ================ Post Training Epoch ================
@@ -1088,6 +1092,7 @@ class Trainer(BaseTrainer):
         metrics_names,
         checkpoint_manager,
         final_steps_per_checkpoint: int,
+        early_stopping_steps: int,
     ) -> bool:
         """Completes one epoch through the data."""
         while not batcher.last_batch():
@@ -1181,6 +1186,7 @@ class Trainer(BaseTrainer):
                     save_path,
                     loss,
                     all_losses,
+                    early_stopping_steps,
                 )
                 if should_break:
                     return should_break
@@ -1282,7 +1288,7 @@ class Trainer(BaseTrainer):
         increase_batch_size_on_plateau_max,
         increase_batch_size_eval_metric,
         increase_batch_size_eval_split,
-        early_stop,
+        early_stopping_steps: int,
         skip_save_model,
     ):
         """Checks the history of validation scores.
@@ -1372,7 +1378,7 @@ class Trainer(BaseTrainer):
         # ========== Early Stop logic ==========
         # If any early stopping condition is satisfied, either lack of improvement for many steps, or via callbacks on
         # any worker, then trigger early stopping.
-        early_stop_bool = 0 < early_stop <= progress_tracker.last_improvement
+        early_stop_bool = 0 < early_stopping_steps <= progress_tracker.last_improvement
         if not early_stop_bool:
             for callback in self.callbacks:
                 if callback.should_early_stop(self, progress_tracker, self.is_coordinator()):

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -978,6 +978,12 @@ class Trainer(BaseTrainer):
                         f"Training for {total_steps} step(s), approximately "
                         f"{int(total_steps / batcher.steps_per_epoch)} epoch(s)."
                     )
+                    logger.info(
+                        f"Early stopping policy: {self.early_stop} round(s) of evaluation, or {early_stopping_steps} "
+                        f"step(s), which is approximately {int(early_stopping_steps / batcher.steps_per_epoch)} "
+                        "epoch(s).\n"
+                    )
+
                     logger.info(f"Starting with step {progress_tracker.steps}, epoch: {progress_tracker.epoch}")
 
                 progress_bar = None
@@ -1391,10 +1397,10 @@ class Trainer(BaseTrainer):
         if should_early_stop.item():
             if self.is_coordinator():
                 logger.info(
-                    "\nEARLY STOPPING due to lack of "
-                    "validation improvement, "
-                    f"it has been {progress_tracker.steps - progress_tracker.last_improvement_steps} step(s) since "
-                    "last validation improvement.\n"
+                    "\nEARLY STOPPING due to lack of validation improvement. "
+                    f"It has been {progress_tracker.steps - progress_tracker.last_improvement_steps} step(s) since "
+                    f"last validation improvement, which is more than {self.early_stop} rounds of evaluation, or "
+                    f"{early_stopping_steps} steps.\n"
                 )
             should_break = True
         return should_break

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -980,7 +980,7 @@ class Trainer(BaseTrainer):
                     )
                     logger.info(
                         f"Early stopping policy: {self.early_stop} round(s) of evaluation, or {early_stopping_steps} "
-                        f"step(s), which is approximately {int(early_stopping_steps / batcher.steps_per_epoch)} "
+                        f"step(s), approximately {int(early_stopping_steps / batcher.steps_per_epoch)} "
                         "epoch(s).\n"
                     )
 

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -1399,8 +1399,7 @@ class Trainer(BaseTrainer):
                 logger.info(
                     "\nEARLY STOPPING due to lack of validation improvement. "
                     f"It has been {progress_tracker.steps - progress_tracker.last_improvement_steps} step(s) since "
-                    f"last validation improvement, which is more than {self.early_stop} rounds of evaluation, or "
-                    f"{early_stopping_steps} steps.\n"
+                    f"last validation improvement.\n"
                 )
             should_break = True
         return should_break

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -79,7 +79,7 @@ default_training_params = {
     "learning_rate": 0.001,
     "batch_size": 128,
     "eval_batch_size": None,
-    "early_stop": 1000,
+    "early_stop": 5,
     "steps_per_checkpoint": 0,
     "reduce_learning_rate_on_plateau": 0,
     "reduce_learning_rate_on_plateau_patience": 5,

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -156,17 +156,21 @@ def get_final_steps_per_checkpoint(
             "other, or specify neither to checkpoint/eval the model every epoch."
         )
 
-    # Set steps_per_checkpoint based on the checkpoints_per_epoch, if it was specified.
+    # Set steps_per_checkpoint based on the checkpoints_per_epoch, if checkpoints_per_epoch was specified.
     if checkpoints_per_epoch != 0:
         steps_per_checkpoint = int(steps_per_epoch / checkpoints_per_epoch)
 
-    # Check steps_per_checkpoint and cap it at steps_per_epoch.
-    if steps_per_checkpoint == 0 or steps_per_checkpoint > steps_per_epoch:
-        steps_per_checkpoint = steps_per_epoch
+    # Cap steps_per_checkpoint at steps_per_epoch.
+    if steps_per_checkpoint > steps_per_epoch:
         if should_log:
             logging.info(
                 f"Note: steps_per_checkpoint (was {steps_per_checkpoint}) is now set to the number of "
                 f"steps per epoch: {steps_per_epoch}.\n"
             )
+        return steps_per_epoch
+
+    # steps_per_checkpoint wasn't specified. Use steps_per_epoch.
+    if steps_per_checkpoint == 0:
+        return steps_per_epoch
 
     return steps_per_checkpoint

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -87,7 +87,7 @@ def generated_data_for_optimizer():
     return GeneratedData(train, validation, test)
 
 
-@pytest.mark.parametrize("early_stop", [105, 168])
+@pytest.mark.parametrize("early_stop", [3, 5])
 def test_early_stopping(early_stop, generated_data, tmp_path):
     input_features, output_features = get_feature_configs()
 
@@ -97,7 +97,6 @@ def test_early_stopping(early_stop, generated_data, tmp_path):
         "combiner": {"type": "concat"},
         TRAINER: {"epochs": 30, "early_stop": early_stop, "batch_size": 16},
     }
-    steps_per_epoch = 21  # (NUMBER_OBSERVATIONS * 0.7) / batch_size
 
     # create sub-directory to store results
     results_dir = tmp_path / "results"
@@ -135,11 +134,10 @@ def test_early_stopping(early_stop, generated_data, tmp_path):
     # retrieve validation losses
     vald_losses_data = train_stats["validation"]["combined"]["loss"]
 
-    last_steps = (len(vald_losses_data) - 1) * steps_per_epoch
-    best_steps = np.argmin(vald_losses_data) * steps_per_epoch
-    steps_interval = last_steps - best_steps
+    last_evaluation = len(vald_losses_data) - 1
+    best_evaluation = np.argmin(vald_losses_data)
 
-    assert steps_interval == early_stop_value
+    assert last_evaluation - best_evaluation == early_stop_value
 
 
 @pytest.mark.parametrize("skip_save_progress", [False])


### PR DESCRIPTION
Example stdout:
```
╒══════════╕
│ TRAINING │
╘══════════╛

Training for 6300 step(s), approximately 100 epoch(s).
Early stopping policy: 5 round(s) of evaluation, or 315 step(s), which is approximately 5 epoch(s).

Starting with step 0, epoch: 0
Training:   1%|█▍                                                                                                                                            | 62/6300 [00:00<01:33, 66.90it/s]
Running evaluation for step: 63, epoch: 0
Evaluation train: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 63/63 [00:00<00:00, 359.85it/s]
Evaluation vali : 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9/9 [00:00<00:00, 345.84it/s]
Evaluation test : 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 18/18 [00:00<00:00, 390.83it/s]
╒════════════╤════════╤═══════════╤════════════╕
│ Survived   │   loss │   roc_auc │   accuracy │
╞════════════╪════════╪═══════════╪════════════╡
│ train      │ 0.7140 │    0.4902 │     0.5460 │
├────────────┼────────┼───────────┼────────────┤
│ vali       │ 0.6802 │    0.4968 │     0.6173 │
├────────────┼────────┼───────────┼────────────┤
│ test       │ 0.7026 │    0.5456 │     0.6111 │
╘════════════╧════════╧═══════════╧════════════╛
╒════════════╤════════╕
│ combined   │   loss │
╞════════════╪════════╡
│ train      │ 0.7140 │
├────────────┼────────┤
│ vali       │ 0.6802 │
├────────────┼────────┤
│ test       │ 0.7026 │
╘════════════╧════════╛
Validation loss on combined improved, model saved.
```