### PR TITLE
Fixes FILL_WITH_MEAN missing value strategy with appropriate cast

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1350,6 +1350,7 @@ def precompute_fill_value(dataset_cols, feature, preprocessing_parameters, backe
     """Precomputes the fill value for a feature.
 
     NOTE: this is called before NaNs are removed from the dataset. Modifications here must handle NaNs gracefully.
+    NOTE: this is called before columns are cast. Modifications here must handle dtype conversion gracefully.
     """
     missing_value_strategy = preprocessing_parameters["missing_value_strategy"]
     if missing_value_strategy == FILL_WITH_CONST:
@@ -1362,7 +1363,7 @@ def precompute_fill_value(dataset_cols, feature, preprocessing_parameters, backe
                 f"Filling missing values with mean is supported "
                 f"only for number types, not for type {feature[TYPE]}.",
             )
-        return backend.df_engine.compute(dataset_cols[feature[COLUMN]].mean())
+        return backend.df_engine.compute(dataset_cols[feature[COLUMN]].astype(float).mean())
     elif missing_value_strategy == FILL_WITH_FALSE:
         distinct_values = backend.df_engine.compute(
             dataset_cols[feature[COLUMN]].drop_duplicates().dropna()

--- a/tests/integration_tests/test_missing_value_strategy.py
+++ b/tests/integration_tests/test_missing_value_strategy.py
@@ -18,9 +18,10 @@ import tempfile
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from ludwig.api import LudwigModel
-from ludwig.constants import DROP_ROW, PREPROCESSING, TRAINER
+from ludwig.constants import DROP_ROW, FILL_WITH_MEAN, PREPROCESSING, TRAINER
 from tests.integration_tests.utils import (
     binary_feature,
     category_feature,
@@ -32,6 +33,7 @@ from tests.integration_tests.utils import (
     set_feature,
     text_feature,
     vector_feature,
+    init_backend,
 )
 
 
@@ -63,6 +65,27 @@ def test_missing_value_prediction(csv_filename):
 
         model = LudwigModel.load(os.path.join(output_dir, "model"))
         model.predict(dataset=dataset)
+
+
+@pytest.mark.parametrize("backend", ["local", "ray"])
+@pytest.mark.distributed
+def test_missing_values_fill_with_mean(backend, csv_filename, tmpdir):
+    data_csv_path = os.path.join(tmpdir, csv_filename)
+
+    kwargs = {PREPROCESSING: {"missing_value_strategy": FILL_WITH_MEAN}}
+    input_features = [
+        number_feature(**kwargs),
+        binary_feature(),
+        category_feature(vocab_size=3),
+    ]
+    output_features = [binary_feature()]
+    training_data_csv_path = generate_data(input_features, output_features, data_csv_path)
+
+    config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 2}}
+    with init_backend(backend):
+        # run preprocessing
+        ludwig_model = LudwigModel(config, backend=backend)
+        ludwig_model.preprocess(dataset=training_data_csv_path)
 
 
 def test_missing_values_drop_rows(csv_filename, tmpdir):

--- a/tests/integration_tests/test_missing_value_strategy.py
+++ b/tests/integration_tests/test_missing_value_strategy.py
@@ -26,6 +26,7 @@ from tests.integration_tests.utils import (
     binary_feature,
     category_feature,
     generate_data,
+    init_backend,
     LocalTestBackend,
     number_feature,
     read_csv_with_nan,
@@ -33,7 +34,6 @@ from tests.integration_tests.utils import (
     set_feature,
     text_feature,
     vector_feature,
-    init_backend,
 )
 
 

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 
 import numpy as np
@@ -12,24 +11,9 @@ from tests.integration_tests.utils import (
     category_feature,
     generate_data,
     LocalTestBackend,
-    ray_cluster,
     sequence_feature,
+    init_backend,
 )
-
-
-@contextlib.contextmanager
-def init_backend(backend: str):
-    if backend == "local":
-        with contextlib.nullcontext():
-            yield
-            return
-
-    if backend == "ray":
-        with ray_cluster():
-            yield
-            return
-
-    raise ValueError(f"Unrecognized backend: {backend}")
 
 
 @pytest.mark.parametrize("backend", ["local", "ray"])

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -10,9 +10,9 @@ from tests.integration_tests.utils import (
     binary_feature,
     category_feature,
     generate_data,
+    init_backend,
     LocalTestBackend,
     sequence_feature,
-    init_backend,
 )
 
 

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -88,6 +88,21 @@ def ray_cluster():
         ray.shutdown()
 
 
+@contextlib.contextmanager
+def init_backend(backend: str):
+    if backend == "local":
+        with contextlib.nullcontext():
+            yield
+            return
+
+    if backend == "ray":
+        with ray_cluster():
+            yield
+            return
+
+    raise ValueError(f"Unrecognized backend: {backend}")
+
+
 class LocalTestBackend(LocalBackend):
     @property
     def supports_multiprocessing(self):


### PR DESCRIPTION
This PR is a follow-up to https://github.com/ludwig-ai/ludwig/pull/2058, which removed the assumption that CSV columns would be loaded with dtypes inferred by Dask/Pandas. Instead, all columns are now initially loaded with dtype `object`, with the expectation that these are casted to their appropriate dtype downstream. Number features column is therefore not read in with dtype `float`. This leads to the following error when attempting to apply the missing value strategy FILL_WITH_MEAN:

```
ludwig/api.py:1276: in preprocess
    preprocessed_data = preprocess_for_training(
ludwig/data/preprocessing.py:1580: in preprocess_for_training
    processed = data_format_processor.preprocess_for_training(
ludwig/data/preprocessing.py:275: in preprocess_for_training
    return _preprocess_file_for_training(
ludwig/data/preprocessing.py:1661: in _preprocess_file_for_training
    data, training_set_metadata = build_dataset(
ludwig/data/preprocessing.py:1099: in build_dataset
    feature_name_to_preprocessing_parameters = build_preprocessing_parameters(
ludwig/data/preprocessing.py:1232: in build_preprocessing_parameters
    fill_value = precompute_fill_value(dataset_cols, feature_config, preprocessing_parameters, backend)
ludwig/data/preprocessing.py:1368: in precompute_fill_value
    return backend.df_engine.compute(dataset_cols[feature[COLUMN]].mean())
venv38/lib/python3.8/site-packages/dask/dataframe/core.py:94: in wrapper
    return func(self, *args, **kwargs)
venv38/lib/python3.8/site-packages/dask/dataframe/core.py:1986: in mean
    _raise_if_object_series(self, "mean")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

x = Dask Series Structure:
npartitions=1
    object
       ...
Name: num_E23AE, dtype: object
Dask Name: getitem, 2 tasks, funcname = 'mean'

    def _raise_if_object_series(x, funcname):
        """
        Utility function to raise an error if an object column does not support
        a certain operation like `mean`.
        """
        if isinstance(x, Series) and hasattr(x, "dtype") and x.dtype == object:
>           raise ValueError("`%s` not supported with object series" % funcname)
E           ValueError: `mean` not supported with object series

venv38/lib/python3.8/site-packages/dask/dataframe/core.py:3161: ValueError
```
This PR fixes this with appropriate dtype casting right before calling `mean()`. This PR also adds a regression test.