### PR TITLE
Make preprocessing for predictions backend-aware

### DIFF
--- a/ludwig/data/dataset/base.py
+++ b/ludwig/data/dataset/base.py
@@ -34,7 +34,7 @@ class Dataset(ABC):
 
 class DatasetManager(ABC):
     @abstractmethod
-    def create(self, dataset, config, training_set_metadata):
+    def create(self, dataset, config, training_set_metadata) -> Dataset:
         raise NotImplementedError()
 
     @abstractmethod

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -79,7 +79,7 @@ class PandasDatasetManager(DatasetManager):
     def __init__(self, backend):
         self.backend = backend
 
-    def create(self, dataset, config, training_set_metadata):
+    def create(self, dataset, config, training_set_metadata) -> PandasDataset:
         return PandasDataset(dataset, get_proc_features(config), training_set_metadata.get(DATA_TRAIN_HDF5_FP))
 
     def save(self, cache_path, dataset, config, training_set_metadata, tag):

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -64,7 +64,6 @@ class RayDataset(Dataset):
         self.training_set_metadata = training_set_metadata
         self.data_hdf5_fp = training_set_metadata.get(DATA_TRAIN_HDF5_FP)
         self.data_parquet_fp = training_set_metadata.get(DATA_TRAIN_PARQUET_FP)
-        self.backend = backend
 
         # TODO ray 1.8: convert to Tensors before shuffle
         # def to_tensors(df: pd.DataFrame) -> pd.DataFrame:

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -64,6 +64,7 @@ class RayDataset(Dataset):
         self.training_set_metadata = training_set_metadata
         self.data_hdf5_fp = training_set_metadata.get(DATA_TRAIN_HDF5_FP)
         self.data_parquet_fp = training_set_metadata.get(DATA_TRAIN_PARQUET_FP)
+        self.backend = backend
 
         # TODO ray 1.8: convert to Tensors before shuffle
         # def to_tensors(df: pd.DataFrame) -> pd.DataFrame:
@@ -124,7 +125,7 @@ class RayDatasetManager(DatasetManager):
     def __init__(self, backend):
         self.backend = backend
 
-    def create(self, dataset: Union[str, DataFrame], config: Dict[str, Any], training_set_metadata: Dict[str, Any]):
+    def create(self, dataset: Union[str, DataFrame], config: Dict[str, Any], training_set_metadata: Dict[str, Any]) -> RayDataset:
         return RayDataset(dataset, get_proc_features(config), training_set_metadata, self.backend)
 
     def save(

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -124,7 +124,9 @@ class RayDatasetManager(DatasetManager):
     def __init__(self, backend):
         self.backend = backend
 
-    def create(self, dataset: Union[str, DataFrame], config: Dict[str, Any], training_set_metadata: Dict[str, Any]) -> RayDataset:
+    def create(
+        self, dataset: Union[str, DataFrame], config: Dict[str, Any], training_set_metadata: Dict[str, Any]
+    ) -> RayDataset:
         return RayDataset(dataset, get_proc_features(config), training_set_metadata, self.backend)
 
     def save(

--- a/ludwig/data/postprocessing.py
+++ b/ludwig/data/postprocessing.py
@@ -21,6 +21,7 @@ import pandas as pd
 import torch
 
 from ludwig.backend import LOCAL_BACKEND
+from ludwig.data.utils import convert_to_dict
 from ludwig.utils.data_utils import DATAFRAME_FORMATS, DICT_FORMATS
 from ludwig.utils.dataframe_utils import to_numpy_dataset, is_dask_object
 from ludwig.utils.misc_utils import get_from_registry
@@ -108,31 +109,6 @@ def convert_predictions(
 ):
     convert_fn = get_from_registry(return_type, conversion_registry)
     return convert_fn(predictions, output_features, backend)
-
-
-def convert_to_dict(
-    predictions,
-    output_features,
-    backend: Optional["Backend"] = None,  # noqa: F821
-):
-    output = {}
-    for of_name, output_feature in output_features.items():
-        feature_keys = {k for k in predictions.columns if k.startswith(of_name)}
-        feature_dict = {}
-        for key in feature_keys:
-            subgroup = key[len(of_name) + 1 :]
-
-            values = predictions[key]
-            if is_dask_object(values, backend):
-                values = values.compute()
-            try:
-                values = np.stack(values.to_numpy())
-            except ValueError:
-                values = values.to_list()
-
-            feature_dict[subgroup] = values
-        output[of_name] = feature_dict
-    return output
 
 
 def convert_to_df(

--- a/ludwig/data/postprocessing.py
+++ b/ludwig/data/postprocessing.py
@@ -22,7 +22,7 @@ import torch
 
 from ludwig.backend import LOCAL_BACKEND
 from ludwig.utils.data_utils import DATAFRAME_FORMATS, DICT_FORMATS
-from ludwig.utils.dataframe_utils import is_dask_df, to_numpy_dataset
+from ludwig.utils.dataframe_utils import is_dask_object, to_numpy_dataset
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.strings_utils import make_safe_filename
 
@@ -123,7 +123,7 @@ def convert_to_dict(
             subgroup = key[len(of_name) + 1 :]
 
             values = predictions[key]
-            if is_dask_df(values, backend):
+            if is_dask_object(values, backend):
                 values = values.compute()
             try:
                 values = np.stack(values.to_numpy())

--- a/ludwig/data/postprocessing.py
+++ b/ludwig/data/postprocessing.py
@@ -23,7 +23,7 @@ import torch
 from ludwig.backend import LOCAL_BACKEND
 from ludwig.data.utils import convert_to_dict
 from ludwig.utils.data_utils import DATAFRAME_FORMATS, DICT_FORMATS
-from ludwig.utils.dataframe_utils import to_numpy_dataset, is_dask_object
+from ludwig.utils.dataframe_utils import to_numpy_dataset
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.strings_utils import make_safe_filename
 

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1737,14 +1737,14 @@ def _preprocess_df_for_training(
 
 def preprocess_for_prediction(
     config,
-    dataset,
+    dataset: Dataset,
     training_set_metadata=None,
     data_format=None,
     split=FULL,
     include_outputs=True,
     backend=LOCAL_BACKEND,
     callbacks=None,
-):
+) -> [Dataset, dict]:
     """Preprocesses the dataset to parse it into a format that is usable by the Ludwig core.
 
     :param model_path: The input data that is joined with the model

--- a/ludwig/data/utils.py
+++ b/ludwig/data/utils.py
@@ -1,17 +1,15 @@
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import numpy as np
 
-from ludwig.utils.dataframe_utils import is_dask_df
-from ludwig.utils.types import DataFrame
+from ludwig.utils.dataframe_utils import is_dask_object
 
 
 def convert_to_dict(
-    predictions: DataFrame,
-    output_features: Dict[str, Any],
+    predictions,
+    output_features,
     backend: Optional["Backend"] = None,  # noqa: F821
 ):
-    """Convert predictions from DataFrame format to a dictionary."""
     output = {}
     for of_name, output_feature in output_features.items():
         feature_keys = {k for k in predictions.columns if k.startswith(of_name)}
@@ -20,7 +18,7 @@ def convert_to_dict(
             subgroup = key[len(of_name) + 1 :]
 
             values = predictions[key]
-            if is_dask_df(values, backend):
+            if is_dask_object(values, backend):
                 values = values.compute()
             try:
                 values = np.stack(values.to_numpy())

--- a/ludwig/data/utils.py
+++ b/ludwig/data/utils.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 import numpy as np
 

--- a/ludwig/data/utils.py
+++ b/ludwig/data/utils.py
@@ -1,15 +1,17 @@
-from typing import Optional
+from typing import Optional, Dict, Any
 
 import numpy as np
 
 from ludwig.utils.dataframe_utils import is_dask_object
+from ludwig.utils.types import DataFrame
 
 
 def convert_to_dict(
-    predictions,
-    output_features,
+    predictions: DataFrame,
+    output_features: Dict[str, Any],
     backend: Optional["Backend"] = None,  # noqa: F821
 ):
+    """Convert predictions from DataFrame format to a dictionary."""
     output = {}
     for of_name, output_feature in output_features.items():
         feature_keys = {k for k in predictions.columns if k.startswith(of_name)}

--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -12,7 +12,7 @@ from ludwig.data.dataset.ray import RayDataset
 from ludwig.data.preprocessing import preprocess_for_prediction
 from ludwig.explain.util import get_feature_name, get_pred_col, prepare_data
 from ludwig.models.ecd import ECD
-from ludwig.utils.dataframe_utils import is_dask_df
+from ludwig.utils.dataframe_utils import is_dask_object
 from ludwig.utils.torch_utils import get_torch_device
 
 DEVICE = get_torch_device()
@@ -69,12 +69,11 @@ def get_input_tensors(model: LudwigModel, input_set: pd.DataFrame) -> List[Varia
 
     if isinstance(dataset, RayDataset):
         dataset_df = dataset.to_df()
-        print("________________________", type(dataset_df), ">>>", dataset.backend)
-        if is_dask_df(dataset_df, dataset.backend.df_engine):
-            dataset_df = dataset_df.compute()
         inputs = {}
         for name, feature in model.model.input_features.items():
             col = dataset_df[feature.proc_column]
+            if is_dask_object(col, model.backend):
+                col = col.compute()
             if isinstance(col, pd.Series):
                 col = col.to_numpy()
             inputs[name] = torch.from_numpy(col).split(model.config["trainer"]["batch_size"])

--- a/ludwig/utils/dataframe_utils.py
+++ b/ludwig/utils/dataframe_utils.py
@@ -1,11 +1,11 @@
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
 
 from ludwig.constants import DASK_MODULE_NAME
 from ludwig.datasets.base_dataset import BaseDataset
-from ludwig.utils.types import DataFrame
+from ludwig.utils.types import DataFrame, Series
 
 
 def is_dask_lib(df_lib) -> bool:
@@ -18,11 +18,11 @@ def is_dask_backend(backend: Optional["Backend"]) -> bool:  # noqa: F821
     return backend is not None and is_dask_lib(backend.df_engine.df_lib)
 
 
-def is_dask_df(df: DataFrame, backend: Optional["Backend"]) -> bool:  # noqa: F821
+def is_dask_object(df: Union[DataFrame, Series], backend: Optional["Backend"]) -> bool:  # noqa: F821
     if is_dask_backend(backend):
         import dask.dataframe as dd
 
-        return isinstance(df, dd.DataFrame)
+        return isinstance(df, dd.DataFrame) or isinstance(df, dd.Series)
     return False
 
 


### PR DESCRIPTION
From the Predibase side, during explanations during training time, we pass in a RayDataset that uses a DaskEngine, which means we have to add logic for `compute()` and converting from `dd.Series -> pd.Series`