### PR TITLE
Bug fix: Use safe rename which works across filesystems when writing checkpoints

### DIFF
--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, Optional
 
 import torch
 
+from ludwig.utils.fs_utils import safe_move_file
+
 LATEST_FNAME = "latest.ckpt"
 
 
@@ -131,10 +133,7 @@ class Checkpoint:
                 tmp_path = os.path.join(tmpdir, "temp.ckpt")
                 torch.save(state, tmp_path)
 
-                # replace is an atomic operation in python
-                # it is POSIX compliant according to docs
-                # https://docs.python.org/3/library/os.html#os.replace
-                os.replace(tmp_path, save_path)
+                safe_move_file(tmp_path, save_path)
                 logging.debug(f"Saved checkpoint at {save_path}.")
         finally:
             # restore SIGINT handler

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -125,7 +125,7 @@ def safe_move_file(src, dst):
         model directories live on different filesystems.  `os.replace()` will
         throw errors if run across filesystems.
 
-    So we try `os.rename()`, but if we detect a cross-filesystem copy, we
+    So we try `os.replace()`, but if we detect a cross-filesystem copy, we
     switch to `shutil.move()` with some wrappers to make it atomic.
     """
     try:

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -15,11 +15,14 @@
 # ==============================================================================
 
 import contextlib
+import errno
 import functools
 import logging
 import os
 import pathlib
+import shutil
 import tempfile
+import uuid
 from typing import Any, Optional, Union
 from urllib.parse import unquote, urlparse
 
@@ -112,13 +115,45 @@ def path_exists(url):
     return fs.exists(path)
 
 
+def safe_move_file(src, dst):
+    """Rename a file from `src` to `dst`. Inspired by: https://alexwlchan.net/2019/03/atomic-cross-filesystem-
+    moves-in-python/
+
+    *   Moves must be atomic.  `shutil.move()` is not atomic.
+
+    *   Moves must work across filesystems.  Sometimes temp directories and the
+        model directories live on different filesystems.  `os.replace()` will
+        throw errors if run across filesystems.
+
+    So we try `os.rename()`, but if we detect a cross-filesystem copy, we
+    switch to `shutil.move()` with some wrappers to make it atomic.
+    """
+    try:
+        os.replace(src, dst)
+    except OSError as err:
+
+        if err.errno == errno.EXDEV:
+            # Generate a unique ID, and copy `<src>` to the target directory with a temporary name `<dst>.<ID>.tmp`.
+            # Because we're copying across a filesystem boundary, this initial copy may not be atomic.  We insert a
+            # random UUID so if different processes are copying into `<dst>`, they don't overlap in their tmp copies.
+            copy_id = uuid.uuid4()
+            tmp_dst = f"{dst}.{copy_id}.tmp"
+            shutil.copyfile(src, tmp_dst)
+
+            # Atomic replace file onto the new name, and clean up original source file.
+            os.replace(tmp_dst, dst)
+            os.unlink(src)
+        else:
+            raise
+
+
 def rename(src, tgt):
     protocol, _ = split_protocol(tgt)
     if protocol is not None:
         fs = fsspec.filesystem(protocol)
         fs.mv(src, tgt, recursive=True)
     else:
-        os.rename(src, tgt)
+        safe_move_file(src, tgt)
 
 
 def makedirs(url, exist_ok=False):


### PR DESCRIPTION
On some systems, the temp directory and model output directory live on different filesystems.  When we write checkpoint to temp directory, then `os.replace` or `os.rename` to the destination, we get:

```
    134 # replace is an atomic operation in python
    135 # it is POSIX compliant according to docs
    136 # https://docs.python.org/3/library/os.html#os.replace
--> 137 os.replace(tmp_path, save_path)
    138 logging.debug(f"Saved checkpoint at {save_path}.")

OSError: [Errno 18] Invalid cross-device link: '/tmp/tmphmthsa9s/temp.ckpt' -> '/tf/app/.../model/training_checkpoints/latest.ckpt'
```

This PR adds `safe_move_file`, which attempts to `os.replace()`, and does an atomic `shutil.copyfile` if we get the cross-filesystem error (errno.EXDEV == 18).