### PR TITLE
Fixes tokenizer type hints during torchscript saving/loading

### DIFF
--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -57,10 +57,12 @@ class SpaceStringToListTokenizer(torch.nn.Module):
     def forward(self, v: Union[str, List[str], torch.Tensor]) -> Any:
         if isinstance(v, torch.Tensor):
             raise ValueError(f"Unsupported input: {v}")
-        elif isinstance(v, str):
-            inputs = [v]
+
+        inputs: List[str] = []
+        if isinstance(v, str):
+            inputs.append(v)
         else:
-            inputs = v
+            inputs.extend(v)
 
         tokens: List[List[str]] = []
         for sequence in inputs:
@@ -86,10 +88,12 @@ class SpacePunctuationStringToListTokenizer(torch.nn.Module):
     def forward(self, v: Union[str, List[str], torch.Tensor]) -> Any:
         if isinstance(v, torch.Tensor):
             raise ValueError(f"Unsupported input: {v}")
-        elif isinstance(v, str):
-            inputs = [v]
+
+        inputs: List[str] = []
+        if isinstance(v, str):
+            inputs.append(v)
         else:
-            inputs = v
+            inputs.extend(v)
 
         tokens: List[List[str]] = []
         for sequence in inputs:
@@ -932,10 +936,12 @@ try:
                 """
                 if isinstance(v, torch.Tensor):
                     raise ValueError(f"Unsupported input: {v}")
-                elif isinstance(v, str):
-                    inputs = [v]
+
+                inputs: List[str] = []
+                if isinstance(v, str):
+                    inputs.append(v)
                 else:
-                    inputs = v
+                    inputs.extend(v)
 
                 token_ids = self.tokenizer(inputs)
                 assert torch.jit.isinstance(token_ids, List[List[str]])

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -59,6 +59,7 @@ class SpaceStringToListTokenizer(torch.nn.Module):
             raise ValueError(f"Unsupported input: {v}")
 
         inputs: List[str] = []
+        # Ludwig calls map on List[str] objects, so we need to handle individual strings as well.
         if isinstance(v, str):
             inputs.append(v)
         else:
@@ -90,6 +91,7 @@ class SpacePunctuationStringToListTokenizer(torch.nn.Module):
             raise ValueError(f"Unsupported input: {v}")
 
         inputs: List[str] = []
+        # Ludwig calls map on List[str] objects, so we need to handle individual strings as well.
         if isinstance(v, str):
             inputs.append(v)
         else:
@@ -938,6 +940,7 @@ try:
                     raise ValueError(f"Unsupported input: {v}")
 
                 inputs: List[str] = []
+                # Ludwig calls map on List[str] objects, so we need to handle individual strings as well.
                 if isinstance(v, str):
                     inputs.append(v)
                 else:

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -264,6 +264,12 @@ def test_torchscript_e2e(csv_filename, tmpdir):
 
     # Create graph inference model (Torchscript) from trained Ludwig model.
     script_module = ludwig_model.to_torchscript()
+
+    # Ensure torchscript saving/loading does not affect final predictions.
+    script_module_path = os.path.join(tmpdir, "inference_module.pt")
+    torch.jit.save(script_module, script_module_path)
+    script_module = torch.jit.load(script_module_path)
+
     df = pd.read_csv(training_data_csv_path)
     inputs = {
         name: to_inference_module_input(df[feature.column], feature.type(), load_paths=True)


### PR DESCRIPTION
This PR adds a fix and a regression test for the new tokenizers. Error-handling in Torchscript when the scripted module stays in memory is different than when the scripted module is first saved, then loaded from disk.