### PR TITLE
Addresses `SettingWithCopyWarning` in `read_csv_with_nan`

### DIFF
--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -525,9 +525,11 @@ def read_csv_with_nan(path, nan_percent=0.0):
     df = pd.read_csv(path)
     if nan_percent > 0:
         num_rows = len(df)
+        num_nans_per_col = int(round(nan_percent * num_rows))
         for col in df.columns:
-            for row in random.sample(range(num_rows), int(round(nan_percent * num_rows))):
-                df[col].iloc[row] = np.nan
+            col_idx = df.columns.get_loc(col)
+            for row_idx in random.sample(range(num_rows), num_nans_per_col):
+                df.iloc[row_idx, col_idx] = np.nan
     return df
 
 


### PR DESCRIPTION
This PR addresses the `SettingWithCopyWarning` that appears in integration tests using `tests.integration_tests.utils.read_csv_with_nan`.

```
SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  df[col].iloc[row] = np.nan
```