### PR TITLE
fix: Make `BaseTrainerConfig` an abstract class

### DIFF
--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Union
 
+from abc import ABCMeta
 from marshmallow_dataclass import dataclass
 
 from ludwig.constants import COMBINED, LOSS, MODEL_ECD, MODEL_GBM, TRAINING, TYPE
@@ -25,7 +26,7 @@ def register_trainer_schema(name: str):
 
 
 @dataclass
-class BaseTrainerConfig(schema_utils.BaseMarshmallowConfig):
+class BaseTrainerConfig(schema_utils.BaseMarshmallowConfig, metaclass=ABCMeta):
     """Common trainer parameter values."""
 
     type: str

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -1,6 +1,6 @@
+from abc import ABCMeta
 from typing import List, Optional, Union
 
-from abc import ABCMeta
 from marshmallow_dataclass import dataclass
 
 from ludwig.constants import COMBINED, LOSS, MODEL_ECD, MODEL_GBM, TRAINING, TYPE

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta
+from abc import ABC
 from typing import List, Optional, Union
 
 from marshmallow_dataclass import dataclass

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -26,7 +26,7 @@ def register_trainer_schema(name: str):
 
 
 @dataclass
-class BaseTrainerConfig(schema_utils.BaseMarshmallowConfig, metaclass=ABCMeta):
+class BaseTrainerConfig(schema_utils.BaseMarshmallowConfig, ABC):
     """Common trainer parameter values."""
 
     type: str


### PR DESCRIPTION
A user should not be able to directly instantiate this class.