### PR TITLE
Changes for enabling checkpoint syncing for hyperopt

### DIFF
--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -329,13 +329,19 @@ class RayTuneExecutor:
                 syncer = get_cloud_sync_client(remote_checkpoint_dir)
 
             return syncer, remote_checkpoint_dir
-        else:
+        elif self.kubernetes_namespace is not None:
             # Kubernetes sync config. Returns driver node name and path.
             # When running on kubernetes, each trial is rsynced to the node running the main process.
-            assert self.kubernetes_namespace is not None
             node_name = self._get_node_address_by_ip()(self.head_node_ip)
-
+            # TODO(shreya): Return kubernetes syncer here
             return (node_name, trial_dir)
+        else:
+            logger.warning(
+                "Checkpoint syncing disabled as syncing is only supported to remote cloud storage or on Kubernetes "
+                "clusters is supported. To use syncing, set the kubernetes_namespace in the config or use a cloud URI "
+                "as the output directory."
+            )
+            return None
 
     @lru_cache(maxsize=1)
     def _get_kubernetes_node_address_by_ip(self) -> Callable:

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -119,6 +119,10 @@ def get_node_name(node_ip):
 
 
 def checkpoint(progress_tracker, save_path):
+
+    def ignore_dot_files(src, files):
+        return [f for f in files if f.startswith(".")]
+
     with CHECKPOINTS_LOCK:
         with tune.checkpoint_dir(step=progress_tracker.tune_checkpoint_num) as checkpoint_dir:
             checkpoint_model = os.path.join(checkpoint_dir, "model")
@@ -130,7 +134,7 @@ def checkpoint(progress_tracker, save_path):
                 tmp_dst = f"{checkpoint_model}.{copy_id}.tmp"
                 assert os.path.exists(save_path)
                 # print(f'\n\n\nRunning everything on : {get_node_name(ray.util.get_node_ip_address())}')
-                shutil.copytree(save_path, tmp_dst)
+                shutil.copytree(save_path, tmp_dst, ignore=ignore_dot_files)
                 try:
                     os.rename(tmp_dst, checkpoint_model)
                 except Exception:

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -38,7 +38,6 @@ try:
     from ray.tune import register_trainable, Stopper
     from ray.tune.schedulers.resource_changing_scheduler import DistributeResources, ResourceChangingScheduler
     from ray.tune.suggest import BasicVariantGenerator, ConcurrencyLimiter, SEARCH_ALG_IMPORT
-    from ray.tune.sync_client import CommandBasedClient
 
     _ray_114 = version.parse(ray.__version__) >= version.parse("1.14")
     if _ray_114:
@@ -473,7 +472,7 @@ class RayTuneExecutor:
                 super().__init__()
                 self.last_steps = 0
 
-            def _get_remote_checkpoint_dir(self) -> Optional[Tuple["CommandBasedClient", str]]:
+            def _get_remote_checkpoint_dir(self) -> Optional[Union[str, Tuple[str, str]]]:
                 # sync client has to be recreated to avoid issues with serialization
                 return tune_executor._get_remote_checkpoint_dir(trial_dir)
 

--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -198,27 +198,9 @@ class CheckpointManager:
         save_path = os.path.join(self.directory, LATEST_FNAME)
         self.checkpoint.save(save_path, global_step)
         self.latest_checkpoint = save_path
-<<<<<<< HEAD
 
     def close(self):
         pass
-=======
-
-        # ckpts = get_files(self.directory, "*.ckpt")[::-1]
-
-        # remove until `max_to_keep` remain
-        # num_remove = len(ckpts) - self.max_to_keep
-        # while num_remove > 0:
-        #     ckpt_name = ckpts.pop()
-        #     os.remove(ckpt_name)
-        #     num_remove -= 1
-
-        # self.queue.put(True)
-
-    def close(self):
-        self.queue.put(False)
-        # self.trim_thread.join()
->>>>>>> 4e0da890... Temporary changes
 
     @staticmethod
     def load_latest_checkpoint(checkpoint: Checkpoint, directory: str, device: torch.device):

--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -198,9 +198,27 @@ class CheckpointManager:
         save_path = os.path.join(self.directory, LATEST_FNAME)
         self.checkpoint.save(save_path, global_step)
         self.latest_checkpoint = save_path
+<<<<<<< HEAD
 
     def close(self):
         pass
+=======
+
+        # ckpts = get_files(self.directory, "*.ckpt")[::-1]
+
+        # remove until `max_to_keep` remain
+        # num_remove = len(ckpts) - self.max_to_keep
+        # while num_remove > 0:
+        #     ckpt_name = ckpts.pop()
+        #     os.remove(ckpt_name)
+        #     num_remove -= 1
+
+        # self.queue.put(True)
+
+    def close(self):
+        self.queue.put(False)
+        # self.trim_thread.join()
+>>>>>>> 4e0da890... Temporary changes
 
     @staticmethod
     def load_latest_checkpoint(checkpoint: Checkpoint, directory: str, device: torch.device):


### PR DESCRIPTION
Changes necessary in order to use a KubernetesSyncer in order to sync checkpoints across pods.

The proposed changes use the storage on the node running the main process as the default storage location where all checkpoints are synced to.

I've left some comments in there right now mostly for debugging, which I plan to remove before merging this PR.