### PR TITLE
Wrap read of cached training set metadata in try/except for robustness

### DIFF
--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -24,7 +24,11 @@ class DatasetCache:
         if not path_exists(training_set_metadata_fp):
             return None
 
-        cache_training_set_metadata = data_utils.load_json(training_set_metadata_fp)
+        try:
+            cache_training_set_metadata = data_utils.load_json(training_set_metadata_fp)
+        except Exception as e:
+            logger.error(f"failed to load cached training set metadata at {training_set_metadata_fp}", exc_info=e)
+            return None
 
         cached_training_set = self.cache_map[TRAINING] if path_exists(self.cache_map[TRAINING]) else None
 


### PR DESCRIPTION
In practice the read may sometimes fail even when the previous existence check passes, although whether this is due to a race condition or some quirk of the underlying filesystem isn't fully understood.

Converting an errored read into a cache miss seems reasonable and more robust behavior.