### PR TITLE
Enable saving hyperopt checkpoints with multi-node clusters

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -369,7 +369,7 @@ class LudwigModel:
 
         if model_resume_path is None:
             if self.backend.is_coordinator():
-                output_directory = get_output_directory(output_directory, experiment_name, model_name)
+                output_directory = get_output_directory(output_directory, experiment_name, model_name, self.backend)
             else:
                 output_directory = None
 
@@ -551,6 +551,7 @@ class LudwigModel:
                         model=self.model,
                         config=self.config,
                         config_fp=self.config_fp,
+                        save_path=model_dir,
                     )
 
                 try:
@@ -1424,7 +1425,7 @@ class LudwigModel:
         self.backend.sync_model(self.model)
 
     def save(self, save_path: str) -> None:
-        """This function allows to save models on disk.
+        """This function allows saving models on disk.
 
         # Inputs
 

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -24,7 +24,7 @@ import pandas as pd
 import psutil
 import torch
 
-from ludwig.data.cache.manager import CacheManager
+from ludwig.data.cache.manager import CacheManager, HyperoptSyncManager
 from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.data.dataset.base import DatasetManager
 from ludwig.data.dataset.pandas import PandasDatasetManager
@@ -43,9 +43,12 @@ class Backend(ABC):
         dataset_manager: DatasetManager,
         cache_dir: Optional[str] = None,
         cache_credentials: Optional[Union[str, dict]] = None,
+        hyperopt_sync_dir: Optional[str] = None,
+        hyperopt_sync_credentials: Optional[Union[str, dict]] = None,
     ):
         self._dataset_manager = dataset_manager
         self._cache_manager = CacheManager(self._dataset_manager, cache_dir, cache_credentials)
+        self._hyperopt_sync_manager = HyperoptSyncManager(hyperopt_sync_dir, hyperopt_sync_credentials)
 
     @property
     def cache(self):
@@ -54,6 +57,10 @@ class Backend(ABC):
     @property
     def dataset_manager(self):
         return self._dataset_manager
+
+    @property
+    def hyperopt_sync_manager(self):
+        return self._hyperopt_sync_manager
 
     @abstractmethod
     def initialize(self):

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -796,8 +796,23 @@ class RayPredictor(BasePredictor):
 class RayBackend(RemoteTrainingMixin, Backend):
     BACKEND_TYPE = "ray"
 
-    def __init__(self, processor=None, trainer=None, loader=None, use_legacy=False, preprocessor_kwargs=None, **kwargs):
-        super().__init__(dataset_manager=RayDatasetManager(self), **kwargs)
+    def __init__(
+        self,
+        processor=None,
+        trainer=None,
+        loader=None,
+        use_legacy=False,
+        preprocessor_kwargs=None,
+        hyperopt_sync_dir: Optional[str] = None,
+        hyperopt_sync_credentials: Optional[Union[str, dict]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            dataset_manager=RayDatasetManager(self),
+            hyperopt_sync_dir=hyperopt_sync_dir,
+            hyperopt_sync_credentials=hyperopt_sync_credentials,
+            **kwargs,
+        )
         self._preprocessor_kwargs = preprocessor_kwargs or {}
         self._df_engine = _get_df_engine(processor)
         self._horovod_kwargs = trainer or {}

--- a/ludwig/callbacks.py
+++ b/ludwig/callbacks.py
@@ -138,6 +138,7 @@ class Callback(ABC):
         model,
         config: Dict[str, Any],
         config_fp: Union[str, None],
+        save_path: Union[str, None] = None,
     ):
         """Called after creation of trainer, before the start of training.
 

--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -230,6 +230,8 @@ POSTPROCESSOR = "postprocessor"
 S3 = "s3"
 CACHE = "cache"
 
+HYPEROPT_LOCAL_DIR = "~/ray_results"
+
 # If `use_torch_profiler=True` in LudwigProfiler, LUDWIG_TAG is prepended to the specified experiment tag
 # (LudwigProfiler(tag="...", ..)). This edited tag is passed in to `torch.profiler.record_function` so we can
 # retrieve torch ops for the tagged code blocks/functions.

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -155,3 +155,23 @@ class CacheManager:
     @property
     def credentials(self) -> Optional[dict]:
         return self._cache_credentials
+
+
+class HyperoptSyncManager:
+    def __init__(
+        self,
+        hyperopt_sync_dir: Optional[str] = None,
+        hyperopt_sync_credentials: Optional[Union[str, dict]] = None,
+    ):
+        self._hyperopt_sync_dir = hyperopt_sync_dir
+        if isinstance(hyperopt_sync_credentials, str):
+            hyperopt_sync_credentials = data_utils.load_json(hyperopt_sync_credentials)
+        self._hyperopt_sync_credentials = hyperopt_sync_credentials
+
+    @property
+    def credentials(self) -> Union[dict, None]:
+        return self._hyperopt_sync_credentials
+
+    @property
+    def sync_dir(self) -> Union[str, None]:
+        return self._hyperopt_sync_dir

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -26,8 +26,8 @@ from ludwig.constants import (
     PARAMETERS,
     PREPROCESSING,
     RAY,
-    SPACE,
     SEARCH_ALG,
+    SPACE,
     SPLIT,
     TEST,
     TRAINING,
@@ -39,8 +39,8 @@ from ludwig.features.feature_registries import output_type_registry
 from ludwig.hyperopt.results import HyperoptResults
 from ludwig.hyperopt.utils import print_hyperopt_results, save_hyperopt_stats, should_tune_preprocessing
 from ludwig.utils.backward_compatibility import upgrade_to_latest_version
-from ludwig.utils.dataset_utils import generate_dataset_statistics
 from ludwig.utils.data_utils import use_credentials
+from ludwig.utils.dataset_utils import generate_dataset_statistics
 from ludwig.utils.defaults import default_random_seed, merge_with_defaults
 from ludwig.utils.fs_utils import makedirs, open_file
 from ludwig.utils.misc_utils import get_class_attributes, get_from_registry, set_default_value, set_default_values

--- a/ludwig/hyperopt/syncer.py
+++ b/ludwig/hyperopt/syncer.py
@@ -1,10 +1,10 @@
 from typing import Callable, Dict, List, Optional, Tuple
 
-from ray.air._internal.remote_storage import delete_at_uri, download_from_uri, upload_to_uri
 from ray.tune.syncer import _BackgroundSyncer
 
 from ludwig.backend import Backend
 from ludwig.utils.data_utils import use_credentials
+from ludwig.utils.fs_utils import delete, download, upload
 
 
 class RemoteSyncer(_BackgroundSyncer):
@@ -14,24 +14,15 @@ class RemoteSyncer(_BackgroundSyncer):
 
     def _sync_up_command(self, local_path: str, uri: str, exclude: Optional[List] = None) -> Tuple[Callable, Dict]:
         with use_credentials(self.backend.hyperopt_sync_manager.credentials):
-            return (
-                upload_to_uri,
-                dict(local_path=local_path, uri=uri, exclude=exclude),
-            )
+            return upload(), dict(lpath=local_path, rpath=uri, recursive=True)
 
     def _sync_down_command(self, uri: str, local_path: str) -> Tuple[Callable, Dict]:
         with use_credentials(self.backend.hyperopt_sync_manager.credentials):
-            return (
-                download_from_uri,
-                dict(uri=uri, local_path=local_path),
-            )
+            return download, dict(rpath=uri, lpath=local_path, recursive=True)
 
     def _delete_command(self, uri: str) -> Tuple[Callable, Dict]:
         with use_credentials(self.backend.hyperopt_sync_manager.credentials):
-            return (
-                delete_at_uri,
-                dict(uri=uri),
-            )
+            return delete(), dict(url=uri, recursive=True)
 
     def __reduce__(self):
         """We need this custom serialization because we can't pickle thread.lock objects that are used by the

--- a/ludwig/hyperopt/syncer.py
+++ b/ludwig/hyperopt/syncer.py
@@ -1,0 +1,44 @@
+from typing import Callable, Dict, List, Optional, Tuple
+
+from ray.air._internal.remote_storage import delete_at_uri, download_from_uri, upload_to_uri
+from ray.tune.syncer import _BackgroundSyncer
+
+from ludwig.backend import Backend
+from ludwig.utils.data_utils import use_credentials
+
+
+class RemoteSyncer(_BackgroundSyncer):
+    def __init__(self, sync_period: float = 300.0, backend: Backend = None):
+        super().__init__(sync_period=sync_period)
+        self.backend = backend
+
+    def _sync_up_command(self, local_path: str, uri: str, exclude: Optional[List] = None) -> Tuple[Callable, Dict]:
+        with use_credentials(self.backend.hyperopt_sync_manager.credentials):
+            return (
+                upload_to_uri,
+                dict(local_path=local_path, uri=uri, exclude=exclude),
+            )
+
+    def _sync_down_command(self, uri: str, local_path: str) -> Tuple[Callable, Dict]:
+        with use_credentials(self.backend.hyperopt_sync_manager.credentials):
+            return (
+                download_from_uri,
+                dict(uri=uri, local_path=local_path),
+            )
+
+    def _delete_command(self, uri: str) -> Tuple[Callable, Dict]:
+        with use_credentials(self.backend.hyperopt_sync_manager.credentials):
+            return (
+                delete_at_uri,
+                dict(uri=uri),
+            )
+
+    def __reduce__(self):
+        """We need this custom serialization because we can't pickle thread.lock objects that are used by the
+        use_credentials context manager.
+
+        https://docs.ray.io/en/latest/ray-core/objects/serialization.html#customized-serialization
+        """
+        deserializer = RemoteSyncer
+        serialized_data = (self.sync_period, self.backend)
+        return deserializer, serialized_data

--- a/ludwig/hyperopt/utils.py
+++ b/ludwig/hyperopt/utils.py
@@ -20,7 +20,6 @@ def print_hyperopt_results(hyperopt_results: HyperoptResults):
     for trial_results in hyperopt_results.ordered_trials:
         if not isinstance(trial_results.metric_score, str):
             logger.info(f"score: {trial_results.metric_score:.6f} | parameters: {trial_results.parameters}")
-    logger.info("")
 
 
 def save_hyperopt_stats(hyperopt_stats, hyperopt_dir_name):
@@ -33,7 +32,7 @@ def load_json_value(v):
         return json.loads(v)
     except Exception as e:
         logger.warning(f"While loading json, encountered exception: {e}")
-        return v
+    return v
 
 
 # define set containing names to return for TrialResults

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -147,16 +147,22 @@ class ECD(BaseModel):
         combiner_outputs = self.combine(encoder_outputs)
         return self.decode(combiner_outputs, targets, mask)
 
-    def save(self, save_path):
+    def save(self, save_path: str):
         """Saves the model to the given path."""
         weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
-        torch.save(self.state_dict(), weights_save_path)
+        try:
+            torch.save(self.state_dict(), weights_save_path)
+        except Exception as e:
+            raise RuntimeError(f"Error saving model weights to {weights_save_path}: {e}")
 
-    def load(self, save_path):
+    def load(self, load_path: str):
         """Loads the model from the given path."""
-        weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
+        weights_load_path = os.path.join(load_path, MODEL_WEIGHTS_FILE_NAME)
         device = torch.device(get_torch_device())
-        self.load_state_dict(torch.load(weights_save_path, map_location=device))
+        try:
+            self.load_state_dict(torch.load(weights_load_path, map_location=device))
+        except Exception as e:
+            raise RuntimeError(f"Error loading model weights from {weights_load_path}: {e}")
 
     def get_args(self):
         """Returns init arguments for constructing this model."""

--- a/ludwig/models/gbm.py
+++ b/ludwig/models/gbm.py
@@ -173,7 +173,7 @@ class GBM(BaseModel):
 
         return output_logits
 
-    def save(self, save_path):
+    def save(self, save_path: str):
         """Saves the model to the given path."""
         if self.lgbm_model is None:
             raise ValueError("Model has not been trained yet.")
@@ -183,7 +183,7 @@ class GBM(BaseModel):
         weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
         joblib.dump(self.lgbm_model, weights_save_path)
 
-    def load(self, save_path):
+    def load(self, load_path: str):
         """Loads the model from the given path."""
         import joblib
 

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -312,3 +312,13 @@ class file_lock(contextlib.AbstractContextManager):
     def __exit__(self, *args, **kwargs):
         if self.lock:
             return self.lock.__exit__(*args, **kwargs)
+
+
+def upload(lpath, rpath, recursive=False):
+    fs, path = get_fs_and_path(rpath)
+    fs.put(lpath, path, recursive=recursive)
+
+
+def download(rpath, lpath, recursive=False):
+    fs, path = get_fs_and_path(rpath)
+    fs.get(path, lpath, recursive=recursive)

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -125,9 +125,14 @@ def get_class_attributes(c):
     return {i for i in dir(c) if not callable(getattr(c, i)) and not i.startswith("_")}
 
 
-def get_output_directory(output_directory, experiment_name, model_name="run"):
+def get_output_directory(output_directory, experiment_name, model_name="run", backend=None):
+    from ludwig.utils.data_utils import use_credentials
+
     base_dir_name = os.path.join(output_directory, experiment_name + ("_" if model_name else "") + (model_name or ""))
-    return fs_utils.abspath(find_non_existing_dir_by_adding_suffix(base_dir_name))
+    if backend is not None:
+        with use_credentials(backend.cache.credentials):
+            return os.path.abspath(find_non_existing_dir_by_adding_suffix(base_dir_name))
+    return os.path.abspath(find_non_existing_dir_by_adding_suffix(base_dir_name))
 
 
 def get_file_names(output_directory):

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -41,7 +41,7 @@ from ludwig.hyperopt.results import HyperoptResults
 from ludwig.hyperopt.run import hyperopt, update_hyperopt_params_with_defaults
 from ludwig.utils.data_utils import load_json
 from ludwig.utils.defaults import merge_with_defaults
-from tests.integration_tests.utils import category_feature, generate_data, text_feature
+from tests.integration_tests.utils import category_feature, generate_data, private_param, remote_tmpdir, text_feature
 
 try:
     import ray
@@ -392,6 +392,18 @@ def test_hyperopt_run_hyperopt(csv_filename, search_space, tmpdir, ray_cluster):
 
     # check for existence of the hyperopt statistics file
     assert os.path.isfile(os.path.join(tmpdir, "test_hyperopt", HYPEROPT_STATISTICS_FILE_NAME))
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize("fs_protocol,bucket", [private_param(("s3", "ludwig-tests"))], ids=["s3"])
+def test_hyperopt_sync_remote(fs_protocol, bucket, csv_filename, ray_cluster):
+    with remote_tmpdir(fs_protocol, bucket) as tmpdir:
+        test_hyperopt_run_hyperopt(
+            csv_filename,
+            "random",
+            tmpdir,
+            ray_cluster,
+        )
 
 
 @pytest.mark.distributed


### PR DESCRIPTION
This PR enables two things:

1. Ludwig users can now create a custom  RayTune `SyncClient` and pass it into RayTune for custom checkpointing syncing behavior.
2. Function calls to `fsspec` related functions in `fs_utils` can now take in custom storage options (credentials) for different protocol types. This means that model metadata, parameters, checkpoints etc can now be written to remote storage options such as GCS, Azure, AWS, Minio, etc - anything that `fsspec` supports.

Both of these changes together enable being able to perform multi-node checkpoint syncing for hyperopt.