### PR TITLE
Torchscript-compatible TabNet

### DIFF
--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -91,6 +91,13 @@ class ECD(LudwigModule):
     def to_torchscript(self):
         self.eval()
         model_inputs = self.get_model_inputs()
+
+        # print("scripting")
+        # test = torch.jit.script(self.combiner)
+        # print("inside to_torchscript")
+        # print(test)
+
+        print("tracing")
         # We set strict=False to enable dict inputs and outputs.
         return torch.jit.trace(self, model_inputs, strict=False)
 

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -91,13 +91,6 @@ class ECD(LudwigModule):
     def to_torchscript(self):
         self.eval()
         model_inputs = self.get_model_inputs()
-
-        # print("scripting")
-        # test = torch.jit.script(self.combiner)
-        # print("inside to_torchscript")
-        # print(test)
-
-        print("tracing")
         # We set strict=False to enable dict inputs and outputs.
         return torch.jit.trace(self, model_inputs, strict=False)
 

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -182,11 +182,11 @@ class FeatureBlock(LudwigModule):
         self.size = size
         units = size * 2 if apply_glu else size
 
+        # Initialize fc_layer before assigning to shared layer for torchscript compatibilty
         self.fc_layer = nn.Linear(input_size, units, bias=False)
         if shared_fc_layer is not None:
             assert shared_fc_layer.weight.shape == self.fc_layer.weight.shape
-            self.fc_layer.weight = shared_fc_layer.weight
-            self.fc_layer.bias = shared_fc_layer.bias
+            self.fc_layer = shared_fc_layer
 
         self.batch_norm = GhostBatchNormalization(
             units, virtual_batch_size=bn_virtual_bs, momentum=bn_momentum, epsilon=bn_epsilon

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -225,7 +225,6 @@ class AttentiveTransformer(LudwigModule):
         super().__init__()
         self.input_size = input_size
         self.size = size
-
         self.entmax_mode = entmax_mode
         if entmax_mode == "adaptive":
             self.register_buffer("trainable_alpha", torch.tensor(entmax_alpha, requires_grad=True))
@@ -309,15 +308,16 @@ class FeatureTransformer(LudwigModule):
         # build blocks
         self.blocks = nn.ModuleList()
         for n in range(num_total_blocks):
+            # Ensure the sizes fed into FeatureBlock are correct regardless of presence of shared_fc_layer
             if n == 0:
                 in_features = input_size
             else:
                 in_features = size
 
             if shared_fc_layers and n < len(shared_fc_layers):
-                kwargs.update({"shared_fc_layer": shared_fc_layers[n]})
-
-            self.blocks.append(FeatureBlock(in_features, size, **kwargs))
+                self.blocks.append(FeatureBlock(in_features, size, **kwargs, shared_fc_layer=shared_fc_layers[n]))
+            else:
+                self.blocks.append(FeatureBlock(in_features, size, **kwargs))
 
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:
         # shape notation

--- a/ludwig/utils/entmax/activations.py
+++ b/ludwig/utils/entmax/activations.py
@@ -226,6 +226,8 @@ def sparsemax(X, dim=-1, k=None, training=True):
     P : torch tensor, same shape as X
         The projection result, such that P.sum(dim=dim) == 1 elementwise.
     """
+    # Avoids call to custom autograd.Function during eval to ensure torchscript compatibility
+    # custom autograd.Function is not scriptable: https://github.com/pytorch/pytorch/issues/22329#issuecomment-506608053
     if not training:
         output, _ = _sparsemax_forward(X, dim, k)
         return output
@@ -261,6 +263,8 @@ def entmax15(X, dim=-1, k=None, training=True):
     P : torch tensor, same shape as X
         The projection result, such that P.sum(dim=dim) == 1 elementwise.
     """
+    # Avoids call to custom autograd.Function during eval to ensure torchscript compatibility
+    # custom autograd.Function is not scriptable: https://github.com/pytorch/pytorch/issues/22329#issuecomment-506608053
     if not training:
         output, _ = _entmax15_forward(X, dim, k)
         return output

--- a/ludwig/utils/entmax/root_finding.py
+++ b/ludwig/utils/entmax/root_finding.py
@@ -50,17 +50,17 @@ def _entmax_bisect_forward(X, alpha, dim, n_iter, ensure_sum_one, cls):
 
 
 class EntmaxBisectFunction(Function):
-    @staticmethod
-    def _gp(x, alpha):
+    @classmethod
+    def _gp(cls, x, alpha):
         return x ** (alpha - 1)
 
-    @staticmethod
-    def _gp_inv(y, alpha):
+    @classmethod
+    def _gp_inv(cls, y, alpha):
         return y ** (1 / (alpha - 1))
 
-    @staticmethod
-    def _p(X, alpha):
-        return EntmaxBisectFunction._gp_inv(torch.clamp(X, min=0), alpha)
+    @classmethod
+    def _p(cls, X, alpha):
+        return cls._gp_inv(torch.clamp(X, min=0), alpha)
 
     @classmethod
     def forward(cls, ctx, X, alpha=1.5, dim=-1, n_iter=50, ensure_sum_one=True):
@@ -110,15 +110,15 @@ def _sparsemax_bisect_forward(X, dim, n_iter, ensure_sum_one):
 
 # slightly more efficient special case for sparsemax
 class SparsemaxBisectFunction(EntmaxBisectFunction):
-    @staticmethod
+    @classmethod
     def _gp(x, alpha):
         return x
 
-    @staticmethod
+    @classmethod
     def _gp_inv(y, alpha):
         return y
 
-    @staticmethod
+    @classmethod
     def _p(x, alpha):
         return torch.clamp(x, min=0)
 

--- a/ludwig/utils/entmax/root_finding.py
+++ b/ludwig/utils/entmax/root_finding.py
@@ -184,6 +184,8 @@ def entmax_bisect(X, alpha=1.5, dim=-1, n_iter=50, ensure_sum_one=True, training
     P : torch tensor, same shape as X
         The projection result, such that P.sum(dim=dim) == 1 elementwise.
     """
+    # Avoids call to custom autograd.Function during eval to ensure torchscript compatibility
+    # custom autograd.Function is not scriptable: https://github.com/pytorch/pytorch/issues/22329#issuecomment-506608053
     if not training:
         output, _ = _entmax_bisect_forward(X, alpha, dim, n_iter, ensure_sum_one)
         return output
@@ -222,6 +224,8 @@ def sparsemax_bisect(X, dim=-1, n_iter=50, ensure_sum_one=True, training=True):
     P : torch tensor, same shape as X
         The projection result, such that P.sum(dim=dim) == 1 elementwise.
     """
+    # Avoids call to custom autograd.Function during eval to ensure torchscript compatibility
+    # custom autograd.Function is not scriptable: https://github.com/pytorch/pytorch/issues/22329#issuecomment-506608053
     if not training:
         output, _ = _sparsemax_bisect_forward(X, dim, n_iter, ensure_sum_one)
         return output

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -267,6 +267,7 @@ def test_torchscript_e2e_tabnet_combiner(csv_filename, tmpdir):
             "type": "tabnet",
             "num_total_blocks": 2,
             "num_shared_blocks": 2,
+            "entmax_mode": "constant",
         },
         TRAINER: {"epochs": 2},
     }
@@ -374,8 +375,6 @@ def validate_torchscript_outputs(tmpdir, config, backend, training_data_csv_path
 
     # Obtain predictions from Python model
     preds_dict, _ = ludwig_model.predict(dataset=training_data_csv_path, return_type=dict)
-
-    print("======================CONVERTING TO TORCHSCRIPT======================")
 
     # Create graph inference model (Torchscript) from trained Ludwig model.
     script_module = ludwig_model.to_torchscript()

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -267,7 +267,6 @@ def test_torchscript_e2e_tabnet_combiner(csv_filename, tmpdir):
             "type": "tabnet",
             "num_total_blocks": 2,
             "num_shared_blocks": 2,
-            "entmax_mode": "constant",
         },
         TRAINER: {"epochs": 2},
     }

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -23,7 +23,7 @@ import pytest
 import torch
 
 from ludwig.api import LudwigModel
-from ludwig.constants import LOGITS, NAME, PREDICTIONS, PROBABILITIES, TRAINER
+from ludwig.constants import COMBINER, LOGITS, NAME, PREDICTIONS, PROBABILITIES, TRAINER
 from ludwig.data.preprocessing import preprocess_for_prediction
 from ludwig.features.number_feature import numeric_transformation_registry
 from ludwig.globals import TRAIN_SET_METADATA_FILE_NAME
@@ -244,6 +244,39 @@ def test_torchscript_e2e_tabular(csv_filename, tmpdir):
     validate_torchscript_outputs(tmpdir, config, backend, training_data_csv_path)
 
 
+def test_torchscript_e2e_tabnet_combiner(csv_filename, tmpdir):
+    data_csv_path = os.path.join(tmpdir, csv_filename)
+    # Configure features to be tested:
+    input_features = [
+        binary_feature(),
+        number_feature(),
+        category_feature(vocab_size=3),
+        bag_feature(vocab_size=3),
+        set_feature(vocab_size=3),
+    ]
+    output_features = [
+        binary_feature(),
+        number_feature(),
+        category_feature(vocab_size=3),
+    ]
+    backend = LocalTestBackend()
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        COMBINER: {
+            "type": "tabnet",
+            "num_total_blocks": 2,
+            "num_shared_blocks": 2,
+        },
+        TRAINER: {"epochs": 2},
+    }
+
+    # Generate training data
+    training_data_csv_path = generate_data(input_features, output_features, data_csv_path)
+
+    validate_torchscript_outputs(tmpdir, config, backend, training_data_csv_path)
+
+
 def test_torchscript_e2e_audio(csv_filename, tmpdir):
     data_csv_path = os.path.join(tmpdir, csv_filename)
     audio_dest_folder = os.path.join(tmpdir, "generated_audio")
@@ -341,6 +374,8 @@ def validate_torchscript_outputs(tmpdir, config, backend, training_data_csv_path
 
     # Obtain predictions from Python model
     preds_dict, _ = ludwig_model.predict(dataset=training_data_csv_path, return_type=dict)
+
+    print("======================CONVERTING TO TORCHSCRIPT======================")
 
     # Create graph inference model (Torchscript) from trained Ludwig model.
     script_module = ludwig_model.to_torchscript()

--- a/tests/ludwig/utils/entmax/test_root_finding.py
+++ b/tests/ludwig/utils/entmax/test_root_finding.py
@@ -15,17 +15,19 @@ from ludwig.utils.entmax.root_finding import entmax_bisect, sparsemax_bisect
 # # gradcheck(f, (x,))
 
 
-def test_sparsemax():
+@pytest.mark.parametrize("training", [True, False])
+def test_sparsemax(training):
     x = 0.5 * torch.randn(4, 6, dtype=torch.float32)
-    p1 = sparsemax(x, 1)
-    p2 = sparsemax_bisect(x)
+    p1 = sparsemax(x, 1, training=training)
+    p2 = sparsemax_bisect(x, training=training)
     assert torch.sum((p1 - p2) ** 2) < 1e-7
 
 
-def test_entmax15():
+@pytest.mark.parametrize("training", [True, False])
+def test_entmax15(training):
     x = 0.5 * torch.randn(4, 6, dtype=torch.float32)
-    p1 = entmax15(x, 1)
-    p2 = entmax_bisect(x, alpha=1.5)
+    p1 = entmax15(x, 1, training=training)
+    p2 = entmax_bisect(x, alpha=1.5, training=training)
     assert torch.sum((p1 - p2) ** 2) < 1e-7
 
 

--- a/tests/ludwig/utils/entmax/test_root_finding.py
+++ b/tests/ludwig/utils/entmax/test_root_finding.py
@@ -16,18 +16,20 @@ from ludwig.utils.entmax.root_finding import entmax_bisect, sparsemax_bisect
 
 
 @pytest.mark.parametrize("training", [True, False])
-def test_sparsemax(training):
+@pytest.mark.parametrize("bisect_training", [True, False])
+def test_sparsemax(training, bisect_training):
     x = 0.5 * torch.randn(4, 6, dtype=torch.float32)
     p1 = sparsemax(x, 1, training=training)
-    p2 = sparsemax_bisect(x, training=training)
+    p2 = sparsemax_bisect(x, training=bisect_training)
     assert torch.sum((p1 - p2) ** 2) < 1e-7
 
 
 @pytest.mark.parametrize("training", [True, False])
-def test_entmax15(training):
+@pytest.mark.parametrize("bisect_training", [True, False])
+def test_entmax15(training, bisect_training):
     x = 0.5 * torch.randn(4, 6, dtype=torch.float32)
     p1 = entmax15(x, 1, training=training)
-    p2 = entmax_bisect(x, alpha=1.5, training=training)
+    p2 = entmax_bisect(x, alpha=1.5, training=bisect_training)
     assert torch.sum((p1 - p2) ** 2) < 1e-7
 
 


### PR DESCRIPTION
This PR implements a Torchscript-compatible TabNet (addressing #2124). The issues in the original implementation were twofold:

1. Some weirdness in the interaction between the Torchscript compiler and the weights shared between `torch.nn.Module` objects. This is a somewhat known issue (HuggingFace explicitly accounts for it through a `torchscript` flag: [link](https://huggingface.co/transformers/v1.0.0/torchscript.html#torchscript-flag-and-tied-weights)). This PR works around it by first registering a module with the exact same properties as the shared module, then doing an overwriting assignment to the shared module immediately following.
2. Inability to script custom `autograd.Function` subclasses. This is also a known issue (https://github.com/pytorch/pytorch/issues/22329). This PR works around it by decomposing the `forward` functions of the custom classes into standalone functions, which are scriptable.

The following validation was run in order to test the new changes: 
1. A new test was added in `tests/integration_tests/test_torchscript.py` which tests that a trained LudwigModel (with a TabNet combiner) has the same outputs as its torchscript equivalent.
2. Existing tests were modified in order to ensure that the custom autograd classes remained unchanged.
3. Two Ludwig models were trained on the Titanic dataset with a TabNet combiner. One was on the master branch (commit: `dd026ca2fb9e7e9dc0ef7fb9bcc73ccaae01b8a7`) and one was on this branch (commit: `34fe6da455d44edb8b6cb4947f4595303cf3511d`). The models were more or less the same: 
![tabnet-performance-comparison](https://user-images.githubusercontent.com/29719151/172950989-6e4e3933-44e8-42cf-9939-d15c1754b3da.png) 
Full config here: 
```
input_features:
  - name: Pclass
    type: category
  - name: Sex
    type: category
  - name: Age
    type: number
    preprocessing:
      missing_value_strategy: fill_with_mean
  - name: SibSp
    type: number
  - name: Parch
    type: number
  - name: Fare
    type: number
    preprocessing:
      missing_value_strategy: fill_with_mean
  - name: Embarked
    type: category

output_features:
  - name: Survived
    type: binary

combiner:
  type: tabnet
```