### PR TITLE
hotfix for shape broadcast issue

### DIFF
--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -235,7 +235,7 @@ class AudioFeatureMixin(BaseFeatureMixin):
         elif normalization_type == "global":
             raise ValueError("not implemented yet")
 
-        feature_length = audio_feature.shape[0]
+        feature_length = audio_feature.shape[1]
         broadcast_feature_length = min(feature_length, max_length)
         audio_feature_padded = np.full((max_length, feature_dim), padding_value, dtype=np.float32)
         audio_feature_padded[:broadcast_feature_length, :] = audio_feature[:max_length, :]


### PR DESCRIPTION
This hotfix attends to a shape broadcasting issue that was causing an issue in staging. The index needs to be changed since the value being passed in is now a torch audio tensor. There will be a more fixes coming to address the speed of the reads however.