### PR TITLE
Triton ensemble export

### DIFF
--- a/ludwig/models/inference.py
+++ b/ludwig/models/inference.py
@@ -70,17 +70,17 @@ class InferenceModule(nn.Module):
             predictions_flattened = self.predictor(preproc_inputs)
             return predictions_flattened
 
-    def postprocessor_forward(self, predictions_flattened: Dict[str, torch.Tensor]) -> Dict[str, Dict[str, Any]]:
+    def postprocessor_forward(self, predictions_flattened: Dict[str, torch.Tensor]) -> Dict[str, Any]:
         """Forward pass through the postprocessor."""
         postproc_outputs_flattened: Dict[str, Any] = self.postprocessor(predictions_flattened)
-        # Turn flat inputs into nested predictions per feature name
-        postproc_outputs: Dict[str, Dict[str, Any]] = _unflatten_dict_by_feature_name(postproc_outputs_flattened)
-        return postproc_outputs
+        return postproc_outputs_flattened
 
     def forward(self, inputs: Dict[str, TorchscriptPreprocessingInput]) -> Dict[str, Dict[str, Any]]:
         preproc_inputs: Dict[str, torch.Tensor] = self.preprocessor_forward(inputs)
         predictions_flattened: Dict[str, torch.Tensor] = self.predictor_forward(preproc_inputs)
-        postproc_outputs: Dict[str, Dict[str, Any]] = self.postprocessor_forward(predictions_flattened)
+        postproc_outputs_flattened: Dict[str, Any] = self.postprocessor_forward(predictions_flattened)
+        # Turn flat inputs into nested predictions per feature name
+        postproc_outputs: Dict[str, Dict[str, Any]] = _unflatten_dict_by_feature_name(postproc_outputs_flattened)
         return postproc_outputs
 
     @torch.jit.unused

--- a/ludwig/utils/triton_utils.py
+++ b/ludwig/utils/triton_utils.py
@@ -2,18 +2,26 @@ import importlib.util
 import os
 import re
 import tempfile
-from typing import Dict, Tuple, Union, List
-
-import torch
-import pandas as pd
-
 from dataclasses import dataclass
+from typing import Dict, List, Tuple, Union
+
+import pandas as pd
+import torch
+
 from ludwig.api import LudwigModel
-from ludwig.models.inference import InferenceModule, _InferencePreprocessor, _InferencePredictor, \
-    _InferencePostprocessor, INFERENCE_STAGES, PREPROCESSOR, PREDICTOR, POSTPROCESSOR
 from ludwig.features.category_feature import CategoryInputFeature
+from ludwig.models.inference import (
+    _InferencePostprocessor,
+    _InferencePredictor,
+    _InferencePreprocessor,
+    INFERENCE_STAGES,
+    InferenceModule,
+    POSTPROCESSOR,
+    PREDICTOR,
+    PREPROCESSOR,
+)
 from ludwig.utils.torch_utils import DEVICE
-from ludwig.utils.types import TorchscriptPreprocessingInput, TorchAudioTuple
+from ludwig.utils.types import TorchAudioTuple, TorchscriptPreprocessingInput
 
 INPUT = "INPUT"
 OUTPUT = "OUTPUT"
@@ -93,8 +101,7 @@ ensemble_scheduling {{
 
 
 def _get_type_map(dtype: str) -> str:
-    """Return the Triton API type mapped to numpy type.
-    """
+    """Return the Triton API type mapped to numpy type."""
     # see: https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md
     return {
         "bool": "TYPE_BOOL",
@@ -110,7 +117,6 @@ def _get_type_map(dtype: str) -> str:
         "float32": "TYPE_FP32",
         "float64": "TYPE_FP64",
         "string": "TYPE_STRING",
-
         "torch.float32": "TYPE_FP32",
         "torch.float": "TYPE_FP32",
         "torch.float64": "TYPE_FP64",
@@ -130,18 +136,18 @@ def _get_type_map(dtype: str) -> str:
 
 
 def raw_feature_to_inference_input(s: pd.Series, feature) -> Union[List[str], torch.Tensor]:
-    """Transform input for a feature to be compatible with what's required by TorchScript.
-    """
+    """Transform input for a feature to be compatible with what's required by TorchScript."""
     if s.dtype == "object" or type(feature) is CategoryInputFeature:
-        return s.astype('str').to_list()
+        return s.astype("str").to_list()
     return torch.from_numpy(s.to_numpy())
 
 
 def raw_to_inference_input(df: pd.DataFrame, model: LudwigModel):
-    """Transform input for all features to be compatible with what's required by TorchScript.
-    """
-    return {name: raw_feature_to_inference_input(df[feature.column], feature) for name, feature in
-            model.model.input_features.items()}
+    """Transform input for all features to be compatible with what's required by TorchScript."""
+    return {
+        name: raw_feature_to_inference_input(df[feature.column], feature)
+        for name, feature in model.model.input_features.items()
+    }
 
 
 def to_triton_dimension(content: Union[List[str], List[torch.Tensor], List[TorchAudioTuple], torch.Tensor]):
@@ -150,7 +156,7 @@ def to_triton_dimension(content: Union[List[str], List[torch.Tensor], List[Torch
             return [len(content)]
         """
         todo (Wael): check these and add other types
-        
+
         if isinstance(content[0], torch.Tensor):
             return (len(content))
         if isinstance(content[0], TorchAudioTuple):
@@ -186,6 +192,7 @@ class TritonConfigFeature:
     :param kind: one of INPUT, OUTPUT.
     :param index: index of the feature in the Triton Config.
     """
+
     name: str
     content: Union[TorchscriptPreprocessingInput, torch.Tensor]
     inference_stage: str
@@ -194,7 +201,7 @@ class TritonConfigFeature:
 
     def __post_init__(self):
         # removing non-alphanumeric characters as this will go in the wrapper function header.
-        self.wrapper_signature_name = re.sub(r'[\W]+', '_', self.name)
+        self.wrapper_signature_name = re.sub(r"[\W]+", "_", self.name)
         # get Triton type
         self.type = to_triton_type(self.content)
         # get dimension
@@ -222,6 +229,7 @@ class TritonMaster:
         input and output dimensions.
     :param inference_stage: one of PREPROCESSOR, PREDICTOR, POSTPROCESSOR.
     """
+
     module: Union[_InferencePreprocessor, _InferencePredictor, _InferencePostprocessor]
     input_data_example: Dict[str, Union[TorchscriptPreprocessingInput, torch.Tensor]]
     inference_stage: str
@@ -230,10 +238,9 @@ class TritonMaster:
     model_version: int
 
     def __post_init__(self):
-        """Extract input and output features and necessary information for a Triton config.
-        """
+        """Extract input and output features and necessary information for a Triton config."""
         if self.inference_stage not in INFERENCE_STAGES:
-            raise ValueError("Invalid inference stage. Choose one of {}".format(INFERENCE_STAGES))
+            raise ValueError(f"Invalid inference stage. Choose one of {INFERENCE_STAGES}")
 
         self.full_model_name = self.model_name + "_" + self.inference_stage
         self.base_path = os.path.join(self.output_path, self.full_model_name)
@@ -241,16 +248,18 @@ class TritonMaster:
 
         # get output for sample input.
         self.output_data_example: Dict[str, Union[TorchscriptPreprocessingInput, torch.Tensor]] = self.module(
-            self.input_data_example)
+            self.input_data_example
+        )
 
         # generate input and output features.
         self.input_features: List[TritonConfigFeature] = [
-            TritonConfigFeature(feature_name, content, self.inference_stage, INPUT, i) for i, (feature_name, content) in
-            enumerate(self.input_data_example.items())]
+            TritonConfigFeature(feature_name, content, self.inference_stage, INPUT, i)
+            for i, (feature_name, content) in enumerate(self.input_data_example.items())
+        ]
         self.output_features: List[TritonConfigFeature] = [
-            TritonConfigFeature(feature_name, content, self.inference_stage, OUTPUT, i) for i, (feature_name, content)
-            in
-            enumerate(self.output_data_example.items())]
+            TritonConfigFeature(feature_name, content, self.inference_stage, OUTPUT, i)
+            for i, (feature_name, content) in enumerate(self.output_data_example.items())
+        ]
 
     def save_model(self) -> str:
         """Scripts the model and saves it.
@@ -263,14 +272,14 @@ class TritonMaster:
 
         os.makedirs(os.path.join(self.base_path, str(self.model_version)), exist_ok=True)
         model_path = os.path.join(self.base_path, str(self.model_version), "model.pt")
-        self.model_ts = TritonModel(self.module, self.output_features, self.output_features,
-                                    self.inference_stage).generate_scripted_module()
+        self.model_ts = TritonModel(
+            self.module, self.output_features, self.output_features, self.inference_stage
+        ).generate_scripted_module()
         self.model_ts.save(model_path)
         return model_path
 
     def save_config(self) -> str:
-        """Save the Triton config.
-        """
+        """Save the Triton config."""
         self.config = TritonConfig(self.full_model_name, self.input_features, self.output_features)
         config_path = os.path.join(self.base_path, "config.pbtxt")
         with open(config_path, "w") as f:
@@ -280,8 +289,8 @@ class TritonMaster:
 
 @dataclass
 class TritonEnsembleConfig:
-    """Dataclass for creating and saving the Triton ensemble config.
-    """
+    """Dataclass for creating and saving the Triton ensemble config."""
+
     triton_master_preprocessor: TritonMaster
     triton_master_predictor: TritonMaster
     triton_master_postprocessor: TritonMaster
@@ -295,11 +304,13 @@ class TritonEnsembleConfig:
 
     def _get_ensemble_scheduling_input_maps(self, triton_features: List[TritonConfigFeature]) -> str:
         return "".join(
-            ENSEMBLE_SCHEDULING_INPUT_MAP.format(key=feature.key, value=feature.value) for feature in triton_features)
+            ENSEMBLE_SCHEDULING_INPUT_MAP.format(key=feature.key, value=feature.value) for feature in triton_features
+        )
 
     def _get_ensemble_scheduling_output_maps(self, triton_features: List[TritonConfigFeature]) -> str:
         return "".join(
-            ENSEMBLE_SCHEDULING_OUTPUT_MAP.format(key=feature.key, value=feature.value) for feature in triton_features)
+            ENSEMBLE_SCHEDULING_OUTPUT_MAP.format(key=feature.key, value=feature.value) for feature in triton_features
+        )
 
     def _get_ensemble_scheduling_step(self, triton_master: TritonMaster):
         return ENSEMBLE_SCHEDULING_STEP.format(
@@ -322,10 +333,14 @@ class TritonEnsembleConfig:
         return ",".join(spec)
 
     def get_config(self):
-        triton_masters = [self.triton_master_preprocessor, self.triton_master_predictor,
-                          self.triton_master_postprocessor]
+        triton_masters = [
+            self.triton_master_preprocessor,
+            self.triton_master_predictor,
+            self.triton_master_postprocessor,
+        ]
         ensemble_scheduling_steps = ",".join(
-            [self._get_ensemble_scheduling_step(triton_master) for triton_master in triton_masters])
+            [self._get_ensemble_scheduling_step(triton_master) for triton_master in triton_masters]
+        )
         return TRITON_ENSEMBLE_CONFIG_TEMPLATE.format(
             model_name=self.ensemble_model_name,
             input_spec=self._get_ensemble_spec(self.triton_master_preprocessor.input_features),
@@ -348,6 +363,7 @@ class TritonConfig:
     :param input_features: input features of the model.
     :param output_features: output features of the model.
     """
+
     full_model_name: str
     input_features: List[TritonConfigFeature]
     output_features: List[TritonConfigFeature]
@@ -370,13 +386,12 @@ class TritonConfig:
         return spec
 
     def get_model_config(self) -> str:
-        """Generate a Triton config for a model from the input and output features.
-        """
+        """Generate a Triton config for a model from the input and output features."""
         config = TRITON_CONFIG_TEMPLATE.format(
             model_name=self.full_model_name,
             input_spec=self._get_triton_spec(self.input_features),
             output_spec=self._get_triton_spec(self.output_features),
-            instance_spec=self._get_instance_spec()
+            instance_spec=self._get_instance_spec(),
         )
         return config
 
@@ -390,6 +405,7 @@ class TritonModel:
     :param output_features: output features of the model.
     :param inference_stage: one of PREPROCESSOR, PREDICTOR, POSTPROCESSOR.
     """
+
     module: Union[_InferencePreprocessor, _InferencePredictor, _InferencePostprocessor]
     input_features: List[TritonConfigFeature]
     output_features: List[TritonConfigFeature]
@@ -416,8 +432,7 @@ class TritonModel:
         return "(" + ", ".join(elems) + ")"
 
     def generate_inference_module_wrapper(self) -> str:
-        """Generate the class wrapper around an inference module.
-        """
+        """Generate the class wrapper around an inference module."""
         return INFERENCE_MODULE_TEMPLATE.format(
             input_signature=self._get_input_signature(self.input_features),
             input_type=self._get_wrapper_signature_type(),
@@ -426,8 +441,7 @@ class TritonModel:
         )
 
     def generate_scripted_module(self):
-        """Generate the scripted module from the wrapper class.
-        """
+        """Generate the scripted module from the wrapper class."""
         wrapper_definition = self.generate_inference_module_wrapper()
         with tempfile.TemporaryDirectory() as tmpdir:
             ts_path = os.path.join(tmpdir, "generated.py")
@@ -443,8 +457,13 @@ class TritonModel:
         return scripted_module
 
 
-def export_triton(model: LudwigModel, data_example: pd.DataFrame, output_path: str = "model_repository",
-                  model_name: str = "ludwig_model", model_version: Union[int, str] = 1) -> Dict[str, Tuple[str, str]]:
+def export_triton(
+    model: LudwigModel,
+    data_example: pd.DataFrame,
+    output_path: str = "model_repository",
+    model_name: str = "ludwig_model",
+    model_version: Union[int, str] = 1,
+) -> Dict[str, Tuple[str, str]]:
     """Exports a torchscript model to a output path that serves as a repository for Triton Inference Server.
 
     # Inputs
@@ -475,12 +494,10 @@ def export_triton(model: LudwigModel, data_example: pd.DataFrame, output_path: s
 
     # saving ensemble config
     triton_master_preprocessor, triton_master_predictor, triton_master_postprocessor = triton_masters
-    ensemble_config = TritonEnsembleConfig(triton_master_preprocessor,
-                                           triton_master_predictor,
-                                           triton_master_postprocessor,
-                                           model_name,
-                                           output_path)
+    ensemble_config = TritonEnsembleConfig(
+        triton_master_preprocessor, triton_master_predictor, triton_master_postprocessor, model_name, output_path
+    )
     ensemble_config_path = ensemble_config.save_ensemble_config()
-    paths[ENSEMBLE] = (ensemble_config_path, )
+    paths[ENSEMBLE] = (ensemble_config_path,)
 
     return paths

--- a/ludwig/utils/triton_utils.py
+++ b/ludwig/utils/triton_utils.py
@@ -1,12 +1,21 @@
 import importlib.util
 import os
 import tempfile
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Tuple, Union, List
 
 import torch
+import pandas as pd
 
+from dataclasses import dataclass
 from ludwig.api import LudwigModel
 from ludwig.constants import NAME
+from ludwig.models.inference import InferenceModule, PREPROCESSOR, PREDICTOR, POSTPROCESSOR, INFERENCE_STAGES
+from ludwig.features.category_feature import CategoryInputFeature
+from ludwig.utils.torch_utils import DEVICE
+from ludwig.utils.types import TorchscriptPreprocessingInput, TorchAudioTuple
+
+INPUT = "INPUT"
+OUTPUT = "OUTPUT"
 
 INFERENCE_MODULE_TEMPLATE = """
 from typing import Any, Dict, List, Union
@@ -48,6 +57,24 @@ output [{output_spec}
 instance_group [{instance_spec}
 ]
 """
+
+TRITON_PREPROCESS_CONFIG_TEMPLATE = """
+name: "ensemble_preprocess"
+platform: "pytorch_libtorch"
+max_batch_size: 0
+input [{input_spec}
+]
+output [{output_spec}
+]
+instance_group [{instance_spec}
+]
+"""
+
+
+
+class EnsemblePreprocessingConfig:
+    pass
+
 
 
 def _get_input_signature(config: Dict[str, Any]) -> str:
@@ -99,7 +126,10 @@ def generate_triton_torchscript(model: LudwigModel) -> torch.jit.ScriptModule:
 
 
 def _get_type_map(dtype: str) -> str:
-    """Return the Triton API type mapped to numpy type."""
+    """Return the Triton API type mapped to numpy type.
+
+    todo (Wael): add pytorch types and what they correspond to.
+    """
     # see: https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md
     return {
         "bool": "BOOL",
@@ -162,14 +192,122 @@ def _get_model_config(model: LudwigModel) -> str:
     return config
 
 
+def single_to_input(s: pd.Series, feature) -> Union[List[str], torch.Tensor]:
+    """Transform input for a feature to be compatible with what's required by TorchScript.
+    """
+    if s.dtype == "object" or type(feature) is CategoryInputFeature:
+        return s.astype('str').to_list()
+    return torch.from_numpy(s.to_numpy())
+
+def all_to_input(df: pd.DataFrame, model: LudwigModel):
+    """Transform input for all features to be compatible with what's required by TorchScript.
+    """
+    return {name: single_to_input(df[feature.column], feature) for name, feature in model.model.input_features.items()}
+
+
+def to_triton_dimension(content: Union[List[str], List[torch.Tensor], List[TorchAudioTuple], torch.Tensor]):
+    if isinstance(content, list) and content:
+        if isinstance(content[0], str):
+            return (len(content))
+        """
+        todo (Wael): check these and add other types
+        
+        if isinstance(content[0], torch.Tensor):
+            return (len(content))
+        if isinstance(content[0], TorchAudioTuple):
+            return (len(content))
+        """
+    elif isinstance(content, torch.Tensor):
+        return tuple(content.size())
+
+def to_triton_type(content: Union[List[str], List[torch.Tensor], List[TorchAudioTuple], torch.Tensor]):
+    if isinstance(content, list) and content:
+        if isinstance(content[0], str):
+            return _get_type_map("string")
+        """
+        todo (Wael): check these and add other types
+
+        if isinstance(content[0], torch.Tensor):
+            return _get_type_map(content.dtype)
+        if isinstance(content[0], TorchAudioTuple):
+            return _get_type_map(content.dtype)
+        """
+    elif isinstance(content, torch.Tensor):
+        return _get_type_map(content.dtype)
+
+
+@dataclass
+class TritonConfigFeature:
+    name: str
+    content: Union[TorchscriptPreprocessingInput, torch.Tensor]
+    inference_stage: str
+    kind: str
+    order: int
+
+    def __post_init__(self):
+        # get Triton type
+        self.type = to_triton_type(self.content)
+        # get dimension
+        self.dimension = to_triton_dimension(self.content)
+        # get ensemble_scheduling output_map key (same as "name" in input/output)
+        self.key = f"{self.kind}__{self.order}"
+        # get ensemble_scheduling output_map value
+        self.value = f"{self.name}_{self.inference_stage}"
+        pass
+
+@dataclass
+class TritonEnsembleConfig:
+    """
+    will store triton config template, call the proper functions to populate it.
+    could store path and have a function for save.
+    """
+    config_template: str
+    pass
+
+@dataclass
+class TritonConfig:
+    """
+    will store triton config template, call the proper functions to populate it.
+    could store path and have a function for save.
+    """
+
+    config_template: str
+    pass
+
+@dataclass
+class TritonModel:
+    """
+    will store wrapper class template, call the proper functions to populate it.
+    will return torchscript of each part of the inference pipeline.
+    could store path and have a function for save.
+    """
+    wrapper_template: str
+    pass
+
+@dataclass
+class TritonMaster: # change name
+    input_data_example: Dict[str, Union[TorchscriptPreprocessingInput, torch.Tensor]]
+    output_data_example: Dict[str, Union[TorchscriptPreprocessingInput, torch.Tensor]]
+    inference_stage: str
+
+    def __post_init__(self):
+        if self.inference_stage in INFERENCE_STAGES:
+            self.input_features = [TritonConfigFeature(feature_name, content, self.inference_stage, INPUT, i) for i, (feature_name, content) in
+                                   enumerate(self.input_data_example.items())]
+            self.output_features = [TritonConfigFeature(feature_name, content, self.inference_stage, OUTPUT, i) for i, (feature_name, content) in
+                                   enumerate(self.output_data_example.items())]
+        else:
+            raise ValueError("Invalid inference stage. Choose one of {}".format(INFERENCE_STAGES))
+
 def export_triton(
-    model: LudwigModel, output_path: str, model_name: str = "ludwig_model", model_version: Union[int, str] = 1
+    model: LudwigModel, data_example: pd.DataFrame, output_path: str, model_name: str = "ludwig_model", model_version: Union[int, str] = 1
 ) -> Tuple[str, str]:
     """Exports a torchscript model to a output path that serves as a repository for Triton Inference Server.
 
     # Inputs
-
     :param model: (LudwigModel) A ludwig model.
+    :param data_example: (pd.DataFrame) an example from the dataset.
+        Used to get dimensions throughout the pipeline.
     :param output_path: (str) The output path for the model repository.
     :param model_name: (str) The optional model name.
     :param model_name: (Union[int,str]) The optional model verison.
@@ -177,6 +315,23 @@ def export_triton(
     # Return
     :return: (str, str) The saved model path, and config path.
     """
+
+
+    inference_module = InferenceModule.from_ludwig_model(model.model, model.config, model.training_set_metadata, DEVICE)
+    data_example = all_to_input(data_example.head(1), model)
+
+    preprocessor_output = inference_module.preprocessor_forward(data_example)
+    preprocessor_triton_config = TritonMaster(data_example, preprocessor_output, PREPROCESSOR)
+
+    predictor_output = inference_module.predictor_forward(preprocessor_output)
+    predictor_triton_config = TritonMaster(preprocessor_output, predictor_output, PREDICTOR)
+
+    postprocessor_output = inference_module.postprocessor_forward(predictor_output)
+    postprocessor_triton_config = TritonMaster(predictor_output, postprocessor_output, POSTPROCESSOR)
+
+
+
+
     model_ts = generate_triton_torchscript(model)
     model_dir = os.path.join(output_path, model_name, str(model_version))
     os.makedirs(model_dir, exist_ok=True)


### PR DESCRIPTION
Exports Triton configs and scripted models as well an an ensemble config.

1. train a ludwig model.
```
from ludwig.api import LudwigModel
from ludwig.datasets import titanic

training_set, test_set, _ = titanic.load(split=True)
model = LudwigModel(config="./titanic.yaml")

train_stats, preprocessed_data, output_directory = model.train(training_set=training_set,
                                                               test_set=test_set,
                                                               experiment_name="simple_experiment",
                                                               model_name="simple_model",
                                                               skip_save_processed_input=True)
```
2. To export to models and configs to a Triton-compliant structure 
```
export_triton(model, test_set, output_path="model_repository", model_name="titanic_ludwig", model_version=1)
```
3. Find the exported models under `model_repository/`