### PR TITLE
Add train_steps as an option for configuring training length.

### DIFF
--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 import psutil
 import torch
+from marshmallow import fields
 from marshmallow_dataclass import dataclass
 from tabulate import tabulate
 from torch.utils.tensorboard import SummaryWriter
@@ -63,7 +64,12 @@ from ludwig.utils.horovod_utils import return_first
 from ludwig.utils.math_utils import exponential_decay, learning_rate_warmup, learning_rate_warmup_distributed
 from ludwig.utils.metric_utils import get_metric_names, TrainerMetric
 from ludwig.utils.misc_utils import set_random_seed
-from ludwig.utils.trainer_utils import get_final_steps_per_checkpoint, get_new_progress_tracker, ProgressTracker
+from ludwig.utils.trainer_utils import (
+    get_final_steps_per_checkpoint,
+    get_new_progress_tracker,
+    get_total_steps,
+    ProgressTracker,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +122,14 @@ class TrainerConfig(schema.BaseMarshmallowConfig):
 
     epochs: int = schema.PositiveInteger(
         default=100, description="Number of epochs the algorithm is intended to be run over."
+    )
+
+    train_steps: int = fields.Integer(
+        default=-1,
+        description=(
+            "Maximum number of training steps the algorithm is intended to be run over. "
+            + "If -1, then `epochs` is used to determine training length."
+        ),
     )
 
     regularization_lambda: float = schema.FloatRange(
@@ -327,6 +341,7 @@ class Trainer(BaseTrainer):
         """
 
         self.epochs = config.epochs
+        self.train_steps = config.train_steps
         self.regularization_lambda = config.regularization_lambda
         self.regularization_type = config.regularization_type
         self.learning_rate = config.learning_rate
@@ -961,7 +976,7 @@ class Trainer(BaseTrainer):
                 horovod=self.horovod,
             ) as batcher:
                 # ================ Training Loop ================
-                total_steps = self.epochs * batcher.steps_per_epoch
+                total_steps = get_total_steps(self.epochs, batcher.steps_per_epoch, self.train_steps)
 
                 # Get the terminal steps per checkpoint.
                 final_steps_per_checkpoint = get_final_steps_per_checkpoint(

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -30,7 +30,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 import psutil
 import torch
-from marshmallow import fields
 from marshmallow_dataclass import dataclass
 from tabulate import tabulate
 from torch.utils.tensorboard import SummaryWriter
@@ -124,11 +123,11 @@ class TrainerConfig(schema.BaseMarshmallowConfig):
         default=100, description="Number of epochs the algorithm is intended to be run over."
     )
 
-    train_steps: int = fields.Integer(
-        default=-1,
+    train_steps: int = schema.PositiveInteger(
+        default=None,
         description=(
             "Maximum number of training steps the algorithm is intended to be run over. "
-            + "If -1, then `epochs` is used to determine training length."
+            + "If unset, then `epochs` is used to determine training length."
         ),
     )
 

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -149,7 +149,7 @@ class ProgressTracker:
 def get_total_steps(epochs: int, steps_per_epoch: int, train_steps: int):
     """Returns train_steps if non-negative.
 
-    Otherwise, use the number of epochs.
+    Otherwise, returns the number of epochs.
     """
     if train_steps != -1:
         return train_steps

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -151,7 +151,7 @@ def get_total_steps(epochs: int, steps_per_epoch: int, train_steps: int):
 
     Otherwise, returns the number of epochs.
     """
-    if train_steps != -1:
+    if train_steps:
         return train_steps
     return epochs * steps_per_epoch
 

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -146,6 +146,16 @@ class ProgressTracker:
         return log_metrics
 
 
+def get_total_steps(epochs: int, steps_per_epoch: int, train_steps: int):
+    """Returns train_steps if non-negative.
+
+    Otherwise, use the number of epochs.
+    """
+    if train_steps != -1:
+        return train_steps
+    return epochs * steps_per_epoch
+
+
 def get_final_steps_per_checkpoint(
     steps_per_epoch: int, steps_per_checkpoint: int = 0, checkpoints_per_epoch: float = 0, should_log: bool = False
 ):

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -542,7 +542,7 @@ def test_api_callbacks_default_train_steps(csv_filename):
         }
         model = LudwigModel(config, callbacks=[mock_callback])
         model.train(
-            dataset=generate_data(
+            training_set=generate_data(
                 input_features, output_features, os.path.join(output_dir, csv_filename), num_examples=num_examples
             )
         )
@@ -569,7 +569,7 @@ def test_api_callbacks_fixed_train_steps(csv_filename):
         }
         model = LudwigModel(config, callbacks=[mock_callback])
         model.train(
-            dataset=generate_data(
+            training_set=generate_data(
                 input_features, output_features, os.path.join(output_dir, csv_filename), num_examples=num_examples
             )
         )

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -25,6 +25,7 @@ from ludwig.api import LudwigModel
 from ludwig.callbacks import Callback
 from ludwig.constants import TRAINER
 from ludwig.models.inference import InferenceLudwigModel
+from ludwig.models.trainer import TrainerConfig
 from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import (
     category_feature,
@@ -519,6 +520,71 @@ def test_api_callbacks_checkpoints_per_epoch(csv_filename, epochs, batch_size, n
 
     assert mock_callback.on_eval_end.call_count == total_checkpoints
     assert mock_callback.on_eval_start.call_count == total_checkpoints
+
+
+def test_api_callbacks_default_train_steps(csv_filename):
+    mock_callback = mock.Mock(wraps=Callback())
+
+    # Default for train_steps is -1: use epochs.
+    train_steps = TrainerConfig.train_steps.dump_default
+    epochs = 10
+    batch_size = 8
+    num_examples = 80
+
+    with tempfile.TemporaryDirectory() as output_dir:
+        input_features = [sequence_feature(reduce_output="sum")]
+        output_features = [category_feature(vocab_size=5, reduce_input="sum")]
+
+        config = {
+            "input_features": input_features,
+            "output_features": output_features,
+            "combiner": {"type": "concat", "output_size": 14},
+            TRAINER: {"epochs": epochs, "train_steps": train_steps, "batch_size": batch_size},
+        }
+        model = LudwigModel(config, callbacks=[mock_callback])
+
+        data_csv = generate_data(
+            input_features, output_features, os.path.join(output_dir, csv_filename), num_examples=num_examples
+        )
+        val_csv = shutil.copyfile(data_csv, os.path.join(output_dir, "validation.csv"))
+        test_csv = shutil.copyfile(data_csv, os.path.join(output_dir, "test.csv"))
+
+        model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv)
+
+    assert mock_callback.on_epoch_start.call_count == epochs
+
+
+def test_api_callbacks_fixed_train_steps(csv_filename):
+    mock_callback = mock.Mock(wraps=Callback())
+
+    # If train_steps is set manually, epochs is ignored.
+    train_steps = 100
+    epochs = 2
+    batch_size = 8
+    num_examples = 80
+
+    with tempfile.TemporaryDirectory() as output_dir:
+        input_features = [sequence_feature(reduce_output="sum")]
+        output_features = [category_feature(vocab_size=5, reduce_input="sum")]
+
+        config = {
+            "input_features": input_features,
+            "output_features": output_features,
+            "combiner": {"type": "concat", "output_size": 14},
+            TRAINER: {"epochs": epochs, "train_steps": train_steps, "batch_size": batch_size},
+        }
+        model = LudwigModel(config, callbacks=[mock_callback])
+
+        data_csv = generate_data(
+            input_features, output_features, os.path.join(output_dir, csv_filename), num_examples=num_examples
+        )
+        val_csv = shutil.copyfile(data_csv, os.path.join(output_dir, "validation.csv"))
+        test_csv = shutil.copyfile(data_csv, os.path.join(output_dir, "test.csv"))
+
+        model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv)
+
+    # There are 10 steps per epoch, so 100 train steps => 10 epochs.
+    assert mock_callback.on_epoch_start.call_count == 10
 
 
 def test_api_save_torchscript(tmpdir):

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -25,7 +25,6 @@ from ludwig.api import LudwigModel
 from ludwig.callbacks import Callback
 from ludwig.constants import TRAINER
 from ludwig.models.inference import InferenceLudwigModel
-from ludwig.models.trainer import TrainerConfig
 from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import (
     category_feature,
@@ -524,7 +523,7 @@ def test_api_callbacks_checkpoints_per_epoch(csv_filename, epochs, batch_size, n
 
 def test_api_callbacks_default_train_steps(csv_filename):
     # Default for train_steps is -1: use epochs.
-    train_steps = TrainerConfig.train_steps.dump_default
+    train_steps = None
     epochs = 10
     batch_size = 8
     num_examples = 80


### PR DESCRIPTION
If `train_steps = None`, then `epochs` is used to determine training length.

By default train_steps is `None` -- the default training behavior is unchanged.