### PR TITLE
Load best weights outside of finally block, since load may throw an exception

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -856,9 +856,9 @@ class Trainer(BaseTrainer):
             if self.is_coordinator() and not self.skip_save_progress:
                 checkpoint_manager.close()
 
-            # Load the best weights from saved checkpoint
-            if self.is_coordinator() and not self.skip_save_model:
-                self.model.load(save_path)
+        # Load the best weights from saved checkpoint
+        if self.is_coordinator() and not self.skip_save_model:
+            self.model.load(save_path)
 
         # restore original sigint signal handler
         if self.original_sigint_handler and threading.current_thread() == threading.main_thread():


### PR DESCRIPTION
The problem here is that if model training fails before the weights are saved, the `finally` block will call `self.model.load(save_path)` which throws a FileNotFound exception, thus the original error is never printed to the console.

Python executes the `finally` block before raising the original exception.

This PR moves `self.model.load(save_path)` outside of the `finally` block.