### PR TITLE
Ensure unit tests are using `tmpdir`

### DIFF
--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -204,11 +204,11 @@ def test_api_training_set(tmpdir):
         "combiner": {"type": "concat", "output_size": 14},
     }
     model = LudwigModel(config)
-    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv)
+    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv, output_directory=tmpdir)
     model.predict(dataset=test_csv)
 
     # Train again, this time the HDF5 cache will be used
-    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv)
+    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv, output_directory=tmpdir)
 
 
 def test_api_training_determinism(tmpdir):
@@ -455,7 +455,7 @@ def test_api_callbacks(tmpdir, csv_filename, epochs, batch_size, num_examples, s
     val_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "validation.csv"))
     test_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "test.csv"))
 
-    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv)
+    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv, output_directory=tmpdir)
 
     assert mock_callback.on_epoch_start.call_count == epochs
     assert mock_callback.on_epoch_end.call_count == epochs
@@ -504,7 +504,7 @@ def test_api_callbacks_checkpoints_per_epoch(
     val_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "validation.csv"))
     test_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "test.csv"))
 
-    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv)
+    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv, output_directory=tmpdir)
 
     assert mock_callback.on_epoch_start.call_count == epochs
     assert mock_callback.on_epoch_end.call_count == epochs

--- a/tests/integration_tests/test_model_save_and_load.py
+++ b/tests/integration_tests/test_model_save_and_load.py
@@ -226,7 +226,7 @@ def test_model_weights_match_training(tmpdir, csv_filename):
         config=config,
     )
 
-    training_stats, _, _ = model.train(training_set=data_csv_path, random_seed=1919)
+    training_stats, _, _ = model.train(training_set=data_csv_path, random_seed=1919, output_directory=tmpdir)
 
     # generate predicitons from training data
     df = pd.read_csv(data_csv_path)

--- a/tests/integration_tests/test_whylogs.py
+++ b/tests/integration_tests/test_whylogs.py
@@ -53,7 +53,13 @@ def test_whylogs_callback_local(tmpdir):
     callback = WhyLogsCallback()
 
     model = LudwigModel(config, callbacks=[callback])
-    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv, experiment_name=exp_name)
+    model.train(
+        training_set=data_csv,
+        validation_set=val_csv,
+        test_set=test_csv,
+        experiment_name=exp_name,
+        output_directory=tmpdir,
+    )
     _, _ = model.predict(test_csv)
 
     local_training_output_dir = "output/training"
@@ -76,7 +82,7 @@ def test_whylogs_callback_dask(tmpdir):
     val_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "validation.csv"))
     test_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "test.csv"))
 
-    run_dask(input_features, output_features, data_csv, val_csv, test_csv)
+    run_dask(input_features, output_features, data_csv, val_csv, test_csv, output_directory=tmpdir)
     local_training_output_dir = "output/training"
     local_prediction_output_dir = "output/prediction"
 
@@ -85,7 +91,7 @@ def test_whylogs_callback_dask(tmpdir):
 
 
 @spawn
-def run_dask(input_features, output_features, data_csv, val_csv, test_csv):
+def run_dask(input_features, output_features, data_csv, val_csv, test_csv, output_directory):
     epochs = 2
     batch_size = 8
     backend = {
@@ -113,5 +119,11 @@ def run_dask(input_features, output_features, data_csv, val_csv, test_csv):
         exp_name = "whylogs_test_ray"
         callback = WhyLogsCallback()
         model = LudwigModel(config, backend=backend, callbacks=[callback])
-        model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv, experiment_name=exp_name)
+        model.train(
+            training_set=data_csv,
+            validation_set=val_csv,
+            test_set=test_csv,
+            experiment_name=exp_name,
+            output_directory=output_directory,
+        )
         _, _ = model.predict(test_csv)


### PR DESCRIPTION
Updated several unit tests to ensure that Ludwig models save their artifacts into the pytest fixture `tmpdir`, in order to ensure cleanup and relieve memory pressure overall during tests.