### PR TITLE
Removes pinned torchtext and torch for windows.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,10 @@ scipy>=0.18
 tabulate>=0.7
 scikit-learn
 tqdm
-torch==1.9.1 ; platform_system == "Windows"  # https://github.com/pytorch/pytorch/issues/65473
-torch>=1.10.0 ; platform_system != "Windows"
+torch>=1.10.0
 torchaudio
 torchtext
-torchvision==0.10.1 ; platform_system == "Windows"  # https://github.com/pytorch/pytorch/issues/65473
-torchvision>=0.10.1 ; platform_system != "Windows"
+torchvision>=0.10.1
 transformers>=4.10.1
 spacy>=2.3
 PyYAML>=3.12


### PR DESCRIPTION
So I have a working stack on windows (Windows 10, conda, python 3.9) installed with:

```
% conda install pytorch torchvision torchtext torchaudio cudatoolkit=11.3 -c pytorch

torch=='1.10.1'
torchaudio='0.10.1'
torchtext=='0.11.1'
torchvision=='0.11.2'
```

But, running `ludwig train` gives the error:
```
pkg_resources.DistributionNotFound: The 'torchvision==0.10.1' distribution was not found and is required by ludwig
```

After removing the windows-specific pinned dependencies, everything works.  I was able to train on an image dataset just fine.

So, I tentatively think that https://github.com/pytorch/pytorch/issues/65473 has been fixed in torchvision 0.11.x and forward, and it should be OK to remove the pinned versions for windows... though maybe we should re-verify the original issue first.