### PR TITLE
Fix error in postproc_predictions calculation in model.evaluate()

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -959,9 +959,7 @@ class LudwigModel:
 
             if collect_predictions:
                 postproc_predictions = convert_predictions(
-                    postproc_predictions,
-                    self.model.output_features,
-                    return_type=return_type,
+                    postproc_predictions, self.model.output_features, return_type=return_type, backend=self.backend
                 )
 
             for callback in self.callbacks:

--- a/ludwig/data/utils.py
+++ b/ludwig/data/utils.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 
-from ludwig.utils.dataframe_utils import is_dask_df
+from ludwig.utils.dataframe_utils import is_dask_series_or_df
 from ludwig.utils.types import DataFrame
 
 
@@ -20,7 +20,7 @@ def convert_to_dict(
             subgroup = key[len(of_name) + 1 :]
 
             values = predictions[key]
-            if is_dask_df(values, backend):
+            if is_dask_series_or_df(values, backend):
                 values = values.compute()
             try:
                 values = np.stack(values.to_numpy())

--- a/ludwig/utils/dataframe_utils.py
+++ b/ludwig/utils/dataframe_utils.py
@@ -18,11 +18,11 @@ def is_dask_backend(backend: Optional["Backend"]) -> bool:  # noqa: F821
     return backend is not None and is_dask_lib(backend.df_engine.df_lib)
 
 
-def is_dask_df(df: DataFrame, backend: Optional["Backend"]) -> bool:  # noqa: F821
+def is_dask_series_or_df(df: DataFrame, backend: Optional["Backend"]) -> bool:  # noqa: F821
     if is_dask_backend(backend):
         import dask.dataframe as dd
 
-        return isinstance(df, dd.DataFrame)
+        return isinstance(df, dd.Series) or isinstance(df, dd.DataFrame)
     return False
 
 


### PR DESCRIPTION
Issue description: https://github.com/ludwig-ai/ludwig/issues/2303

1. We weren't passing in the backend before, which is something we should've done during the call to `convert_predictions`
2. We want to check if `values` is either a Dask DataFrame or a Dask Series - in either case, we want to explicitly call compute. 