### PR TITLE
Don't skip normalization in TabNet during inference on a single row.

### DIFF
--- a/ludwig/modules/normalization_modules.py
+++ b/ludwig/modules/normalization_modules.py
@@ -27,7 +27,7 @@ class GhostBatchNormalization(LudwigModule):
             x = [self.bn(x) for x in splits]
             return torch.cat(x, 0)
 
-        if batch_size != 1:
+        if batch_size != 1 or not self.training:
             return self.bn(inputs)
         return inputs
 

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -108,7 +108,7 @@ class TabNet(LudwigModule):
         masks = []
         total_entropy = 0.0
 
-        if batch_size != 1:
+        if batch_size != 1 or not self.training:
             # Skip batch normalization if the batch size is 1.
             features = self.batch_norm(features)  # [b_s, i_s]
         masked_features = features

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -109,7 +109,7 @@ class TabNet(LudwigModule):
         total_entropy = 0.0
 
         if batch_size != 1 or not self.training:
-            # Skip batch normalization if the batch size is 1.
+            # Skip batch normalization training if the batch size is 1.
             features = self.batch_norm(features)  # [b_s, i_s]
         masked_features = features
 


### PR DESCRIPTION
Should fix https://github.com/ludwig-ai/ludwig/discussions/2290

The problem is that TabNet gives different outputs if you predict a single row vs. if you predict a batch.

The cause is this line in `normalization_modules.py:32`:
```
        if batch_size != 1:
            return self.bn(inputs)
       return inputs
```

and also `tabnet_modules.py:111`:
```
        if batch_size != 1:
            # Skip batch normalization if the batch size is 1.
            features = self.batch_norm(features)  # [b_s, i_s]
```
