### PR TITLE
Fix creating tensor from copy of numpy array warning messages

### DIFF
--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -135,7 +135,7 @@ class Predictor(BasePredictor):
             predictions: dictionary of predictions
         """
         inputs = {
-            i_feat.feature_name: torch.from_numpy(batch[i_feat.proc_column]).to(self.device)
+            i_feat.feature_name: torch.from_numpy(np.array(batch[i_feat.proc_column]), copy=True).to(self.device)
             for i_feat in model.input_features.values()
         }
 
@@ -178,11 +178,15 @@ class Predictor(BasePredictor):
                         f"memory used: {psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB"
                     )
                     inputs = {
-                        i_feat.feature_name: torch.from_numpy(batch[i_feat.proc_column]).to(self.device)
+                        i_feat.feature_name: torch.from_numpy(np.array(batch[i_feat.proc_column]), copy=True).to(
+                            self.device
+                        )
                         for i_feat in self.model.input_features.values()
                     }
                     targets = {
-                        o_feat.feature_name: torch.from_numpy(batch[o_feat.proc_column]).to(self.device)
+                        o_feat.feature_name: torch.from_numpy(np.array(batch[o_feat.proc_column]), copy=True).to(
+                            self.device
+                        )
                         for o_feat in self.model.output_features.values()
                     }
 
@@ -239,7 +243,9 @@ class Predictor(BasePredictor):
                     batch = batcher.next_batch()
 
                     inputs = {
-                        i_feat.feature_name: torch.from_numpy(batch[i_feat.proc_column]).to(self.device)
+                        i_feat.feature_name: torch.from_numpy(np.array(batch[i_feat.proc_column]), copy=True).to(
+                            self.device
+                        )
                         for i_feat in self.model.input_features.values()
                     }
                     outputs = self.model(inputs)

--- a/ludwig/models/trainer.py
+++ b/ludwig/models/trainer.py
@@ -355,11 +355,15 @@ class Trainer(BaseTrainer):
             while not batcher.last_batch() and step_count < total_steps:
                 batch = batcher.next_batch()
                 inputs = {
-                    i_feat.feature_name: torch.from_numpy(batch[i_feat.proc_column]).to(self.device)
+                    i_feat.feature_name: torch.from_numpy(np.array(batch[i_feat.proc_column]), copy=True).to(
+                        self.device
+                    )
                     for i_feat in self.model.input_features.values()
                 }
                 targets = {
-                    o_feat.feature_name: torch.from_numpy(batch[o_feat.proc_column]).to(self.device)
+                    o_feat.feature_name: torch.from_numpy(np.array(batch[o_feat.proc_column]), copy=True).to(
+                        self.device
+                    )
                     for o_feat in self.model.output_features.values()
                 }
 
@@ -421,11 +425,15 @@ class Trainer(BaseTrainer):
                 while not batcher.last_batch() and step_count < total_training_steps:
                     batch = batcher.next_batch()
                     inputs = {
-                        i_feat.feature_name: torch.from_numpy(batch[i_feat.proc_column]).to(self.device)
+                        i_feat.feature_name: torch.from_numpy(np.array(batch[i_feat.proc_column]), copy=True).to(
+                            self.device
+                        )
                         for i_feat in self.model.input_features.values()
                     }
                     targets = {
-                        o_feat.feature_name: torch.from_numpy(batch[o_feat.proc_column]).to(self.device)
+                        o_feat.feature_name: torch.from_numpy(np.array(batch[o_feat.proc_column]), copy=True).to(
+                            self.device
+                        )
                         for o_feat in self.model.output_features.values()
                     }
 
@@ -1050,11 +1058,15 @@ class Trainer(BaseTrainer):
             while not batcher.last_batch():
                 batch = batcher.next_batch()
                 inputs = {
-                    i_feat.feature_name: torch.from_numpy(batch[i_feat.proc_column]).to(self.device)
+                    i_feat.feature_name: torch.from_numpy(np.array(batch[i_feat.proc_column]), copy=True).to(
+                        self.device
+                    )
                     for i_feat in self.model.input_features.values()
                 }
                 targets = {
-                    o_feat.feature_name: torch.from_numpy(batch[o_feat.proc_column]).to(self.device)
+                    o_feat.feature_name: torch.from_numpy(np.array(batch[o_feat.proc_column]), copy=True).to(
+                        self.device
+                    )
                     for o_feat in self.model.output_features.values()
                 }
 

--- a/tests/integration_tests/test_regularizers.py
+++ b/tests/integration_tests/test_regularizers.py
@@ -82,11 +82,11 @@ def test_regularizers(
         )
 
         inputs = {
-            i_feat.feature_name: torch.from_numpy(batch[i_feat.proc_column]).to(DEVICE)
+            i_feat.feature_name: torch.from_numpy(np.array(batch[i_feat.proc_column]), copy=True).to(DEVICE)
             for i_feat in model.model.input_features.values()
         }
         targets = {
-            o_feat.feature_name: torch.from_numpy(batch[o_feat.proc_column]).to(DEVICE)
+            o_feat.feature_name: torch.from_numpy(np.array(batch[o_feat.proc_column]), copy=True).to(DEVICE)
             for o_feat in model.model.output_features.values()
         }
         predictions = model.model((inputs, targets))


### PR DESCRIPTION
This PR is created for the following [issue](https://github.com/ludwig-ai/ludwig/issues/2169). 

PyTorch wants us to create a tensor for input and output features from a copy of the numpy array instead of directly using the numpy array. This typically results in the following error message:

```
UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /root/pytorch/torch/csrc/utils/tensor_numpy.cpp:172.)
```

This PR should fix this everywhere within Ludwig. 