### PR TITLE
Custom to_dask() implementation to include meta during Dask DataFrame creation

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -106,7 +106,10 @@ jobs:
           if [ "$MARKERS" == "distributed" ]; then
             if [ "$RAY_VERSION" == "nightly" ]; then
               # NOTE: hardcoded for python 3.9 on Linux
-              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+              # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+
+              # NOTE: pinned to last commit from 7/21/22 to get tests passing
+              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/c557c7877f099d02a9e43c5c56c958860b6dd737/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
             else
               pip install ray==$RAY_VERSION
             fi

--- a/ludwig/data/dataframe/dask.py
+++ b/ludwig/data/dataframe/dask.py
@@ -145,8 +145,9 @@ class DaskEngine(DataFrameEngine):
                 )
             return block.to_pandas()
 
-        # Use first row from ray dataset to generate meta
-        meta = dataset.limit(1).to_pandas()
+        # Use first few row from ray dataset to generate meta to infer types even if there are NaNs
+        meta = dataset.limit(100).to_pandas()
+        # meta = meta.dtypes.apply(lambda x: x.name).to_dict()
         ddf = dd.from_delayed([block_to_df(block) for block in dataset.get_internal_block_refs()], meta=meta)
         return ddf
 


### PR DESCRIPTION
Ray's [`to_dask()`](https://docs.ray.io/en/latest/_modules/ray/data/dataset.html#Dataset.to_dask) function is called when predictions are being generated, but the Ray implementation doesn't pass in any meta related information into `dd.from_delayed`. I believe that in some instances (small dataset with a large number of partitions, empty partitions, etc.), there isn't enough data in the first Dask partition for Dask to infer the meta correctly (or at all). 

This PR updates `from_ray_dataset` within our DaskEngine to use a custom implementation that creates meta information from the first 100 rows of the ray dataset and uses it during the creation of the Dask DataFrame from the Ray Dataset. Dask won't need to infer the meta information anymore for the dataframe, guaranteeing fewer problems in downstream transformations. This gives us more downstream control.

The hack has been added because in Ray 1.12 and 1.13, the resulting column from `read_binary_files` was cast into type object for being passed into Dask, but in Ray nightly, they've started casting the column to type TensorDtype (thanks for the catch @geoffreyangus). This change is also needed for https://github.com/ludwig-ai/ludwig/pull/2241 to pass the tests for Ray nightly.