### PR TITLE
fix: Move `combiner_registry`

### DIFF
--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -39,10 +39,21 @@ from ludwig.schema.combiners import (
     TabTransformerCombinerConfig,
     TransformerCombinerConfig,
 )
-from ludwig.schema.combiners.utils import combiner_registry, register_combiner
 from ludwig.utils.misc_utils import get_from_registry
+from ludwig.utils.registry import Registry
 from ludwig.utils.torch_utils import LudwigModule, sequence_length_3D
 from ludwig.utils.torch_utils import sequence_mask as torch_sequence_mask
+
+combiner_registry = Registry()
+
+
+def register_combiner(name: str):
+    def wrap(cls):
+        combiner_registry[name] = cls
+        return cls
+
+    return wrap
+
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/schema/combiners/utils.py
+++ b/ludwig/schema/combiners/utils.py
@@ -1,15 +1,5 @@
+from ludwig.combiners.combiners import combiner_registry
 from ludwig.schema import utils as schema_utils
-from ludwig.utils.registry import Registry
-
-combiner_registry = Registry()
-
-
-def register_combiner(name: str):
-    def wrap(cls):
-        combiner_registry[name] = cls
-        return cls
-
-    return wrap
 
 
 def get_combiner_jsonschema():


### PR DESCRIPTION
Moves the `combiner_registry` object back to its original place in `ludwig/combiners/combiners.py`.

The current placement can yield unexpected results - in particular it is possible to import the `combiner_registry` object directly and get an empty set but otherwise import it *indirectly* and get the full (expected) set of combiners.