### PR TITLE
catching urllib3 exception

### DIFF
--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -29,7 +29,6 @@ from urllib.parse import unquote, urlparse
 import certifi
 import fsspec
 import h5py
-import requests
 import urllib3
 from filelock import FileLock
 from fsspec.core import split_protocol

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -77,7 +77,7 @@ def get_bytes_obj_from_path(path: str) -> Optional[bytes]:
     if is_http(path):
         try:
             return get_bytes_obj_from_http_path(path)
-        except requests.exceptions.RequestException as e:
+        except Exception as e:
             logging.warning(e)
             return None
     else:


### PR DESCRIPTION
Changed exception catching in `ludwig.utils.fs_utils.get_bytes_obj_from_path` from `except requests.exceptions.RequestException as e` to `except Exception as e`.

Used `Exception` instead of a `urllib3` specific base exception because `urllib3` doesn't have one.