### PR TITLE
feat: Update Dockerfile to use py38 base images

### DIFF
--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM rayproject/ray:1.12.0-py37-cu111
+FROM rayproject/ray:1.12.1-py38-cu111
 
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
 RUN sudo apt-key del 7fa2af80 && \

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM rayproject/ray:1.12.0-py37
+FROM rayproject/ray:1.12.1-py38
 
 RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y \
 	build-essential \

--- a/docker/ludwig/Dockerfile
+++ b/docker/ludwig/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM python:3.7.12-slim
+FROM python:3.8.13-slim
 
 RUN apt-get -y update && apt-get -y install \
     git \


### PR DESCRIPTION
Updating Docker files target the python 3.8 for the cpu, gpu and ray base images.