### PR TITLE
Update torch nightly and pin torchvision to fix CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -87,7 +87,9 @@ jobs:
           if [ $PYTORCH == "nightly" ]; then
             cat requirements.txt | sed '/^torch[>=<]/d' > requirements-temp && mv requirements-temp requirements.txt
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            pip install --pre torch==1.13.0.dev20220527+cpu torchtext torchaudio --extra-index-url $extra_index_url
+            # TODO: temp fix for https://github.com/pytorch/vision/issues/6103
+            pip install https://download.pytorch.org/whl/nightly/cpu/torchvision-0.14.0.dev20220527%2Bcpu-cp39-cp39-linux_x86_64.whl
           else
             extra_index_url=https://download.pytorch.org/whl/cpu
             pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -87,8 +87,7 @@ jobs:
           if [ $PYTORCH == "nightly" ]; then
             cat requirements.txt | sed '/^torch[>=<]/d' > requirements-temp && mv requirements-temp requirements.txt
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            # TODO: temp fix for https://github.com/pytorch/vision/issues/5873
-            pip install --pre torch==1.12.0.dev20220421+cpu torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
           else
             extra_index_url=https://download.pytorch.org/whl/cpu
             pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url

--- a/ludwig/data/batcher/bucketed.py
+++ b/ludwig/data/batcher/bucketed.py
@@ -111,7 +111,7 @@ class BucketedBatcher(Batcher):
         self.steps_per_epoch = self._compute_steps_per_epoch()
 
     def _compute_steps_per_epoch(self) -> int:
-        return int(np.asscalar(np.sum(np.ceil(self.bucket_sizes / self.batch_size))))
+        return int(np.sum(np.ceil(self.bucket_sizes / self.batch_size)).item())
 
 
 # dynamic_length_encoders = {

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1456,13 +1456,13 @@ def compare_classifiers_performance_from_prob(
         hits_at_k = 0
         for j in range(len(ground_truth)):
             hits_at_k += np.in1d(ground_truth[j], topk[j])
-        hits_at_ks.append(np.asscalar(hits_at_k) / len(ground_truth))
+        hits_at_ks.append(hits_at_k.item() / len(ground_truth))
 
         mrr = 0
         for j in range(len(ground_truth)):
             ground_truth_pos_in_probs = prob[j] == ground_truth[j]
             if np.any(ground_truth_pos_in_probs):
-                mrr += 1 / -(np.asscalar(np.argwhere(ground_truth_pos_in_probs)) - prob.shape[1])
+                mrr += 1 / -(np.argwhere(ground_truth_pos_in_probs).item() - prob.shape[1])
         mrrs.append(mrr / len(ground_truth))
 
     filename = None
@@ -1663,7 +1663,7 @@ def compare_classifiers_performance_subset(
         hits_at_k = 0
         for j in range(len(gt_subset)):
             hits_at_k += np.in1d(gt_subset[j], top3_subset[i, :])
-        hits_at_ks.append(np.asscalar(hits_at_k) / len(gt_subset))
+        hits_at_ks.append(hits_at_k.item() / len(gt_subset))
 
     title = None
     if subset == "ground_truth":


### PR DESCRIPTION
https://github.com/pytorch/vision/issues/6103 is causing a really old version of torchvision to be installed. When we later install all of Ludwig's deps, it detects that the currently installed version of torchvision is not compatible, so it installs the stable torchvision, which is pinned to torch 1.11.

This fix temporarily installs a compatible torchvision wheel by exact URL, until the upstream issue is resolved.