### PR TITLE
Unifies `to_input` function for InferenceModule.forward

### DIFF
--- a/ludwig/models/inference.py
+++ b/ludwig/models/inference.py
@@ -5,12 +5,13 @@ import pandas as pd
 import torch
 from torch import nn
 
-from ludwig.constants import NAME, TYPE
+from ludwig.constants import COLUMN, NAME, TYPE
 from ludwig.data.postprocessing import convert_dict_to_df
 from ludwig.data.preprocessing import load_metadata
 from ludwig.features.feature_registries import input_type_registry, output_type_registry
 from ludwig.features.feature_utils import get_module_dict_key_from_name, get_name_from_module_dict_key
 from ludwig.globals import INFERENCE_MODULE_FILE_NAME, MODEL_HYPERPARAMETERS_FILE_NAME, TRAIN_SET_METADATA_FILE_NAME
+from ludwig.utils import image_utils
 
 # Prevents circular import errors from typing.
 if TYPE_CHECKING:
@@ -91,20 +92,16 @@ class InferenceLudwigModel:
         self.config = load_json(os.path.join(model_dir, MODEL_HYPERPARAMETERS_FILE_NAME))
         self.training_set_metadata = load_metadata(os.path.join(model_dir, TRAIN_SET_METADATA_FILE_NAME))
 
-    def _to_input(self, s: pd.Series) -> Union[List[str], torch.Tensor]:
-        if s.dtype == "object":
-            return s.to_list()
-        return torch.from_numpy(s.to_numpy())
-
     def predict(
-        self, batch: pd.DataFrame, return_type: Union[dict, pd.DataFrame] = pd.DataFrame
+        self, dataset: pd.DataFrame, return_type: Union[dict, pd.DataFrame] = pd.DataFrame
     ) -> Union[pd.DataFrame, dict]:
         """Predict on a batch of data.
 
         One difference between InferenceLudwigModel and LudwigModel is that the input data must be a pandas DataFrame.
         """
         inputs = {
-            if_config["name"]: self._to_input(batch[if_config["column"]]) for if_config in self.config["input_features"]
+            if_config["name"]: to_inference_module_input(dataset[if_config[COLUMN]], if_config[TYPE])
+            for if_config in self.config["input_features"]
         }
 
         preds = self.model(inputs)
@@ -112,3 +109,13 @@ class InferenceLudwigModel:
         if return_type == pd.DataFrame:
             preds = convert_dict_to_df(preds)
         return preds, None  # Second return value is for compatibility with LudwigModel.predict
+
+
+def to_inference_module_input(s: pd.Series, feature_type: str, load_paths=False) -> Union[List[str], torch.Tensor]:
+    """Converts a pandas Series to be compatible with a torchscripted InferenceModule forward pass."""
+    if feature_type == "image":
+        if load_paths:
+            return [image_utils.read_image(v) for v in s]
+    if feature_type in {"binary", "category", "bag", "set", "text", "sequence"}:
+        return s.astype(str).to_list()
+    return torch.from_numpy(s.to_numpy())

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -27,6 +27,7 @@ from ludwig.api import LudwigModel
 from ludwig.constants import LOGITS, NAME, PREDICTIONS, PROBABILITIES, TRAINER
 from ludwig.data.preprocessing import preprocess_for_prediction
 from ludwig.globals import TRAIN_SET_METADATA_FILE_NAME
+from ludwig.models.inference import to_inference_module_input
 from ludwig.utils import output_feature_utils
 from ludwig.utils.tokenizers import TORCHSCRIPT_ENABLED_TOKENIZERS
 from tests.integration_tests import utils
@@ -45,7 +46,6 @@ from tests.integration_tests.utils import (
     set_feature,
     text_feature,
     timeseries_feature,
-    to_inference_module_input,
     vector_feature,
 )
 
@@ -270,7 +270,7 @@ def test_torchscript_e2e(csv_filename, tmpdir):
     script_module = ludwig_model.to_torchscript()
     df = pd.read_csv(training_data_csv_path)
     inputs = {
-        name: to_inference_module_input(df[feature.column])
+        name: to_inference_module_input(df[feature.column], feature.type(), load_paths=True)
         for name, feature in ludwig_model.model.input_features.items()
     }
     outputs = script_module(inputs)


### PR DESCRIPTION
Cleans up the `to_input` function used by `InferenceLudwigModel` and `test_torchscript.py::test_torchscript_e2e`. Unifies the implementation because both cases call the function to prep input for `InferenceModule.forward`