### PR TITLE
Select number of Ray training workers based on dataset size

### DIFF
--- a/ludwig/utils/automl/data_source.py
+++ b/ludwig/utils/automl/data_source.py
@@ -34,6 +34,10 @@ class DataSource(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def size_bytes(self) -> int:
+        raise NotImplementedError()
+
+    @abstractmethod
     def __len__(self) -> int:
         raise NotImplementedError()
 
@@ -74,6 +78,9 @@ class DataframeSourceMixin:
 
     def is_string_type(self, dtype: str) -> bool:
         return dtype in ["str", "string", "object"]
+
+    def size_bytes(self) -> int:
+        return sum(self.df.memory_usage(deep=True))
 
     def __len__(self) -> int:
         return len(self.df)


### PR DESCRIPTION
When using a Ray backend for training, the number of workers is now by determined by the size (in bytes) of the dataset (after preprocessing), doubling the number of GPUs at each order of magnitude (<1GB, 1GB, 10GB, and so on). This enables us to take advantage of autoscaling Ray clusters instead of pinning to whatever number of GPUs happens to be visible at the start.


