### PR TITLE
fix: Adjust custom JSON schema for `betas` field on optimizers

### DIFF
--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -17,7 +17,7 @@
 #     ... <file for each combiner> ...
 #     └──  transformer.py     <-- Location of `TransformerCombinerConfig`
 #
-from jsonschema import Draft202012Validator, validate
+from jsonschema import Draft7Validator, validate
 from jsonschema.validators import extend
 
 from ludwig.constants import COMBINER, HYPEROPT, PREPROCESSING, TRAINER
@@ -144,6 +144,6 @@ def validate_config(config):
     def custom_is_array(checker, instance):
         return isinstance(instance, list) or isinstance(instance, tuple)
 
-    type_checker = Draft202012Validator.TYPE_CHECKER.redefine("array", custom_is_array)
-    CustomValidator = extend(Draft202012Validator, type_checker=type_checker)
+    type_checker = Draft7Validator.TYPE_CHECKER.redefine("array", custom_is_array)
+    CustomValidator = extend(Draft7Validator, type_checker=type_checker)
     validate(instance=config, schema=get_schema(), cls=CustomValidator)

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -458,7 +458,7 @@ def FloatRangeTupleDataclassField(N=2, default: Tuple = (0.9, 0.999), min=0, max
             validate_range(default)
             return {
                 "type": "array",
-                "prefixItems": [
+                "items": [
                     {
                         "type": "number",
                         "minimum": min,


### PR DESCRIPTION
Small change, necessary for proper UI rendering. The other implication of this change is that array fields (like `betas` or anything that may use `FloatRangeTupleDataclassField` in the future) must be validated [Draft-4 spec](https://json-schema.org/understanding-json-schema/reference/array.html#id7)-style for now.