### PR TITLE
fix: pin protobuf to 3.20.1 in tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -93,6 +93,7 @@ jobs:
             extra_index_url=https://download.pytorch.org/whl/cpu
             pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
           fi
+          pip install protobuf==3.20.1 # https://github.com/databrickslabs/dbx/issues/257
           pip install ray==$RAY_VERSION
 
           torch_expected=$(python -c "import torch; print(torch.__version__)")


### PR DESCRIPTION
Follow-up to #2062, as it looks like Ray may pull in an undesired version of protobuf if the right one doesn't happen to be cached. See https://github.com/ludwig-ai/ludwig/runs/6630463124?check_suite_focus=true, for instance.