### PR TITLE
Remove `tune_batch_size` from tabnet config

### DIFF
--- a/ludwig/automl/defaults/combiner/tabnet_config.yaml
+++ b/ludwig/automl/defaults/combiner/tabnet_config.yaml
@@ -12,9 +12,6 @@ trainer:
   # early_stop: 300
   optimizer:
     type: adam
-  tune_batch_size:
-    type: bin_search
-    substitute_with_max: True
 
 hyperopt:
   # goal: maximize


### PR DESCRIPTION
Not supported in `TrainerConfig` or used elsewhere, so OK to remove?