### PR TITLE
Return dask dataframe for pandas read_x fallbacks

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -235,7 +235,7 @@ def read_html(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_html() since dask backend does not support it")
-        return dd.from_pandas(pd.read_html(data_fp), npartitions=1)
+        return dd.from_pandas(pd.read_html(data_fp)[0], npartitions=1)
     return df_lib.read_html(data_fp)[0]
 
 

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -198,6 +198,7 @@ def read_excel(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_excel() since dask backend does not support it")
+        return dd.from_pandas(pd.read_excel(data_fp, engine=excel_engine), npartitions=1)
     return pd.read_excel(data_fp, engine=excel_engine)
 
 
@@ -211,6 +212,7 @@ def read_pickle(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_pickle() since dask backend does not support it")
+        return dd.from_pandas(pd.read_pickle(data_fp), npartitions=1)
     return pd.read_pickle(data_fp)
 
 
@@ -224,6 +226,7 @@ def read_feather(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_feather() since dask backend does not support it")
+        return dd.from_pandas(pd.read_feather(data_fp), npartitions=1)
     return pd.read_feather(data_fp)
 
 
@@ -232,6 +235,7 @@ def read_html(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_html() since dask backend does not support it")
+        return dd.from_pandas(pd.read_html(data_fp), npartitions=1)
     return pd.read_html(data_fp)[0]
 
 
@@ -245,6 +249,7 @@ def read_sas(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_sas() since dask backend does not support it")
+        return dd.from_pandas(pd.read_sas(data_fp), npartitions=1)
     return pd.read_sas(data_fp)
 
 
@@ -253,6 +258,7 @@ def read_spss(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_spss() since dask backend does not support it")
+        return dd.from_pandas(pd.read_spss(data_fp), npartitions=1)
     return pd.read_spss(data_fp)
 
 
@@ -261,6 +267,7 @@ def read_stata(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_stata() since dask backend does not support it")
+        return dd.from_pandas(pd.read_stata(data_fp), npartitions=1)
     return pd.read_stata(data_fp)
 
 

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -199,7 +199,7 @@ def read_excel(data_fp, df_lib):
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_excel() since dask backend does not support it")
         return dd.from_pandas(pd.read_excel(data_fp, engine=excel_engine), npartitions=1)
-    return pd.read_excel(data_fp, engine=excel_engine)
+    return df_lib.read_excel(data_fp, engine=excel_engine)
 
 
 @spread
@@ -213,7 +213,7 @@ def read_pickle(data_fp, df_lib):
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_pickle() since dask backend does not support it")
         return dd.from_pandas(pd.read_pickle(data_fp), npartitions=1)
-    return pd.read_pickle(data_fp)
+    return df_lib.read_pickle(data_fp)
 
 
 @spread
@@ -227,7 +227,7 @@ def read_feather(data_fp, df_lib):
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_feather() since dask backend does not support it")
         return dd.from_pandas(pd.read_feather(data_fp), npartitions=1)
-    return pd.read_feather(data_fp)
+    return df_lib.read_feather(data_fp)
 
 
 @spread
@@ -236,7 +236,7 @@ def read_html(data_fp, df_lib):
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_html() since dask backend does not support it")
         return dd.from_pandas(pd.read_html(data_fp), npartitions=1)
-    return pd.read_html(data_fp)[0]
+    return df_lib.read_html(data_fp)[0]
 
 
 @spread
@@ -250,7 +250,7 @@ def read_sas(data_fp, df_lib):
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_sas() since dask backend does not support it")
         return dd.from_pandas(pd.read_sas(data_fp), npartitions=1)
-    return pd.read_sas(data_fp)
+    return df_lib.read_sas(data_fp)
 
 
 @spread
@@ -259,7 +259,7 @@ def read_spss(data_fp, df_lib):
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_spss() since dask backend does not support it")
         return dd.from_pandas(pd.read_spss(data_fp), npartitions=1)
-    return pd.read_spss(data_fp)
+    return df_lib.read_spss(data_fp)
 
 
 @spread
@@ -268,7 +268,7 @@ def read_stata(data_fp, df_lib):
     if df_lib.__name__ == DASK_MODULE_NAME:
         logger.warning("Falling back to pd.read_stata() since dask backend does not support it")
         return dd.from_pandas(pd.read_stata(data_fp), npartitions=1)
-    return pd.read_stata(data_fp)
+    return df_lib.read_stata(data_fp)
 
 
 @spread


### PR DESCRIPTION
using `dd.from_pandas()` since the client will expect a dask dataframe if theyre using a dask backend

followup of #2005

also tried:

```
parts = dask.delayed(pd.read_excel)(data_fp, engine=excel_engine)
return dd.from_delayed(parts)
```

```
from ray.util.dask import ray_dask_get
parts = dask.delayed(pd.read_excel)(data_fp, engine=excel_engine)
parts.compute(scheduler=ray_dask_get)
```

but neither work from the pred side, though they work locally