### PR TITLE
Add test with encoder dependencies for global defaults

### DIFF
--- a/tests/integration_tests/test_config_global_defaults.py
+++ b/tests/integration_tests/test_config_global_defaults.py
@@ -91,3 +91,24 @@ def test_global_default_parameters_merge_with_defaults(csv_filename):
 
     output_feature = updated_config[OUTPUT_FEATURES][0]
     assert output_feature[DECODER] == updated_config[DEFAULTS][output_feature[TYPE]][DECODER][TYPE]
+
+
+def test_global_defaults_with_encoder_dependencies(csv_filename):
+    input_features = [text_feature(name="title", reduce_output="sum")]
+    output_features = [category_feature(name="article", embedding_size=3)]
+
+    config = {
+        INPUT_FEATURES: input_features,
+        OUTPUT_FEATURES: output_features,
+        DEFAULTS: {
+            TEXT: {
+                ENCODER: {TYPE: "bert"},
+            }
+        },
+    }
+
+    # Config should populate with the additional required fields for bert
+    updated_config = merge_with_defaults(config)
+
+    assert updated_config[INPUT_FEATURES][0][ENCODER] == "bert"
+    assert updated_config[INPUT_FEATURES][0]["pretrained_model_name_or_path"] == "bert-base-uncased"


### PR DESCRIPTION
This PR adds a test for global defaults that uses an encoder with additional dependencies. Specifically, when the encoder is set to something like `bert`, there are additional fields from the encoder class that need to be injected into the input feature for things to work correctly. This PR makes sure that the fields are being populated as expected. 