### PR TITLE
Fixed handling of invalud number values to treat as missing values

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1288,6 +1288,10 @@ def build_data(
     proc_cols = {}
     for feature_config in feature_configs:
         preprocessing_parameters = training_set_metadata[feature_config[NAME]][PREPROCESSING]
+
+        # Need to run this again here as cast_columns may have introduced new missing values
+        handle_missing_values(input_cols, feature_config, preprocessing_parameters)
+
         get_from_registry(feature_config[TYPE], base_type_registry).add_feature_data(
             feature_config,
             input_cols,


### PR DESCRIPTION
In #2058, the second call to `handle_missing_values` was removed, but this was necessary to ensure that invalid values (which are cast to NaN) during `cast_columns`) are properly considered as missing values.

It's an open question as to whether this is the desired behavior, or if we should instead treat this as a user error (the user needs to clean the data to conform to the expected dtype). The correct answer here may be to make this configurable per feature.

However, because this changes the behavior from v0.5.2 to v0.5.3, this should be considered a regression and reverted to the prior behavior for now. This change will require a patch release.