### PR TITLE
Update R2 score to handle single sample computation

### DIFF
--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -17,7 +17,6 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import Any, Callable, Generator, Optional
 
-import numpy as np
 import torch
 import torchmetrics.functional as metrics_F
 from torch import Tensor, tensor
@@ -299,7 +298,7 @@ class R2Score(LudwigMetric):
             logger.warning(
                 """R-squared (r2) is not defined for one sample. It needs at least two samples. Returning NaN."""
             )
-            return np.nan
+            return torch.tensor(float("nan"))
 
         return _r2_score_compute(
             self.sum_squared_error, self.sum_error, self.residual, self.total, self.adjusted, self.multioutput

--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -248,7 +248,11 @@ class RMSPEMetric(MeanMetric):
 @register_metric(R2, [NUMBER, VECTOR])
 class R2Score(LudwigMetric):
     """Custom R-squared metric implementation that modifies torchmetrics R-squared implementation in scenarios
-    where there is only one sample."""
+    where there is only one sample.
+
+    Custom implementation uses code from torchmetrics v0.9.2's implementation of R2:
+    https://github.com/Lightning-AI/metrics/blob/master/src/torchmetrics/regression/r2.py
+    """
 
     def __init__(
         self, num_outputs: int = 1, adjusted: int = 0, multioutput: str = "uniform_average", **kwargs: Any

--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -247,8 +247,8 @@ class RMSPEMetric(MeanMetric):
 
 @register_metric(R2, [NUMBER, VECTOR])
 class R2Score(LudwigMetric):
-    """Custom R-squared metric implementation that modifies torchmetrics R-squared implementation in scenarios
-    where there is only one sample.
+    """Custom R-squared metric implementation that modifies torchmetrics R-squared implementation to return Nan
+    when there is only sample. This is because R-squared is only defined for two or more samples.
 
     Custom implementation uses code from torchmetrics v0.9.2's implementation of R2:
     https://github.com/Lightning-AI/metrics/blob/master/src/torchmetrics/regression/r2.py

--- a/tests/ludwig/modules/test_metric_modules.py
+++ b/tests/ludwig/modules/test_metric_modules.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 import torch
 
@@ -37,17 +36,18 @@ def test_rmspe_metric(preds: torch.Tensor, target: torch.Tensor, output: torch.T
     [
         (torch.arange(3), torch.arange(3, 6), 1, torch.tensor(-12.5)),
         (torch.arange(6).reshape(3, 2), torch.arange(6, 12).reshape(3, 2), 2, torch.tensor(-12.5)),
-        (torch.tensor([0.8]), torch.arange(1), 1, np.nan),
     ],
 )
 def test_r2_score(preds: torch.Tensor, target: torch.Tensor, num_outputs: int, output: torch.Tensor):
     metric = metric_modules.R2Score(num_outputs=num_outputs)
     metric.update(preds, target)
-    computed_score = metric.compute()
-    if np.isnan(computed_score):
-        assert np.isnan(output)
-    else:
-        assert computed_score == output
+    assert metric.compute() == output
+
+
+def test_r2_score_single_sample():
+    metric = metric_modules.R2Score(num_outputs=1)
+    metric.update(preds=torch.tensor([0.8]), target=torch.arange(1))
+    assert torch.isnan(metric.compute())
 
 
 @pytest.mark.parametrize("preds", [torch.arange(6).reshape(3, 2).float()])

--- a/tests/ludwig/modules/test_metric_modules.py
+++ b/tests/ludwig/modules/test_metric_modules.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import torch
 
@@ -36,12 +37,17 @@ def test_rmspe_metric(preds: torch.Tensor, target: torch.Tensor, output: torch.T
     [
         (torch.arange(3), torch.arange(3, 6), 1, torch.tensor(-12.5)),
         (torch.arange(6).reshape(3, 2), torch.arange(6, 12).reshape(3, 2), 2, torch.tensor(-12.5)),
+        (torch.tensor([0.8]), torch.arange(1), 1, np.nan),
     ],
 )
 def test_r2_score(preds: torch.Tensor, target: torch.Tensor, num_outputs: int, output: torch.Tensor):
     metric = metric_modules.R2Score(num_outputs=num_outputs)
     metric.update(preds, target)
-    assert metric.compute() == output
+    computed_score = metric.compute()
+    if np.isnan(computed_score):
+        assert np.isnan(output)
+    else:
+        assert computed_score == output
 
 
 @pytest.mark.parametrize("preds", [torch.arange(6).reshape(3, 2).float()])


### PR DESCRIPTION
One of the users in Ludwig's OSS reported an issue with R2 computation in v0.5 where R2 scores can't be computed if the sample size during prediction is just 1 row. The error `torchmetrics` returns is logically correct because R2 scores can't be calculated for just one sample.

This PR updates the implementation of R2 to return `NaN` when one sample is used for R2 computation and logs a user-facing warning to use two or more samples for non NaN R2 score calculation.