### PR TITLE
Pin nightly versions to fix CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -96,8 +96,7 @@ jobs:
           if [ "$PYTORCH" == "nightly" ]; then
             cat requirements.txt | sed '/^torch[>=<]/d' | sed '/^torchtext[>=<]/d' | sed '/^torchvision[>=<]/d' | sed '/^torchaudio[>=<]/d' > requirements-temp && mv requirements-temp requirements.txt
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            # Pinned to fix issues with torchvision nightly
-            pip install --pre torch==1.13.0.dev20220726 torchtext==0.14.0.dev20220726 torchaudio==0.13.0.dev20220726 torchvision==0.14.0.dev20220726 --extra-index-url $extra_index_url
+            pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
           else
             extra_index_url=https://download.pytorch.org/whl/cpu
             pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -108,8 +108,9 @@ jobs:
             if [ "$RAY_VERSION" == "nightly" ]; then
               # NOTE: hardcoded for python 3.9 on Linux
               # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
-              # NOTE: pinned to last commit from 7/26/22 to get tests passing
-              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/3322558287e701d1d1d6a7d7894c08087d55b465/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+              
+              # NOTE: pinned to last commit from 7/28/22 to get tests passing
+              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/693856975ab135cd513c41a72b0455fb3385e14b/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
             else
               pip install ray==$RAY_VERSION
             fi

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -108,7 +108,7 @@ jobs:
             if [ "$RAY_VERSION" == "nightly" ]; then
               # NOTE: hardcoded for python 3.9 on Linux
               # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
-              
+
               # NOTE: pinned to last commit from 7/21/22 to get tests passing
               pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/c557c7877f099d02a9e43c5c56c958860b6dd737/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
             else

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -109,8 +109,8 @@ jobs:
               # NOTE: hardcoded for python 3.9 on Linux
               # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
               
-              # NOTE: pinned to last commit from 7/28/22 to get tests passing
-              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/693856975ab135cd513c41a72b0455fb3385e14b/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+              # NOTE: pinned to last commit from 7/21/22 to get tests passing
+              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/c557c7877f099d02a9e43c5c56c958860b6dd737/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
             else
               pip install ray==$RAY_VERSION
             fi

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -96,8 +96,8 @@ jobs:
           if [ "$PYTORCH" == "nightly" ]; then
             cat requirements.txt | sed '/^torch[>=<]/d' | sed '/^torchtext[>=<]/d' | sed '/^torchvision[>=<]/d' | sed '/^torchaudio[>=<]/d' > requirements-temp && mv requirements-temp requirements.txt
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch==1.13.0.dev20220727 torchtext torchaudio --extra-index-url $extra_index_url
-            pip install https://download.pytorch.org/whl/nightly/torchvision-0.14.0.dev20220727-cp39-cp39-macosx_10_9_x86_64.whl
+            # Pinned to fix issues with torchvision nightly
+            pip install --pre torch==1.13.0.dev20220726 torchtext==0.14.0.dev20220726 torchaudio==0.13.0.dev20220726 torchvision==0.14.0.dev20220726 --extra-index-url $extra_index_url
           else
             extra_index_url=https://download.pytorch.org/whl/cpu
             pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -106,7 +106,9 @@ jobs:
           if [ "$MARKERS" == "distributed" ]; then
             if [ "$RAY_VERSION" == "nightly" ]; then
               # NOTE: hardcoded for python 3.9 on Linux
-              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+              # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+              # NOTE: pinned to last commit from 7/26/22 to get tests passing
+              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/3322558287e701d1d1d6a7d7894c08087d55b465/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
             else
               pip install ray==$RAY_VERSION
             fi

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -96,7 +96,8 @@ jobs:
           if [ "$PYTORCH" == "nightly" ]; then
             cat requirements.txt | sed '/^torch[>=<]/d' | sed '/^torchtext[>=<]/d' | sed '/^torchvision[>=<]/d' | sed '/^torchaudio[>=<]/d' > requirements-temp && mv requirements-temp requirements.txt
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            pip install --pre torch==1.13.0.dev20220727 torchtext torchaudio --extra-index-url $extra_index_url
+            pip install https://download.pytorch.org/whl/nightly/torchvision-0.14.0.dev20220727-cp39-cp39-macosx_10_9_x86_64.whl
           else
             extra_index_url=https://download.pytorch.org/whl/cpu
             pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -108,7 +108,7 @@ jobs:
               # NOTE: hardcoded for python 3.9 on Linux
               # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
               # NOTE: pinned to last commit from 7/26/22 to get tests passing
-              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/3322558287e701d1d1d6a7d7894c08087d55b465/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/3322558287e701d1d1d6a7d7894c08087d55b465/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
             else
               pip install ray==$RAY_VERSION
             fi


### PR DESCRIPTION
This PR pins Ray nightly to a working commit to ensure tests pass.

In addition, we pin torchvision and subsequently torch, torchtext, and torchaudio due to a similar bug to that found here: https://github.com/ludwig-ai/ludwig/pull/2072.