### PR TITLE
Removed import warnings when LightGBM and Ray not requested

### DIFF
--- a/ludwig/backend/__init__.py
+++ b/ludwig/backend/__init__.py
@@ -22,12 +22,6 @@ from ludwig.utils.horovod_utils import has_horovodrun
 
 logger = logging.getLogger(__name__)
 
-try:
-    import ray as _ray
-except Exception as e:
-    logger.warning(f"import ray failed with exception: {e}")
-    _ray = None
-
 
 LOCAL_BACKEND = LocalBackend()
 
@@ -45,18 +39,12 @@ def _has_ray():
     if "PYTEST_CURRENT_TEST" in os.environ:
         return False
 
-    if _ray is None:
-        return False
-
-    if _ray.is_initialized():
-        return True
-
     try:
-        _ray.init("auto", ignore_reinit_error=True)
-        return True
-    except Exception as e:
-        logger.error(f"ray.init() failed: {e}")
+        import ray
+    except ImportError:
         return False
+
+    return ray.is_initialized()
 
 
 def get_local_backend(**kwargs):

--- a/ludwig/models/registry.py
+++ b/ludwig/models/registry.py
@@ -3,18 +3,21 @@ import logging
 from ludwig.constants import MODEL_ECD, MODEL_GBM
 from ludwig.models.ecd import ECD
 
+
+def gbm(*args, **kwargs):
+    try:
+        from ludwig.models.gbm import GBM
+    except ImportError:
+        logging.warning(
+            "Importing GBM requirements failed. Not loading GBM model type. "
+            "If you want to use GBM, install Ludwig's 'tree' extra."
+        )
+        raise
+
+    return GBM(*args, **kwargs)
+
+
 model_type_registry = {
     MODEL_ECD: ECD,
+    MODEL_GBM: gbm,
 }
-
-try:
-    import lightgbm  # noqa: F401
-
-    from ludwig.models.gbm import GBM
-
-    model_type_registry[MODEL_GBM] = GBM
-except ImportError:
-    logging.warning(
-        "Importing GBM requirements failed. Not loading GBM model type. "
-        "If you want to use GBM, install Ludwig's 'tree' extra."
-    )

--- a/ludwig/trainers/__init__.py
+++ b/ludwig/trainers/__init__.py
@@ -1,14 +1,8 @@
 # register trainers
-import logging
 
 import ludwig.trainers.trainer  # noqa: F401
 
 try:
-    import lightgbm  # noqa: F401
-
     import ludwig.trainers.trainer_lightgbm  # noqa: F401
 except ImportError:
-    logging.warning(
-        "Importing GBM requirements failed. Not loading LightGBM trainer. "
-        "If you want to use LightGBM, install Ludwig's 'tree' extra."
-    )
+    pass


### PR DESCRIPTION
This PR removes logger warnings when the user is missing optional LightGBM or Ray dependencies but are not making use of those features. The previous behavior can create the impression from the user that there's something wrong that needs to be fixed, but in truth because the deps are optional, their setup is completely fine.