### PR TITLE
fix: Properly serialize `ParameterMetadata` to JSON

### DIFF
--- a/ludwig/schema/metadata/parameter_metadata.py
+++ b/ludwig/schema/metadata/parameter_metadata.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, List, Union
 
+from dataclasses_json import dataclass_json, LetterCase
+
 
 class ExpectedImpact(int, Enum):
     """The expected impact of determining a "good" value for a specific parameter.
@@ -17,6 +19,7 @@ class ExpectedImpact(int, Enum):
     HIGH = 3
 
 
+@dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass
 class ParameterMetadata:
     """Contains descriptive information that pertains to a Ludwig configuration parameter."""

--- a/ludwig/schema/metadata/parameter_metadata.py
+++ b/ludwig/schema/metadata/parameter_metadata.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, List, Union
 
-from dataclasses_json import dataclass_json, LetterCase
+from dataclasses_json import dataclass_json
 
 
 class ExpectedImpact(int, Enum):
@@ -19,7 +19,7 @@ class ExpectedImpact(int, Enum):
     HIGH = 3
 
 
-@dataclass_json(letter_case=LetterCase.CAMEL)
+@dataclass_json()
 @dataclass
 class ParameterMetadata:
     """Contains descriptive information that pertains to a Ludwig configuration parameter."""

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -134,7 +134,7 @@ def String(
                 dump_default=default,
                 metadata={"description": description},
             ),
-            "parameter_metadata": parameter_metadata,
+            "parameter_metadata": parameter_metadata.to_json(),
         },
         default=default,
     )
@@ -170,7 +170,7 @@ def StringOptions(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata},
+                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
             )
         },
         default=default,
@@ -191,7 +191,7 @@ def Boolean(default: bool, description: str, parameter_metadata: ParameterMetada
                 allow_none=False,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata},
+                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
             )
         },
         default=default,
@@ -216,7 +216,7 @@ def Integer(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata},
+                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
             )
         },
         default=default,
@@ -245,7 +245,7 @@ def PositiveInteger(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata},
+                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
             )
         },
         default=default,
@@ -277,7 +277,7 @@ def NonNegativeInteger(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata},
+                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
             )
         },
         default=default,
@@ -313,7 +313,7 @@ def IntegerRange(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata},
+                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
             )
         },
         default=default,
@@ -343,7 +343,7 @@ def NonNegativeFloat(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata},
+                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
             )
         },
         default=default,
@@ -378,7 +378,7 @@ def FloatRange(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata},
+                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
             )
         },
         default=default,
@@ -400,7 +400,7 @@ def Dict(default: Union[None, TDict] = None, description: str = "", parameter_me
                 allow_none=True,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata},
+                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
             )
         },
         default_factory=lambda: default,
@@ -427,7 +427,7 @@ def DictList(
                 allow_none=True,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata},
+                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
             )
         },
         default_factory=lambda: default,
@@ -757,7 +757,7 @@ def NumericOrStringOptionsField(
                 "title": self.name,
                 "description": description,
                 "default": default,
-                "parameter_metadata": parameter_metadata,
+                "parameter_metadata": parameter_metadata.to_json(),
             }
 
     return field(
@@ -765,7 +765,7 @@ def NumericOrStringOptionsField(
             "marshmallow_field": IntegerOrStringOptionsField(
                 allow_none=allow_none, load_default=default, dump_default=default, metadata={"description": description}
             ),
-            "parameter_metadata": parameter_metadata,
+            "parameter_metadata": parameter_metadata.to_json(),
         },
         default=default,
     )

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -134,7 +134,7 @@ def String(
                 dump_default=default,
                 metadata={"description": description},
             ),
-            "parameter_metadata": parameter_metadata.to_json(),
+            "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
         },
         default=default,
     )
@@ -170,7 +170,10 @@ def StringOptions(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
+                metadata={
+                    "description": description,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                },
             )
         },
         default=default,
@@ -191,7 +194,10 @@ def Boolean(default: bool, description: str, parameter_metadata: ParameterMetada
                 allow_none=False,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
+                metadata={
+                    "description": description,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                },
             )
         },
         default=default,
@@ -216,7 +222,10 @@ def Integer(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
+                metadata={
+                    "description": description,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                },
             )
         },
         default=default,
@@ -245,7 +254,10 @@ def PositiveInteger(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
+                metadata={
+                    "description": description,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                },
             )
         },
         default=default,
@@ -277,7 +289,10 @@ def NonNegativeInteger(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
+                metadata={
+                    "description": description,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                },
             )
         },
         default=default,
@@ -313,7 +328,10 @@ def IntegerRange(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
+                metadata={
+                    "description": description,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                },
             )
         },
         default=default,
@@ -343,7 +361,10 @@ def NonNegativeFloat(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
+                metadata={
+                    "description": description,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                },
             )
         },
         default=default,
@@ -378,7 +399,10 @@ def FloatRange(
                 allow_none=allow_none,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
+                metadata={
+                    "description": description,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                },
             )
         },
         default=default,
@@ -400,7 +424,10 @@ def Dict(default: Union[None, TDict] = None, description: str = "", parameter_me
                 allow_none=True,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
+                metadata={
+                    "description": description,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                },
             )
         },
         default_factory=lambda: default,
@@ -427,7 +454,10 @@ def DictList(
                 allow_none=True,
                 load_default=default,
                 dump_default=default,
-                metadata={"description": description, "parameter_metadata": parameter_metadata.to_json()},
+                metadata={
+                    "description": description,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                },
             )
         },
         default_factory=lambda: default,
@@ -757,7 +787,7 @@ def NumericOrStringOptionsField(
                 "title": self.name,
                 "description": description,
                 "default": default,
-                "parameter_metadata": parameter_metadata.to_json(),
+                "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
             }
 
     return field(
@@ -765,7 +795,7 @@ def NumericOrStringOptionsField(
             "marshmallow_field": IntegerOrStringOptionsField(
                 allow_none=allow_none, load_default=default, dump_default=default, metadata={"description": description}
             ),
-            "parameter_metadata": parameter_metadata.to_json(),
+            "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
         },
         default=default,
     )

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -134,7 +134,7 @@ def String(
                 dump_default=default,
                 metadata={"description": description},
             ),
-            "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+            "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
         },
         default=default,
     )
@@ -172,7 +172,7 @@ def StringOptions(
                 dump_default=default,
                 metadata={
                     "description": description,
-                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
                 },
             )
         },
@@ -196,7 +196,7 @@ def Boolean(default: bool, description: str, parameter_metadata: ParameterMetada
                 dump_default=default,
                 metadata={
                     "description": description,
-                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
                 },
             )
         },
@@ -224,7 +224,7 @@ def Integer(
                 dump_default=default,
                 metadata={
                     "description": description,
-                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
                 },
             )
         },
@@ -256,7 +256,7 @@ def PositiveInteger(
                 dump_default=default,
                 metadata={
                     "description": description,
-                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
                 },
             )
         },
@@ -291,7 +291,7 @@ def NonNegativeInteger(
                 dump_default=default,
                 metadata={
                     "description": description,
-                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
                 },
             )
         },
@@ -330,7 +330,7 @@ def IntegerRange(
                 dump_default=default,
                 metadata={
                     "description": description,
-                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
                 },
             )
         },
@@ -363,7 +363,7 @@ def NonNegativeFloat(
                 dump_default=default,
                 metadata={
                     "description": description,
-                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
                 },
             )
         },
@@ -401,7 +401,7 @@ def FloatRange(
                 dump_default=default,
                 metadata={
                     "description": description,
-                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
                 },
             )
         },
@@ -426,7 +426,7 @@ def Dict(default: Union[None, TDict] = None, description: str = "", parameter_me
                 dump_default=default,
                 metadata={
                     "description": description,
-                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
                 },
             )
         },
@@ -456,7 +456,7 @@ def DictList(
                 dump_default=default,
                 metadata={
                     "description": description,
-                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                    "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
                 },
             )
         },
@@ -787,7 +787,7 @@ def NumericOrStringOptionsField(
                 "title": self.name,
                 "description": description,
                 "default": default,
-                "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+                "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
             }
 
     return field(
@@ -795,7 +795,7 @@ def NumericOrStringOptionsField(
             "marshmallow_field": IntegerOrStringOptionsField(
                 allow_none=allow_none, load_default=default, dump_default=default, metadata={"description": description}
             ),
-            "parameter_metadata": parameter_metadata.to_json() if parameter_metadata is not None else None,
+            "parameter_metadata": parameter_metadata.to_json() if parameter_metadata else None,
         },
         default=default,
     )


### PR DESCRIPTION
Currently, because `ParameterMetadata` is just a dataclass when we add it to any JSON payload it is never serialized.