### PR TITLE
Cleans up test_torchscript.py and tokenizer constants

### DIFF
--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -56,7 +56,7 @@ from ludwig.utils.strings_utils import (
     tokenizer_registry,
     UNKNOWN_SYMBOL,
 )
-from ludwig.utils.tokenizers import TORCHSCRIPT_ENABLED_TOKENIZERS
+from ludwig.utils.tokenizers import TORCHSCRIPT_COMPATIBLE_TOKENIZERS
 from ludwig.utils.types import DataFrame
 
 logger = logging.getLogger(__name__)
@@ -67,10 +67,10 @@ class _SequencePreprocessing(torch.nn.Module):
 
     def __init__(self, metadata: Dict[str, Any]):
         super().__init__()
-        if metadata["preprocessing"]["tokenizer"] not in TORCHSCRIPT_ENABLED_TOKENIZERS:
+        if metadata["preprocessing"]["tokenizer"] not in TORCHSCRIPT_COMPATIBLE_TOKENIZERS:
             raise ValueError(
                 f"{metadata['preprocessing']['tokenizer']} is not supported by torchscript. Please use "
-                f"one of {TORCHSCRIPT_ENABLED_TOKENIZERS}."
+                f"one of {TORCHSCRIPT_COMPATIBLE_TOKENIZERS}."
             )
 
         self.lowercase = metadata["preprocessing"]["lowercase"]

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -42,7 +42,7 @@ from ludwig.features.feature_utils import set_str_to_idx
 from ludwig.utils import output_feature_utils
 from ludwig.utils.misc_utils import get_from_registry, set_default_value
 from ludwig.utils.strings_utils import create_vocabulary, tokenizer_registry, UNKNOWN_SYMBOL
-from ludwig.utils.tokenizers import TORCHSCRIPT_ENABLED_TOKENIZERS
+from ludwig.utils.tokenizers import TORCHSCRIPT_COMPATIBLE_TOKENIZERS
 
 logger = logging.getLogger(__name__)
 
@@ -56,10 +56,10 @@ class _SetPreprocessing(torch.nn.Module):
 
     def __init__(self, metadata: Dict[str, Any], is_bag: bool = False):
         super().__init__()
-        if metadata["preprocessing"]["tokenizer"] not in TORCHSCRIPT_ENABLED_TOKENIZERS:
+        if metadata["preprocessing"]["tokenizer"] not in TORCHSCRIPT_COMPATIBLE_TOKENIZERS:
             raise ValueError(
                 f"{metadata['preprocessing']['tokenizer']} is not supported by torchscript. Please use "
-                f"one of {TORCHSCRIPT_ENABLED_TOKENIZERS}."
+                f"one of {TORCHSCRIPT_COMPATIBLE_TOKENIZERS}."
             )
 
         self.lowercase = metadata["preprocessing"]["lowercase"]

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -29,12 +29,8 @@ logger = logging.getLogger(__name__)
 SPACE_PUNCTUATION_REGEX = re.compile(r"\w+|[^\w\s]")
 COMMA_REGEX = re.compile(r"\s*,\s*")
 UNDERSCORE_REGEX = re.compile(r"\s*_\s*")
-TORCHTEXT_TOKENIZERS = {
-    "sentencepiece",
-    "clip",
-    "gpt2bpe",
-}  # requires torchtext>=0.12.0
-TORCHSCRIPT_ENABLED_TOKENIZERS = {"space", "space_punct", *TORCHTEXT_TOKENIZERS}
+TORCHSCRIPT_COMPATIBLE_TOKENIZERS = {"space", "space_punct"}
+TORCHTEXT_TOKENIZERS = {"sentencepiece", "clip", "gpt2bpe"}
 
 
 class BaseTokenizer:
@@ -987,7 +983,7 @@ try:
                 "gpt2bpe": GPT2BPETokenizer,
             }
         )
-
+        TORCHSCRIPT_COMPATIBLE_TOKENIZERS.update(TORCHTEXT_TOKENIZERS)
     else:
         raise ImportError
 

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -28,7 +28,7 @@ from ludwig.constants import LOGITS, NAME, PREDICTIONS, PROBABILITIES, TRAINER
 from ludwig.data.preprocessing import preprocess_for_prediction
 from ludwig.globals import TRAIN_SET_METADATA_FILE_NAME
 from ludwig.utils import output_feature_utils
-from ludwig.utils.tokenizers import TORCHSCRIPT_ENABLED_TOKENIZERS
+from ludwig.utils.tokenizers import TORCHSCRIPT_COMPATIBLE_TOKENIZERS
 from tests.integration_tests import utils
 from tests.integration_tests.utils import (
     audio_feature,
@@ -198,18 +198,15 @@ def test_torchscript(csv_filename, should_load_model):
         assert np.all(original_predictions_df[predictions_column_name] == restored_predictions)
 
 
-@pytest.mark.skipif(
-    torch.torch_version.TorchVersion(torchtext.__version__) < (0, 12, 0), reason="requires torchtext 0.12.0 or higher"
-)
 def test_torchscript_e2e(csv_filename, tmpdir):
     data_csv_path = os.path.join(tmpdir, csv_filename)
     image_dest_folder = os.path.join(tmpdir, "generated_images")
 
     # Configure features to be tested:
     bin_str_feature = binary_feature()
-    torchscript_enabled_text_features = [
+    torchscript_compatible_text_features = [
         text_feature(vocab_size=3, preprocessing={"tokenizer": tokenizer})
-        for tokenizer in TORCHSCRIPT_ENABLED_TOKENIZERS
+        for tokenizer in TORCHSCRIPT_COMPATIBLE_TOKENIZERS
     ]
     input_features = [
         bin_str_feature,
@@ -217,7 +214,7 @@ def test_torchscript_e2e(csv_filename, tmpdir):
         number_feature(),
         category_feature(vocab_size=3),
         image_feature(image_dest_folder),
-        *torchscript_enabled_text_features,
+        *torchscript_compatible_text_features,
         bag_feature(vocab_size=3),
         set_feature(vocab_size=3),
         sequence_feature(vocab_size=3, preprocessing={"tokenizer": "space"}),

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -21,7 +21,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
-import torchtext
 
 from ludwig.api import LudwigModel
 from ludwig.constants import LOGITS, NAME, PREDICTIONS, PROBABILITIES, TRAINER


### PR DESCRIPTION
This PR updates test_torchscript.py in light of #1965 and #1971. Because there are non-torchtext torchscript-compatible tokenizers available, we no longer have to skip `tests/integration_tests/test_torchscript.py::test_torchscript_e2e` if torchtext<0.12.0.