### PR TITLE
Fixes prediction saving for models with Set output

### DIFF
--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -373,7 +373,8 @@ class SetOutputFeature(SetFeatureMixin, OutputFeature):
             threshold = self.threshold
 
             def get_prob(prob_set):
-                return np.array([prob for prob in prob_set if prob >= threshold])
+                # Cast to float32 because empty np.array objects are np.float64, causing mismatch errors during saving.
+                return np.array([prob for prob in prob_set if prob >= threshold], dtype=np.float32)
 
             result[probabilities_col] = backend.df_engine.map_objects(
                 result[probabilities_col],

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -31,6 +31,7 @@ from tests.integration_tests.utils import (
     init_backend,
     RAY_BACKEND_CONFIG,
     set_feature,
+    text_feature,
 )
 
 
@@ -163,7 +164,7 @@ def test_binary_predictions_with_number_dtype(tmpdir, backend, distinct_values):
 def test_set_feature_saving(tmpdir, pct_positive):
     backend = "local"
     input_features = [
-        category_feature(vocab_size=3),
+        text_feature(vocab_size=3),
     ]
 
     feature = set_feature()

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -159,7 +159,7 @@ def test_binary_predictions_with_number_dtype(tmpdir, backend, distinct_values):
         assert np.allclose(prob_0, 1 - prob_1)
 
 
-@pytest.mark.parametrize("pct_positive", [0.1])
+@pytest.mark.parametrize("pct_positive", [1.0, 0.5, 0.0])
 def test_set_feature_saving(tmpdir, pct_positive):
     backend = "local"
     input_features = [

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -30,7 +30,25 @@ from tests.integration_tests.utils import (
     generate_data,
     init_backend,
     RAY_BACKEND_CONFIG,
+    set_feature,
 )
+
+
+def random_binary_logits(*args, num_predict_samples, **kwargs):
+    # Produce an even mix of True and False predictions, as the model may be biased
+    # towards one direction without training
+    return torch.tensor(np.random.uniform(low=-1.0, high=1.0, size=(num_predict_samples,)), dtype=torch.float32)
+
+
+def random_set_logits(*args, num_predict_samples, vocab_size, pct_positive, **kwargs):
+    # Produce a desired mix of predictions based on the pct_positive, as the model may be biased
+    # towards one direction without training
+    num_positive = int(num_predict_samples * pct_positive)
+    num_negative = num_predict_samples - num_positive
+    negative_logits = np.random.uniform(low=-1.0, high=-0.1, size=(num_negative, vocab_size))
+    positive_logits = np.random.uniform(low=0.1, high=1.0, size=(num_positive, vocab_size))
+    logits = np.concatenate([negative_logits, positive_logits], axis=0)
+    return torch.tensor(logits, dtype=torch.float32)  # simulate torch model output
 
 
 @pytest.mark.distributed
@@ -61,7 +79,12 @@ def test_binary_predictions(tmpdir, backend, distinct_values):
 
     config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 1}}
 
-    preds_df = predict_with_backend(tmpdir, config, data_csv_path, backend, num_predict_samples=len(data_df))
+    patch_args = (
+        "ludwig.features.binary_feature.BinaryOutputFeature.logits",
+        partial(random_binary_logits, num_predict_samples=len(data_df)),
+    )
+
+    preds_df, _ = predict_with_backend(tmpdir, config, data_csv_path, backend, patch_args=patch_args)
     cols = set(preds_df.columns)
     assert f"{feature[NAME]}_predictions" in cols
     assert f"{feature[NAME]}_probabilities_{str(false_value)}" in cols
@@ -110,7 +133,12 @@ def test_binary_predictions_with_number_dtype(tmpdir, backend, distinct_values):
 
     config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 1}}
 
-    preds_df = predict_with_backend(tmpdir, config, data_csv_path, backend, num_predict_samples=len(data_df))
+    patch_args = (
+        "ludwig.features.binary_feature.BinaryOutputFeature.logits",
+        partial(random_binary_logits, num_predict_samples=len(data_df)),
+    )
+
+    preds_df, _ = predict_with_backend(tmpdir, config, data_csv_path, backend, patch_args=patch_args)
     cols = set(preds_df.columns)
     assert f"{feature[NAME]}_predictions" in cols
     assert f"{feature[NAME]}_probabilities_False" in cols
@@ -131,7 +159,48 @@ def test_binary_predictions_with_number_dtype(tmpdir, backend, distinct_values):
         assert np.allclose(prob_0, 1 - prob_1)
 
 
-def predict_with_backend(tmpdir, config, data_csv_path, backend, num_predict_samples=None):
+@pytest.mark.parametrize("pct_positive", [0.1])
+def test_set_feature_saving(tmpdir, pct_positive):
+    backend = "local"
+    input_features = [
+        category_feature(vocab_size=3),
+    ]
+
+    feature = set_feature()
+    output_features = [
+        feature,
+    ]
+
+    data_csv_path = generate_data(
+        input_features,
+        output_features,
+        os.path.join(tmpdir, "dataset.csv"),
+        num_examples=100,
+    )
+    data_df = pd.read_csv(data_csv_path)
+
+    config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 1}}
+
+    patch_args = (
+        "ludwig.features.set_feature.SetOutputFeature.logits",
+        partial(
+            random_set_logits,
+            num_predict_samples=len(data_df),
+            vocab_size=feature["vocab_size"] + 1,  # +1 for UNK
+            pct_positive=pct_positive,
+        ),
+    )
+
+    preds_df, ludwig_model = predict_with_backend(tmpdir, config, data_csv_path, backend, patch_args=patch_args)
+    cols = set(preds_df.columns)
+    assert f"{feature[NAME]}_predictions" in cols
+    assert f"{feature[NAME]}_probabilities" in cols
+
+    backend = ludwig_model.backend
+    backend.df_engine.to_parquet(preds_df, os.path.join(tmpdir, "preds.parquet"))  # test saving
+
+
+def predict_with_backend(tmpdir, config, data_csv_path, backend, patch_args=None):
     with init_backend(backend):
         if backend == "ray":
             backend = RAY_BACKEND_CONFIG
@@ -145,18 +214,10 @@ def predict_with_backend(tmpdir, config, data_csv_path, backend, num_predict_sam
         # Check that metadata JSON saves and loads correctly
         ludwig_model = LudwigModel.load(os.path.join(output_directory, "model"))
 
-        # Produce an even mix of True and False predictions, as the model may be biased towards
-        # one direction without training
-        def random_logits(*args, num_predict_samples=None, **kwargs):
-            return torch.tensor(np.random.uniform(low=-1.0, high=1.0, size=(num_predict_samples,)))
-
-        if num_predict_samples is not None:
-            with mock.patch(
-                "ludwig.features.binary_feature.BinaryOutputFeature.logits",
-                partial(random_logits, num_predict_samples=num_predict_samples),
-            ):
+        if patch_args is not None:
+            with mock.patch(*patch_args):
                 preds_df, _ = ludwig_model.predict(dataset=data_csv_path)
         else:
             preds_df, _ = ludwig_model.predict(dataset=data_csv_path)
 
-    return preds_df
+    return preds_df, ludwig_model


### PR DESCRIPTION
This PR fixes prediction saving for Set features (#2199). 

Prior to this change, the list of probabilities crossing `threshold` was converted to `np.array` with no dtype specified. If any of the probabilities crossed the threshold, the `np.array` generated would be the dtype of the probability, typically the dtype `float32` commonly used by PyTorch. However, if NO probabilities crossed the threshold, the `np.array` generated would be dtype `float64`, which is the default for `np.array`. This PR ensures that the dtype of the generated numpy array is `float32`.

