### PR TITLE
fix for conversion error of categorical feature to float64 on PandasD…

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1137,7 +1137,7 @@ def build_dataset(
     # At this point, there should be no missing values left in the dataframe, unless
     # the DROP_ROW preprocessing option was selected, in which case we need to drop those
     # rows.
-    dataset = dataset.dropna()
+    dataset = dataset.dropna().astype({key: proc_cols[key].dtype for key in proc_cols})
 
     return dataset, metadata
 

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1137,7 +1137,7 @@ def build_dataset(
     # At this point, there should be no missing values left in the dataframe, unless
     # the DROP_ROW preprocessing option was selected, in which case we need to drop those
     # rows.
-    dataset = dataset.dropna().astype({key: proc_cols[key].dtype for key in proc_cols})
+    dataset = dataset.dropna()
 
     return dataset, metadata
 


### PR DESCRIPTION
…ataset

# Code Pull Requests

Please provide the following:

- The fix ensures that categorical input/output features during the preprocessing match the types in proc_cols
- Error was when we create a pd.DataFrame from proc_cols, we don't specify the proper dtypes, so they're inferred.
- Running LudwigModel.experiment() on connect4 dataset
