### PR TITLE
Fixes TensorDtype TypeError in Ray nightly

### DIFF
--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -35,7 +35,7 @@ from ray.util.dask import ray_dask_get
 from ludwig.backend.base import Backend, RemoteTrainingMixin
 from ludwig.constants import MODEL_ECD, MODEL_GBM, NAME, PREPROCESSING, PROC_COLUMN
 from ludwig.data.dataframe.base import DataFrameEngine
-from ludwig.data.dataset.ray import RayDataset, RayDatasetManager, RayDatasetShard, cast_as_tensor_dtype
+from ludwig.data.dataset.ray import cast_as_tensor_dtype, RayDataset, RayDatasetManager, RayDatasetShard
 from ludwig.models.base import BaseModel
 from ludwig.models.ecd import ECD
 from ludwig.models.predictor import BasePredictor, get_output_columns, Predictor, RemotePredictor

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -30,13 +30,12 @@ from fsspec.config import conf
 from packaging import version
 from ray import ObjectRef
 from ray.data.dataset_pipeline import DatasetPipeline
-from ray.data.extensions import TensorDtype
 from ray.util.dask import ray_dask_get
 
 from ludwig.backend.base import Backend, RemoteTrainingMixin
 from ludwig.constants import MODEL_ECD, MODEL_GBM, NAME, PREPROCESSING, PROC_COLUMN
 from ludwig.data.dataframe.base import DataFrameEngine
-from ludwig.data.dataset.ray import RayDataset, RayDatasetManager, RayDatasetShard
+from ludwig.data.dataset.ray import RayDataset, RayDatasetManager, RayDatasetShard, cast_as_tensor_dtype
 from ludwig.models.base import BaseModel
 from ludwig.models.ecd import ECD
 from ludwig.models.predictor import BasePredictor, get_output_columns, Predictor, RemotePredictor
@@ -653,7 +652,7 @@ class RayPredictor(BasePredictor):
 
         def to_tensors(df: pd.DataFrame) -> pd.DataFrame:
             for c in columns:
-                df[c] = df[c].astype(TensorDtype())
+                df[c] = cast_as_tensor_dtype(df[c])
             return df
 
         # TODO(shreya): self.trainer_kwargs should have the correct resources; debug.


### PR DESCRIPTION
This PR fixes the hanging unit tests in the py39 (Ray nightly) unit tests. The change here accounts for recent changes to the Ray interface for Tensor type casting (https://github.com/ray-project/ray/issues/27031).