### PR TITLE
Adds registry to organize backward compatibility updates around versions and config sections

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1355,6 +1355,11 @@ class LudwigModel:
 
         config = backend.broadcast_return(lambda: load_json(os.path.join(model_dir, MODEL_HYPERPARAMETERS_FILE_NAME)))
 
+        if "ludwig_version" not in config:
+            # Configs saved with 0.5 and above should have "ludwig_version" key, so if the config has none then assume
+            # it was saved by an older version of Ludwig and run all upgrades.
+            config["ludwig_version"] = "0.4"
+
         # Upgrades deprecated fields and adds new required fields in case the config loaded from disk is old.
         config = upgrade_to_latest_version(config)
         # Merge upgraded config with defaults.

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -76,6 +76,7 @@ from ludwig.models.registry import model_type_registry
 from ludwig.schema import validate_config
 from ludwig.schema.utils import load_trainer_with_kwargs
 from ludwig.utils import metric_utils
+from ludwig.utils.backward_compatibility import upgrade_to_latest_version
 from ludwig.utils.config_utils import merge_config_preprocessing_with_feature_specific_defaults
 from ludwig.utils.data_utils import (
     figure_data_format,
@@ -212,9 +213,10 @@ class LudwigModel:
             config_dict = copy.deepcopy(config)
             self.config_fp = None
 
-        # merge config with defaults
-        self.base_config = copy.deepcopy(config_dict)
-        self.config = merge_with_defaults(config_dict)
+        # Upgrades deprecated fields and adds new required fields in case the config loaded from disk is old.
+        self.base_config = upgrade_to_latest_version(config_dict)
+        # Merge upgraded config with defaults.
+        self.config = merge_with_defaults(copy.deepcopy(self.base_config))
         validate_config(self.config)
 
         # setup logging
@@ -1353,7 +1355,9 @@ class LudwigModel:
 
         config = backend.broadcast_return(lambda: load_json(os.path.join(model_dir, MODEL_HYPERPARAMETERS_FILE_NAME)))
 
-        # Upgrades deprecated fields and adds new required fields, in case the config loaded from disk is old.
+        # Upgrades deprecated fields and adds new required fields in case the config loaded from disk is old.
+        config = upgrade_to_latest_version(config)
+        # Merge upgraded config with defaults.
         config = merge_with_defaults(config)
 
         if backend_param is None and "backend" in config:

--- a/ludwig/data/dataset_synthesizer.py
+++ b/ludwig/data/dataset_synthesizer.py
@@ -94,6 +94,20 @@ DATETIME_FORMATS = {
 }
 
 
+def _get_feature_encoder_or_decoder(feature):
+    """Returns the nested decoder or encoder dictionary for a feature.
+
+    If neither encoder nor decoder is present, creates an empty encoder dict and returns it.
+    """
+    if DECODER in feature:
+        return feature[DECODER]
+    elif ENCODER in feature:
+        return feature[ENCODER]
+    else:
+        feature[ENCODER] = {}
+        return feature[ENCODER]
+
+
 def generate_string(length):
     sequence = []
     for _ in range(length):
@@ -113,12 +127,9 @@ def return_none(feature):
 
 
 def assign_vocab(feature):
-    if DECODER in feature:
-        feature["idx2str"] = build_vocab(feature[DECODER].get("vocab_size", 10))
-    elif ENCODER in feature:
-        feature["idx2str"] = build_vocab(feature[ENCODER].get("vocab_size", 10))
-    else:
-        feature["idx2str"] = build_vocab(10)
+    encoder_or_decoder = _get_feature_encoder_or_decoder(feature)
+    encoder_or_decoder["idx2str"] = build_vocab(encoder_or_decoder.get("vocab_size", 10))
+    encoder_or_decoder["vocab_size"] = len(encoder_or_decoder["idx2str"])
 
 
 def build_feature_parameters(features):
@@ -206,7 +217,12 @@ def generate_datapoint(features):
 
 
 def generate_category(feature):
-    return random.choice(feature["idx2str"])
+    if DECODER in feature:
+        return random.choice(feature[DECODER]["idx2str"])
+    elif ENCODER in feature:
+        return random.choice(feature[ENCODER]["idx2str"])
+    else:
+        logger.error(f"Feature {str(feature)} should have either an encoder or decoder.")
 
 
 def generate_number(feature):
@@ -220,45 +236,50 @@ def generate_binary(feature):
 
 
 def generate_sequence(feature):
-    length = feature.get("max_len", 10)
-    if "min_len" in feature:
-        length = random.randint(feature["min_len"], length)
-    sequence = [random.choice(feature["idx2str"]) for _ in range(length)]
-    if "vocab_size" not in feature:
-        feature["vocab_size"] = len(feature["idx2str"])
-    feature["vocab_size"] = feature["vocab_size"] + 4  # For special symbols: START, STOP, PAD, UNK.
+    encoder_or_decoder = _get_feature_encoder_or_decoder(feature)
+    length = encoder_or_decoder.get("max_len", 10)
+    if "min_len" in encoder_or_decoder:
+        length = random.randint(encoder_or_decoder["min_len"], length)
+    sequence = [random.choice(encoder_or_decoder["idx2str"]) for _ in range(length)]
+    encoder_or_decoder["vocab_size"] = (
+        encoder_or_decoder["vocab_size"] + 4
+    )  # For special symbols: START, STOP, PAD, UNK.
     return " ".join(sequence)
 
 
 def generate_set(feature):
+    encoder_or_decoder = _get_feature_encoder_or_decoder(feature)
     elems = []
-    for _ in range(random.randint(0, feature.get("max_len", 3))):
-        elems.append(random.choice(feature["idx2str"]))
+    for _ in range(random.randint(0, encoder_or_decoder.get("max_len", 3))):
+        elems.append(random.choice(encoder_or_decoder["idx2str"]))
     return " ".join(list(set(elems)))
 
 
 def generate_bag(feature):
+    encoder_or_decoder = _get_feature_encoder_or_decoder(feature)
     elems = []
-    for _ in range(random.randint(0, feature.get("max_len", 3))):
-        elems.append(random.choice(feature["idx2str"]))
+    for _ in range(random.randint(0, encoder_or_decoder.get("max_len", 3))):
+        elems.append(random.choice(encoder_or_decoder["idx2str"]))
     return " ".join(elems)
 
 
 def generate_text(feature):
-    length = feature.get("max_len", 10)
+    encoder_or_decoder = _get_feature_encoder_or_decoder(feature)
+    length = encoder_or_decoder.get("max_len", 10)
     text = []
     for _ in range(random.randint(length - int(length * 0.2), length)):
-        text.append(random.choice(feature["idx2str"]))
+        text.append(random.choice(encoder_or_decoder["idx2str"]))
     return " ".join(text)
 
 
 def generate_timeseries(feature, max_len=10):
+    encoder = _get_feature_encoder_or_decoder(feature)
     series = []
-    if "max_len" in feature:
-        max_len = feature["max_len"]
+    if "max_len" in encoder:
+        max_len = encoder["max_len"]
     series_len = random.randint(max_len - 2, max_len)  # simulates variable length
     for _ in range(series_len):
-        series.append(str(random.uniform(feature.get("min", 0), feature.get("max", 1))))
+        series.append(str(random.uniform(encoder.get("min", 0), encoder.get("max", 1))))
     return " ".join(series)
 
 
@@ -307,9 +328,10 @@ def generate_image(feature, save_as_numpy=False):
         width = feature[PREPROCESSING].get("width", 28)
         num_channels = feature[PREPROCESSING].get("num_channels", 1)
     else:
-        height = feature.get("height", 28)
-        width = feature.get("width", 28)
-        num_channels = feature.get("num_channels", 1)
+        encoder = _get_feature_encoder_or_decoder(feature)
+        height = encoder.get("height", 28)
+        width = encoder.get("width", 28)
+        num_channels = encoder.get("num_channels", 1)
 
     if width <= 0 or height <= 0 or num_channels < 1:
         raise ValueError("Invalid arguments for generating images")
@@ -406,9 +428,10 @@ category_cycle = 0
 
 def cycle_category(feature):
     global category_cycle
-    if category_cycle >= len(feature["idx2str"]):
+    idx2str = feature[DECODER]["idx2str"] if DECODER in feature else feature[ENCODER]["idx2str"]
+    if category_cycle >= len(idx2str):
         category_cycle = 0
-    category = feature["idx2str"][category_cycle]
+    category = idx2str[category_cycle]
     category_cycle += 1
     return category
 

--- a/ludwig/data/dataset_synthesizer.py
+++ b/ludwig/data/dataset_synthesizer.py
@@ -217,12 +217,8 @@ def generate_datapoint(features):
 
 
 def generate_category(feature):
-    if DECODER in feature:
-        return random.choice(feature[DECODER]["idx2str"])
-    elif ENCODER in feature:
-        return random.choice(feature[ENCODER]["idx2str"])
-    else:
-        logger.error(f"Feature {str(feature)} should have either an encoder or decoder.")
+    encoder_or_decoder = _get_feature_encoder_or_decoder(feature)
+    return encoder_or_decoder["idx2str"]
 
 
 def generate_number(feature):

--- a/ludwig/data/dataset_synthesizer.py
+++ b/ludwig/data/dataset_synthesizer.py
@@ -218,7 +218,7 @@ def generate_datapoint(features):
 
 def generate_category(feature):
     encoder_or_decoder = _get_feature_encoder_or_decoder(feature)
-    return encoder_or_decoder["idx2str"]
+    return random.choice(encoder_or_decoder["idx2str"])
 
 
 def generate_number(feature):

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -228,7 +228,8 @@ def _upgrade_encoder_decoder_params(feature: Dict[str, Any], input_feature: bool
         module_type = DECODER
 
     module = feature.get(module_type, {})
-    keys = INPUT_FEATURE_KEYS if module_type == ENCODER else FC_LAYER_KEYS + OUTPUT_FEATURE_KEYS + [ENCODER, DECODER]
+    # List of keys to keep in the output feature.
+    feature_keys = INPUT_FEATURE_KEYS if module_type == ENCODER else FC_LAYER_KEYS + OUTPUT_FEATURE_KEYS
     if isinstance(module, str):
         module = {TYPE: module}
         feature[module_type] = module
@@ -236,7 +237,7 @@ def _upgrade_encoder_decoder_params(feature: Dict[str, Any], input_feature: bool
 
     nested_params = []
     for k, v in feature.items():
-        if k not in keys:
+        if k not in feature_keys:
             module[k] = v
             nested_params.append(k)
             warn = True

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -98,7 +98,7 @@ def upgrade_to_latest_version(config: Dict):
 
 
 def _traverse_dicts(config: Any, f: Callable[[Dict], None]):
-    """Recursively Applies function f to every dictionary contained in config.
+    """Recursively applies function f to every dictionary contained in config.
 
     f should in-place modify the config dict. f will be called on leaves first, root last.
     """

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -58,9 +58,11 @@ config_transformation_registry = VersionTransformationRegistry()
 
 
 def register_config_transformation(version: str, prefixes: List[str] = []):
-    """Registers a transformation for a config version. The version should be the first version that this config.
+    """This decorator registers a transformation function for a config version. Version is the first version which
+    requires the transform. For example, since "training" is renamed to "trainer" in 0.5, this change should be
+    registered with 0.5.
 
-    Args:
+    version
     """
 
     def wrap(fn: Callable[[Dict], Dict]):
@@ -97,7 +99,7 @@ def _traverse_dicts(config: Any, f: Callable[[Dict], None]):
             _traverse_dicts(v, f)
 
 
-@register_config_transformation("0.4")
+@register_config_transformation("0.5")
 def rename_training_to_trainer(config: Dict[str, Any]):
     if TRAINING in config:
         warnings.warn('Config section "training" renamed to "trainer" and will be removed in v0.6', DeprecationWarning)

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -52,7 +52,6 @@ from ludwig.features.feature_utils import compute_feature_hash
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.schema.combiners.utils import combiner_registry
 from ludwig.schema.utils import load_config_with_kwargs, load_trainer_with_kwargs
-from ludwig.utils.backward_compatibility import upgrade_deprecated_fields
 from ludwig.utils.config_utils import get_default_encoder_or_decoder, get_defaults_section_for_feature_type
 from ludwig.utils.data_utils import load_config_from_str, load_yaml
 from ludwig.utils.fs_utils import open_file
@@ -244,7 +243,6 @@ def update_feature_from_defaults(config: Dict[str, Any], feature_dict: Dict[str,
 
 def merge_with_defaults(config: dict) -> dict:  # noqa: F821
     config = copy.deepcopy(config)
-    upgrade_deprecated_fields(config)
     _perform_sanity_checks(config)
     _set_feature_column(config)
     _set_proc_column(config)

--- a/ludwig/utils/version_transformation.py
+++ b/ludwig/utils/version_transformation.py
@@ -1,0 +1,84 @@
+#! /usr/bin/env python
+# Copyright (c) 2022 Predibase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import copy
+from collections import defaultdict
+from functools import total_ordering
+from typing import Callable, Dict, List, Optional
+
+
+@total_ordering
+class VersionTransformation:
+    def __init__(self, transform: Callable[[Dict], Dict], version: str, prefix: Optional[str] = None):
+        self.transform = transform
+        self.version = version
+        self.prefix = prefix if prefix else ""
+
+    def transform_config(self, config: Dict, prefix: Optional[str] = None) -> Dict:
+        """Applied this version transformation to the config, returns the updated config."""
+        if prefix:
+            components = prefix.split(".", 1)
+            key = components[0]
+            rest_of_prefix = key[1] if len(key) > 1 else ""
+            if key in config:
+                subsection = config[key]
+                if isinstance(subsection, list):
+                    config[key] = [self.transform_config(v) if isinstance(v, dict) else v for v in subsection]
+                elif isinstance(subsection, dict):
+                    config[key] = self.transform_config(subsection, prefix=rest_of_prefix)
+            return config
+        else:
+            # Base case: no prefix specified, pass entire dictionary to transform function.
+            return self.transform(config)
+
+    @property
+    def prefix_length(self):
+        return len(self.prefix.split(".")) if self.prefix else 0
+
+    def __lt__(self, other):
+        """Defines sort order of version transformations. Sorted by:
+
+        - version (ascending)
+        - prefix length (descending)  Process most specific transformations before more general ones.
+        - prefix (ascending)
+        """
+        return (self.version, -self.prefix_length, self.prefix) < (other.version, -other.prefix_length, other.prefix)
+
+    def __repr__(self):
+        return f'VersionTransformation(<function>, version="{self.version}", prefix="{self.prefix}")'
+
+
+class VersionTransformationRegistry:
+    """Allows callers to register transformations which update versioned config files."""
+
+    def __init__(self):
+        self._registry = defaultdict(list)  # Maps version number to list of transformations.
+
+    def register(self, transformation: VersionTransformation):
+        self._registry[transformation.version].append(transformation)
+
+    def get_transformations(self, from_version: str, to_version: str) -> List[VersionTransformation]:
+        """Get the config transformations from one version to the next."""
+        versions = [v for v in self._registry.keys() if v <= to_version and v > from_version]
+        transforms = sorted(t for v in versions for t in self._registry[v])
+        return transforms
+
+    def update_config(self, config: Dict, from_version: str, to_version: str) -> Dict:
+        """Applies the transformations from an older version to a newer version."""
+        transformations = self.get_transformations(from_version, to_version)
+        updated_config = copy.deepcopy(config)
+        for t in transformations:
+            updated_config = t.transform_config(updated_config, t.prefix)
+        return updated_config

--- a/ludwig/utils/version_transformation.py
+++ b/ludwig/utils/version_transformation.py
@@ -56,10 +56,10 @@ class VersionTransformation:
         """Defines sort order of version transformations. Sorted by:
 
         - version (ascending)
-        - prefix length (descending)  Process most specific transformations before more general ones.
+        - prefix_length (ascending)  Process outer config transformations before inner.
         - prefix (ascending)
         """
-        return (self.version, -self.prefix_length, self.prefix) < (other.version, -other.prefix_length, other.prefix)
+        return (self.version, self.prefix_length, self.prefix) < (other.version, other.prefix_length, other.prefix)
 
     def __repr__(self):
         return f'VersionTransformation(<function>, version="{self.version}", prefix="{self.prefix}")'

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -341,8 +341,7 @@ def test_ray_image(tmpdir, dataset_type):
         image_feature(
             folder=image_dest_folder,
             preprocessing={"in_memory": True, "height": 12, "width": 12, "num_channels": 3, "num_processes": 5},
-            output_size=16,
-            num_filters=8,
+            encoder={"output_size": 16, "num_filters": 8},
         ),
     ]
     output_features = [binary_feature()]
@@ -384,14 +383,12 @@ def test_ray_image_multiple_features(tmpdir):
         image_feature(
             folder=os.path.join(tmpdir, "generated_images_1"),
             preprocessing={"in_memory": True, "height": 12, "width": 12, "num_channels": 3, "num_processes": 5},
-            output_size=16,
-            num_filters=8,
+            encoder={"output_size": 16, "num_filters": 8},
         ),
         image_feature(
             folder=os.path.join(tmpdir, "generated_images_2"),
             preprocessing={"in_memory": True, "height": 12, "width": 12, "num_channels": 3, "num_processes": 5},
-            output_size=16,
-            num_filters=8,
+            encoder={"output_size": 16, "num_filters": 8},
         ),
     ]
     output_features = [binary_feature()]

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 
 from ludwig.api import LudwigModel
-from ludwig.constants import TRAINER
+from ludwig.constants import DECODER, TRAINER
 from ludwig.serve import ALL_FEATURES_PRESENT_ERROR, server
 from ludwig.utils.data_utils import read_csv
 from tests.integration_tests.utils import (
@@ -83,7 +83,7 @@ def output_keys_for(output_features):
             keys.append(f"{name}_probability")
             keys.append(f"{name}_probabilities")
             keys.append(f"{name}_probabilities_<UNK>")
-            for category in feature["idx2str"]:
+            for category in feature[DECODER]["idx2str"]:
                 keys.append(f"{name}_probabilities_{category}")
 
         elif feature["type"] == "number":

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -34,7 +34,7 @@ from PIL import Image
 
 from ludwig.api import LudwigModel
 from ludwig.backend import LocalBackend
-from ludwig.constants import COLUMN, ENCODER, NAME, PROC_COLUMN, TRAINER, VECTOR
+from ludwig.constants import COLUMN, DECODER, ENCODER, NAME, PROC_COLUMN, TRAINER, VECTOR
 from ludwig.data.dataset_synthesizer import build_synthetic_dataset, DATETIME_FORMATS
 from ludwig.experiment import experiment_cli
 from ludwig.features.feature_utils import compute_feature_hash
@@ -236,64 +236,120 @@ def number_feature(normalization=None, **kwargs):
     return feature
 
 
-def category_feature(**kwargs):
+def category_feature(output_feature=False, **kwargs):
+    if DECODER in kwargs:
+        output_feature = True
     feature = {
         "type": "category",
         "name": "category_" + random_string(),
-        ENCODER: {"type": "dense", "vocab_size": 10, "embedding_size": 5},
     }
+    if output_feature:
+        feature.update(
+            {
+                DECODER: {"type": "classifier", "vocab_size": 10},
+            }
+        )
+    else:
+        feature.update(
+            {
+                ENCODER: {"type": "dense", "vocab_size": 10, "embedding_size": 5},
+            }
+        )
     recursive_update(feature, kwargs)
     feature[COLUMN] = feature[NAME]
     feature[PROC_COLUMN] = compute_feature_hash(feature)
     return feature
 
 
-def text_feature(**kwargs):
+def text_feature(output_feature=False, **kwargs):
+    if DECODER in kwargs:
+        output_feature = True
     feature = {
         "name": "text_" + random_string(),
         "type": "text",
-        ENCODER: {
-            "type": "parallel_cnn",
-            "vocab_size": 5,
-            "min_len": 7,
-            "max_len": 7,
-            "embedding_size": 8,
-            "state_size": 8,
-        },
     }
+    if output_feature:
+        feature.update(
+            {
+                DECODER: {"type": "generator", "vocab_size": 5, "max_len": 7},
+            }
+        )
+    else:
+        feature.update(
+            {
+                ENCODER: {
+                    "type": "parallel_cnn",
+                    "vocab_size": 5,
+                    "min_len": 7,
+                    "max_len": 7,
+                    "embedding_size": 8,
+                    "state_size": 8,
+                },
+            }
+        )
     recursive_update(feature, kwargs)
     feature[COLUMN] = feature[NAME]
     feature[PROC_COLUMN] = compute_feature_hash(feature)
     return feature
 
 
-def set_feature(**kwargs):
+def set_feature(output_feature=False, **kwargs):
+    if DECODER in kwargs:
+        output_feature = True
     feature = {
         "type": "set",
         "name": "set_" + random_string(),
-        ENCODER: {"type": "embed", "vocab_size": 10, "max_len": 5, "embedding_size": 5},
     }
+    if output_feature:
+        feature.update(
+            {
+                DECODER: {"type": "classifier", "vocab_size": 10, "max_len": 5},
+            }
+        )
+    else:
+        feature.update(
+            {
+                ENCODER: {"type": "embed", "vocab_size": 10, "max_len": 5, "embedding_size": 5},
+            }
+        )
     recursive_update(feature, kwargs)
     feature[COLUMN] = feature[NAME]
     feature[PROC_COLUMN] = compute_feature_hash(feature)
     return feature
 
 
-def sequence_feature(**kwargs):
+def sequence_feature(output_feature=False, **kwargs):
+    if DECODER in kwargs:
+        output_feature = True
     feature = {
         "type": "sequence",
         "name": "sequence_" + random_string(),
-        ENCODER: {
-            "type": "embed",
-            "vocab_size": 10,
-            "max_len": 7,
-            "embedding_size": 8,
-            "output_size": 8,
-            "state_size": 8,
-            "num_filters": 8,
-            "hidden_size": 8,
-        },
     }
+    if output_feature:
+        feature.update(
+            {
+                DECODER: {
+                    "type": "generator",
+                    "vocab_size": 10,
+                    "max_len": 7,
+                }
+            }
+        )
+    else:
+        feature.update(
+            {
+                ENCODER: {
+                    "type": "embed",
+                    "vocab_size": 10,
+                    "max_len": 7,
+                    "embedding_size": 8,
+                    "output_size": 8,
+                    "state_size": 8,
+                    "num_filters": 8,
+                    "hidden_size": 8,
+                },
+            }
+        )
     recursive_update(feature, kwargs)
     feature[COLUMN] = feature[NAME]
     feature[PROC_COLUMN] = compute_feature_hash(feature)

--- a/tests/ludwig/utils/test_backward_compatibility.py
+++ b/tests/ludwig/utils/test_backward_compatibility.py
@@ -1,8 +1,21 @@
-from ludwig.constants import INPUT_FEATURES, OUTPUT_FEATURES
+import pytest
+
+from ludwig.constants import (
+    EVAL_BATCH_SIZE,
+    HYPEROPT,
+    INPUT_FEATURES,
+    NUMBER,
+    OUTPUT_FEATURES,
+    PREPROCESSING,
+    SPLIT,
+    TRAINER,
+    TYPE,
+)
 from ludwig.utils.backward_compatibility import (
     _upgrade_encoder_decoder_params,
     _upgrade_feature,
     _upgrade_preprocessing_split,
+    upgrade_to_latest_version,
 )
 
 
@@ -245,3 +258,82 @@ def test_encoder_decoder_backwards_compatibility():
             },
         ],
     }
+
+
+def test_deprecated_field_aliases():
+    config = {
+        "ludwig_version": "0.4",
+        INPUT_FEATURES: [{"name": "num_in", "type": "numerical"}],
+        OUTPUT_FEATURES: [{"name": "num_out", "type": "numerical"}],
+        "training": {
+            "epochs": 2,
+            "eval_batch_size": 0,
+        },
+        HYPEROPT: {
+            "parameters": {
+                "training.learning_rate": {
+                    "space": "loguniform",
+                    "lower": 0.001,
+                    "upper": 0.1,
+                },
+            },
+            "goal": "minimize",
+            "sampler": {"type": "grid", "num_samples": 2, "scheduler": {"type": "fifo"}},
+            "executor": {
+                "type": "grid",
+                "search_alg": "bohb",
+            },
+        },
+    }
+
+    updated_config = upgrade_to_latest_version(config)
+
+    assert updated_config["input_features"][0][TYPE] == NUMBER
+    assert updated_config["output_features"][0][TYPE] == NUMBER
+
+    assert "training" not in updated_config
+    assert updated_config[TRAINER]["epochs"] == 2
+    assert updated_config[TRAINER][EVAL_BATCH_SIZE] is None
+
+    hparams = updated_config[HYPEROPT]["parameters"]
+    assert "training.learning_rate" not in hparams
+    assert "trainer.learning_rate" in hparams
+
+    assert "sampler" not in updated_config[HYPEROPT]
+
+    assert updated_config[HYPEROPT]["executor"]["type"] == "ray"
+    assert "num_samples" in updated_config[HYPEROPT]["executor"]
+    assert "scheduler" in updated_config[HYPEROPT]["executor"]
+
+
+@pytest.mark.parametrize("force_split", [None, False, True])
+@pytest.mark.parametrize("stratify", [None, "cat_in"])
+def test_deprecated_split_aliases(stratify, force_split):
+    split_probabilities = [0.6, 0.2, 0.2]
+    config = {
+        "ludwig_version": "0.4",
+        INPUT_FEATURES: [{"name": "num_in", "type": "number"}, {"name": "cat_in", "type": "category"}],
+        OUTPUT_FEATURES: [{"name": "num_out", "type": "number"}],
+        PREPROCESSING: {
+            "force_split": force_split,
+            "split_probabilities": split_probabilities,
+            "stratify": stratify,
+        },
+    }
+
+    updated_config = upgrade_to_latest_version(config)
+
+    assert "force_split" not in updated_config[PREPROCESSING]
+    assert "split_probabilities" not in updated_config[PREPROCESSING]
+    assert "stratify" not in updated_config[PREPROCESSING]
+
+    assert SPLIT in updated_config[PREPROCESSING]
+    split = updated_config[PREPROCESSING][SPLIT]
+
+    assert split["probabilities"] == split_probabilities
+    if stratify is None:
+        if force_split:
+            assert split.get(TYPE) == "random"
+    else:
+        assert split.get(TYPE) == "stratify"
+        assert split.get("column") == stratify

--- a/tests/ludwig/utils/test_defaults.py
+++ b/tests/ludwig/utils/test_defaults.py
@@ -23,7 +23,6 @@ from ludwig.constants import (
     REDUCE_DEPENDENCIES,
     REDUCE_INPUT,
     SCHEDULER,
-    SPLIT,
     SUM,
     TIED,
     TOP_K,

--- a/tests/ludwig/utils/test_version_transformation.py
+++ b/tests/ludwig/utils/test_version_transformation.py
@@ -22,7 +22,7 @@ def test_version_transformation_registry():
     transformation_registry = VersionTransformationRegistry()
     transformation_registry.register(VersionTransformation(transform=transform_a, version="0.1"))
     transformation_registry.register(VersionTransformation(transform=transform_b, version="0.2"))
-    transformation_registry.register(VersionTransformation(transform=transform_e, version="0.2", prefix="e"))
+    transformation_registry.register(VersionTransformation(transform=transform_e, version="0.2", prefixes=["e"]))
     input_config = {"a": "a value", "e": {"f": "f_value"}}
 
     transformed_0_1 = transformation_registry.update_config(input_config, from_version="0.0", to_version="0.1")

--- a/tests/ludwig/utils/test_version_transformation.py
+++ b/tests/ludwig/utils/test_version_transformation.py
@@ -36,7 +36,3 @@ def test_version_transformation_registry():
     assert "e" in transformed_0_2
     assert "f" not in transformed_0_2["e"]
     assert transformed_0_2["e"]["g"] == "f_value"
-
-
-if __name__ == "__main__":
-    test_version_transformation_registry()

--- a/tests/ludwig/utils/test_version_transformation.py
+++ b/tests/ludwig/utils/test_version_transformation.py
@@ -1,0 +1,42 @@
+from ludwig.utils.version_transformation import VersionTransformation, VersionTransformationRegistry
+
+
+def test_version_transformation_registry():
+    def transform_a(config):
+        config["b"] = config["a"]
+        del config["a"]
+        return config
+
+    def transform_b(config):
+        config["c"] = config["b"]
+        del config["b"]
+        return config
+
+    def transform_e(e):
+        print("-------- transform_e:")
+        print(e)
+        e["g"] = e["f"]
+        del e["f"]
+        return e
+
+    transformation_registry = VersionTransformationRegistry()
+    transformation_registry.register(VersionTransformation(transform=transform_a, version="0.1"))
+    transformation_registry.register(VersionTransformation(transform=transform_b, version="0.2"))
+    transformation_registry.register(VersionTransformation(transform=transform_e, version="0.2", prefix="e"))
+    input_config = {"a": "a value", "e": {"f": "f_value"}}
+
+    transformed_0_1 = transformation_registry.update_config(input_config, from_version="0.0", to_version="0.1")
+    assert "a" not in transformed_0_1
+    assert transformed_0_1["b"] == "a value"
+
+    transformed_0_2 = transformation_registry.update_config(input_config, from_version="0.0", to_version="0.2")
+    assert "a" not in transformed_0_2
+    assert "b" not in transformed_0_2
+    assert transformed_0_2["c"] == "a value"
+    assert "e" in transformed_0_2
+    assert "f" not in transformed_0_2["e"]
+    assert transformed_0_2["e"]["g"] == "f_value"
+
+
+if __name__ == "__main__":
+    test_version_transformation_registry()

--- a/tests/ludwig/utils/test_version_transformation.py
+++ b/tests/ludwig/utils/test_version_transformation.py
@@ -13,8 +13,6 @@ def test_version_transformation_registry():
         return config
 
     def transform_e(e):
-        print("-------- transform_e:")
-        print(e)
         e["g"] = e["f"]
         del e["f"]
         return e


### PR DESCRIPTION
[DRAFT PR]: feature complete but needs documentation.

- Adds `version_transformation.py`, which defines a registry of transformation functions tagged by version.

- `version_transformation.py` provides `upgrade_to_latest_version()`
- Removes compatibility updating code from`defaults.py`'s `merge_with_defaults()`.  Moves update tests to `test_backward_compatibility.py`

Breaks up functions in `backward_compatibility.py` into smaller units, tags each one with a version, i.e.
```
@register_config_transformation("0.5")
def rename_training_to_trainer(config: Dict[str, Any]):
    if TRAINING in config:
        warnings.warn('Config section "training" renamed to "trainer" and will be removed in v0.6', DeprecationWarning)
        config[TRAINER] = config[TRAINING]
        del config[TRAINING]
    return config
```