### PR TITLE
Fixes #2279

### DIFF
--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -68,7 +68,9 @@ class DateFeatureMixin(BaseFeatureMixin):
     @staticmethod
     def date_to_list(date_str, datetime_format, preprocessing_parameters):
         try:
-            if datetime_format is not None:
+            if isinstance(date_str, datetime): 
+                datetime_obj = date_str
+            elif datetime_format is not None:
                 datetime_obj = datetime.strptime(date_str, datetime_format)
             else:
                 datetime_obj = parse(date_str)

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -68,7 +68,7 @@ class DateFeatureMixin(BaseFeatureMixin):
     @staticmethod
     def date_to_list(date_str, datetime_format, preprocessing_parameters):
         try:
-            if isinstance(date_str, datetime): 
+            if isinstance(date_str, datetime):
                 datetime_obj = date_str
             elif datetime_format is not None:
                 datetime_obj = datetime.strptime(date_str, datetime_format)

--- a/tests/ludwig/features/test_date_feature.py
+++ b/tests/ludwig/features/test_date_feature.py
@@ -1,6 +1,7 @@
+from datetime import datetime
+
 import pytest
 
-from datetime import datetime
 from ludwig.features import date_feature
 
 
@@ -18,9 +19,10 @@ def test_date_to_list(date_str, datetime_format, expected_list):
         date_feature.DateInputFeature.date_to_list(date_str, datetime_format, preprocessing_parameters) == expected_list
     )
 
+
 def test_date_to_list__DatetimeObjectFromParsedJSON():
     preprocessing_parameters = None
-    datetime_obj = datetime.fromisoformat('2022-06-25')
+    datetime_obj = datetime.fromisoformat("2022-06-25")
     assert date_feature.DateInputFeature.date_to_list(datetime_obj, None, preprocessing_parameters) == [
         2022,
         6,

--- a/tests/ludwig/features/test_date_feature.py
+++ b/tests/ludwig/features/test_date_feature.py
@@ -1,5 +1,6 @@
 import pytest
 
+from datetime import datetime
 from ludwig.features import date_feature
 
 
@@ -16,6 +17,21 @@ def test_date_to_list(date_str, datetime_format, expected_list):
     assert (
         date_feature.DateInputFeature.date_to_list(date_str, datetime_format, preprocessing_parameters) == expected_list
     )
+
+def test_date_to_list__DatetimeObjectFromParsedJSON():
+    preprocessing_parameters = None
+    datetime_obj = datetime.fromisoformat('2022-06-25')
+    assert date_feature.DateInputFeature.date_to_list(datetime_obj, None, preprocessing_parameters) == [
+        2022,
+        6,
+        25,
+        5,
+        176,
+        0,
+        0,
+        0,
+        0,
+    ]
 
 
 def test_date_to_list__UsesFillValueOnInvalidDate():


### PR DESCRIPTION
This PR (temporarily) fixes a case where `pandas.read_json` parses a date feature as a `datetime` object prior to feature data building.  Test case included and passing.  As discussed in #2279.
