### PR TITLE
Add default split config

### DIFF
--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -255,7 +255,6 @@ def merge_with_defaults(config: dict) -> dict:  # noqa: F821
         config[DEFAULTS] = dict()
 
     # Update defaults with the default feature specific preprocessing parameters
-    config[DEFAULTS][PREPROCESSING][SPLIT] = base_preprocessing_split
     for feature_type, preprocessing_defaults in default_feature_specific_preprocessing_parameters.items():
         # Create a new key with feature type if defaults is empty
         if feature_type not in config.get(DEFAULTS):
@@ -263,7 +262,7 @@ def merge_with_defaults(config: dict) -> dict:  # noqa: F821
                 config[DEFAULTS][feature_type] = preprocessing_defaults
             else:
                 config[DEFAULTS][feature_type] = {PREPROCESSING: preprocessing_defaults}
-        # Feature type exists but preprocessing hasn't be specified
+        # Feature type exists but preprocessing hasn't been specified
         elif PREPROCESSING not in config[DEFAULTS][feature_type]:
             config[DEFAULTS][feature_type][PREPROCESSING] = preprocessing_defaults
         # Preprocessing parameters exist for feature type, update defaults with parameters from config
@@ -325,7 +324,6 @@ def merge_with_defaults(config: dict) -> dict:  # noqa: F821
     # ===== Hyperpot =====
     if HYPEROPT in config:
         set_default_value(config[HYPEROPT][EXECUTOR], TYPE, RAY)
-
     return config
 
 

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -46,7 +46,7 @@ from ludwig.constants import (
     TYPE,
 )
 from ludwig.contrib import add_contrib_callback_args
-from ludwig.data.split import get_splitter, DEFAULT_PROBABILITIES
+from ludwig.data.split import DEFAULT_PROBABILITIES, get_splitter
 from ludwig.features.feature_registries import base_type_registry, input_type_registry, output_type_registry
 from ludwig.features.feature_utils import compute_feature_hash
 from ludwig.globals import LUDWIG_VERSION
@@ -64,10 +64,7 @@ logger = logging.getLogger(__name__)
 default_random_seed = 42
 
 base_preprocessing_parameters = {
-    "split": {
-        "type": "random",
-        "probabilities": list(DEFAULT_PROBABILITIES)
-    },
+    "split": {"type": "random", "probabilities": list(DEFAULT_PROBABILITIES)},
     "undersample_majority": None,
     "oversample_minority": None,
     "sample_ratio": 1.0,

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -63,9 +63,9 @@ logger = logging.getLogger(__name__)
 
 default_random_seed = 42
 
-base_preprocessing_split = {"type": "random", "probabilities": list(DEFAULT_PROBABILITIES)}
+BASE_PREPROCESSING_SPLIT_CONFIG = {"type": "random", "probabilities": list(DEFAULT_PROBABILITIES)}
 base_preprocessing_parameters = {
-    "split": base_preprocessing_split,
+    "split": BASE_PREPROCESSING_SPLIT_CONFIG,
     "undersample_majority": None,
     "oversample_minority": None,
     "sample_ratio": 1.0,

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -63,8 +63,9 @@ logger = logging.getLogger(__name__)
 
 default_random_seed = 42
 
+base_preprocessing_split = {"type": "random", "probabilities": list(DEFAULT_PROBABILITIES)}
 base_preprocessing_parameters = {
-    "split": {"type": "random", "probabilities": list(DEFAULT_PROBABILITIES)},
+    "split": base_preprocessing_split,
     "undersample_majority": None,
     "oversample_minority": None,
     "sample_ratio": 1.0,
@@ -254,6 +255,7 @@ def merge_with_defaults(config: dict) -> dict:  # noqa: F821
         config[DEFAULTS] = dict()
 
     # Update defaults with the default feature specific preprocessing parameters
+    config[DEFAULTS][PREPROCESSING][SPLIT] = base_preprocessing_split
     for feature_type, preprocessing_defaults in default_feature_specific_preprocessing_parameters.items():
         # Create a new key with feature type if defaults is empty
         if feature_type not in config.get(DEFAULTS):

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -46,7 +46,7 @@ from ludwig.constants import (
     TYPE,
 )
 from ludwig.contrib import add_contrib_callback_args
-from ludwig.data.split import get_splitter
+from ludwig.data.split import get_splitter, DEFAULT_PROBABILITIES
 from ludwig.features.feature_registries import base_type_registry, input_type_registry, output_type_registry
 from ludwig.features.feature_utils import compute_feature_hash
 from ludwig.globals import LUDWIG_VERSION
@@ -64,7 +64,10 @@ logger = logging.getLogger(__name__)
 default_random_seed = 42
 
 base_preprocessing_parameters = {
-    "split": {},
+    "split": {
+        "type": "random",
+        "probabilities": list(DEFAULT_PROBABILITIES)
+    },
     "undersample_majority": None,
     "oversample_minority": None,
     "sample_ratio": 1.0,

--- a/tests/ludwig/utils/test_defaults.py
+++ b/tests/ludwig/utils/test_defaults.py
@@ -405,12 +405,13 @@ def test_merge_with_defaults():
             "learning_rate_scaling": "linear",
         },
         PREPROCESSING: {
-            "split": {},
+            "split": {"type": "random", "probabilities": [0.7, 0.1, 0.2]},
             "undersample_majority": None,
             "oversample_minority": None,
             "sample_ratio": 1.0,
         },
         DEFAULTS: {
+            "split": {"type": "random", "probabilities": [0.7, 0.1, 0.2]},
             "text": {
                 PREPROCESSING: {
                     "tokenizer": "space_punct",

--- a/tests/ludwig/utils/test_defaults.py
+++ b/tests/ludwig/utils/test_defaults.py
@@ -25,7 +25,7 @@ from ludwig.constants import (
     TYPE,
 )
 from ludwig.schema.trainer import ECDTrainerConfig
-from ludwig.utils.defaults import merge_with_defaults
+from ludwig.utils.defaults import merge_with_defaults, base_preprocessing_split
 from ludwig.utils.misc_utils import merge_dict
 from tests.integration_tests.utils import (
     binary_feature,
@@ -405,13 +405,12 @@ def test_merge_with_defaults():
             "learning_rate_scaling": "linear",
         },
         PREPROCESSING: {
-            "split": {"type": "random", "probabilities": [0.7, 0.1, 0.2]},
+            "split": base_preprocessing_split,
             "undersample_majority": None,
             "oversample_minority": None,
             "sample_ratio": 1.0,
         },
         DEFAULTS: {
-            "split": {"type": "random", "probabilities": [0.7, 0.1, 0.2]},
             "text": {
                 PREPROCESSING: {
                     "tokenizer": "space_punct",

--- a/tests/ludwig/utils/test_defaults.py
+++ b/tests/ludwig/utils/test_defaults.py
@@ -25,7 +25,7 @@ from ludwig.constants import (
     TYPE,
 )
 from ludwig.schema.trainer import ECDTrainerConfig
-from ludwig.utils.defaults import merge_with_defaults, BASE_PREPROCESSING_SPLIT_CONFIG
+from ludwig.utils.defaults import BASE_PREPROCESSING_SPLIT_CONFIG, merge_with_defaults
 from ludwig.utils.misc_utils import merge_dict
 from tests.integration_tests.utils import (
     binary_feature,

--- a/tests/ludwig/utils/test_defaults.py
+++ b/tests/ludwig/utils/test_defaults.py
@@ -25,7 +25,7 @@ from ludwig.constants import (
     TYPE,
 )
 from ludwig.schema.trainer import ECDTrainerConfig
-from ludwig.utils.defaults import merge_with_defaults, base_preprocessing_split
+from ludwig.utils.defaults import merge_with_defaults, BASE_PREPROCESSING_SPLIT_CONFIG
 from ludwig.utils.misc_utils import merge_dict
 from tests.integration_tests.utils import (
     binary_feature,
@@ -405,7 +405,7 @@ def test_merge_with_defaults():
             "learning_rate_scaling": "linear",
         },
         PREPROCESSING: {
-            "split": base_preprocessing_split,
+            "split": BASE_PREPROCESSING_SPLIT_CONFIG,
             "undersample_majority": None,
             "oversample_minority": None,
             "sample_ratio": 1.0,


### PR DESCRIPTION
Currently on the predibase side, we rely on `defaults` to render preprocessing forms (I assume this will be replaced later by rjsf, but for now, the split form is missing)

we can either
1) Update the defaults here (though not sure this should be the default)
2) Update the split defaults on the predibase engine side
2) Hardcode the split probabilities form on the predibase client side

edit:
```
E               AssertionError: Defaults specified for `preprocessing` but `preprocessing` is
E                               not a feature type recognised by Ludwig.
```
does this mean there is no longer a global preprocessing?