### PR TITLE
Enables saving Torchscript modules during training

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -329,7 +329,6 @@ class LudwigModel:
             improves. This can be time consuming. If turned off, the inference
             module will not be loadable later on. If skip_save_model is True,
             skip_save_inference_module is automatically set to True.
-        saves
         :param output_directory: (str, default: `'results'`) the directory that
             will contain the training statistics, TensorBoard logs, the saved
             model and the training progress files.

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -638,10 +638,7 @@ class LudwigModel:
                         logger.info("Attempting to save inference module with best weights from saved checkpoint...")
                         inference_module_path = os.path.join(model_dir, INFERENCE_MODULE_FILE_NAME)
                         try:
-                            self.model.save_inference_module(
-                                inference_module_path,
-                                **{"config": self.config, "training_set_metadata": self.training_set_metadata},
-                            ),
+                            self.save_torchscript(inference_module_path)
                             logger.info(f'Saved inference module to: "{inference_module_path}"')
                         except Exception:
                             logger.warning(

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1478,7 +1478,7 @@ class LudwigModel:
         save_json(model_hyperparameters_path, self.config)
 
     def to_torchscript(self, model_only: bool = False):
-        """Returns a scripted ECD model.
+        """Returns a scripted model.
 
         The input to this model is a dictionary of input features. For every input feature, the user must provide a
         tensor, a list of tensors or a list of strings.
@@ -1487,7 +1487,7 @@ class LudwigModel:
         outputs. The outputs will be a list of strings for predictions with string types, while other outputs will be
         tensors of varying dimensions for probabilities, logits, etc.
 
-        :param model_only: (bool, default: `False`) if `True`, only the model will be converted to torchscript. If
+        :param model_only: (bool, default: `False`) if `True`, only the ECD model will be converted to torchscript. If
             `False`, the preprocessing and postprocessing modules will be included in  the torchscript module as well.
 
         :return: (torch.nn.Module) a scripted model.

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -23,7 +23,6 @@ from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.data.dataset.base import DatasetManager
 from ludwig.data.dataset.pandas import PandasDatasetManager
 from ludwig.models.ecd import ECD
-
 from ludwig.utils.torch_utils import initialize_pytorch
 
 
@@ -112,7 +111,7 @@ class LocalTrainingMixin:
 
         return Trainer(**kwargs)
 
-    def create_predictor(self, model: "ECD", **kwargs):
+    def create_predictor(self, model: ECD, **kwargs):
         from ludwig.models.predictor import Predictor
 
         return Predictor(model, **kwargs)

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -16,16 +16,13 @@
 
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Optional, TYPE_CHECKING, Union
+from typing import Optional, Union
 
 from ludwig.data.cache.manager import CacheManager
 from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.data.dataset.base import DatasetManager
 from ludwig.data.dataset.pandas import PandasDatasetManager
-
-# Prevents circular import errors from typing.
-if TYPE_CHECKING:
-    from ludwig.models.ecd import ECD
+from ludwig.models.ecd import ECD
 
 from ludwig.utils.torch_utils import initialize_pytorch
 

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -16,13 +16,17 @@
 
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Optional, Union
+from typing import Optional, TYPE_CHECKING, Union
 
 from ludwig.data.cache.manager import CacheManager
 from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.data.dataset.base import DatasetManager
 from ludwig.data.dataset.pandas import PandasDatasetManager
-from ludwig.models.ecd import ECD
+
+# Prevents circular import errors from typing.
+if TYPE_CHECKING:
+    from ludwig.models.ecd import ECD
+
 from ludwig.utils.torch_utils import initialize_pytorch
 
 
@@ -111,7 +115,7 @@ class LocalTrainingMixin:
 
         return Trainer(**kwargs)
 
-    def create_predictor(self, model: ECD, **kwargs):
+    def create_predictor(self, model: "ECD", **kwargs):
         from ludwig.models.predictor import Predictor
 
         return Predictor(model, **kwargs)

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -72,7 +72,7 @@ class _BinaryPreprocessing(torch.nn.Module):
         if self.should_lower:
             v = [s.lower() for s in v]
         indices = [self.str2bool.get(s, False) for s in v]
-        return torch.tensor(indices, dtype=torch.bool)
+        return torch.tensor(indices, dtype=torch.float32)
 
 
 class _BinaryPostprocessing(torch.nn.Module):

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -12,7 +12,6 @@ from ludwig.constants import COMBINED, LOSS, NAME, TIED, TYPE
 from ludwig.features.base_feature import InputFeature, OutputFeature
 from ludwig.features.feature_registries import input_type_registry, output_type_registry
 from ludwig.features.feature_utils import LudwigFeatureDict
-from ludwig.models.inference import InferenceModule
 from ludwig.schema.utils import load_config_with_kwargs
 from ludwig.utils import output_feature_utils
 from ludwig.utils.algorithms_utils import topological_sort_feature_dependencies
@@ -98,32 +97,6 @@ class ECD(LudwigModule):
         model_inputs = self.get_model_inputs()
         # We set strict=False to enable dict inputs and outputs.
         return torch.jit.trace(self, model_inputs, strict=False)
-
-    def save_torchscript(self, save_path):
-        """Saves a scripted ECD model to save_path.
-
-        To save end-to-end module, use ECD.save_inference_module.
-        """
-        traced = self.to_torchscript()
-        traced.save(save_path)
-
-    def to_inference_module(self, **inference_module_kwargs):
-        """Returns a scripted ECD model.
-
-        The input to this model is a dictionary of input features. For every input feature, the user must provide a
-        tensor, a list of tensors or a list of strings.
-
-        Similarly, the output will be a dictionary of dictionaries, where each feature has its own dictionary of
-        outputs. The outputs will be a list of strings for predictions with string types, while other outputs will be
-        tensors of varying dimensions for probabilities, logits, etc.
-        """
-        inference_module = InferenceModule(self, **inference_module_kwargs)
-        return torch.jit.script(inference_module)
-
-    def save_inference_module(self, save_path, **inference_module_kwargs):
-        """Saves a scripted InferenceModule to save_path."""
-        inference_module = self.to_inference_module(**inference_module_kwargs)
-        inference_module.save(save_path)
 
     @property
     def input_shape(self):

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -98,6 +98,10 @@ class ECD(LudwigModule):
         # We set strict=False to enable dict inputs and outputs.
         return torch.jit.trace(self, model_inputs, strict=False)
 
+    def save_torchscript(self, save_path):
+        traced = self.to_torchscript()
+        traced.save(save_path)
+
     @property
     def input_shape(self):
         # TODO(justin): Remove dummy implementation. Make input_shape and output_shape functions.

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -12,6 +12,7 @@ from ludwig.constants import COMBINED, LOSS, NAME, TIED, TYPE
 from ludwig.features.base_feature import InputFeature, OutputFeature
 from ludwig.features.feature_registries import input_type_registry, output_type_registry
 from ludwig.features.feature_utils import LudwigFeatureDict
+from ludwig.models.inference import InferenceModule
 from ludwig.schema.utils import load_config_with_kwargs
 from ludwig.utils import output_feature_utils
 from ludwig.utils.algorithms_utils import topological_sort_feature_dependencies
@@ -89,14 +90,40 @@ class ECD(LudwigModule):
         return total_size
 
     def to_torchscript(self):
+        """Returns a scripted ECD model.
+
+        To get an end-to-end module, use ECD.to_inference_module.
+        """
         self.eval()
         model_inputs = self.get_model_inputs()
         # We set strict=False to enable dict inputs and outputs.
         return torch.jit.trace(self, model_inputs, strict=False)
 
     def save_torchscript(self, save_path):
+        """Saves a scripted ECD model to save_path.
+
+        To save end-to-end module, use ECD.save_inference_module.
+        """
         traced = self.to_torchscript()
         traced.save(save_path)
+
+    def to_inference_module(self, **inference_module_kwargs):
+        """Returns a scripted ECD model.
+
+        The input to this model is a dictionary of input features. For every input feature, the user must provide a
+        tensor, a list of tensors or a list of strings.
+
+        Similarly, the output will be a dictionary of dictionaries, where each feature has its own dictionary of
+        outputs. The outputs will be a list of strings for predictions with string types, while other outputs will be
+        tensors of varying dimensions for probabilities, logits, etc.
+        """
+        inference_module = InferenceModule(self, **inference_module_kwargs)
+        return torch.jit.script(inference_module)
+
+    def save_inference_module(self, save_path, **inference_module_kwargs):
+        """Saves a scripted InferenceModule to save_path."""
+        inference_module = self.to_inference_module(**inference_module_kwargs)
+        inference_module.save(save_path)
 
     @property
     def input_shape(self):

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -91,7 +91,7 @@ class ECD(LudwigModule):
     def to_torchscript(self):
         """Returns a scripted ECD model.
 
-        To get an end-to-end module, use ECD.to_inference_module.
+        To get an end-to-end module, use LudwigModel.to_torchscript.
         """
         self.eval()
         model_inputs = self.get_model_inputs()

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -636,10 +636,10 @@ def test_api_save_torchscript(tmpdir):
     test_df = pd.read_csv(test_csv)
     output_df_expected, _ = model.predict(test_df, return_type=pd.DataFrame)
 
-    save_path = os.path.join(output_dir, "model")
-    os.makedirs(save_path, exist_ok=True)
-    model.save_torchscript(save_path)
-    inference_model = InferenceLudwigModel(save_path)
+    save_dir = os.path.join(output_dir, "model")
+    os.makedirs(save_dir, exist_ok=True)
+    model.save_torchscript(os.path.join(save_dir, INFERENCE_MODULE_FILE_NAME))
+    inference_model = InferenceLudwigModel(save_dir)
     output_df, _ = inference_model.predict(test_df, return_type=pd.DataFrame)
 
     for col in output_df.columns:

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -636,10 +636,10 @@ def test_api_save_torchscript(tmpdir):
     test_df = pd.read_csv(test_csv)
     output_df_expected, _ = model.predict(test_df, return_type=pd.DataFrame)
 
-    save_dir = os.path.join(output_dir, "model")
-    os.makedirs(save_dir, exist_ok=True)
-    model.save_torchscript(os.path.join(save_dir, INFERENCE_MODULE_FILE_NAME))
-    inference_model = InferenceLudwigModel(save_dir)
+    save_path = os.path.join(output_dir, "model")
+    os.makedirs(save_path, exist_ok=True)
+    model.save_torchscript(save_path)
+    inference_model = InferenceLudwigModel(save_path)
     output_df, _ = inference_model.predict(test_df, return_type=pd.DataFrame)
 
     for col in output_df.columns:

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -24,6 +24,7 @@ import torch
 from ludwig.api import LudwigModel
 from ludwig.callbacks import Callback
 from ludwig.constants import TRAINER
+from ludwig.globals import INFERENCE_MODULE_FILE_NAME
 from ludwig.models.inference import InferenceLudwigModel
 from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import (
@@ -635,10 +636,10 @@ def test_api_save_torchscript(tmpdir):
     test_df = pd.read_csv(test_csv)
     output_df_expected, _ = model.predict(test_df, return_type=pd.DataFrame)
 
-    save_path = os.path.join(output_dir, "model")
-    os.makedirs(save_path, exist_ok=True)
-    model.save_torchscript(save_path)
-    inference_model = InferenceLudwigModel(save_path)
+    save_dir = os.path.join(output_dir, "model")
+    os.makedirs(save_dir, exist_ok=True)
+    model.save_torchscript(os.path.join(save_dir, INFERENCE_MODULE_FILE_NAME))
+    inference_model = InferenceLudwigModel(save_dir)
     output_df, _ = inference_model.predict(test_df, return_type=pd.DataFrame)
 
     for col in output_df.columns:


### PR DESCRIPTION
This Pr adds saving Torchscript modules to training and tests to confirm this behavior.

There is a slight change in the API– namely `LudwigModel.save_torchscript` now takes a full path instead of just a directory. This is for added flexibility.