### PR TITLE
Removed unnecessary deepcopy of executable_kwargs to prevent segfault

### DIFF
--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -579,8 +579,8 @@ class RayBackend(RemoteTrainingMixin, Backend):
             return RayTrainerV2(
                 model,
                 copy.deepcopy(self._horovod_kwargs),
-                copy.deepcopy(self._data_loader_kwargs),
-                copy.deepcopy(executable_kwargs),
+                self._data_loader_kwargs,
+                executable_kwargs,
             )
         else:
             # TODO: deprecated 0.5
@@ -591,8 +591,8 @@ class RayBackend(RemoteTrainingMixin, Backend):
         return RayPredictor(
             model,
             copy.deepcopy(self._horovod_kwargs),
-            copy.deepcopy(self._data_loader_kwargs),
-            **copy.deepcopy(executable_kwargs),
+            self._data_loader_kwargs,
+            **executable_kwargs,
         )
 
     def set_distributed_kwargs(self, **kwargs):


### PR DESCRIPTION
When making a deepcopy of the `executable_kwargs` dict, because this can contain arbitrary user callbacks, some of the objects in these callbacks can not be safely deepcopied. For example, deepcopying Ray actor handles can result in segfaults under certain conditions:

```
(do_train_model pid=14564) *** SIGSEGV received at time=1651248078 on cpu 0 ***
(do_train_model pid=14564) PC: @     0x7f6c17b31988  (unknown)  absl::lts_20211102::container_internal::raw_hash_set<>::find<>()
(do_train_model pid=14564)     @     0x7f6c18fd53c0  (unknown)  (unknown)
(do_train_model pid=14564)     @     0x7f6c17b36fa5        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564)     @ ... and at least 1000 more frames
(do_train_model pid=14564) [2022-04-29 09:01:18,592 E 14564 14564] logging.cc:325: *** SIGSEGV received at time=1651248078 on cpu 0 ***
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325: PC: @     0x7f6c17b31988  (unknown)  absl::lts_20211102::container_internal::raw_hash_set<>::find<>()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c18fd53c0  (unknown)  (unknown)
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b36fa5        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @     0x7f6c17b37194        128  ray::core::ReferenceCounter::GetAndClearLocalBorrowersInternal()
(do_train_model pid=14564) [2022-04-29 09:01:18,593 E 14564 14564] logging.cc:325:     @ ... and at least 1000 more frames
(do_train_model pid=14564) Fatal Python error: Segmentation fault
(do_train_model pid=14564) 
(do_train_model pid=14564) Stack (most recent call first):
(do_train_model pid=14564)   File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/actor.py", line 1111 in __del__
(do_train_model pid=14564)   File "/home/ray/src/predibase_engine/ray_serve.py", line 105 in do_train_model
(do_train_model pid=14564)   File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/worker.py", line 449 in main_loop
(do_train_model pid=14564)   File "/home/ray/anaconda3/lib/python3.7/site-packages/ray/workers/default_worker.py", line 235 in <module>
```