### PR TITLE
Adds rule of thumb for determining embeddings size

### DIFF
--- a/ludwig/encoders/category_encoders.py
+++ b/ludwig/encoders/category_encoders.py
@@ -31,7 +31,7 @@ class CategoricalEmbedEncoder(Encoder):
     def __init__(
         self,
         vocab: List[str],
-        embedding_size: int = 50,
+        embedding_size: Optional[int] = None,
         embeddings_trainable: bool = True,
         pretrained_embeddings: Optional[str] = None,
         embeddings_on_cpu: bool = False,

--- a/ludwig/modules/embedding_modules.py
+++ b/ludwig/modules/embedding_modules.py
@@ -30,7 +30,7 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
 def embedding_matrix(
     vocab: List[str],
-    embedding_size: int,
+    embedding_size: Optional[int] = None,
     representation: str = "dense",
     embeddings_trainable: bool = True,
     pretrained_embeddings: Optional[str] = None,
@@ -43,7 +43,10 @@ def embedding_matrix(
     if representation == "dense":
         if pretrained_embeddings:
             embeddings_matrix = load_pretrained_embeddings(pretrained_embeddings, vocab)
-            if embeddings_matrix.shape[-1] != embedding_size:
+            if embedding_size is None:
+                embedding_size = embeddings_matrix.shape[-1]
+                logger.info(f"Setting embedding size to be equal to {embeddings_matrix.shape[-1]}.")
+            elif embeddings_matrix.shape[-1] != embedding_size:
                 if not force_embedding_size:
                     embedding_size = embeddings_matrix.shape[-1]
                     logger.info(f"Setting embedding size to be equal to {embeddings_matrix.shape[-1]}.")
@@ -57,7 +60,10 @@ def embedding_matrix(
             embedding_initializer_obj = torch.tensor(embeddings_matrix, dtype=torch.float32)
 
         else:
-            if vocab_size < embedding_size and not force_embedding_size:
+            if embedding_size is None:
+                # use embedding size rule of thumb
+                embedding_size = min(512, int(round(1.6 * vocab_size**0.56)))
+            elif vocab_size < embedding_size and not force_embedding_size:
                 logger.info(
                     f"  embedding_size ({embedding_size}) is greater than "
                     f"vocab_size ({vocab_size}). Setting embedding size to be "
@@ -86,7 +92,7 @@ def embedding_matrix(
 
 def embedding_matrix_on_device(
     vocab: List[str],
-    embedding_size: int,
+    embedding_size: Optional[int] = None,
     representation: str = "dense",
     embeddings_trainable: bool = True,
     pretrained_embeddings: Optional[str] = None,
@@ -96,7 +102,7 @@ def embedding_matrix_on_device(
 ) -> Tuple[nn.Module, int]:
     embeddings, embedding_size = embedding_matrix(
         vocab,
-        embedding_size,
+        embedding_size=embedding_size,
         representation=representation,
         embeddings_trainable=embeddings_trainable,
         pretrained_embeddings=pretrained_embeddings,
@@ -117,7 +123,7 @@ class Embed(LudwigModule):
     def __init__(
         self,
         vocab: List[str],
-        embedding_size: int,
+        embedding_size: Optional[int] = None,
         representation: str = "dense",
         embeddings_trainable: bool = True,
         pretrained_embeddings: Optional[str] = None,


### PR DESCRIPTION
Also changes the default behavior for dense category embed encoder. This has repercussions on documentation, where we should document the rule of thumb for determining size if unspecified: min(512, round(1.6 * x**0.56))