### PR TITLE
Fix postprocessing on binary feature columns with number dtype

### DIFF
--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -177,7 +177,6 @@ class BinaryFeatureMixin(BaseFeatureMixin):
                 f"Binary feature column {column.name} expects 2 distinct values, "
                 f"found: {distinct_values.values.tolist()}"
             )
-
         if "fallback_true_label" in preprocessing_parameters:
             fallback_true_label = preprocessing_parameters["fallback_true_label"]
         else:

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -82,10 +82,6 @@ class _BinaryPostprocessing(torch.nn.Module):
     def __init__(self, metadata: Dict[str, Any]):
         super().__init__()
         bool2str = metadata.get("bool2str")
-        # If the values in column could have been inferred as boolean dtype, do not convert preds to strings.
-        # This preserves the behavior of this feature before #2058.
-        if strings_utils.values_are_pandas_bools(bool2str):
-            bool2str = None
         self.bool2str = {i: v for i, v in enumerate(bool2str)} if bool2str is not None else None
         self.predictions_key = PREDICTIONS
         self.probabilities_key = PROBABILITIES

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -153,15 +153,23 @@ class BinaryFeatureMixin(BaseFeatureMixin):
 
     @staticmethod
     def cast_column(column, backend):
-        # Binary features are always read as strings. column.astype(bool) for all non-empty cells returns True.
-        return column.astype(str)
+        values = backend.df_engine.compute(column.drop_duplicates())
+        # If values are strings, converting to bools directly will make them all True.
+        if strings_utils.values_are_pandas_objects(values):
+            return column.astype(object)
+        else:
+            return column.astype(bool)
 
     @staticmethod
     def get_feature_meta(column: DataFrame, preprocessing_parameters: Dict[str, Any], backend) -> Dict[str, Any]:
-        distinct_values = backend.df_engine.compute(column.drop_duplicates()).tolist()
+        if column.dtype != object:
+            return {}
+
+        distinct_values = backend.df_engine.compute(column.drop_duplicates())
         if len(distinct_values) > 2:
             raise ValueError(
-                f"Binary feature column {column.name} expects 2 distinct values, " f"found: {distinct_values}"
+                f"Binary feature column {column.name} expects 2 distinct values, "
+                f"found: {distinct_values.values.tolist()}"
             )
 
         if "fallback_true_label" in preprocessing_parameters:
@@ -195,9 +203,7 @@ class BinaryFeatureMixin(BaseFeatureMixin):
     ) -> None:
         column = input_df[feature_config[COLUMN]]
 
-        column_np_dtype = np.dtype(column.dtype)
-        # np.str_ is dtype of modin cols
-        if any(column_np_dtype == np_dtype for np_dtype in {np.object_, np.str_}):
+        if column.dtype == object:
             metadata = metadata[feature_config[NAME]]
             if "str2bool" in metadata:
                 column = backend.df_engine.map_objects(column, lambda x: metadata["str2bool"][str(x)])
@@ -356,13 +362,10 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
         predictions_col = f"{self.feature_name}_{PREDICTIONS}"
         if predictions_col in result:
             if "bool2str" in metadata:
-                # If the values in column could have been inferred as boolean dtype, do not convert preds to strings.
-                # This preserves the behavior of this feature before #2058.
-                if not strings_utils.values_are_pandas_bools(class_names):
-                    result[predictions_col] = backend.df_engine.map_objects(
-                        result[predictions_col],
-                        lambda pred: metadata["bool2str"][pred],
-                    )
+                result[predictions_col] = backend.df_engine.map_objects(
+                    result[predictions_col],
+                    lambda pred: metadata["bool2str"][pred],
+                )
 
         probabilities_col = f"{self.feature_name}_{PROBABILITIES}"
         if probabilities_col in result:

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -92,14 +92,6 @@ def str2bool(v: str, fallback_true_label=None) -> bool:
     return v == fallback_true_label
 
 
-def values_are_pandas_bools(values: List[str]):
-    """Returns True if values would be read by pandas as dtype bool."""
-    for v in values:
-        if not (str(v).lower() in PANDAS_TRUE_STRS | PANDAS_FALSE_STRS):
-            return False
-    return True
-
-
 def values_are_pandas_numbers(values: List[str]):
     """Returns True if values would be read by pandas as dtype float or int."""
     for v in values:
@@ -108,6 +100,12 @@ def values_are_pandas_numbers(values: List[str]):
         except ValueError:
             return False
     return True
+
+
+def values_are_pandas_bools(values: List[str]):
+    """Returns True if values would be read by pandas as dtype bool."""
+    lowercase_values_set = {str(v).lower() for v in values}
+    return lowercase_values_set.issubset(PANDAS_FALSE_STRS | PANDAS_TRUE_STRS)
 
 
 def are_conventional_bools(values: List[Union[str, bool]]) -> bool:

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -92,15 +92,20 @@ def str2bool(v: str, fallback_true_label=None) -> bool:
     return v == fallback_true_label
 
 
-def column_is_bool(column: Series) -> bool:
-    """Returns whether a column could have been cast by read_csv as boolean."""
-    distinct_values = column.drop_duplicates()
-    return values_are_pandas_bools(distinct_values)
+def values_are_pandas_objects(values: List[Union[str, bool]]):
+    """Returns True if values would be read by pandas as dtype object."""
+    for v in values:
+        # check if readable as bool
+        if str(v).lower() in PANDAS_TRUE_STRS | PANDAS_FALSE_STRS:
+            return False
 
-
-def values_are_pandas_bools(values: List[Union[str, bool]]):
-    lowercase_values_set = {str(v).lower() for v in values}
-    return lowercase_values_set.issubset(PANDAS_FALSE_STRS | PANDAS_TRUE_STRS)
+        # check if readable as float/int
+        try:
+            float(v)
+            return False
+        except ValueError:
+            continue
+    return True
 
 
 def are_conventional_bools(values: List[Union[str, bool]]) -> bool:

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -92,19 +92,21 @@ def str2bool(v: str, fallback_true_label=None) -> bool:
     return v == fallback_true_label
 
 
-def values_are_pandas_objects(values: List[Union[str, bool]]):
-    """Returns True if values would be read by pandas as dtype object."""
+def values_are_pandas_bools(values: List[str]):
+    """Returns True if values would be read by pandas as dtype bool."""
     for v in values:
-        # check if readable as bool
-        if str(v).lower() in PANDAS_TRUE_STRS | PANDAS_FALSE_STRS:
+        if not (str(v).lower() in PANDAS_TRUE_STRS | PANDAS_FALSE_STRS):
             return False
+    return True
 
-        # check if readable as float/int
+
+def values_are_pandas_numbers(values: List[str]):
+    """Returns True if values would be read by pandas as dtype float or int."""
+    for v in values:
         try:
             float(v)
-            return False
         except ValueError:
-            continue
+            return False
     return True
 
 

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -44,7 +44,6 @@ from ludwig.utils.data_utils import (
 from ludwig.utils.dataframe_utils import to_numpy_dataset, unflatten_df
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.print_utils import logging_level_registry
-from ludwig.utils.strings_utils import column_is_bool
 
 logger = logging.getLogger(__name__)
 
@@ -68,15 +67,8 @@ def _convert_ground_truth(ground_truth, feature_metadata, ground_truth_apply_idx
             # non-standard boolean representation
             ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2bool"], ground_truth_apply_idx)
         else:
-            # If the values in column could have been inferred as boolean dtype, cast (strings) as booleans.
-            # This preserves the behavior of this feature before #2058.
-            if column_is_bool(ground_truth):
-                ground_truth = _vectorize_ground_truth(
-                    ground_truth, {"false": False, "False": False, "true": True, "True": True}, ground_truth_apply_idx
-                )
-            else:
-                # standard boolean representation
-                ground_truth = ground_truth.values
+            # standard boolean representation
+            ground_truth = ground_truth.values
 
         # ensure positive_label is 1 for binary feature
         positive_label = 1
@@ -233,7 +225,10 @@ def _extract_ground_truth_values(
     reader = get_from_registry(data_format, external_data_reader_registry)
 
     # retrieve ground truth from source data set
-    gt_df = reader(ground_truth)
+    if data_format in {"csv", "tsv"}:
+        gt_df = reader(ground_truth, dtype=None)  # allow type inference
+    else:
+        gt_df = reader(ground_truth)
 
     # extract ground truth for visualization
     if SPLIT in gt_df:

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -33,6 +33,7 @@ from tests.integration_tests.utils import (
 )
 
 
+@pytest.mark.distributed
 @pytest.mark.parametrize("backend", ["local", "ray"])
 @pytest.mark.parametrize("distinct_values", [(False, True), ("No", "Yes")])
 def test_binary_predictions(tmpdir, backend, distinct_values):
@@ -81,6 +82,7 @@ def test_binary_predictions(tmpdir, backend, distinct_values):
         assert np.allclose(prob_0, 1 - prob_1)
 
 
+@pytest.mark.distributed
 @pytest.mark.parametrize("backend", ["local", "ray"])
 @pytest.mark.parametrize("distinct_values", [(0.0, 1.0), (0, 1)])
 def test_binary_predictions_with_number_dtype(tmpdir, backend, distinct_values):

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 
 import os
+from functools import partial
 from unittest import mock
 
 import numpy as np
@@ -23,11 +24,18 @@ import torch
 
 from ludwig.api import LudwigModel
 from ludwig.constants import NAME, TRAINER
-from tests.integration_tests.utils import binary_feature, category_feature, generate_data
+from tests.integration_tests.utils import (
+    binary_feature,
+    category_feature,
+    generate_data,
+    init_backend,
+    RAY_BACKEND_CONFIG,
+)
 
 
+@pytest.mark.parametrize("backend", ["local", "ray"])
 @pytest.mark.parametrize("distinct_values", [(False, True), ("No", "Yes")])
-def test_binary_predictions(tmpdir, distinct_values):
+def test_binary_predictions(tmpdir, backend, distinct_values):
     input_features = [
         category_feature(vocab_size=3),
     ]
@@ -47,24 +55,11 @@ def test_binary_predictions(tmpdir, distinct_values):
     # Optionally convert bool values to strings, e.g., {'Yes', 'No'}
     false_value, true_value = distinct_values
     data_df[feature[NAME]] = data_df[feature[NAME]].map(lambda x: true_value if x else false_value)
+    data_df.to_csv(data_csv_path, index=False)
 
     config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 1}}
-    ludwig_model = LudwigModel(config)
-    _, _, output_directory = ludwig_model.train(
-        dataset=data_df,
-        output_directory=os.path.join(tmpdir, "output"),
-    )
 
-    # Check that metadata JSON saves and loads correctly
-    ludwig_model = LudwigModel.load(os.path.join(output_directory, "model"))
-
-    # Produce an even mix of True and False predictions, as the model may be biased towards
-    # one direction without training
-    def random_logits(*args, **kwargs):
-        return torch.tensor(np.random.uniform(low=-1.0, high=1.0, size=(len(data_df),)))
-
-    with mock.patch("ludwig.features.binary_feature.BinaryOutputFeature.logits", random_logits):
-        preds_df, _ = ludwig_model.predict(dataset=data_csv_path)
+    preds_df = predict_with_backend(tmpdir, config, data_csv_path, backend)
 
     cols = set(preds_df.columns)
     assert f"{feature[NAME]}_predictions" in cols
@@ -83,11 +78,12 @@ def test_binary_predictions(tmpdir, distinct_values):
             assert prob_1 == prob
         else:
             assert prob_0 == prob
-        assert prob_0 == 1 - prob_1
+        assert np.allclose(prob_0, 1 - prob_1)
 
 
+@pytest.mark.parametrize("backend", ["local", "ray"])
 @pytest.mark.parametrize("distinct_values", [(0.0, 1.0), (0, 1)])
-def test_binary_predictions_with_number_dtype(tmpdir, distinct_values):
+def test_binary_predictions_with_number_dtype(tmpdir, backend, distinct_values):
     input_features = [
         category_feature(vocab_size=3),
     ]
@@ -107,24 +103,11 @@ def test_binary_predictions_with_number_dtype(tmpdir, distinct_values):
     # Optionally convert bool values to strings, e.g., {'Yes', 'No'}
     false_value, true_value = distinct_values
     data_df[feature[NAME]] = data_df[feature[NAME]].map(lambda x: true_value if x else false_value)
+    data_df.to_csv(data_csv_path, index=False)
 
     config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 1}}
-    ludwig_model = LudwigModel(config)
-    _, _, output_directory = ludwig_model.train(
-        dataset=data_df,
-        output_directory=os.path.join(tmpdir, "output"),
-    )
 
-    # Check that metadata JSON saves and loads correctly
-    ludwig_model = LudwigModel.load(os.path.join(output_directory, "model"))
-
-    # Produce an even mix of True and False predictions, as the model may be biased towards
-    # one direction without training
-    def random_logits(*args, **kwargs):
-        return torch.tensor(np.random.uniform(low=-1.0, high=1.0, size=(len(data_df),)))
-
-    with mock.patch("ludwig.features.binary_feature.BinaryOutputFeature.logits", random_logits):
-        preds_df, _ = ludwig_model.predict(dataset=data_csv_path)
+    preds_df = predict_with_backend(tmpdir, config, data_csv_path, backend)
 
     cols = set(preds_df.columns)
     assert f"{feature[NAME]}_predictions" in cols
@@ -138,9 +121,40 @@ def test_binary_predictions_with_number_dtype(tmpdir, distinct_values):
         preds_df[f"{feature[NAME]}_probabilities_True"],
         preds_df[f"{feature[NAME]}_probability"],
     ):
-        assert type(pred) == bool
+        assert isinstance(pred, bool)
         if pred:
             assert prob_1 == prob
         else:
             assert prob_0 == prob
-        assert prob_0 == 1 - prob_1
+        assert np.allclose(prob_0, 1 - prob_1)
+
+
+def predict_with_backend(tmpdir, config, data_csv_path, backend, num_predict_samples=None):
+    with init_backend(backend):
+        if backend == "ray":
+            backend = RAY_BACKEND_CONFIG
+            backend["processor"]["type"] = "dask"
+
+        ludwig_model = LudwigModel(config, backend=backend)
+        _, _, output_directory = ludwig_model.train(
+            dataset=data_csv_path,
+            output_directory=os.path.join(tmpdir, "output"),
+        )
+
+        # Check that metadata JSON saves and loads correctly
+        ludwig_model = LudwigModel.load(os.path.join(output_directory, "model"))
+
+        # Produce an even mix of True and False predictions, as the model may be biased towards
+        # one direction without training
+        def random_logits(num_predict_samples, *args, **kwargs):
+            return torch.tensor(np.random.uniform(low=-1.0, high=1.0, size=(num_predict_samples,)))
+
+        if num_predict_samples is not None:
+            with mock.patch(
+                "ludwig.features.binary_feature.BinaryOutputFeature.logits",
+                partial(random_logits, num_samples=num_predict_samples),
+            ):
+                preds_df, _ = ludwig_model.predict(dataset=data_csv_path)
+        else:
+            preds_df, _ = ludwig_model.predict(dataset=data_csv_path)
+    return preds_df

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -59,7 +59,7 @@ def test_binary_predictions(tmpdir, backend, distinct_values):
 
     config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 1}}
 
-    preds_df = predict_with_backend(tmpdir, config, data_csv_path, backend)
+    preds_df = predict_with_backend(tmpdir, config, data_csv_path, backend, num_predict_samples=len(data_df))
 
     cols = set(preds_df.columns)
     assert f"{feature[NAME]}_predictions" in cols
@@ -107,7 +107,7 @@ def test_binary_predictions_with_number_dtype(tmpdir, backend, distinct_values):
 
     config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 1}}
 
-    preds_df = predict_with_backend(tmpdir, config, data_csv_path, backend)
+    preds_df = predict_with_backend(tmpdir, config, data_csv_path, backend, num_predict_samples=len(data_df))
 
     cols = set(preds_df.columns)
     assert f"{feature[NAME]}_predictions" in cols
@@ -146,13 +146,13 @@ def predict_with_backend(tmpdir, config, data_csv_path, backend, num_predict_sam
 
         # Produce an even mix of True and False predictions, as the model may be biased towards
         # one direction without training
-        def random_logits(num_predict_samples, *args, **kwargs):
+        def random_logits(*args, num_predict_samples=None, **kwargs):
             return torch.tensor(np.random.uniform(low=-1.0, high=1.0, size=(num_predict_samples,)))
 
         if num_predict_samples is not None:
             with mock.patch(
                 "ludwig.features.binary_feature.BinaryOutputFeature.logits",
-                partial(random_logits, num_samples=num_predict_samples),
+                partial(random_logits, num_predict_samples=num_predict_samples),
             ):
                 preds_df, _ = ludwig_model.predict(dataset=data_csv_path)
         else:

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -84,3 +84,63 @@ def test_binary_predictions(tmpdir, distinct_values):
         else:
             assert prob_0 == prob
         assert prob_0 == 1 - prob_1
+
+
+@pytest.mark.parametrize("distinct_values", [(0.0, 1.0), (0, 1)])
+def test_binary_predictions_with_number_dtype(tmpdir, distinct_values):
+    input_features = [
+        category_feature(vocab_size=3),
+    ]
+
+    feature = binary_feature()
+    output_features = [
+        feature,
+    ]
+
+    data_csv_path = generate_data(
+        input_features,
+        output_features,
+        os.path.join(tmpdir, "dataset.csv"),
+    )
+    data_df = pd.read_csv(data_csv_path)
+
+    # Optionally convert bool values to strings, e.g., {'Yes', 'No'}
+    false_value, true_value = distinct_values
+    data_df[feature[NAME]] = data_df[feature[NAME]].map(lambda x: true_value if x else false_value)
+
+    config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 1}}
+    ludwig_model = LudwigModel(config)
+    _, _, output_directory = ludwig_model.train(
+        dataset=data_df,
+        output_directory=os.path.join(tmpdir, "output"),
+    )
+
+    # Check that metadata JSON saves and loads correctly
+    ludwig_model = LudwigModel.load(os.path.join(output_directory, "model"))
+
+    # Produce an even mix of True and False predictions, as the model may be biased towards
+    # one direction without training
+    def random_logits(*args, **kwargs):
+        return torch.tensor(np.random.uniform(low=-1.0, high=1.0, size=(len(data_df),)))
+
+    with mock.patch("ludwig.features.binary_feature.BinaryOutputFeature.logits", random_logits):
+        preds_df, _ = ludwig_model.predict(dataset=data_csv_path)
+
+    cols = set(preds_df.columns)
+    assert f"{feature[NAME]}_predictions" in cols
+    assert f"{feature[NAME]}_probabilities_False" in cols
+    assert f"{feature[NAME]}_probabilities_True" in cols
+    assert f"{feature[NAME]}_probability" in cols
+
+    for pred, prob_0, prob_1, prob in zip(
+        preds_df[f"{feature[NAME]}_predictions"],
+        preds_df[f"{feature[NAME]}_probabilities_False"],
+        preds_df[f"{feature[NAME]}_probabilities_True"],
+        preds_df[f"{feature[NAME]}_probability"],
+    ):
+        assert type(pred) == bool
+        if pred:
+            assert prob_1 == prob
+        else:
+            assert prob_0 == prob
+        assert prob_0 == 1 - prob_1

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 
 import os
-import shutil
 
 import numpy as np
 import pandas as pd
@@ -56,7 +55,7 @@ def test_binary_predictions(tmpdir, backend, distinct_values):
     data_df[feature[NAME]] = data_df[feature[NAME]].map(lambda x: true_value if x else false_value)
     data_df.to_csv(data_csv_path, index=False)
 
-    config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 1}}
+    config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 2}}
 
     preds_df = predict_with_backend(tmpdir, config, data_csv_path, backend)
 
@@ -105,7 +104,7 @@ def test_binary_predictions_with_number_dtype(tmpdir, backend, distinct_values):
     data_df[feature[NAME]] = data_df[feature[NAME]].map(lambda x: true_value if x else false_value)
     data_df.to_csv(data_csv_path, index=False)
 
-    config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 1}}
+    config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 2}}
 
     preds_df = predict_with_backend(tmpdir, config, data_csv_path, backend)
 
@@ -135,17 +134,13 @@ def predict_with_backend(tmpdir, config, data_csv_path, backend):
             backend = RAY_BACKEND_CONFIG
             backend["processor"]["type"] = "dask"
 
-        try:
-            ludwig_model = LudwigModel(config, backend=backend)
-            _, _, output_directory = ludwig_model.train(
-                dataset=data_csv_path,
-                output_directory=os.path.join(tmpdir, "output"),
-            )
-            # Check that metadata JSON saves and loads correctly
-            ludwig_model = LudwigModel.load(os.path.join(output_directory, "model"))
-            preds_df, _ = ludwig_model.predict(dataset=data_csv_path)
-        finally:
-            # Remove results/intermediate data saved to disk
-            shutil.rmtree(output_directory, ignore_errors=True)
+        ludwig_model = LudwigModel(config, backend=backend)
+        _, _, output_directory = ludwig_model.train(
+            dataset=data_csv_path,
+            output_directory=os.path.join(tmpdir, "output"),
+        )
+        # Check that metadata JSON saves and loads correctly
+        ludwig_model = LudwigModel.load(os.path.join(output_directory, "model"))
+        preds_df, _ = ludwig_model.predict(dataset=data_csv_path)
 
     return preds_df

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import contextlib
 import os
 import tempfile
 
@@ -37,6 +36,8 @@ from tests.integration_tests.utils import (
     h3_feature,
     image_feature,
     number_feature,
+    RAY_BACKEND_CONFIG,
+    ray_start,
     sequence_feature,
     set_feature,
     text_feature,
@@ -64,36 +65,6 @@ try:
 
 except ImportError:
     ray = None
-
-
-RAY_BACKEND_CONFIG = {
-    "type": "ray",
-    "processor": {
-        "parallelism": 2,
-    },
-    "trainer": {
-        "use_gpu": False,
-        "num_workers": 2,
-        "resources_per_worker": {
-            "CPU": 0.1,
-            "GPU": 0,
-        },
-    },
-}
-
-
-@contextlib.contextmanager
-def ray_start(num_cpus=2, num_gpus=None):
-    res = ray.init(
-        num_cpus=num_cpus,
-        num_gpus=num_gpus,
-        include_dashboard=False,
-        object_store_memory=150 * 1024 * 1024,
-    )
-    try:
-        yield res
-    finally:
-        ray.shutdown()
 
 
 def run_api_experiment(config, dataset, backend_config, skip_save_processed_input=True):


### PR DESCRIPTION
This PR ensures that the postprocessing behavior before #2058 is preserved when dealing with binary feature columns of dtype float/int. This is done primarily by reverting the changes introduced by #2058 in `ludwig/features/binary_feature.py` and `ludwig/visualize.py`. You can see the full changes in `binary_feature.py` and `visualize.py` relative to 0.5.2 [here](https://github.com/ludwig-ai/ludwig/compare/dd026ca..f7dbb45#diff-1bcb267f1a0a83aea88c3f15b64f346e2c42ea81e99400ea1504744e662ddb5f) and [here](https://github.com/ludwig-ai/ludwig/compare/dd026ca..f7dbb45#diff-a6e3d9afdd95decfc7a71b4140a9d7eb6f38dc3de3c0eb8491bf581dfa6ca234), respectively.

That said, in order to achieve this, we add several checks upstream in `cast_column` to ensure that the old behavior when determining dtypes is preserved.  The one caveat is that this requires calling `compute()`, which could be expensive in large datasets.