### PR TITLE
Resource tracker threading

### DIFF
--- a/ludwig/benchmarking/resource_usage_tracker.py
+++ b/ludwig/benchmarking/resource_usage_tracker.py
@@ -4,11 +4,11 @@ tracker/blob/master/experiment_impact_tracker/compute_tracker.py."""
 import os
 import shutil
 import sys
+import threading
 import time
 import traceback
-import threading
-from queue import Queue
 from queue import Empty as EmptyQueueException
+from queue import Queue
 from statistics import mean
 from typing import Any, Dict, Optional
 
@@ -32,7 +32,9 @@ sys.stdout = sys.__stdout__
 STOP_MESSAGE = "stop"
 
 
-def monitor(queue: Queue, info: Dict[str, Any], output_dir: str, logging_interval: int, cuda_is_available: bool) -> None:
+def monitor(
+    queue: Queue, info: Dict[str, Any], output_dir: str, logging_interval: int, cuda_is_available: bool
+) -> None:
     """Monitors hardware resource use.
 
     Populate `info` with system specific metrics (GPU, CPU, RAM) at a `logging_interval` interval and saves the output

--- a/ludwig/benchmarking/resource_usage_tracker.py
+++ b/ludwig/benchmarking/resource_usage_tracker.py
@@ -120,7 +120,7 @@ class ResourceUsageTracker:
         self.info["system"]["num_cpu"] = cpu_info["count"]
         self.info["system"]["cpu_name"] = cpu_info["brand_raw"]
         # divide by 1.0e6 to convert bytes to megabytes.
-        self.info["system"]["ram_available"] = psutil.virtual_memory() // 1.0e6
+        self.info["system"]["ram_available"] = psutil.virtual_memory().available // 1.0e6
 
         # GPU information
         if torch.cuda.is_available():

--- a/ludwig/benchmarking/resource_usage_tracker.py
+++ b/ludwig/benchmarking/resource_usage_tracker.py
@@ -52,8 +52,9 @@ def monitor(queue: Queue, info: Dict[str, Any], output_dir: str, logging_interva
     tracked_process = psutil.Process(os.getpid())
 
     # will return a meaningless 0 value on the first call because `interval` arg is set to None.
-    tracked_process.cpu_percent()
+    tracked_process.cpu_percent(interval=logging_interval)
     while True:
+        time.sleep(logging_interval)
         try:
             message = queue.get(block=False)
             if isinstance(message, str):
@@ -73,7 +74,6 @@ def monitor(queue: Queue, info: Dict[str, Any], output_dir: str, logging_interva
             info["system"]["cpu_utilization"].append(tracked_process.cpu_percent())
             # divide by 1.0e6 to convert bytes to megabytes.
             info["system"]["ram_utilization"].append(tracked_process.memory_full_info().uss // 1.0e6)
-        time.sleep(logging_interval)
 
 
 class ResourceUsageTracker:

--- a/ludwig/benchmarking/resource_usage_tracker.py
+++ b/ludwig/benchmarking/resource_usage_tracker.py
@@ -71,6 +71,7 @@ def monitor(queue: Queue, info: Dict[str, Any], output_dir: str, logging_interva
                 info["system"][gpu_key]["memory_used"].append(gpu_info.memory_used)
         with tracked_process.oneshot():
             info["system"]["cpu_utilization"].append(tracked_process.cpu_percent())
+            # divide by 1.0e6 to convert bytes to megabytes.
             info["system"]["ram_utilization"].append(tracked_process.memory_full_info().uss // 1.0e6)
         time.sleep(logging_interval)
 
@@ -118,6 +119,8 @@ class ResourceUsageTracker:
         self.info["system"]["cpu_architecture"] = cpu_info["arch"]
         self.info["system"]["num_cpu"] = cpu_info["count"]
         self.info["system"]["cpu_name"] = cpu_info["brand_raw"]
+        # divide by 1.0e6 to convert bytes to megabytes.
+        self.info["system"]["ram_available"] = psutil.virtual_memory() // 1.0e6
 
         # GPU information
         if torch.cuda.is_available():


### PR DESCRIPTION
Improvements:

- using `threading` instead of `multiprocessing` to track resources in running process
- targeting the process that ludwig is running on to track CPU and RAM (instead of global RAM and CPU usage): we can run multiple ludwig experiments on one machine and get accurate metrics.