### PR TITLE
Log number of failed image reads

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -107,6 +107,8 @@ jobs:
             if [ "$RAY_VERSION" == "nightly" ]; then
               # NOTE: hardcoded for python 3.9 on Linux
               # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+
+              # NOTE: pinned to last commit from 7/21/22 to get tests passing
               pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/c557c7877f099d02a9e43c5c56c958860b6dd737/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
             else
               pip install ray==$RAY_VERSION

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -106,7 +106,8 @@ jobs:
           if [ "$MARKERS" == "distributed" ]; then
             if [ "$RAY_VERSION" == "nightly" ]; then
               # NOTE: hardcoded for python 3.9 on Linux
-              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+              # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/c557c7877f099d02a9e43c5c56c958860b6dd737/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
             else
               pip install ray==$RAY_VERSION
             fi

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -468,8 +468,8 @@ class ImageFeatureMixin(BaseFeatureMixin):
 
         if num_failed_image_reads > 0:
             logging.warning(
-                f"""Failed to read {num_failed_image_reads} images while preprocessing feature `{name}`. Using
-                default image for these rows in the dataset."""
+                f"Failed to read {num_failed_image_reads} images while preprocessing feature `{name}`. "
+                "Using default image for these rows in the dataset."
             )
 
         return proc_df

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -439,9 +439,10 @@ class ImageFeatureMixin(BaseFeatureMixin):
 
             proc_col = backend.read_binary_files(abs_path_column, map_fn=read_image_if_bytes_obj_and_resize)
 
-            num_failed_image_reads = proc_col.isna().sum()
-            if is_dask_series_or_df(num_failed_image_reads, backend):
-                num_failed_image_reads = num_failed_image_reads.compute()
+            if is_dask_series_or_df(proc_col, backend):
+                num_failed_image_reads = proc_col.isna().sum().compute()
+            else:
+                num_failed_image_reads = proc_col.isna().sum()
 
             proc_col = backend.df_engine.map_objects(proc_col, lambda row: row if row is not None else default_image)
             proc_df[feature_config[PROC_COLUMN]] = proc_col

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -457,7 +457,7 @@ class ImageFeatureMixin(BaseFeatureMixin):
                 )
                 for i, img_entry in enumerate(abs_path_column):
                     res = read_image_if_bytes_obj_and_resize(img_entry)
-                    if res is not None:
+                    if res:
                         image_dataset[i, :height, :width, :] = res
                     else:
                         image_dataset[i, :height, :width, :] = default_image

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -439,10 +439,9 @@ class ImageFeatureMixin(BaseFeatureMixin):
 
             proc_col = backend.read_binary_files(abs_path_column, map_fn=read_image_if_bytes_obj_and_resize)
 
-            if is_dask_series_or_df(proc_col, backend):
-                num_failed_image_reads = proc_col.isna().sum().compute()
-            else:
-                num_failed_image_reads = proc_col.isna().sum()
+            num_failed_image_reads = (
+                proc_col.isna().sum().compute() if is_dask_series_or_df(proc_col, backend) else proc_col.isna().sum()
+            )
 
             proc_col = backend.df_engine.map_objects(proc_col, lambda row: row if row is not None else default_image)
             proc_df[feature_config[PROC_COLUMN]] = proc_col

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -61,8 +61,6 @@ from ludwig.utils.image_utils import (
 from ludwig.utils.misc_utils import set_default_value
 from ludwig.utils.types import Series, TorchscriptPreprocessingInput
 
-logger = logging.getLogger(__name__)
-
 # TODO(shreya): Confirm if it's ok to do per channel normalization
 # TODO(shreya): Also confirm if this is being used anywhere
 # TODO(shreya): Confirm if ok to use imagenet means and std devs
@@ -469,7 +467,7 @@ class ImageFeatureMixin(BaseFeatureMixin):
             proc_df[feature_config[PROC_COLUMN]] = np.arange(num_images)
 
         if num_failed_image_reads > 0:
-            logger.warning(
+            logging.warning(
                 f"""Failed to read {num_failed_image_reads} images while preprocessing feature `{name}`. Using
                 default image for these rows in the dataset."""
             )


### PR DESCRIPTION
This PR logs the number of images that couldn't be read during preprocessing an image column. It only logs to stdout if 1 or more images failed to be read.