### PR TITLE
Fix to_numpy_dataset() for Dask series

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -383,7 +383,10 @@ def unflatten_df(df, column_shapes, backend):
 def to_numpy_dataset(df):
     dataset = {}
     for col in df.columns:
-        dataset[col] = np.stack(df[col].to_numpy())
+        res = df[col]
+        if isinstance(res, dd.core.Series):
+            res = res.compute()
+        dataset[col] = np.stack(res.to_numpy())
     return dataset
 
 

--- a/tests/ludwig/utils/test_data_utils.py
+++ b/tests/ludwig/utils/test_data_utils.py
@@ -23,7 +23,7 @@ from ludwig.utils.data_utils import (
     figure_data_format_dataset,
     get_abs_path,
     hash_dict,
-    use_credentials,
+    use_credentials, to_numpy_dataset,
 )
 
 
@@ -73,26 +73,26 @@ def test_figure_data_format_dataset():
     assert figure_data_format_dataset({"a": "b"}) == dict
     assert figure_data_format_dataset(pd.DataFrame([1, 2, 3, 4, 5], columns=["x"])) == pd.DataFrame
     assert (
-        figure_data_format_dataset(
-            dd.from_pandas(pd.DataFrame([1, 2, 3, 4, 5], columns=["x"]), npartitions=1).reset_index()
-        )
-        == dd.core.DataFrame
-    )
-    assert (
-        figure_data_format_dataset(
-            CacheableDataframe(df=pd.DataFrame([1, 2, 3, 4, 5], columns=["x"]), name="test", checksum="test123")
-        )
-        == pd.DataFrame
-    )
-    assert (
-        figure_data_format_dataset(
-            CacheableDataframe(
-                df=dd.from_pandas(pd.DataFrame([1, 2, 3, 4, 5], columns=["x"]), npartitions=1).reset_index(),
-                name="test",
-                checksum="test123",
+            figure_data_format_dataset(
+                dd.from_pandas(pd.DataFrame([1, 2, 3, 4, 5], columns=["x"]), npartitions=1).reset_index()
             )
-        )
-        == dd.core.DataFrame
+            == dd.core.DataFrame
+    )
+    assert (
+            figure_data_format_dataset(
+                CacheableDataframe(df=pd.DataFrame([1, 2, 3, 4, 5], columns=["x"]), name="test", checksum="test123")
+            )
+            == pd.DataFrame
+    )
+    assert (
+            figure_data_format_dataset(
+                CacheableDataframe(
+                    df=dd.from_pandas(pd.DataFrame([1, 2, 3, 4, 5], columns=["x"]), npartitions=1).reset_index(),
+                    name="test",
+                    checksum="test123",
+                )
+            )
+            == dd.core.DataFrame
     )
 
 
@@ -120,3 +120,9 @@ def test_use_credentials():
         assert conf == s3_creds
 
     assert len(conf) == 0
+
+
+def test_to_numpy_dataset_with_dask():
+    dd_df = dd.from_pandas(pd.DataFrame([[1, 2, 3]], columns=["col1", "col2", "col3"]), npartitions=1)
+    np_df = to_numpy_dataset(dd_df)
+    assert np_df == {'col1': np.array([1]), 'col2': np.array([2]), 'col3': np.array([3])}

--- a/tests/ludwig/utils/test_data_utils.py
+++ b/tests/ludwig/utils/test_data_utils.py
@@ -23,7 +23,8 @@ from ludwig.utils.data_utils import (
     figure_data_format_dataset,
     get_abs_path,
     hash_dict,
-    use_credentials, to_numpy_dataset,
+    to_numpy_dataset,
+    use_credentials,
 )
 
 
@@ -73,26 +74,26 @@ def test_figure_data_format_dataset():
     assert figure_data_format_dataset({"a": "b"}) == dict
     assert figure_data_format_dataset(pd.DataFrame([1, 2, 3, 4, 5], columns=["x"])) == pd.DataFrame
     assert (
-            figure_data_format_dataset(
-                dd.from_pandas(pd.DataFrame([1, 2, 3, 4, 5], columns=["x"]), npartitions=1).reset_index()
-            )
-            == dd.core.DataFrame
+        figure_data_format_dataset(
+            dd.from_pandas(pd.DataFrame([1, 2, 3, 4, 5], columns=["x"]), npartitions=1).reset_index()
+        )
+        == dd.core.DataFrame
     )
     assert (
-            figure_data_format_dataset(
-                CacheableDataframe(df=pd.DataFrame([1, 2, 3, 4, 5], columns=["x"]), name="test", checksum="test123")
-            )
-            == pd.DataFrame
+        figure_data_format_dataset(
+            CacheableDataframe(df=pd.DataFrame([1, 2, 3, 4, 5], columns=["x"]), name="test", checksum="test123")
+        )
+        == pd.DataFrame
     )
     assert (
-            figure_data_format_dataset(
-                CacheableDataframe(
-                    df=dd.from_pandas(pd.DataFrame([1, 2, 3, 4, 5], columns=["x"]), npartitions=1).reset_index(),
-                    name="test",
-                    checksum="test123",
-                )
+        figure_data_format_dataset(
+            CacheableDataframe(
+                df=dd.from_pandas(pd.DataFrame([1, 2, 3, 4, 5], columns=["x"]), npartitions=1).reset_index(),
+                name="test",
+                checksum="test123",
             )
-            == dd.core.DataFrame
+        )
+        == dd.core.DataFrame
     )
 
 
@@ -125,4 +126,4 @@ def test_use_credentials():
 def test_to_numpy_dataset_with_dask():
     dd_df = dd.from_pandas(pd.DataFrame([[1, 2, 3]], columns=["col1", "col2", "col3"]), npartitions=1)
     np_df = to_numpy_dataset(dd_df)
-    assert np_df == {'col1': np.array([1]), 'col2': np.array([2]), 'col3': np.array([3])}
+    assert np_df == {"col1": np.array([1]), "col2": np.array([2]), "col3": np.array([3])}


### PR DESCRIPTION
```
    model.evaluate(
  File "/Users/hw/mambaforge/envs/based/lib/python3.8/site-packages/ludwig/api.py", line 914, in evaluate
    postproc_predictions = postprocess(
  File "/Users/hw/mambaforge/envs/based/lib/python3.8/site-packages/ludwig/data/postprocessing.py", line 43, in postprocess
    _save_as_numpy(predictions, output_directory, saved_keys)
  File "/Users/hw/mambaforge/envs/based/lib/python3.8/site-packages/ludwig/data/postprocessing.py", line 63, in _save_as_numpy
    numpy_predictions = to_numpy_dataset(predictions)
  File "/Users/hw/mambaforge/envs/based/lib/python3.8/site-packages/ludwig/utils/data_utils.py", line 386, in to_numpy_dataset
    dataset[col] = np.stack(df[col].to_numpy())
AttributeError: 'Series' object has no attribute 'to_numpy' (type: RayTaskError(AttributeError), retryable: true)
```