### PR TITLE
Update to packing version instead of LooseVersion

### DIFF
--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -17,7 +17,6 @@
 import contextlib
 import copy
 import logging
-from distutils.version import LooseVersion
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -27,6 +26,7 @@ import pandas as pd
 import ray
 import torch
 import tqdm
+from packaging import version
 from ray import ObjectRef
 from ray.data.dataset_pipeline import DatasetPipeline
 from ray.data.extensions import TensorDtype
@@ -44,7 +44,8 @@ from ludwig.utils.horovod_utils import initialize_horovod
 from ludwig.utils.torch_utils import get_torch_device, initialize_pytorch
 from ludwig.utils.types import Series
 
-_ray112 = LooseVersion("1.12") <= LooseVersion(ray.__version__) < LooseVersion("1.13")
+_ray112 = version.parse("1.12") <= version.parse(ray.__version__) < version.parse("1.13")
+
 import ray.train as rt  # noqa: E402
 from ray.train.trainer import Trainer  # noqa: E402
 

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -2,8 +2,9 @@ import logging
 import os
 import queue
 import threading
-from distutils.version import LooseVersion
 from typing import Any, Dict
+
+from packaging import version
 
 from ludwig.callbacks import Callback
 from ludwig.constants import TRAINER
@@ -135,7 +136,7 @@ class MlflowCallback(Callback):
     def prepare_ray_tune(self, train_fn, tune_config, tune_callbacks):
         import ray
 
-        if LooseVersion(ray.__version__) >= LooseVersion("1.11"):
+        if version.parse(ray.__version__) >= version.parse("1.11"):
             from ludwig.contribs.mlflow._ray_111.mlflow import mlflow_mixin
         else:
             from ray.tune.integration.mlflow import mlflow_mixin

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -17,13 +17,13 @@ import contextlib
 import math
 import queue
 import threading
-from distutils.version import LooseVersion
 from functools import lru_cache
 from typing import Any, Dict, Iterator, Optional, Union
 
 import numpy as np
 import pandas as pd
 import ray
+from packaging import version
 from pyarrow.fs import FSSpecHandler, PyFileSystem
 from ray.data import read_parquet
 from ray.data.dataset_pipeline import DatasetPipeline
@@ -38,8 +38,7 @@ from ludwig.utils.fs_utils import get_fs_and_path
 from ludwig.utils.misc_utils import get_proc_features
 from ludwig.utils.types import DataFrame
 
-_ray113 = LooseVersion(ray.__version__) == LooseVersion("1.13.0")
-
+_ray113 = version.parse(ray.__version__) == version.parse("1.13.0")
 
 _SCALAR_TYPES = {BINARY, CATEGORY, NUMBER}
 

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -10,9 +10,10 @@ import time
 import traceback
 import uuid
 from abc import ABC, abstractmethod
-from distutils.version import LooseVersion
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
+
+from packaging import version
 
 from ludwig.api import LudwigModel
 from ludwig.backend import initialize_backend, RAY
@@ -38,7 +39,7 @@ try:
     from ray.tune.suggest import BasicVariantGenerator, ConcurrencyLimiter, SEARCH_ALG_IMPORT
     from ray.tune.sync_client import CommandBasedClient
 
-    _ray_114 = LooseVersion(ray.__version__) >= LooseVersion("1.14")
+    _ray_114 = version.parse(ray.__version__) >= version.parse("1.14")
     if _ray_114:
         from ray.tune.syncer import get_node_to_storage_syncer, SyncConfig
     else:

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -17,11 +17,11 @@ import copy
 import logging
 import sys
 from collections import Counter
-from distutils.version import LooseVersion
 from sys import platform
 
 import numpy as np
 import pandas as pd
+from packaging import version
 
 from ludwig.constants import SPACE, TRAINING, VALIDATION
 
@@ -56,7 +56,7 @@ RAY_TUNE_FLOAT_SPACES = {"uniform", "quniform", "loguniform", "qloguniform", "ra
 RAY_TUNE_INT_SPACES = {"randint", "qrandint", "lograndint", "qlograndint"}
 RAY_TUNE_CATEGORY_SPACES = {"choice", "grid_search"}
 
-_matplotlib_34 = LooseVersion(mpl.__version__) >= LooseVersion("3.4")
+_matplotlib_34 = version.parse(mpl.__version__) >= version.parse("3.4")
 
 
 # plt.rc('xtick', labelsize='x-large')

--- a/tests/integration_tests/test_hyperopt_ray_horovod.py
+++ b/tests/integration_tests/test_hyperopt_ray_horovod.py
@@ -17,10 +17,10 @@ import logging
 import os.path
 import shutil
 import uuid
-from distutils.version import LooseVersion
 from unittest.mock import patch
 
 import pytest
+from packaging import version
 
 from ludwig.api import LudwigModel
 from ludwig.callbacks import Callback
@@ -33,7 +33,7 @@ from tests.integration_tests.utils import binary_feature, create_data_set_to_use
 try:
     import ray
 
-    _ray_114 = LooseVersion(ray.__version__) >= LooseVersion("1.14")
+    _ray_114 = version.parse(ray.__version__) >= version.parse("1.14")
     if _ray_114:
         from ray.tune.syncer import get_node_to_storage_syncer, SyncConfig
     else:


### PR DESCRIPTION
Moving from `distutils` to `packaging` to remove some deprecation warnings, for example:

```
DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _ray113 = LooseVersion(ray.__version__) == LooseVersion("1.13.0")
```