### PR TITLE
fix: update `jsonschema` pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ requests
 tables
 fsspec[http]
 dataclasses-json
-jsonschema>=4.5.0
+jsonschema==4.6.*
 marshmallow
 marshmallow-jsonschema
 marshmallow-dataclass==8.5.5


### PR DESCRIPTION
Current failures are due to more precise error handling from this change in `jsonschema`: https://github.com/python-jsonschema/jsonschema/issues/728