### PR TITLE
Accept kwargs in read_xsv

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -139,7 +139,7 @@ def spread(fn):
 
 
 @spread
-def read_xsv(data_fp, df_lib=PANDAS_DF, separator=",", header=0, nrows=None, skiprows=None):
+def read_xsv(data_fp, df_lib=PANDAS_DF, separator=",", header=0, nrows=None, skiprows=None, **kwargs):
     """Helper method to read a csv file. Wraps around pd.read_csv to handle some exceptions. Can extend to cover
     cases as necessary.
 
@@ -161,7 +161,7 @@ def read_xsv(data_fp, df_lib=PANDAS_DF, separator=",", header=0, nrows=None, ski
 
     # NOTE: we read all XSV columns in as dtype=object, bypassing all type inference. This is to avoid silent issues
     # related to incorrect type inference (e.g. NaNs in bool columns). Convert data to correct types after reading in.
-    kwargs = dict(sep=separator, header=header, skiprows=skiprows, dtype=object)
+    kwargs = dict(sep=separator, header=header, skiprows=skiprows, dtype=object, **kwargs)
 
     if nrows is not None:
         kwargs["nrows"] = nrows


### PR DESCRIPTION
Since `df_lib` can vary, adding support for kwargs allows passing non-universal params to the underlying library.