### PR TITLE
Cleaning hyperopt logging

### DIFF
--- a/ludwig/backend/_ray112_compat.py
+++ b/ludwig/backend/_ray112_compat.py
@@ -41,7 +41,7 @@ class HorovodConfig(BackendConfig):
     """
 
     nics: Optional[Set[str]] = None
-    verbose: int = 1
+    verbose: int = 0  # Turn off verbosity by default
     key: Optional[str] = None
     ssh_port: Optional[int] = None
     ssh_identity_file: Optional[str] = None

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -971,11 +971,11 @@ class Trainer(BaseTrainer):
 
             # Move tensors to cuda here.
             inputs = {
-                i_feat.feature_name: torch.from_numpy(batch[i_feat.proc_column]).to(self.device)
+                i_feat.feature_name: torch.from_numpy(np.array(batch[i_feat.proc_column], copy=True)).to(self.device)
                 for i_feat in self.model.input_features.values()
             }
             targets = {
-                o_feat.feature_name: torch.from_numpy(batch[o_feat.proc_column]).to(self.device)
+                o_feat.feature_name: torch.from_numpy(np.array(batch[o_feat.proc_column], copy=True)).to(self.device)
                 for o_feat in self.model.output_features.values()
             }
 


### PR DESCRIPTION
This PR aims to resolve two different logging messages seen generally during training and also during hyperopt. (See issue [here](https://github.com/ludwig-ai/ludwig/issues/2156))

- The `scope global has keys` logging messages during hyperopt show up because the verbosity for logging is set to 1 by default for `HorovodConfig` when using Ray 11.2. The easiest fix is to disable verbosity for the HorovodConfig in our 11.2 compatibility module.
- Instead of creating a Tensor from the input/target feature `ndarrays` directly, pytorch wants us to create Tensors from a copy of the numpy array during training.