### PR TITLE
Fix: Don't skip saving the model if the save path already exists.

### DIFF
--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -15,7 +15,6 @@ from ludwig.models.base import BaseModel
 from ludwig.schema.utils import load_config_with_kwargs
 from ludwig.utils import output_feature_utils
 from ludwig.utils.data_utils import clear_data_cache
-from ludwig.utils.fs_utils import open_file, path_exists
 from ludwig.utils.torch_utils import get_torch_device
 
 
@@ -152,9 +151,7 @@ class ECD(BaseModel):
     def save(self, save_path):
         """Saves the model to the given path."""
         weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
-        if not path_exists(weights_save_path):
-            with open_file(weights_save_path, "wb") as f:
-                torch.save(self.state_dict(), f)
+        torch.save(self.state_dict(), weights_save_path)
 
     def load(self, save_path):
         """Loads the model from the given path."""

--- a/tests/integration_tests/test_model_save_and_load.py
+++ b/tests/integration_tests/test_model_save_and_load.py
@@ -1,13 +1,16 @@
+import logging
 import os.path
 import random
 import tempfile
 
 import numpy as np
+import pandas as pd
 import torch
 
 from ludwig.api import LudwigModel
-from ludwig.constants import TRAINER
+from ludwig.constants import LOSS, NAME, TRAINER, TRAINING
 from ludwig.data.split import get_splitter
+from ludwig.modules.loss_modules import MSELoss
 from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import (
     audio_feature,
@@ -206,3 +209,48 @@ def test_gbm_model_save_reload_api(csv_filename, tmp_path):
     # Test loading the model from the experiment directory
     ludwig_model_exp = LudwigModel.load(os.path.join(output_dir, "model"), backend=backend)
     check_model_equal(ludwig_model_exp)
+
+
+def test_model_weights_match_training(csv_filename):
+    np.random.seed(1)
+
+    input_features = [number_feature()]
+    output_features = [number_feature()]
+    output_feature_name = output_features[0][NAME]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Generate test data
+        data_csv_path = generate_data(
+            input_features,
+            output_features,
+            os.path.join(tmpdir, csv_filename),
+            num_examples=100
+        )
+
+        config = {"input_features": input_features, "output_features": output_features,
+                  "trainer": {"epochs": 5, "batch_size": 32}}
+
+        model = LudwigModel(config=config, )
+
+        training_stats, _, _ = model.train(
+            training_set=data_csv_path, random_seed=1919)
+
+        # generate predicitons from training data
+        df = pd.read_csv(data_csv_path)
+        predictions = model.predict(df)
+
+        # compute loss on predictions from training data
+        loss_function = MSELoss()
+        loss = loss_function(
+            torch.tensor(predictions[0][output_feature_name + "_predictions"].values),  # predictions
+            torch.tensor(df[output_feature_name].values),  # target
+        ).type(torch.float32)
+
+        # get last loss value from training
+        last_training_loss = torch.tensor(training_stats[TRAINING][output_feature_name][LOSS][-1])
+
+        # loss from predictions should match last loss value recorded during training
+        assert torch.isclose(loss, last_training_loss), (
+            "Model predictions on training set did not generate same loss value as in training. "
+            "Need to confirm that weights were correctly captured in model."
+        )

--- a/tests/integration_tests/test_model_save_and_load.py
+++ b/tests/integration_tests/test_model_save_and_load.py
@@ -1,4 +1,3 @@
-import logging
 import os.path
 import random
 import tempfile


### PR DESCRIPTION
Without this change, the model is only saved the first time `save()` is called (at the end of the first round of evaluation).

This is a bug that was introduced in #2027. This was not caught by any model loading unit tests like `tests/integration_tests/test_model_save_and_load.py` because the best saved weights are reloaded automatically at the end of `train()`, so there's never a discrepancy between the model returned from `train()` and models loaded from disk.

@jimthompson5802 will send a follow up PR that adds a test that catches this regression specifically.

Closes #2259