### PR TITLE
Use the Backend to check for dask dataframes, instead of a hard check.

### DIFF
--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -172,3 +172,5 @@ HYPEROPT_WARNING = (
 CONTINUE_PROMPT = "Do you want to continue? "
 
 DEFAULT_AUDIO_TENSOR_LENGTH = 70000
+
+DASK_MODULE_NAME = "dask.dataframe"

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -21,8 +21,8 @@ from ludwig.constants import PREPROCESSING, TRAINING
 from ludwig.data.batcher.random_access import RandomAccessBatcher
 from ludwig.data.dataset.base import Dataset, DatasetManager
 from ludwig.data.sampler import DistributedSampler
-from ludwig.utils import data_utils
-from ludwig.utils.data_utils import DATA_TRAIN_HDF5_FP, from_numpy_dataset, to_numpy_dataset
+from ludwig.utils.data_utils import DATA_TRAIN_HDF5_FP, save_hdf5
+from ludwig.utils.dataframe_utils import from_numpy_dataset, to_numpy_dataset
 from ludwig.utils.fs_utils import download_h5
 from ludwig.utils.misc_utils import get_proc_features
 
@@ -83,7 +83,7 @@ class PandasDatasetManager(DatasetManager):
         return PandasDataset(dataset, get_proc_features(config), training_set_metadata.get(DATA_TRAIN_HDF5_FP))
 
     def save(self, cache_path, dataset, config, training_set_metadata, tag):
-        data_utils.save_hdf5(cache_path, dataset)
+        save_hdf5(cache_path, dataset)
         if tag == TRAINING:
             training_set_metadata[DATA_TRAIN_HDF5_FP] = cache_path
         return dataset

--- a/ludwig/data/postprocessing.py
+++ b/ludwig/data/postprocessing.py
@@ -52,15 +52,15 @@ def postprocess(
 
     # Save any new columns but do not save the original columns again
     if not skip_save_unprocessed_output:
-        _save_as_numpy(predictions, output_directory, saved_keys)
+        _save_as_numpy(predictions, output_directory, saved_keys, backend)
 
     return predictions
 
 
-def _save_as_numpy(predictions, output_directory, saved_keys):
+def _save_as_numpy(predictions, output_directory, saved_keys, backend):
     predictions = predictions[[c for c in predictions.columns if c not in saved_keys]]
     npy_filename = os.path.join(output_directory, "{}.npy")
-    numpy_predictions = to_numpy_dataset(predictions)
+    numpy_predictions = to_numpy_dataset(predictions, backend)
     for k, v in numpy_predictions.items():
         k = k.replace("<", "[").replace(">", "]")  # Replace <UNK> and <PAD> with [UNK], [PAD]
         if k not in saved_keys:

--- a/ludwig/data/postprocessing.py
+++ b/ludwig/data/postprocessing.py
@@ -21,7 +21,8 @@ import pandas as pd
 import torch
 
 from ludwig.backend import LOCAL_BACKEND
-from ludwig.utils.data_utils import DATAFRAME_FORMATS, DICT_FORMATS, to_numpy_dataset
+from ludwig.utils.data_utils import DATAFRAME_FORMATS, DICT_FORMATS
+from ludwig.utils.dataframe_utils import to_numpy_dataset
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.strings_utils import make_safe_filename
 

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -22,7 +22,8 @@ from ludwig.globals import (
 )
 from ludwig.models.ecd import ECD
 from ludwig.progress_bar import LudwigProgressBar
-from ludwig.utils.data_utils import flatten_df, from_numpy_dataset, save_csv, save_json
+from ludwig.utils.data_utils import save_csv, save_json
+from ludwig.utils.dataframe_utils import flatten_df, from_numpy_dataset
 from ludwig.utils.horovod_utils import return_first
 from ludwig.utils.print_utils import repr_ordered_dict
 from ludwig.utils.strings_utils import make_safe_filename

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -39,6 +39,7 @@ from pandas.errors import ParserError
 from sklearn.model_selection import KFold
 
 from ludwig.data.cache.types import CacheableDataset
+from ludwig.utils.dataframe_utils import from_numpy_dataset, is_dask_lib, to_numpy_dataset
 from ludwig.utils.fs_utils import download_h5, open_file, upload_h5
 from ludwig.utils.misc_utils import get_from_registry
 
@@ -99,7 +100,6 @@ CACHEABLE_FORMATS = set.union(
 )
 
 PANDAS_DF = pd
-DASK_MODULE_NAME = "dask.dataframe"
 
 
 # Lock over the entire interpreter as we can only have one set
@@ -197,7 +197,7 @@ def read_excel(data_fp, df_lib):
         excel_engine = "openpyxl"
 
     # https://github.com/dask/dask/issues/9055
-    if df_lib.__name__ == DASK_MODULE_NAME:
+    if is_dask_lib(df_lib):
         logger.warning("Falling back to pd.read_excel() since dask backend does not support it")
         return dd.from_pandas(pd.read_excel(data_fp, engine=excel_engine), npartitions=1)
     return df_lib.read_excel(data_fp, engine=excel_engine)
@@ -211,7 +211,7 @@ def read_parquet(data_fp, df_lib):
 @spread
 def read_pickle(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
-    if df_lib.__name__ == DASK_MODULE_NAME:
+    if is_dask_lib(df_lib):
         logger.warning("Falling back to pd.read_pickle() since dask backend does not support it")
         return dd.from_pandas(pd.read_pickle(data_fp), npartitions=1)
     return df_lib.read_pickle(data_fp)
@@ -225,7 +225,7 @@ def read_fwf(data_fp, df_lib):
 @spread
 def read_feather(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
-    if df_lib.__name__ == DASK_MODULE_NAME:
+    if is_dask_lib(df_lib):
         logger.warning("Falling back to pd.read_feather() since dask backend does not support it")
         return dd.from_pandas(pd.read_feather(data_fp), npartitions=1)
     return df_lib.read_feather(data_fp)
@@ -234,7 +234,7 @@ def read_feather(data_fp, df_lib):
 @spread
 def read_html(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
-    if df_lib.__name__ == DASK_MODULE_NAME:
+    if is_dask_lib(df_lib):
         logger.warning("Falling back to pd.read_html() since dask backend does not support it")
         return dd.from_pandas(pd.read_html(data_fp)[0], npartitions=1)
     return df_lib.read_html(data_fp)[0]
@@ -248,7 +248,7 @@ def read_orc(data_fp, df_lib):
 @spread
 def read_sas(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
-    if df_lib.__name__ == DASK_MODULE_NAME:
+    if is_dask_lib(df_lib):
         logger.warning("Falling back to pd.read_sas() since dask backend does not support it")
         return dd.from_pandas(pd.read_sas(data_fp), npartitions=1)
     return df_lib.read_sas(data_fp)
@@ -257,7 +257,7 @@ def read_sas(data_fp, df_lib):
 @spread
 def read_spss(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
-    if df_lib.__name__ == DASK_MODULE_NAME:
+    if is_dask_lib(df_lib):
         logger.warning("Falling back to pd.read_spss() since dask backend does not support it")
         return dd.from_pandas(pd.read_spss(data_fp), npartitions=1)
     return df_lib.read_spss(data_fp)
@@ -266,7 +266,7 @@ def read_spss(data_fp, df_lib):
 @spread
 def read_stata(data_fp, df_lib):
     # https://github.com/dask/dask/issues/9055
-    if df_lib.__name__ == DASK_MODULE_NAME:
+    if is_dask_lib(df_lib):
         logger.warning("Falling back to pd.read_stata() since dask backend does not support it")
         return dd.from_pandas(pd.read_stata(data_fp), npartitions=1)
     return df_lib.read_stata(data_fp)
@@ -353,57 +353,6 @@ def flatten_dict(d, parent_key="", sep="."):
         else:
             items.append((new_key, v))
     return dict(items)
-
-
-def flatten_df(df, backend):
-    # Workaround for: https://issues.apache.org/jira/browse/ARROW-5645
-    column_shapes = {}
-    for c in df.columns:
-        df = backend.df_engine.persist(df)
-        shape = backend.df_engine.compute(
-            backend.df_engine.map_objects(
-                df[c],
-                lambda x: np.array(x).shape,
-            ).max()
-        )
-
-        if len(shape) > 1:
-            column_shapes[c] = shape
-            df[c] = backend.df_engine.map_objects(df[c], lambda x: np.array(x).reshape(-1))
-    return df, column_shapes
-
-
-def unflatten_df(df, column_shapes, backend):
-    for c in df.columns:
-        shape = column_shapes.get(c)
-        if shape:
-            df[c] = backend.df_engine.map_objects(df[c], lambda x: np.array(x).reshape(shape))
-    return df
-
-
-def to_numpy_dataset(df):
-    dataset = {}
-    for col in df.columns:
-        res = df[col]
-        if isinstance(res, dd.core.Series):
-            res = res.compute()
-        dataset[col] = np.stack(res.to_numpy())
-    return dataset
-
-
-def from_numpy_dataset(dataset):
-    col_mapping = {}
-    for k, v in dataset.items():
-        if len(v.shape) > 1:
-            # unstacking, needed for ndarrays of dimension 2 and more
-            (*vals,) = v
-        else:
-            # not unstacking. Needed because otherwise pandas casts types
-            # the way it wants, like converting a list of float32 scalats
-            # to a column of float64
-            vals = v
-        col_mapping[k] = vals
-    return pd.DataFrame.from_dict(col_mapping)
 
 
 def save_hdf5(data_fp, data):

--- a/ludwig/utils/dataframe_utils.py
+++ b/ludwig/utils/dataframe_utils.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 import numpy as np
 import pandas as pd
 
-from ludwig.backend import Backend, LOCAL_BACKEND
 from ludwig.constants import DASK_MODULE_NAME
+from ludwig.utils.types import DataFrame
 
 
 def is_dask_lib(df_lib):
@@ -10,12 +12,12 @@ def is_dask_lib(df_lib):
     return df_lib.__name__ == DASK_MODULE_NAME
 
 
-def is_dask_backend(backend: Backend):
+def is_dask_backend(backend: "Backend"):  # noqa: F821
     """Returns whether the backend's dataframe is dask."""
     return backend.df_engine.df_lib.__name__ == DASK_MODULE_NAME
 
 
-def flatten_df(df, backend):
+def flatten_df(df: DataFrame, backend: "Backend"):  # noqa: F821
     # Workaround for: https://issues.apache.org/jira/browse/ARROW-5645
     column_shapes = {}
     for c in df.columns:
@@ -33,7 +35,7 @@ def flatten_df(df, backend):
     return df, column_shapes
 
 
-def unflatten_df(df, column_shapes, backend):
+def unflatten_df(df: DataFrame, column_shapes, backend: "Backend"):  # noqa: F821
     for c in df.columns:
         shape = column_shapes.get(c)
         if shape:
@@ -41,17 +43,17 @@ def unflatten_df(df, column_shapes, backend):
     return df
 
 
-def to_numpy_dataset(df, backend=LOCAL_BACKEND):
+def to_numpy_dataset(df: DataFrame, backend: Optional["Backend"] = None):  # noqa: F821
     dataset = {}
     for col in df.columns:
         res = df[col]
-        if is_dask_backend(backend):
+        if backend and is_dask_backend(backend):
             res = res.compute()
         dataset[col] = np.stack(res.to_numpy())
     return dataset
 
 
-def from_numpy_dataset(dataset):
+def from_numpy_dataset(dataset) -> pd.DataFrame:
     col_mapping = {}
     for k, v in dataset.items():
         if len(v.shape) > 1:

--- a/ludwig/utils/dataframe_utils.py
+++ b/ludwig/utils/dataframe_utils.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pandas as pd
+
+from ludwig.backend import Backend, LOCAL_BACKEND
+from ludwig.constants import DASK_MODULE_NAME
+
+
+def is_dask_lib(df_lib):
+    """Returns whether the dataframe library is dask."""
+    return df_lib.__name__ == DASK_MODULE_NAME
+
+
+def is_dask_backend(backend: Backend):
+    """Returns whether the backend's dataframe is dask."""
+    return backend.df_engine.df_lib.__name__ == DASK_MODULE_NAME
+
+
+def flatten_df(df, backend):
+    # Workaround for: https://issues.apache.org/jira/browse/ARROW-5645
+    column_shapes = {}
+    for c in df.columns:
+        df = backend.df_engine.persist(df)
+        shape = backend.df_engine.compute(
+            backend.df_engine.map_objects(
+                df[c],
+                lambda x: np.array(x).shape,
+            ).max()
+        )
+
+        if len(shape) > 1:
+            column_shapes[c] = shape
+            df[c] = backend.df_engine.map_objects(df[c], lambda x: np.array(x).reshape(-1))
+    return df, column_shapes
+
+
+def unflatten_df(df, column_shapes, backend):
+    for c in df.columns:
+        shape = column_shapes.get(c)
+        if shape:
+            df[c] = backend.df_engine.map_objects(df[c], lambda x: np.array(x).reshape(shape))
+    return df
+
+
+def to_numpy_dataset(df, backend=LOCAL_BACKEND):
+    dataset = {}
+    for col in df.columns:
+        res = df[col]
+        if is_dask_backend(backend):
+            res = res.compute()
+        dataset[col] = np.stack(res.to_numpy())
+    return dataset
+
+
+def from_numpy_dataset(dataset):
+    col_mapping = {}
+    for k, v in dataset.items():
+        if len(v.shape) > 1:
+            # unstacking, needed for ndarrays of dimension 2 and more
+            (*vals,) = v
+        else:
+            # not unstacking. Needed because otherwise pandas casts types
+            # the way it wants, like converting a list of float32 scalats
+            # to a column of float64
+            vals = v
+        col_mapping[k] = vals
+    return pd.DataFrame.from_dict(col_mapping)

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -40,9 +40,8 @@ from ludwig.utils.data_utils import (
     load_from_file,
     load_json,
     replace_file_extension,
-    to_numpy_dataset,
-    unflatten_df,
 )
+from ludwig.utils.dataframe_utils import to_numpy_dataset, unflatten_df
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.print_utils import logging_level_registry
 
@@ -259,7 +258,7 @@ def _get_cols_from_predictions(predictions_paths, cols, metadata):
                 if "str2idx" in feature_metadata:
                     pred_df[col] = pred_df[col].map(lambda x: feature_metadata["str2idx"][x])
 
-        pred_df = to_numpy_dataset(pred_df)
+        pred_df = to_numpy_dataset(pred_df, LOCAL_BACKEND)
         results_per_model += [pred_df[col] for col in cols]
 
     return results_per_model

--- a/tests/ludwig/utils/test_data_utils.py
+++ b/tests/ludwig/utils/test_data_utils.py
@@ -23,7 +23,6 @@ from ludwig.utils.data_utils import (
     figure_data_format_dataset,
     get_abs_path,
     hash_dict,
-    to_numpy_dataset,
     use_credentials,
 )
 
@@ -121,9 +120,3 @@ def test_use_credentials():
         assert conf == s3_creds
 
     assert len(conf) == 0
-
-
-def test_to_numpy_dataset_with_dask():
-    dd_df = dd.from_pandas(pd.DataFrame([[1, 2, 3]], columns=["col1", "col2", "col3"]), npartitions=1)
-    np_df = to_numpy_dataset(dd_df)
-    assert np_df == {"col1": np.array([1]), "col2": np.array([2]), "col3": np.array([3])}

--- a/tests/ludwig/utils/test_dataframe_utils.py
+++ b/tests/ludwig/utils/test_dataframe_utils.py
@@ -1,0 +1,39 @@
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+import pytest
+
+from ludwig.backend import create_backend, LOCAL_BACKEND
+from ludwig.utils.dataframe_utils import to_numpy_dataset
+
+
+def test_to_numpy_dataset_with_dask():
+    dd_df = dd.from_pandas(pd.DataFrame([[1, 2, 3]], columns=["col1", "col2", "col3"]), npartitions=1)
+    ray_backend = create_backend("ray")
+
+    np_df = to_numpy_dataset(dd_df, backend=ray_backend)
+
+    assert np_df == {"col1": np.array([1]), "col2": np.array([2]), "col3": np.array([3])}
+
+
+def test_to_numpy_dataset_with_dask_backend_mismatch():
+    dd_df = dd.from_pandas(pd.DataFrame([[1, 2, 3]], columns=["col1", "col2", "col3"]), npartitions=1)
+
+    with pytest.raises(AttributeError):
+        to_numpy_dataset(dd_df, backend=LOCAL_BACKEND)
+
+
+def test_to_numpy_dataset_with_pandas():
+    pd_df = pd.DataFrame([[1, 2, 3]], columns=["col1", "col2", "col3"])
+
+    np_df = to_numpy_dataset(pd_df, backend=LOCAL_BACKEND)
+
+    assert np_df == {"col1": np.array([1]), "col2": np.array([2]), "col3": np.array([3])}
+
+
+def test_to_numpy_dataset_with_pandas_backend_mismatch():
+    pd_df = pd.DataFrame([[1, 2, 3]], columns=["col1", "col2", "col3"])
+    ray_backend = create_backend("ray")
+
+    with pytest.raises(AttributeError):
+        to_numpy_dataset(pd_df, backend=ray_backend)


### PR DESCRIPTION
Dask is not a required dependency for Ludwig.

To maintain this abstraction, we pipe in the Ludwig `backend` and use the backend's `df_engine` to check if the dataframe should be treated as a Dask dataframe.