### PR TITLE
fix: GBM tests failing after new release from upstream dependency

### DIFF
--- a/requirements_tree.txt
+++ b/requirements_tree.txt
@@ -1,3 +1,4 @@
+onnxconverter-common<1.12
 hummingbird-ml
 lightgbm
 lightgbm-ray


### PR DESCRIPTION
hummingbird-ml depends on onnxconverter-common. onnxconverter-common 1.12 introduced a dependency on onnxruntime. Since we do not use the onnx features from hummingbird, we can avoid the addition of onnxruntime dependency.