### PR TITLE
Allow injection of additional callbacks when predicting using a trained model

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -691,6 +691,7 @@ class LudwigModel:
         skip_save_predictions: bool = True,
         output_directory: str = "results",
         return_type: Union[str, dict, pd.DataFrame] = pd.DataFrame,
+        additional_callbacks: Optional[List[Callback]] = None,
         **kwargs,
     ) -> Tuple[Union[dict, pd.DataFrame], str]:
         """Using a trained model, make predictions from the provided dataset.
@@ -742,7 +743,7 @@ class LudwigModel:
             split=split,
             include_outputs=False,
             backend=self.backend,
-            callbacks=self.callbacks,
+            callbacks=self.callbacks + (additional_callbacks or []),
         )
 
         logger.debug("Predicting")


### PR DESCRIPTION
Callbacks are typically provided to `LudwigModel` at init time. This change allows the caller of `LudwigModel.predict` to provide additional callbacks desired in that invocation of `predict`.
