### PR TITLE
Parallelizes URL reads for images using Ray/Multithreading

### DIFF
--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -194,7 +194,7 @@ class ImageFeatureMixin(BaseFeatureMixin):
         """
         img = read_image_if_bytes_obj(img_entry, num_channels)
         if not isinstance(img, torch.Tensor):
-            logging.info(f"{img} cannot be read")
+            logging.info(f"Image with value {img} cannot be read")
             return None
 
         img_num_channels = num_channels_in_image(img)
@@ -396,14 +396,14 @@ class ImageFeatureMixin(BaseFeatureMixin):
         return (should_resize, width, height, num_channels, user_specified_num_channels)
 
     @staticmethod
-    def add_abs_path_to_img_entries(column, src_path):
+    def add_abs_path_to_img_entries(column, src_path, backend):
         def get_abs_path_if_entry_is_str(entry):
             if not isinstance(entry, str) or has_remote_protocol(entry):
                 return entry
             else:
                 return get_abs_path(src_path, entry)
 
-        return column.map(get_abs_path_if_entry_is_str)
+        return backend.df_engine.map_objects(column, get_abs_path_if_entry_is_str)
 
     @staticmethod
     def add_feature_data(
@@ -416,7 +416,7 @@ class ImageFeatureMixin(BaseFeatureMixin):
         src_path = None
         if SRC in metadata:
             src_path = os.path.dirname(os.path.abspath(metadata.get(SRC)))
-        abs_path_column = ImageFeatureMixin.add_abs_path_to_img_entries(column, src_path)
+        abs_path_column = ImageFeatureMixin.add_abs_path_to_img_entries(column, src_path, backend)
 
         (
             should_resize,

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -58,10 +58,6 @@ from ludwig.utils.image_utils import (
 from ludwig.utils.misc_utils import set_default_value
 from ludwig.utils.types import Series
 
-logger = logging.getLogger(__name__)
-
-IMAGE_COLUMN_SUPPORTED_TYPES = {str, torch.Tensor}
-
 
 # TODO(shreya): Confirm if it's ok to do per channel normalization
 # TODO(shreya): Also confirm if this is being used anywhere
@@ -196,10 +192,9 @@ class ImageFeatureMixin(BaseFeatureMixin):
         If the user specifies a number of channels, we try to convert all the
         images to the specifications by dropping channels/padding 0 channels
         """
-
         img = read_image_if_bytes_obj(img_entry, num_channels)
-        if img is None:
-            logger.info(f"{img_entry} cannot be read")
+        if not isinstance(img, torch.Tensor):
+            logging.info(f"{img} cannot be read")
             return None
 
         img_num_channels = num_channels_in_image(img)
@@ -223,7 +218,7 @@ class ImageFeatureMixin(BaseFeatureMixin):
                 img = torch.nn.functional.pad(img, [0, 0, 0, 0, 0, extra_channels])
 
             if img_num_channels != num_channels:
-                logger.warning(
+                logging.warning(
                     "Image has {} channels, where as {} "
                     "channels are expected. Dropping/adding channels "
                     "with 0s as appropriate".format(img_num_channels, num_channels)
@@ -271,7 +266,7 @@ class ImageFeatureMixin(BaseFeatureMixin):
         height = min(int(round(height_avg)), max_height)
         width = min(int(round(width_avg)), max_width)
 
-        logger.debug(f"Inferring height: {height} and width: {width}")
+        logging.debug(f"Inferring height: {height} and width: {width}")
         return height, width
 
     @staticmethod

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -163,6 +163,29 @@ def read_image_from_str(img: str, num_channels: Optional[int] = None) -> torch.T
         return None
 
 
+def read_image_if_bytes_obj(bytes_obj: Optional[bytes] = None) -> Union[Any, Optional[torch.Tensor]]:
+    """Gets bytes string if `bytes_obj` is a bytes object.
+
+    If it is not a bytes object, return as-is.
+    """
+    if not isinstance(bytes_obj, bytes):
+        return bytes_obj
+    return read_image_from_bytes_obj(bytes_obj)
+
+
+def read_image_from_bytes_obj(bytes_obj: Optional[bytes] = None) -> Optional[torch.Tensor]:
+    try:
+        with BytesIO(bytes_obj) as buffer:
+            buffer_view = buffer.getbuffer()
+            image = decode_image(torch.frombuffer(buffer_view, dtype=torch.uint8))
+            del buffer_view
+
+            return image
+    except Exception as e:
+        logger.warning(e)
+        return None
+
+
 def pad(
     img: torch.Tensor,
     new_size: Union[int, Tuple[int, int]],

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -339,7 +339,7 @@ def test_ray_image(dataset_type):
             ),
         ]
         output_features = [binary_feature()]
-        run_test_with_features(input_features, output_features, dataset_type=dataset_type, nan_percent=0.5)
+        run_test_with_features(input_features, output_features, dataset_type=dataset_type, nan_percent=0.1)
 
 
 @pytest.mark.skip(reason="flaky: ray is running out of resources")

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -336,7 +336,7 @@ def test_ray_image():
             ),
         ]
         output_features = [binary_feature()]
-        run_test_with_features(input_features, output_features)
+        run_test_with_features(input_features, output_features, nan_percent=0.5)
 
 
 @pytest.mark.skip(reason="flaky: ray is running out of resources")

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -324,8 +324,9 @@ def test_ray_audio(dataset_type, feature_type):
         run_test_with_features(input_features, output_features, dataset_type=dataset_type, nan_percent=0.1)
 
 
+@pytest.mark.parametrize("dataset_type", ["csv", "parquet"])
 @pytest.mark.distributed
-def test_ray_image():
+def test_ray_image(dataset_type):
     with tempfile.TemporaryDirectory() as tmpdir:
         image_dest_folder = os.path.join(tmpdir, "generated_images")
         input_features = [
@@ -338,7 +339,7 @@ def test_ray_image():
             ),
         ]
         output_features = [binary_feature()]
-        run_test_with_features(input_features, output_features, nan_percent=0.1)
+        run_test_with_features(input_features, output_features, dataset_type=dataset_type, nan_percent=0.5)
 
 
 @pytest.mark.skip(reason="flaky: ray is running out of resources")

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -336,7 +336,7 @@ def test_ray_image():
             ),
         ]
         output_features = [binary_feature()]
-        run_test_with_features(input_features, output_features, nan_percent=0.5)
+        run_test_with_features(input_features, output_features, nan_percent=0.1)
 
 
 @pytest.mark.skip(reason="flaky: ray is running out of resources")

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -526,8 +526,9 @@ def read_csv_with_nan(path, nan_percent=0.0):
     if nan_percent > 0:
         num_rows = len(df)
         for col in df.columns:
-            for row in random.sample(range(num_rows), int(round(nan_percent * num_rows))):
-                df[col].iloc[row] = np.nan
+            col_idx = df.columns.get_loc(col)
+            for row_idx in random.sample(range(num_rows), int(round(nan_percent * num_rows))):
+                df.iloc[row_idx, col_idx] = np.nan
     return df
 
 


### PR DESCRIPTION
This PR parallelizes URL reads for images, similar to what is done for audio in #2040. Because there are multiple image reads before the whole column is read (namely, the first image and the sample set of images), this PR also refactors the process of inferring image feature properties to unify the byte reading and loading workflow introduced in #2040.