### PR TITLE
Set saved_weights_in_checkpoint immediately after creating model. Also adds test.

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1362,6 +1362,7 @@ class LudwigModel:
         )
 
         # generate model from config
+        set_saved_weights_in_checkpoint_flag(config)
         ludwig_model.model = LudwigModel.create_model(config)
 
         # load model weights

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -86,7 +86,7 @@ from ludwig.utils.data_utils import (
 )
 from ludwig.utils.defaults import default_random_seed, merge_with_defaults
 from ludwig.utils.fs_utils import makedirs, open_file, path_exists, upload_output_directory
-from ludwig.utils.misc_utils import get_file_names, get_output_directory
+from ludwig.utils.misc_utils import get_file_names, get_output_directory, set_saved_weights_in_checkpoint_flag
 from ludwig.utils.print_utils import print_boxed
 from ludwig.utils.torch_utils import get_torch_device
 
@@ -492,6 +492,7 @@ class LudwigModel:
                 update_config_with_metadata(self.config, training_set_metadata)
                 logger.info("Warnings and other logs:")
                 self.model = LudwigModel.create_model(self.config, random_seed=random_seed)
+                set_saved_weights_in_checkpoint_flag(self.config)
 
             # Convert config dictionary into an instance of TrainerConfig.
             trainer_config, _ = load_config_with_kwargs(Trainer.get_schema_cls(), self.config[TRAINER])
@@ -617,10 +618,6 @@ class LudwigModel:
                     if not path_exists(weights_save_path):
                         with open_file(weights_save_path, "wb") as f:
                             torch.save(self.model.state_dict(), f)
-                    # Adds a flag to all input features indicating that the weights are saved in the checkpoint.
-                    for input_feature in self.config["input_features"]:
-                        input_feature["saved_weights_in_checkpoint"] = True
-                    self.save_config(model_dir)
 
                 # Synchronize model weights between workers
                 self.backend.sync_model(self.model)
@@ -683,6 +680,7 @@ class LudwigModel:
         if not self.model:
             update_config_with_metadata(self.config, training_set_metadata)
             self.model = LudwigModel.create_model(self.config, random_seed=random_seed)
+            set_saved_weights_in_checkpoint_flag(self.config)
 
         if not self._online_trainer:
             config, _ = load_config_with_kwargs(Trainer.get_schema_cls(), self.config[TRAINER])

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -130,3 +130,13 @@ def get_proc_features(config):
 
 def get_proc_features_from_lists(*args):
     return {feature[PROC_COLUMN]: feature for features in args for feature in features}
+
+
+def set_saved_weights_in_checkpoint_flag(config):
+    """Adds a flag to all input features indicating that the weights are saved in the checkpoint.
+
+    Next time the model is loaded we will restore pre-trained encoder weights from ludwig model (and not load from cache
+    or model hub).
+    """
+    for input_feature in config.get("input_features", []):
+        input_feature["saved_weights_in_checkpoint"] = True

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -650,7 +650,8 @@ def test_api_save_torchscript(tmpdir):
 
 
 def test_saved_weights_in_checkpoint(tmpdir):
-    input_features = [text_feature(), image_feature()]
+    image_dest_folder = os.path.join(tmpdir, "generated_images")
+    input_features = [text_feature(), image_feature(image_dest_folder)]
     output_features = [category_feature(name="class")]
 
     data_csv = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"))

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import json
 import os
 import shutil
 import tempfile
@@ -24,6 +25,7 @@ import torch
 from ludwig.api import LudwigModel
 from ludwig.callbacks import Callback
 from ludwig.constants import TRAINER
+from ludwig.globals import MODEL_HYPERPARAMETERS_FILE_NAME
 from ludwig.models.inference import InferenceLudwigModel
 from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import (
@@ -31,8 +33,10 @@ from tests.integration_tests.utils import (
     ENCODERS,
     generate_data,
     get_weights,
+    image_feature,
     run_api_experiment,
     sequence_feature,
+    text_feature,
 )
 
 
@@ -643,3 +647,29 @@ def test_api_save_torchscript(tmpdir):
 
     for col in output_df.columns:
         assert output_df[col].equals(output_df_expected[col])
+
+
+def test_saved_weights_in_checkpoint(tmpdir):
+    input_features = [text_feature(), image_feature()]
+    output_features = [category_feature(name="class")]
+
+    data_csv = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"))
+    val_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "validation.csv"))
+    test_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "test.csv"))
+
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+    }
+    model = LudwigModel(config)
+    _, _, output_dir = model.train(
+        training_set=data_csv, validation_set=val_csv, test_set=test_csv, output_directory=tmpdir
+    )
+
+    config_save_path = os.path.join(output_dir, "model", MODEL_HYPERPARAMETERS_FILE_NAME)
+    with open(config_save_path) as f:
+        saved_config = json.load(f)
+    saved_input_features = saved_config["input_features"]
+    for saved_input_feature in saved_input_features:
+        assert "saved_weights_in_checkpoint" in saved_input_feature
+        assert saved_input_feature["saved_weights_in_checkpoint"]


### PR DESCRIPTION
This is a follow-up to "[Prevent loading pre-trained encoder weights when loading a trained Ludwig model](https://github.com/ludwig-ai/ludwig/pull/1877)".

The original issue is that ludwig was loading pre-trained models from huggingface hub at inference time when running in a container.

This also ensures that models saved by versions of Ludwig prior to #1877, or models which encountered an error during training will be restored without fetching a pretrained model from model hub.