### PR TITLE
Fix SIGINT handler to modify the number of remaining training steps.

### DIFF
--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -341,6 +341,8 @@ class Trainer(BaseTrainer):
 
         self.epochs = config.epochs
         self.train_steps = config.train_steps
+        self.total_steps = 0  # Computed during training, after batcher has been initialized.
+
         self.regularization_lambda = config.regularization_lambda
         self.regularization_type = config.regularization_type
         self.learning_rate = config.learning_rate

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -399,9 +399,9 @@ class Trainer(BaseTrainer):
         self.lr_scale_fn = learning_rate_scale_fns[config.learning_rate_scaling]
 
         # when training starts the sigint handler will be replaced with
-        # set_epochs_to_1_or_quit so this is needed to remember
+        # set_steps_to_1_or_quit so this is needed to remember
         # the original sigint to restore at the end of training
-        # and before set_epochs_to_1_or_quit returns
+        # and before set_steps_to_1_or_quit returns
         self.original_sigint_handler = None
 
         # TODO(Justin): Move to config validation when that's ready.
@@ -867,7 +867,7 @@ class Trainer(BaseTrainer):
             # set the original sigint signal handler
             # as we want to restore it at the end of training
             self.original_sigint_handler = signal.getsignal(signal.SIGINT)
-            signal.signal(signal.SIGINT, self.set_epochs_to_1_or_quit)
+            signal.signal(signal.SIGINT, self.set_steps_to_1_or_quit)
 
         metrics_names = get_metric_names(output_features)
 
@@ -975,7 +975,7 @@ class Trainer(BaseTrainer):
                 horovod=self.horovod,
             ) as batcher:
                 # ================ Training Loop ================
-                total_steps = get_total_steps(self.epochs, batcher.steps_per_epoch, self.train_steps)
+                self.total_steps = get_total_steps(self.epochs, batcher.steps_per_epoch, self.train_steps)
 
                 # Get the terminal steps per checkpoint.
                 final_steps_per_checkpoint = get_final_steps_per_checkpoint(
@@ -989,8 +989,8 @@ class Trainer(BaseTrainer):
 
                 if self.is_coordinator():
                     logger.info(
-                        f"Training for {total_steps} step(s), approximately "
-                        f"{int(total_steps / batcher.steps_per_epoch)} epoch(s)."
+                        f"Training for {self.total_steps} step(s), approximately "
+                        f"{int(self.total_steps / batcher.steps_per_epoch)} epoch(s)."
                     )
                     logger.info(
                         f"Early stopping policy: {self.early_stop} round(s) of evaluation, or {early_stopping_steps} "
@@ -1004,12 +1004,12 @@ class Trainer(BaseTrainer):
                 if self.is_coordinator():
                     progress_bar = tqdm(
                         desc="Training",
-                        total=total_steps,
+                        total=self.total_steps,
                         file=sys.stdout,
                         disable=is_progressbar_disabled(),
                     )
 
-                while progress_tracker.steps < total_steps:
+                while progress_tracker.steps < self.total_steps:
                     # note that batch size may change over epochs
                     batcher.set_epoch(progress_tracker.epoch, progress_tracker.batch_size)
 
@@ -1418,21 +1418,21 @@ class Trainer(BaseTrainer):
             should_break = True
         return should_break
 
-    def set_epochs_to_1_or_quit(self, signum, frame):
+    def set_steps_to_1_or_quit(self, signum, frame):
+        """Custom SIGINT handler used to elegantly exit training.
+
+        A single SIGINT will stop training after the next training step. A second SIGINT will stop training immediately.
+        """
         if not self.received_sigint:
-            self.epochs = 1
+            self.total_steps = 1
             self.received_sigint = True
-            logger.critical("\nReceived SIGINT, will finish this epoch and then conclude " "the training")
-            logger.critical("Send another SIGINT to immediately interrupt the process")
+            logger.critical("\nReceived SIGINT, will finish this training step and then conclude training.")
+            logger.critical("Send another SIGINT to immediately interrupt the process.")
         else:
             logger.critical("\nReceived a second SIGINT, will now quit")
             if self.original_sigint_handler:
                 signal.signal(signal.SIGINT, self.original_sigint_handler)
             sys.exit(1)
-
-    def quit_training(self, signum, frame):
-        logger.critical("Received SIGQUIT, will kill training")
-        sys.exit(1)
 
     def resume_training_progress_tracker(self, training_progress_tracker_path):
         if self.is_coordinator():


### PR DESCRIPTION
- First SIGINT will try to finish training at the very next training step.
- Another SIGINT will stop training abruptly.

Also, removes `quit_training` -- this is no longer called anywhere.