### PR TITLE
Save checkpoint if train_steps is smaller than batcher's steps_per_epoch

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -765,6 +765,7 @@ class Trainer(BaseTrainer):
                     self.checkpoints_per_epoch,
                     self.is_coordinator(),
                 )
+                final_steps_per_checkpoint = min(final_steps_per_checkpoint, self.total_steps)
 
                 early_stopping_steps = final_steps_per_checkpoint * self.early_stop
 


### PR DESCRIPTION
If you try to train using a total number of steps smaller than steps_per_epoch, the model weights are not saved and ludwig throws an exception.

This is useful for doing quick tests by training for a small number of steps to generate a saved model, i.e.

```
trainer:
  train_steps: 50
```


Output:
```
Training: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [02:35<00:00,  3.11s/it]Traceback (most recent call last):
  File "/Users/daniel/mambaforge/envs/ludwig39-dev/bin/ludwig", line 33, in <module>
    sys.exit(load_entry_point('ludwig', 'console_scripts', 'ludwig')())
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/cli.py", line 166, in main
    CLI()
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/cli.py", line 66, in __init__
    getattr(self, args.command)()
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/cli.py", line 71, in train
    train.cli(sys.argv[2:])
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/train.py", line 387, in cli
    train_cli(**vars(args))
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/train.py", line 181, in train_cli
    model.train(
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/api.py", line 552, in train
    train_stats = trainer.train(
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/trainers/trainer.py", line 862, in train
    self.model.load(save_path)
  File "/Users/daniel/Desktop/github/dantreiman-ludwig/ludwig/models/ecd.py", line 160, in load
    self.load_state_dict(torch.load(weights_save_path, map_location=device))
  File "/Users/daniel/mambaforge/envs/ludwig39-dev/lib/python3.9/site-packages/torch/serialization.py", line 699, in load
    with _open_file_like(f, 'rb') as opened_file:
  File "/Users/daniel/mambaforge/envs/ludwig39-dev/lib/python3.9/site-packages/torch/serialization.py", line 230, in _open_file_like
    return _open_file(name_or_buffer, mode)
  File "/Users/daniel/mambaforge/envs/ludwig39-dev/lib/python3.9/site-packages/torch/serialization.py", line 211, in __init__
    super(_open_file, self).__init__(open(name, mode))
FileNotFoundError: [Errno 2] No such file or directory: '/Users/daniel/Desktop/github/dantreiman-ludwig/examples/rotten_tomatoes/results/experiment_run/model/model_weights'
``` 