### PR TITLE
fix: Mlflow config being injected in hyperopt config

### DIFF
--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -446,6 +446,7 @@ class RayTuneExecutor:
 
         # Some config values may be JSON encoded as strings, so decode them here
         config = self.decode_values(config, decode_ctx)
+        del config["mlflow"]
 
         trial_id = tune.get_trial_id()
         trial_dir = Path(tune.get_trial_dir())


### PR DESCRIPTION
alternatively, can remove this? https://github.com/ludwig-ai/ludwig/blob/e3c03c942e8fa1ba9a529652a588b5ee16d73607/ludwig/contribs/mlflow/__init__.py#L136

closes #https://github.com/ludwig-ai/ludwig/issues/2288