### PR TITLE
Updated MlFlow logic to restart a previously existing run_id in case of resume

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -472,7 +472,7 @@ class LudwigModel:
                     experiment_name=experiment_name,
                     model_name=model_name,
                     output_directory=output_directory,
-                    resume=model_resume_path is not None,
+                    resume_directory=model_resume_path,
                 )
 
             # Build model if not provided

--- a/ludwig/callbacks.py
+++ b/ludwig/callbacks.py
@@ -113,7 +113,7 @@ class Callback(ABC):
         experiment_name: str,
         model_name: str,
         output_directory: str,
-        resume: Union[str, None],
+        resume_directory: Union[str, None],
     ):
         """Called after preprocessing, but before the creation of the model and trainer objects.
 
@@ -122,7 +122,7 @@ class Callback(ABC):
         :param experiment_name: The experiment name.
         :param model_name: The model name.
         :param output_directory: file path to where training results are stored.
-        :param resume: model directory to resume training from, or None.
+        :param resume_directory: model directory to resume training from, or None.
         """
         pass
 

--- a/ludwig/contribs/comet.py
+++ b/ludwig/contribs/comet.py
@@ -37,7 +37,7 @@ class CometCallback(Callback):
         experiment_name,
         model_name,
         output_directory,
-        resume,
+        resume_directory,
     ):
         if self.cometml_experiment:
             # Comet ML already initialized

--- a/ludwig/contribs/wandb.py
+++ b/ludwig/contribs/wandb.py
@@ -33,7 +33,7 @@ class WandbCallback(Callback):
         experiment_name,
         model_name,
         output_directory,
-        resume,
+        resume_directory,
     ):
         logger.info("wandb.on_train_init() called...")
         wandb.init(

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -14,13 +14,17 @@ from ludwig import globals as global_vars
 from ludwig.api import LudwigModel
 from ludwig.backend import LOCAL_BACKEND
 from ludwig.constants import TRAINER, TRAINING
+from ludwig.contribs.mlflow import MlflowCallback
 from ludwig.experiment import experiment_cli
 from ludwig.features.number_feature import numeric_transformation_registry
 from ludwig.globals import TRAINING_PREPROC_FILE_NAME
 from ludwig.modules.optimization_modules import optimizer_registry
 from ludwig.utils.data_utils import load_json, replace_file_extension
 from ludwig.utils.misc_utils import get_from_registry
+from ludwig.utils.package_utils import LazyLoader
 from tests.integration_tests.utils import category_feature, generate_data, LocalTestBackend
+
+mlflow = LazyLoader("mlflow", globals(), "mlflow")
 
 RANDOM_SEED = 42
 NUMBER_OBSERVATIONS = 500
@@ -239,6 +243,48 @@ def test_resume_training(optimizer, generated_data, tmp_path):
     print("y_pred1", y_pred1)
     print("y_pred2", y_pred2)
     assert np.all(np.isclose(y_pred1, y_pred2))
+
+
+@pytest.mark.parametrize("optimizer", ["sgd", "adam"])
+def test_resume_training_mlflow(optimizer, generated_data, tmp_path):
+    input_features, output_features = get_feature_configs()
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        "combiner": {"type": "concat"},
+        TRAINER: {"epochs": 2, "batch_size": 16, "optimizer": {"type": optimizer}},
+    }
+
+    # create sub-directory to store results
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    mlflow_uri = f"file://{tmp_path}/mlruns"
+    experiment_name = optimizer + "_experiment"
+
+    _, _, _, _, output_dir1 = experiment_cli(
+        config,
+        training_set=generated_data.train_df,
+        validation_set=generated_data.validation_df,
+        test_set=generated_data.test_df,
+        callbacks=[MlflowCallback(mlflow_uri)],
+        experiment_name=experiment_name
+    )
+    # Can't change any artifact spec on a run once it has been logged to mlflow, so skipping changing epochs
+
+    _, _, _, _, output_dir2 = experiment_cli(
+        config,
+        training_set=generated_data.train_df,
+        validation_set=generated_data.validation_df,
+        test_set=generated_data.test_df,
+        model_resume_path=output_dir1,
+        callbacks=[MlflowCallback(mlflow_uri)],
+        experiment_name=experiment_name
+    )
+
+    # make sure there is only one mlflow run id
+    experiment = mlflow.get_experiment_by_name(experiment_name)
+    previous_runs = mlflow.search_runs([experiment.experiment_id])
+    assert len(previous_runs) == 1
 
 
 @pytest.mark.parametrize("optimizer_type", optimizer_registry)

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -267,7 +267,7 @@ def test_resume_training_mlflow(optimizer, generated_data, tmp_path):
         validation_set=generated_data.validation_df,
         test_set=generated_data.test_df,
         callbacks=[MlflowCallback(mlflow_uri)],
-        experiment_name=experiment_name
+        experiment_name=experiment_name,
     )
     # Can't change any artifact spec on a run once it has been logged to mlflow, so skipping changing epochs
 
@@ -278,7 +278,7 @@ def test_resume_training_mlflow(optimizer, generated_data, tmp_path):
         test_set=generated_data.test_df,
         model_resume_path=output_dir1,
         callbacks=[MlflowCallback(mlflow_uri)],
-        experiment_name=experiment_name
+        experiment_name=experiment_name,
     )
 
     # make sure there is only one mlflow run id


### PR DESCRIPTION
In case a MlFlow experiment run was created and we're resuming the experiment, we want to resume the MlFlow run as well without creating a new run_id. This change makes sure we fetch the previous run_id and set it as the new run_id.

