### PR TITLE
Make ExpectedImpact JSON serializable

### DIFF
--- a/ludwig/schema/metadata/parameter_metadata.py
+++ b/ludwig/schema/metadata/parameter_metadata.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Any, List, Union
 
 
-class ExpectedImpact(Enum):
+class ExpectedImpact(int, Enum):
     """The expected impact of determining a "good" value for a specific parameter.
 
     - HIGH: this parameter should almost always be included in a hyperopt run and can make or break a good model.


### PR DESCRIPTION
```
  File "/Users/hw/mambaforge/envs/based/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type ExpectedImpact is not JSON serializable.' -- invalid character 'T' looking for beginning of value
```