### PR TITLE
Adds step tracking at epoch level

### DIFF
--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -931,8 +931,8 @@ class Trainer(BaseTrainer):
         final_steps_per_checkpoint: int,
         early_stopping_steps: int,
     ) -> bool:
-        """Completes one epoch through the data."""
-        while not batcher.last_batch():
+        """Completes up to one epoch through the data."""
+        while not batcher.last_batch() and progress_tracker.steps < self.total_steps:
             self.callback(lambda c: c.on_batch_start(self, progress_tracker, save_path))
 
             # Set learning rate for this batch


### PR DESCRIPTION
This PR fixes evaluation continuing despite being at the end of steps-based training. This happens when the user trains on <1 epoch (typically while debugging).