### PR TITLE
Fix nan in entmax loss and flaky sparsemax/entmax loss tests

### DIFF
--- a/ludwig/utils/entmax/losses.py
+++ b/ludwig/utils/entmax/losses.py
@@ -17,14 +17,14 @@ class _GenericLoss(nn.Module):
         loss = self.loss(X, target)
         if self.ignore_index >= 0:
             ignored_positions = target == self.ignore_index
-            size = float((target.size(0) - ignored_positions.sum()).item())
+            size = (target.size(0) - ignored_positions.sum()).item()
             loss.masked_fill_(ignored_positions, 0.0)
         else:
-            size = float(target.size(0))
+            size = target.size(0)
         if self.reduction == "sum":
             loss = loss.sum()
         elif self.reduction == "elementwise_mean":
-            loss = torch.nan_to_num(loss.sum() / size)
+            loss = 0 if size == 0 else torch.nan_to_num(loss.sum() / float(size))
         return loss
 
 

--- a/ludwig/utils/entmax/losses.py
+++ b/ludwig/utils/entmax/losses.py
@@ -24,7 +24,11 @@ class _GenericLoss(nn.Module):
         if self.reduction == "sum":
             loss = loss.sum()
         elif self.reduction == "elementwise_mean":
-            loss = 0 if size == 0 else torch.nan_to_num(loss.sum() / float(size))
+            if size == 0:
+                # Returns zero loss and zero gradient in the rare case that all row targets are ignored.
+                loss = loss.sum() * 0.0
+            else:
+                loss = loss.sum() / float(size)
         return loss
 
 

--- a/ludwig/utils/entmax/losses.py
+++ b/ludwig/utils/entmax/losses.py
@@ -24,7 +24,7 @@ class _GenericLoss(nn.Module):
         if self.reduction == "sum":
             loss = loss.sum()
         elif self.reduction == "elementwise_mean":
-            loss = loss.sum() / size
+            loss = torch.nan_to_num(loss.sum() / size)
         return loss
 
 

--- a/tests/ludwig/utils/entmax/test_losses.py
+++ b/tests/ludwig/utils/entmax/test_losses.py
@@ -51,4 +51,5 @@ def test_index_ignored(Loss):
     loss_ignore = Loss(reduction="sum", ignore_index=y[0])
     loss_noignore = Loss(reduction="sum", ignore_index=-100)
 
-    assert loss_ignore(x, y) < loss_noignore(x, y)
+    # Note: since these are sparse losses, it is possible that an element makes no contribution to the loss.
+    assert loss_ignore(x, y) <= loss_noignore(x, y)


### PR DESCRIPTION
Should fix https://github.com/ludwig-ai/ludwig/issues/2228

I observed two situations where these tests fail:
1.  The original issue, which happens only with `elementwise_mean` reduction and `ignore_index=True`.  With `ignore_index=True` we choose `iix = y[0]`.  Since the batch size is 5, there is a 1/1000 chance that all y[i] == y[0].  This results in a divide by zero in the loss reduction.  Modified loss function to return zero loss if size is 0.
2.  In `test_index_ignored`, it is possible (since this is a sparse loss function) that the ignored index makes exactly 0 contribution to the total loss.  In that case, the strict less-than `assert loss_ignore(x, y) < loss_noignore(x, y)` fails.  Changed to less than or equal to (<=)