### PR TITLE
[Torchscript] Add Date feature preprocessing

### DIFF
--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -24,11 +24,25 @@ from dateutil.parser import parse
 from ludwig.constants import COLUMN, DATE, FILL_WITH_CONST, MISSING_VALUE_STRATEGY_OPTIONS, PROC_COLUMN, TIED
 from ludwig.features.base_feature import BaseFeatureMixin, InputFeature
 from ludwig.utils.misc_utils import set_default_value
-from ludwig.utils.types import DataFrame
+from ludwig.utils.types import DataFrame, TorchscriptPreprocessingInput
 
 logger = logging.getLogger(__name__)
 
 DATE_VECTOR_LENGTH = 9
+
+
+class _DatePreprocessing(torch.nn.Module):
+    def __init__(self, metadata: Dict[str, Any]):
+        super().__init__()
+
+    def forward(self, v: TorchscriptPreprocessingInput) -> torch.Tensor:
+        if torch.jit.isinstance(v, List[torch.Tensor]):
+            v = torch.stack(v)
+
+        if torch.jit.isinstance(v, torch.Tensor):
+            return v.to(dtype=torch.int)
+        else:
+            raise ValueError(f"Unsupported input: {v}")
 
 
 class DateFeatureMixin(BaseFeatureMixin):
@@ -80,22 +94,7 @@ class DateFeatureMixin(BaseFeatureMixin):
             else:
                 datetime_obj = datetime.now()
 
-        yearday = datetime_obj.toordinal() - date(datetime_obj.year, 1, 1).toordinal() + 1
-
-        midnight = datetime_obj.replace(hour=0, minute=0, second=0, microsecond=0)
-        second_of_day = (datetime_obj - midnight).seconds
-
-        return [
-            datetime_obj.year,
-            datetime_obj.month,
-            datetime_obj.day,
-            datetime_obj.weekday(),
-            yearday,
-            datetime_obj.hour,
-            datetime_obj.minute,
-            datetime_obj.second,
-            second_of_day,
-        ]
+        return create_vector_from_datetime_obj(datetime_obj)
 
     def add_feature_data(
         feature_config: Dict[str, Any],
@@ -156,21 +155,25 @@ class DateInputFeature(DateFeatureMixin, InputFeature):
     def populate_defaults(input_feature):
         set_default_value(input_feature, TIED, None)
 
-
-import time
-
-
-def parse_date_from_string(s: str) -> List[int]:
-    d = time.strptime(s, "%a %b %d %Y")
-    return [d.year, d.month, d.day]
+    @staticmethod
+    def create_preproc_module(metadata: Dict[str, Any]) -> torch.nn.Module:
+        return _DatePreprocessing(metadata)
 
 
-def main():
-    import torch
+def create_vector_from_datetime_obj(datetime_obj):
+    yearday = datetime_obj.toordinal() - date(datetime_obj.year, 1, 1).toordinal() + 1
 
-    script_fn = torch.jit.trace(parse_date_from_string, "Mon Feb 15 2010")
-    print(script_fn)
+    midnight = datetime_obj.replace(hour=0, minute=0, second=0, microsecond=0)
+    second_of_day = (datetime_obj - midnight).seconds
 
-
-if __name__ == "__main__":
-    main()
+    return [
+        datetime_obj.year,
+        datetime_obj.month,
+        datetime_obj.day,
+        datetime_obj.weekday(),
+        yearday,
+        datetime_obj.hour,
+        datetime_obj.minute,
+        datetime_obj.second,
+        second_of_day,
+    ]

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -15,7 +15,7 @@
 # ==============================================================================
 import logging
 from datetime import date, datetime
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import numpy as np
 import torch
@@ -72,7 +72,7 @@ class DateFeatureMixin(BaseFeatureMixin):
                 "in the config. "
                 "The preprocessing fill in value will be used."
                 "For more details: "
-                "https://ludwig.ai/user_guide/#date-features-preprocessing"
+                "https://ludwig-ai.github.io/ludwig-docs/0.5/configuration/features/date_features/"
             )
             fill_value = preprocessing_parameters["fill_value"]
             if fill_value != "":
@@ -155,3 +155,22 @@ class DateInputFeature(DateFeatureMixin, InputFeature):
     @staticmethod
     def populate_defaults(input_feature):
         set_default_value(input_feature, TIED, None)
+
+
+import time
+
+
+def parse_date_from_string(s: str) -> List[int]:
+    d = time.strptime(s, "%a %b %d %Y")
+    return [d.year, d.month, d.day]
+
+
+def main():
+    import torch
+
+    script_fn = torch.jit.trace(parse_date_from_string, "Mon Feb 15 2010")
+    print(script_fn)
+
+
+if __name__ == "__main__":
+    main()

--- a/ludwig/models/inference.py
+++ b/ludwig/models/inference.py
@@ -122,7 +122,10 @@ def to_inference_module_input_from_dataframe(
     inputs = {}
     for if_config in config["input_features"]:
         inputs[if_config[NAME]] = _to_inference_model_input_from_series(
-            dataset[if_config[COLUMN]], if_config[TYPE], feature_config=if_config
+            dataset[if_config[COLUMN]],
+            if_config[TYPE],
+            load_paths=load_paths,
+            feature_config=if_config,
         )
     return inputs
 

--- a/ludwig/models/inference.py
+++ b/ludwig/models/inference.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Any, Dict, List, TYPE_CHECKING, Optional, Union
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
 import pandas as pd
 import torch

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -431,7 +431,7 @@ def validate_torchscript_outputs(tmpdir, config, backend, training_data_csv_path
     script_module = torch.jit.load(script_module_path)
 
     df = pd.read_csv(training_data_csv_path)
-    inputs = to_inference_module_input_from_dataframe(df, config)
+    inputs = to_inference_module_input_from_dataframe(df, config, load_paths=True)
     outputs = script_module(inputs)
 
     # TODO: these are the only outputs we provide from Torchscript for now

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -27,7 +27,7 @@ from ludwig.constants import COMBINER, LOGITS, NAME, PREDICTIONS, PROBABILITIES,
 from ludwig.data.preprocessing import preprocess_for_prediction
 from ludwig.features.number_feature import numeric_transformation_registry
 from ludwig.globals import TRAIN_SET_METADATA_FILE_NAME
-from ludwig.models.inference import to_inference_module_input
+from ludwig.models.inference import to_inference_module_input_from_dataframe
 from ludwig.utils import output_feature_utils
 from ludwig.utils.tokenizers import TORCHSCRIPT_COMPATIBLE_TOKENIZERS
 from tests.integration_tests import utils
@@ -376,6 +376,21 @@ def test_torchscript_e2e_timeseries(tmpdir, csv_filename):
     validate_torchscript_outputs(tmpdir, config, backend, training_data_csv_path)
 
 
+def test_torchscript_e2e_date(tmpdir, csv_filename):
+    data_csv_path = os.path.join(tmpdir, csv_filename)
+    input_features = [
+        date_feature(),
+    ]
+    output_features = [
+        binary_feature(),
+    ]
+    backend = LocalTestBackend()
+    config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 2}}
+    training_data_csv_path = generate_data(input_features, output_features, data_csv_path)
+
+    validate_torchscript_outputs(tmpdir, config, backend, training_data_csv_path)
+
+
 def validate_torchscript_outputs(tmpdir, config, backend, training_data_csv_path, tolerance=1e-8):
     # Train Ludwig (Pythonic) model:
     ludwig_model = LudwigModel(config, backend=backend)
@@ -401,10 +416,7 @@ def validate_torchscript_outputs(tmpdir, config, backend, training_data_csv_path
     script_module = torch.jit.load(script_module_path)
 
     df = pd.read_csv(training_data_csv_path)
-    inputs = {
-        name: to_inference_module_input(df[feature.column], feature.type(), load_paths=True)
-        for name, feature in ludwig_model.model.input_features.items()
-    }
+    inputs = to_inference_module_input_from_dataframe(df, config)
     outputs = script_module(inputs)
 
     # TODO: these are the only outputs we provide from Torchscript for now


### PR DESCRIPTION
This PR implements Date feature preprocessing in Torchscript.

Date feature preprocessing in Torchscript deviates from vanilla preprocessing in one key way: instead of being able to pass in the raw date-formatted string into the torchscript model, the user must first featurize it into a vector with the values found in `vector` (below).

```
yearday = datetime_obj.toordinal() - date(datetime_obj.year, 1, 1).toordinal() + 1

midnight = datetime_obj.replace(hour=0, minute=0, second=0, microsecond=0)
second_of_day = (datetime_obj - midnight).seconds

vector = [
    datetime_obj.year,
    datetime_obj.month,
    datetime_obj.day,
    datetime_obj.weekday(),
    yearday,
    datetime_obj.hour,
    datetime_obj.minute,
    datetime_obj.second,
    second_of_day,
]
```

A utility function for converting `datetime` objects into this exact type of vector can be found at `ludwig.features.date_feature.create_vector_from_datetime_obj`.

This deviation occurs because the `datetime` and `dateutil` libraries are not currently scriptable (https://pytorch.org/docs/stable/jit.html#python-functions-and-modules).

In general, if the user plans on deploying with Torchscript _with a Python backend_, they can use the utility  function `ludwig.models.inference.to_inference_module_input_from_dataframe` to ensure that their input features are being passed into the torchscript model correctly.
