### PR TITLE
Convert nan to 0 in avg_num_tokens()

### DIFF
--- a/ludwig/automl/utils.py
+++ b/ludwig/automl/utils.py
@@ -4,8 +4,8 @@ import os
 from dataclasses import dataclass
 from typing import Dict, List
 
-import numpy as np
 from dataclasses_json import dataclass_json, LetterCase
+from numpy import nan_to_num
 from pandas import Series
 
 from ludwig.constants import COMBINER, CONFIG, HYPEROPT, NAME, NUMBER, PARAMETERS, SAMPLER, TRAINER, TYPE
@@ -59,7 +59,7 @@ def avg_num_tokens(field: Series) -> int:
     if len(field) > 5000:
         field = field.sample(n=5000, random_state=40)
     unique_entries = field.unique()
-    avg_words = round(np.nan_to_num(Series(unique_entries).str.split().str.len().mean()))
+    avg_words = round(nan_to_num(Series(unique_entries).str.split().str.len().mean()))
     return avg_words
 
 

--- a/ludwig/automl/utils.py
+++ b/ludwig/automl/utils.py
@@ -4,6 +4,7 @@ import os
 from dataclasses import dataclass
 from typing import Dict, List
 
+import numpy as np
 from dataclasses_json import dataclass_json, LetterCase
 from pandas import Series
 
@@ -58,7 +59,7 @@ def avg_num_tokens(field: Series) -> int:
     if len(field) > 5000:
         field = field.sample(n=5000, random_state=40)
     unique_entries = field.unique()
-    avg_words = round(Series(unique_entries).str.split().str.len().mean())
+    avg_words = round(np.nan_to_num(Series(unique_entries).str.split().str.len().mean()))
     return avg_words
 
 

--- a/tests/ludwig/automl/test_utils.py
+++ b/tests/ludwig/automl/test_utils.py
@@ -6,6 +6,12 @@ from ludwig.automl.utils import avg_num_tokens
 np.asarray([None])
 
 
-@pytest.mark.parametrize("field,expected", [np.asarray([None], 0), np.asarray(["string1", "string2", "string3"], 1)])
+@pytest.mark.parametrize(
+    "field,expected",
+    [
+        (np.asarray([None]), 0),
+        (np.asarray(["string1", "string2", "string3"]), 1)
+    ]
+)
 def test_avg_num_tokens(field, expected):
     assert avg_num_tokens(field) == expected

--- a/tests/ludwig/automl/test_utils.py
+++ b/tests/ludwig/automl/test_utils.py
@@ -4,12 +4,6 @@ import pytest
 from ludwig.automl.utils import avg_num_tokens
 
 
-@pytest.mark.parametrize(
-    "field,expected",
-    [
-        (pd.Series([None]), 0),
-        (pd.Series(["string1", "string2", "string3"]), 1)
-    ]
-)
+@pytest.mark.parametrize("field,expected", [(pd.Series([None]), 0), (pd.Series(["string1", "string2", "string3"]), 1)])
 def test_avg_num_tokens(field, expected):
     assert avg_num_tokens(field) == expected

--- a/tests/ludwig/automl/test_utils.py
+++ b/tests/ludwig/automl/test_utils.py
@@ -6,12 +6,6 @@ from ludwig.automl.utils import avg_num_tokens
 np.asarray([None])
 
 
-@pytest.mark.parametrize(
-    "field,expected",
-    [
-        np.asarray([None], 0),
-        np.asarray(["string1", "string2", "string3"], 1)
-    ]
-)
+@pytest.mark.parametrize("field,expected", [np.asarray([None], 0), np.asarray(["string1", "string2", "string3"], 1)])
 def test_avg_num_tokens(field, expected):
     assert avg_num_tokens(field) == expected

--- a/tests/ludwig/automl/test_utils.py
+++ b/tests/ludwig/automl/test_utils.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pytest
+
+from ludwig.automl.utils import avg_num_tokens
+
+np.asarray([None])
+
+
+@pytest.mark.parametrize(
+    "field,expected",
+    [
+        np.asarray([None], 0),
+        np.asarray(["string1", "string2", "string3"], 1)
+    ]
+)
+def test_avg_num_tokens(field, expected):
+    assert avg_num_tokens(field) == expected

--- a/tests/ludwig/automl/test_utils.py
+++ b/tests/ludwig/automl/test_utils.py
@@ -7,11 +7,7 @@ np.asarray([None])
 
 
 @pytest.mark.parametrize(
-    "field,expected",
-    [
-        (np.asarray([None]), 0),
-        (np.asarray(["string1", "string2", "string3"]), 1)
-    ]
+    "field,expected", [(np.asarray([None]), 0), (np.asarray(["string1", "string2", "string3"]), 1)]
 )
 def test_avg_num_tokens(field, expected):
     assert avg_num_tokens(field) == expected

--- a/tests/ludwig/automl/test_utils.py
+++ b/tests/ludwig/automl/test_utils.py
@@ -1,13 +1,15 @@
-import numpy as np
+import pandas as pd
 import pytest
 
 from ludwig.automl.utils import avg_num_tokens
 
-np.asarray([None])
-
 
 @pytest.mark.parametrize(
-    "field,expected", [(np.asarray([None]), 0), (np.asarray(["string1", "string2", "string3"]), 1)]
+    "field,expected",
+    [
+        (pd.Series([None]), 0),
+        (pd.Series(["string1", "string2", "string3"]), 1)
+    ]
 )
 def test_avg_num_tokens(field, expected):
     assert avg_num_tokens(field) == expected


### PR DESCRIPTION
`avg_num_tokens()` should always return an int, but it's possible for it to return a nan.

```
titanic_simple_df = pd.DataFrame(
    {
        "PassengerId": [1], "Survived": [0], "Pclass": [3], "Name": ["Braund, Mr. Owen Harris"],
        "Sex": ["male"], "Age": [22.0], "SibSp": [1], "Parch": [0], "Ticket": ["A/5 21171"], "Fare": ["7.25"],
        "Cabin": [None], "Embarked": ["S"], "split": [0]
    }
)

>>> cab = titanic_simple_df["Cabin"]
>>> Series(cab).str.split().str.len()
0    None
dtype: object
>>> Series(cab).str.split().str.len().mean()
nan
```

```
get_dataset_info_from_source(table_source).to_dict()\n  File 
"/home/ray/anaconda3/lib/python3.8/site-packages/ludwig/automl/base_config.py", 
line 189, in get_dataset_info_from_source\n    avg_words = 
source.get_avg_num_tokens(field)\n  File 
"/home/ray/src/predibase_engine/sources/dask_util.py", line 46, in 
get_avg_num_tokens\n    return avg_num_tokens(self.sample)\n  File 
"/home/ray/anaconda3/lib/python3.8/site-packages/ludwig/automl/utils.py", line 
61, in avg_num_tokens\n    avg_words = 
round(Series(unique_entries).str.split().str.len().mean())\nValueError: cannot 
convert float NaN to integer (type: ErrorResponse, retryable: true)')
```