### PR TITLE
Use warnings to suppress repeated logs for failed image reads

### DIFF
--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -15,6 +15,7 @@
 # ==============================================================================
 import logging
 import os
+import warnings
 from collections import Counter
 from functools import partial
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -185,7 +186,7 @@ class ImageFeatureMixin(BaseFeatureMixin):
             img = img_entry
 
         if not isinstance(img, torch.Tensor):
-            logging.info(f"Image with value {img} cannot be read")
+            warnings.warn(f"Image with value {img} cannot be read")
             return None
 
         img_num_channels = num_channels_in_image(img)

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 import logging
+import warnings
 from collections.abc import Iterable
 from io import BytesIO
 from typing import List, Optional, Tuple, Union
@@ -105,7 +106,7 @@ def read_image_from_bytes_obj(
     if image is None:
         image = read_image_as_numpy(bytes_obj)
     if image is None:
-        logger.warning("Unable to read image from bytes object.")
+        warnings.warn("Unable to read image from bytes object.")
     return image
 
 
@@ -123,7 +124,7 @@ def read_image_as_png(
             del buffer_view
             return image
     except Exception as e:
-        logger.warning(f"Failed to read image from PNG file. Original exception: {e}")
+        warnings.warn(f"Failed to read image from PNG file. Original exception: {e}")
         return None
 
 
@@ -134,7 +135,7 @@ def read_image_as_numpy(bytes_obj: Optional[bytes] = None) -> Optional[torch.Ten
             image = np.load(buffer)
             return torch.from_numpy(image)
     except Exception as e:
-        logger.warning(f"Failed to read image from numpy file. Original exception: {e}")
+        warnings.warn(f"Failed to read image from numpy file. Original exception: {e}")
         return None
 
 


### PR DESCRIPTION
By switching to `warnings.warn`, we can suppress repeated image failed log messages making this much cleaner for larger datasets.