### PR TITLE
Fixes dtype of SPLIT column if already provided in CSV

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1420,7 +1420,7 @@ def get_split(
     random_seed=default_random_seed,
 ):
     if SPLIT in dataset_df and not force_split:
-        split = dataset_df[SPLIT]
+        split = dataset_df[SPLIT].astype(np.int8)
     else:
         set_random_seed(random_seed)
         if stratify is None or stratify not in dataset_df:

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -85,3 +85,38 @@ def test_strip_whitespace_category(csv_filename, tmpdir):
 
     # expect values containing whitespaces to be properly mapped to vocab_size unique values
     assert len(np.unique(train_ds.dataset[cat_feat[PROC_COLUMN]])) == cat_feat["vocab_size"]
+
+
+@pytest.mark.parametrize("backend", ["local", "ray"])
+@pytest.mark.distributed
+def test_with_split(backend, csv_filename, tmpdir):
+    num_examples = 10
+    train_set_size = int(num_examples * 0.8)
+    val_set_size = int(num_examples * 0.1)
+    test_set_size = int(num_examples * 0.1)
+
+    input_features = [sequence_feature(reduce_output="sum")]
+    output_features = [category_feature(vocab_size=5, reduce_input="sum")]
+    data_csv = generate_data(
+        input_features, output_features, os.path.join(tmpdir, csv_filename), num_examples=num_examples
+    )
+    data_df = pd.read_csv(data_csv)
+    data_df["split"] = [0] * train_set_size + [1] * val_set_size + [2] * test_set_size
+    data_df.to_csv(data_csv, index=False)
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        "trainer": {
+            "epochs": 2,
+        },
+    }
+
+    with init_backend(backend):
+        model = LudwigModel(config, backend=backend)
+        train_set, val_set, test_set, _ = model.preprocess(
+            data_csv,
+            skip_save_processed_input=False,
+        )
+        assert len(train_set) == train_set_size
+        assert len(val_set) == val_set_size
+        assert len(test_set) == test_set_size


### PR DESCRIPTION
This PR is a follow-up to #2058, which removed the assumption that CSV columns would be read with correct dtypes. All columns are initially read in with dtype `object`. The SPLIT column is therefore not read in with dtype `int`. This leads to the following error when saving out the SPLIT column: 

```
ludwig/api.py:1276: in preprocess
    preprocessed_data = preprocess_for_training(
ludwig/data/preprocessing.py:1577: in preprocess_for_training
    processed = data_format_processor.preprocess_for_training(
ludwig/data/preprocessing.py:275: in preprocess_for_training
    return _preprocess_file_for_training(
ludwig/data/preprocessing.py:1674: in _preprocess_file_for_training
    save_array(split_fp, data[SPLIT])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
data_fp = '/var/folders/23/8ddc07cj3knbkldhnfv2cmbr0000gn/T/tmpdjpna6ui/23500A2F7A.split.csv'
array = Dask Series Structure:
npartitions=1
    object
       ...
Name: split, dtype: object
Dask Name: getitem, 21 tasks

    def save_array(data_fp, array):
        with open_file(data_fp, "w") as output_file:
>           for x in np.nditer(array):
E           TypeError: Iterator operand or requested dtype holds references, but the REFS_OK flag was not enabled

ludwig/utils/data_utils.py:411: TypeError
```

This PR ensures that the SPLIT column provided is given the same dtype as it would be if the split was randomly generated. This PR also includes a regression test.