### PR TITLE
Create dataset util to form repeatable train/vali/test split

### DIFF
--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -114,6 +114,9 @@ VALIDATION = "validation"
 TEST = "test"
 SPLIT = "split"
 FULL = "full"
+TRAIN_SPLIT = 0
+VALIDATION_SPLIT = 1
+TEST_SPLIT = 2
 
 META = "meta"
 

--- a/ludwig/utils/dataset_utils.py
+++ b/ludwig/utils/dataset_utils.py
@@ -1,0 +1,88 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split
+
+from ludwig.constants import TEST_SPLIT, TRAIN_SPLIT, VALIDATION_SPLIT
+
+
+def get_repeatable_train_val_test_split(
+    df_input,
+    stratify_colname,
+    random_seed,
+    frac_train=0.7, frac_val=0.1, frac_test=0.2):
+    """
+    Return df_input with split column containing (if possible) non-zero rows
+    in the train split, validation split, and test split categories.
+
+    If the input dataframe does not contain an existing split column or if the
+    number of rows in both the validation and test split is 0, return df_input
+    with split column set according to frac_<type> and stratify_colname.
+
+    Else stratify_colname is ignored, and:
+     If the input dataframe contains an existing split column and non-zero row
+      counts for all three split types, return df_input.
+     If the input dataframe contains an existing split column but only one of
+      validation and test split has non-zero row counts, return df_input with
+      missing split getting rows from train split as per frac_<type>.
+
+    Parameters
+    ----------
+    df_input : Pandas dataframe
+        Input dataframe to be split.
+    stratify_colname : str
+        The column used for stratification; usually the label column.
+    random_seed : int
+        Seed used to get repeatable split.
+    frac_train : float
+    frac_val   : float
+    frac_test  : float
+        The ratios with which to split the dataframe into train, val, and test data;
+        should sum to 1.0.
+
+    Returns
+    -------
+    df_split :
+        Dataframe containing the three splits.
+    """
+
+    if frac_train + frac_val + frac_test != 1.0:
+        raise ValueError('fractions %f, %f, %f do not add up to 1.0' % \
+                         (frac_train, frac_val, frac_test))
+    if stratify_colname not in df_input.columns:
+        raise ValueError('%s is not a column in the dataframe' % (stratify_colname))
+
+    do_stratify_split = True
+    if "split" in df_input.columns:
+        df_train = df_input[df_input["split"] == TRAIN_SPLIT]
+        df_val = df_input[df_input["split"] == VALIDATION_SPLIT]
+        df_test = df_input[df_input["split"] == TEST_SPLIT]
+        if len(df_val) != 0 or len(df_test) != 0:
+            if len(df_val) == 0:
+                df_val = df_train.sample(frac=frac_val, replace=False, random_state=random_seed)
+                df_train = df_train.drop(df_val.index)
+            if len(df_test) == 0:
+                df_test = df_train.sample(frac=frac_test, replace=False, random_state=random_seed)
+                df_train = df_train.drop(df_test.index)
+            do_stratify_split = False
+
+    if do_stratify_split:
+        # Split original dataframe into train and temp dataframes.
+        y = df_input[[stratify_colname]] # Dataframe of just the column on which to stratify.
+        df_train, df_temp, y_train, y_temp = train_test_split(df_input,
+                                                              y,
+                                                              stratify=y,
+                                                              test_size=(1.0 - frac_train),
+                                                              random_state=random_seed)
+        # Split the temp dataframe into val and test dataframes.
+        relative_frac_test = frac_test / (frac_val + frac_test)
+        df_val, df_test, y_val, y_test = train_test_split(df_temp,
+                                                          y_temp,
+                                                          stratify=y_temp,
+                                                          test_size=relative_frac_test,
+                                                          random_state=random_seed)
+
+    assert len(df_input) == len(df_train) + len(df_val) + len(df_test)
+    df_train['split'] = TRAIN_SPLIT
+    df_val['split'] = VALIDATION_SPLIT
+    df_test['split'] = TEST_SPLIT
+    df_split = pd.concat([df_train, df_val, df_test], ignore_index=True)
+    return df_split

--- a/tests/ludwig/utils/test_dataset_utils.py
+++ b/tests/ludwig/utils/test_dataset_utils.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2019 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import numpy as np
+import pandas as pd
+import pytest
+from fsspec.config import conf
+
+from ludwig.utils.dataset_utils import get_repeatable_train_val_test_split
+
+
+def test_get_repeatable_train_val_test_split():
+
+    # Test adding split with stratify
+    df = pd.DataFrame(
+        [
+            [0, 0],
+            [1, 0],
+            [2, 0],
+            [3, 0],
+            [4, 0],
+            [5, 1],
+            [6, 1],
+            [7, 1],
+            [8, 1],
+            [9, 1],
+            [10, 0],
+            [11, 0],
+            [12, 0],
+            [13, 0],
+            [14, 0],
+            [15, 1],
+            [16, 1],
+            [17, 1],
+            [18, 1],
+            [19, 1],
+        ],
+        columns=["input", "target"],
+    )
+    split_df = get_repeatable_train_val_test_split(df, 'target', random_seed=42)
+    assert split_df.equals(
+        pd.DataFrame(
+            [
+                [7, 1, 0],
+                [16, 1, 0],
+                [5, 1, 0],
+                [14, 0, 0],
+                [19, 1, 0],
+                [6, 1, 0],
+                [11, 0, 0],
+                [18, 1, 0],
+                [1, 0, 0],
+                [10, 0, 0],
+                [2, 0, 0],
+                [15, 1, 0],
+                [0, 0, 0],
+                [17, 1, 1],
+                [12, 0, 1],
+                [8, 1, 2],
+                [4, 0, 2],
+                [13, 0, 2],
+                [3, 0, 2],
+                [9, 1, 2],
+            ],
+            columns=["input", "target", "split"],
+        )
+    )
+
+    # Test needing no change
+    df = pd.DataFrame(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [2, 0, 0],
+            [5, 1, 0],
+            [6, 1, 0],
+            [7, 1, 0],
+            [10, 0, 0],
+            [11, 0, 0],
+            [14, 0, 0],
+            [15, 1, 0],
+            [16, 1, 0],
+            [18, 1, 0],
+            [19, 1, 0],
+            [12, 0, 1],
+            [17, 1, 1],
+            [3, 0, 2],
+            [4, 0, 2],
+            [8, 1, 2],
+            [9, 1, 2],
+            [13, 0, 2],
+        ],
+        columns=["input", "target", "split"],
+    )
+    split_df = get_repeatable_train_val_test_split(df, 'target', random_seed=42)
+    assert split_df.equals(
+        pd.DataFrame(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [2, 0, 0],
+                [5, 1, 0],
+                [6, 1, 0],
+                [7, 1, 0],
+                [10, 0, 0],
+                [11, 0, 0],
+                [14, 0, 0],
+                [15, 1, 0],
+                [16, 1, 0],
+                [18, 1, 0],
+                [19, 1, 0],
+                [12, 0, 1],
+                [17, 1, 1],
+                [3, 0, 2],
+                [4, 0, 2],
+                [8, 1, 2],
+                [9, 1, 2],
+                [13, 0, 2],
+            ],
+            columns=["input", "target", "split"],
+        )
+    )
+
+    # Test adding only validation split
+    df = pd.DataFrame(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [2, 0, 0],
+            [5, 1, 0],
+            [6, 1, 0],
+            [7, 1, 0],
+            [10, 0, 0],
+            [11, 0, 0],
+            [14, 0, 0],
+            [15, 1, 0],
+            [16, 1, 0],
+            [18, 1, 0],
+            [19, 1, 0],
+            [12, 0, 0],
+            [17, 1, 0],
+            [3, 0, 2],
+            [4, 0, 2],
+            [8, 1, 2],
+            [9, 1, 2],
+            [13, 0, 2],
+        ],
+        columns=["input", "target", "split"],
+    )
+    split_df = get_repeatable_train_val_test_split(df, 'target', random_seed=42)
+    assert split_df.equals(
+        pd.DataFrame(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [2, 0, 0],
+                [5, 1, 0],
+                [6, 1, 0],
+                [7, 1, 0],
+                [10, 0, 0],
+                [11, 0, 0],
+                [14, 0, 0],
+                [16, 1, 0],
+                [19, 1, 0],
+                [12, 0, 0],
+                [17, 1, 0],
+                [15, 1, 1],
+                [18, 1, 1],
+                [3, 0, 2],
+                [4, 0, 2],
+                [8, 1, 2],
+                [9, 1, 2],
+                [13, 0, 2],
+            ],
+            columns=["input", "target", "split"],
+        )
+    )
+


### PR DESCRIPTION
Forming a repeatable train/validation/test split for datasets that are not pre-split is
a common operation that is currently handled by custom code in the experiments repo.
Also, forming those splits w/ output feature stratification is desirable for imbalanced datasets.

This PR provides a utility method for handling this, as discussed in issue 2136.
The PR generalizes the custom methods for doing this that are currently in the experiments repo.

The PR was tested on the new unit tests and on selected experiment repo datasets.