### PR TITLE
Set a default value for size_bytes in DatasetInfo

### DIFF
--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -51,7 +51,7 @@ MAX_DISTINCT_VALUES_TO_RETURN = 10
 class DatasetInfo:
     fields: List[FieldInfo]
     row_count: int
-    size_bytes: int
+    size_bytes: int = -1
 
 
 def allocate_experiment_resources(resources: dict) -> dict:


### PR DESCRIPTION
This avoids errors when loading old DatasetInfos generated without the `size_bytes` field.