### PR TITLE
Use pandas instead of dask to read excel

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -195,8 +195,8 @@ def read_excel(data_fp, df_lib):
     else:
         excel_engine = "openpyxl"
 
+    # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
-        # https://github.com/dask/dask/issues/9055
         logger.warning("Falling back to pd.read_excel() since dask backend does not support it")
     return pd.read_excel(data_fp, engine=excel_engine)
 
@@ -208,8 +208,8 @@ def read_parquet(data_fp, df_lib):
 
 @spread
 def read_pickle(data_fp, df_lib):
+    # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
-        # https://github.com/dask/dask/issues/9055
         logger.warning("Falling back to pd.read_pickle() since dask backend does not support it")
     return pd.read_pickle(data_fp)
 
@@ -221,16 +221,16 @@ def read_fwf(data_fp, df_lib):
 
 @spread
 def read_feather(data_fp, df_lib):
+    # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
-        # https://github.com/dask/dask/issues/9055
         logger.warning("Falling back to pd.read_feather() since dask backend does not support it")
     return pd.read_feather(data_fp)
 
 
 @spread
 def read_html(data_fp, df_lib):
+    # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
-        # https://github.com/dask/dask/issues/9055
         logger.warning("Falling back to pd.read_html() since dask backend does not support it")
     return pd.read_html(data_fp)[0]
 
@@ -242,24 +242,24 @@ def read_orc(data_fp, df_lib):
 
 @spread
 def read_sas(data_fp, df_lib):
+    # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
-        # https://github.com/dask/dask/issues/9055
         logger.warning("Falling back to pd.read_sas() since dask backend does not support it")
     return pd.read_sas(data_fp)
 
 
 @spread
 def read_spss(data_fp, df_lib):
+    # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
-        # https://github.com/dask/dask/issues/9055
         logger.warning("Falling back to pd.read_spss() since dask backend does not support it")
     return pd.read_spss(data_fp)
 
 
 @spread
 def read_stata(data_fp, df_lib):
+    # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
-        # https://github.com/dask/dask/issues/9055
         logger.warning("Falling back to pd.read_stata() since dask backend does not support it")
     return pd.read_stata(data_fp)
 

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -193,7 +193,8 @@ def read_excel(data_fp, df_lib):
         excel_engine = "xlrd"
     else:
         excel_engine = "openpyxl"
-    return df_lib.read_excel(data_fp, engine=excel_engine)
+    # Dask does not support read_excel
+    return pd.read_excel(data_fp, engine=excel_engine)
 
 
 @spread

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -98,6 +98,7 @@ CACHEABLE_FORMATS = set.union(
 )
 
 PANDAS_DF = pd
+DASK_MODULE_NAME = "dask.dataframe"
 
 
 # Lock over the entire interpreter as we can only have one set
@@ -193,7 +194,10 @@ def read_excel(data_fp, df_lib):
         excel_engine = "xlrd"
     else:
         excel_engine = "openpyxl"
-    # Dask does not support read_excel
+
+    if df_lib.__name__ == DASK_MODULE_NAME:
+        # https://github.com/dask/dask/issues/9055
+        logger.warning("Falling back to pd.read_excel() since dask backend does not support it")
     return pd.read_excel(data_fp, engine=excel_engine)
 
 
@@ -204,7 +208,10 @@ def read_parquet(data_fp, df_lib):
 
 @spread
 def read_pickle(data_fp, df_lib):
-    return df_lib.read_pickle(data_fp)
+    if df_lib.__name__ == DASK_MODULE_NAME:
+        # https://github.com/dask/dask/issues/9055
+        logger.warning("Falling back to pd.read_pickle() since dask backend does not support it")
+    return pd.read_pickle(data_fp)
 
 
 @spread
@@ -214,12 +221,18 @@ def read_fwf(data_fp, df_lib):
 
 @spread
 def read_feather(data_fp, df_lib):
-    return df_lib.read_feather(data_fp)
+    if df_lib.__name__ == DASK_MODULE_NAME:
+        # https://github.com/dask/dask/issues/9055
+        logger.warning("Falling back to pd.read_feather() since dask backend does not support it")
+    return pd.read_feather(data_fp)
 
 
 @spread
 def read_html(data_fp, df_lib):
-    return df_lib.read_html(data_fp)[0]
+    if df_lib.__name__ == DASK_MODULE_NAME:
+        # https://github.com/dask/dask/issues/9055
+        logger.warning("Falling back to pd.read_html() since dask backend does not support it")
+    return pd.read_html(data_fp)[0]
 
 
 @spread
@@ -229,17 +242,26 @@ def read_orc(data_fp, df_lib):
 
 @spread
 def read_sas(data_fp, df_lib):
-    return df_lib.read_sas(data_fp)
+    if df_lib.__name__ == DASK_MODULE_NAME:
+        # https://github.com/dask/dask/issues/9055
+        logger.warning("Falling back to pd.read_sas() since dask backend does not support it")
+    return pd.read_sas(data_fp)
 
 
 @spread
 def read_spss(data_fp, df_lib):
-    return df_lib.read_spss(data_fp)
+    if df_lib.__name__ == DASK_MODULE_NAME:
+        # https://github.com/dask/dask/issues/9055
+        logger.warning("Falling back to pd.read_spss() since dask backend does not support it")
+    return pd.read_spss(data_fp)
 
 
 @spread
 def read_stata(data_fp, df_lib):
-    return df_lib.read_stata(data_fp)
+    if df_lib.__name__ == DASK_MODULE_NAME:
+        # https://github.com/dask/dask/issues/9055
+        logger.warning("Falling back to pd.read_stata() since dask backend does not support it")
+    return pd.read_stata(data_fp)
 
 
 @spread


### PR DESCRIPTION
alternatively, check the `df_lib` type and only replace it with pandas if `df_lib = dask`, and return `dask.delayed(pd.read_excel)`

or we can leave as-is and expect the client to use pandas for excel files

```
module 'dask.dataframe' has no attribute 'read_excel' 
```

<img width="1243" alt="Screen Shot 2022-05-06 at 5 06 30 PM" src="https://user-images.githubusercontent.com/85463385/167229443-57ade15d-d338-43a2-a229-fb17b3b4461e.png">


https://github.com/dask/dask/issues/9055