### PR TITLE
Update get_repeatable_train_val_test_split to handle non-stratified split w/ no existing split

### DIFF
--- a/ludwig/utils/dataset_utils.py
+++ b/ludwig/utils/dataset_utils.py
@@ -5,14 +5,15 @@ from ludwig.constants import TEST_SPLIT, TRAIN_SPLIT, VALIDATION_SPLIT
 
 
 def get_repeatable_train_val_test_split(
-    df_input, stratify_colname, random_seed, frac_train=0.7, frac_val=0.1, frac_test=0.2
+    df_input, stratify_colname = "", random_seed = 42, frac_train=0.7, frac_val=0.1, frac_test=0.2
 ):
     """Return df_input with split column containing (if possible) non-zero rows in the train, validation, and test
     data subset categories.
 
     If the input dataframe does not contain an existing split column or if the
-    number of rows in both the validation and test split is 0, return df_input
-    with split column set according to frac_<subset_name> and stratify_colname.
+    number of rows in both the validation and test split is 0 and non-empty
+    stratify_colname specified, return df_input with split column set according
+    to frac_<subset_name> and stratify_colname.
 
     Else stratify_colname is ignored, and:
      If the input dataframe contains an existing split column and non-zero row
@@ -26,7 +27,7 @@ def get_repeatable_train_val_test_split(
     df_input : Pandas dataframe
         Input dataframe to be split.
     stratify_colname : str
-        The column used for stratification; usually the label column.
+        The column used for stratification (if desired); usually the label column.
     random_seed : int
         Seed used to get repeatable split.
     frac_train : float
@@ -43,15 +44,20 @@ def get_repeatable_train_val_test_split(
 
     if frac_train + frac_val + frac_test != 1.0:
         raise ValueError(f"fractions {frac_train:f}, {frac_val:f}, {frac_test:f} do not add up to 1.0")
-    if stratify_colname not in df_input.columns:
-        raise ValueError("%s is not a column in the dataframe" % (stratify_colname))
+    if stratify_colname:
+        do_stratify_split = True
+        if stratify_colname not in df_input.columns:
+            raise ValueError("%s is not a column in the dataframe" % (stratify_colname))
+    else:
+        do_stratify_split = False
+        if "split" not in df_input.columns:
+            df_input["split"] = 0  # set up for non-stratified split path
 
-    do_stratify_split = True
     if "split" in df_input.columns:
         df_train = df_input[df_input["split"] == TRAIN_SPLIT]
         df_val = df_input[df_input["split"] == VALIDATION_SPLIT]
         df_test = df_input[df_input["split"] == TEST_SPLIT]
-        if len(df_val) != 0 or len(df_test) != 0:
+        if not do_stratify_split or len(df_val) != 0 or len(df_test) != 0:
             if len(df_val) == 0:
                 df_val = df_train.sample(frac=frac_val, replace=False, random_state=random_seed)
                 df_train = df_train.drop(df_val.index)

--- a/tests/ludwig/utils/test_dataset_utils.py
+++ b/tests/ludwig/utils/test_dataset_utils.py
@@ -60,6 +60,61 @@ def test_get_repeatable_train_val_test_split():
         )
     )
 
+    # Test adding split without stratify
+    df = pd.DataFrame(
+        [
+            [0, 0],
+            [1, 0],
+            [2, 0],
+            [3, 0],
+            [4, 0],
+            [5, 1],
+            [6, 1],
+            [7, 1],
+            [8, 1],
+            [9, 1],
+            [10, 0],
+            [11, 0],
+            [12, 0],
+            [13, 0],
+            [14, 0],
+            [15, 1],
+            [16, 1],
+            [17, 1],
+            [18, 1],
+            [19, 1],
+        ],
+        columns=["input", "target"],
+    )
+    split_df = get_repeatable_train_val_test_split(df, random_seed=42)
+    assert split_df.equals(
+        pd.DataFrame(
+            [
+                [3, 0, 0],
+                [4, 0, 0],
+                [5, 1, 0],
+                [7, 1, 0],
+                [8, 1, 0],
+                [10, 0, 0],
+                [11, 0, 0],
+                [12, 0, 0],
+                [13, 0, 0],
+                [14, 0, 0],
+                [15, 1, 0],
+                [16, 1, 0],
+                [18, 1, 0],
+                [19, 1, 0],
+                [0, 0, 1],
+                [17, 1, 1],
+                [1, 0, 2],
+                [2, 0, 2],
+                [9, 1, 2],
+                [6, 1, 2],
+            ],
+            columns=["input", "target", "split"],
+        )
+    )
+
     # Test needing no change
     df = pd.DataFrame(
         [


### PR DESCRIPTION
As titled.

Tested using new unit test added as well as on experiments repo regression datasets with no existing split column.