### PR TITLE
Add boolean postprocessing to dataset type inference for automl

### DIFF
--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -201,6 +201,11 @@ def get_dataset_info_from_source(source: DataSource) -> DatasetInfo:
         image_values = source.get_image_values(field)
         audio_values = source.get_audio_values(field)
         avg_words = None
+        if dtype == "object":
+            # Check if it is a nullboolean field
+            is_boolean = source.check_if_boolean(field)
+            if is_boolean:
+                dtype = "bool"
         if source.is_string_type(dtype):
             avg_words = source.get_avg_num_tokens(field)
         fields.append(

--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -202,7 +202,9 @@ def get_dataset_info_from_source(source: DataSource) -> DatasetInfo:
         audio_values = source.get_audio_values(field)
         avg_words = None
         if dtype == "object":
-            # Check if it is a nullboolean field
+            # Check if it is a nullboolean field. We do this since if you read a csv with 
+            # pandas that has a column of booleans and some missing values, the column is 
+            # interpreted as object dtype instead of bool
             is_boolean = source.check_if_boolean(field)
             if is_boolean:
                 dtype = "bool"

--- a/ludwig/automl/data_source.py
+++ b/ludwig/automl/data_source.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List, Tuple
 
-from ludwig.automl.utils import avg_num_tokens
+from ludwig.automl.utils import avg_num_tokens, check_if_boolean
 from ludwig.utils.audio_utils import is_audio_score
 from ludwig.utils.image_utils import is_image_score
 from ludwig.utils.types import DataFrame
@@ -27,6 +27,10 @@ class DataSource(ABC):
 
     @abstractmethod
     def get_avg_num_tokens(self, column: str) -> int:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def check_if_boolean(self, column: str) -> bool:
         raise NotImplementedError()
 
     @abstractmethod
@@ -68,6 +72,9 @@ class DataframeSourceMixin:
 
     def get_avg_num_tokens(self, column: str) -> int:
         return avg_num_tokens(self.df[column])
+
+    def check_if_boolean(self, column: str) -> bool:
+        return check_if_boolean(self.df[column])
 
     def is_string_type(self, dtype: str) -> bool:
         return dtype in ["str", "string", "object"]

--- a/ludwig/automl/utils.py
+++ b/ludwig/automl/utils.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Dict, List
 
 from dataclasses_json import dataclass_json, LetterCase
-from numpy import nan_to_num
+from numpy import nan_to_num, isnan
 from pandas import Series
 
 from ludwig.constants import (
@@ -76,6 +76,23 @@ def avg_num_tokens(field: Series) -> int:
     unique_entries = field.unique()
     avg_words = round(nan_to_num(Series(unique_entries).str.split().str.len().mean()))
     return avg_words
+
+
+def check_if_boolean(field: Series) -> bool:
+    if len(field) > 5000:
+        field = field.sample(n=5000, random_state=40)
+    unique_entries = field.unique()
+    if len(unique_entries) <= 3:
+        for entry in unique_entries:
+            try:
+                if isnan(entry):
+                    continue
+            except TypeError:
+                return False
+            if isinstance(entry, bool):
+                continue
+            return False
+    return True
 
 
 def get_available_resources() -> dict:


### PR DESCRIPTION
# Code Pull Requests

When a csv file is read in via pandas, if it contains a column of boolean values with some missing values, it is misinterpreted as an object dtype instead of a bool dtype. This corrects that. 