### PR TITLE
fix: restore overwrite of eval_batch_size on GBM schema

### DIFF
--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -312,6 +312,19 @@ class GBMTrainerConfig(BaseTrainerConfig):
         allow_none=False,
     )
 
+    # NOTE: Overwritten here to provide a default value. In many places, we fall back to eval_batch_size if batch_size
+    # is not specified. GBM does not have a value for batch_size, so we need to specify eval_batch_size here.
+    eval_batch_size: Union[None, int, str] = schema_utils.IntegerOrAutoField(
+        default=128,
+        allow_none=False,
+        min_exclusive=0,
+        description=(
+            "Size of batch to pass to the model for evaluation. "
+            "If ’auto’, the biggest batch size (power of 2) that can fit in memory will be used."
+        ),
+        parameter_metadata=TRAINER_METADATA["eval_batch_size"],
+    )
+
     # LightGBM core parameters (https://lightgbm.readthedocs.io/en/latest/Parameters.html)
     boosting_type: str = schema_utils.StringOptions(
         ["gbdt", "rf", "dart", "goss"],

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 
 from marshmallow_dataclass import dataclass
 
-from ludwig.constants import AUTO, COMBINED, LOSS, MODEL_ECD, MODEL_GBM, TRAINING, TYPE
+from ludwig.constants import COMBINED, LOSS, MODEL_ECD, MODEL_GBM, TRAINING, TYPE
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.metadata.trainer_metadata import TRAINER_METADATA
 from ludwig.schema.optimizers import (
@@ -315,13 +315,10 @@ class GBMTrainerConfig(BaseTrainerConfig):
     # NOTE: Overwritten here to provide a default value. In many places, we fall back to eval_batch_size if batch_size
     # is not specified. GBM does not have a value for batch_size, so we need to specify eval_batch_size here.
     eval_batch_size: Union[None, int, str] = schema_utils.IntegerOrAutoField(
-        default=AUTO,
+        default=128,
         allow_none=False,
         min_exclusive=0,
-        description=(
-            "Size of batch to pass to the model for evaluation. "
-            "Defaults to 'auto': the biggest batch size (power of 2) that can fit in memory will be used."
-        ),
+        description=("Size of batch to pass to the model for evaluation."),
         parameter_metadata=TRAINER_METADATA["eval_batch_size"],
     )
 

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -316,7 +316,7 @@ class GBMTrainerConfig(BaseTrainerConfig):
     # is not specified. GBM does not have a value for batch_size, so we need to specify eval_batch_size here.
     eval_batch_size: Union[None, int, str] = schema_utils.IntegerOrAutoField(
         default=128,
-        allow_none=False,
+        allow_none=True,
         min_exclusive=0,
         description=("Size of batch to pass to the model for evaluation."),
         parameter_metadata=TRAINER_METADATA["eval_batch_size"],

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 
 from marshmallow_dataclass import dataclass
 
-from ludwig.constants import COMBINED, LOSS, MODEL_ECD, MODEL_GBM, TRAINING, TYPE
+from ludwig.constants import AUTO, COMBINED, LOSS, MODEL_ECD, MODEL_GBM, TRAINING, TYPE
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.metadata.trainer_metadata import TRAINER_METADATA
 from ludwig.schema.optimizers import (
@@ -315,12 +315,12 @@ class GBMTrainerConfig(BaseTrainerConfig):
     # NOTE: Overwritten here to provide a default value. In many places, we fall back to eval_batch_size if batch_size
     # is not specified. GBM does not have a value for batch_size, so we need to specify eval_batch_size here.
     eval_batch_size: Union[None, int, str] = schema_utils.IntegerOrAutoField(
-        default=128,
+        default=AUTO,
         allow_none=False,
         min_exclusive=0,
         description=(
             "Size of batch to pass to the model for evaluation. "
-            "If ’auto’, the biggest batch size (power of 2) that can fit in memory will be used."
+            "Defaults to 'auto': the biggest batch size (power of 2) that can fit in memory will be used."
         ),
         parameter_metadata=TRAINER_METADATA["eval_batch_size"],
     )

--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -63,7 +63,7 @@ class LightGBMTrainer(BaseTrainer):
         self.skip_save_progress = skip_save_progress
         self.skip_save_model = skip_save_model
 
-        self.eval_batch_size = config.eval_batch_size or 128
+        self.eval_batch_size = config.eval_batch_size
         self._validation_field = config.validation_field
         self._validation_metric = config.validation_metric
         self.evaluate_training_set = config.evaluate_training_set


### PR DESCRIPTION
Overwritten here to provide a default value. In some places, we fall back to `eval_batch_size` if `batch_size` is not specified. GBM does not have a value for `batch_size`, so we need to specify `eval_batch_size` here.