### PR TITLE
Simplify ludwig.benchmarking.benchmark API and add ludwig benchmark CLI

### DIFF
--- a/ludwig/benchmarking/benchmark.py
+++ b/ludwig/benchmarking/benchmark.py
@@ -1,14 +1,14 @@
+import argparse
 import importlib
 import logging
 import os
 import shutil
-import argparse
 from typing import Any, Dict, Union
 
 from ludwig.api import LudwigModel
 from ludwig.benchmarking.utils import export_artifacts, load_from_module
-from ludwig.utils.data_utils import load_yaml
 from ludwig.contrib import add_contrib_callback_args
+from ludwig.utils.data_utils import load_yaml
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -70,14 +70,17 @@ def benchmark(bench_config_path: str) -> None:
             benchmark_one_local(experiment, export_artifacts_dict=config["export"][0])
         except Exception:
             logging.exception(
-                "Benchmarking {} {} failed".format(experiment["dataset_name"], experiment["experiment_name"]))
+                "Benchmarking {} {} failed".format(experiment["dataset_name"], experiment["experiment_name"])
+            )
 
 
 def cli(sys_argv):
     parser = argparse.ArgumentParser(
         description="This script runs a ludwig experiment on datasets specified in the benchmark config and exports "
-                    "the experiment artifact for each of the datasets following the export parameters specified in"
-                    "the benchmarking config.", prog="ludwig benchmark", usage="%(prog)s [options]"
+        "the experiment artifact for each of the datasets following the export parameters specified in"
+        "the benchmarking config.",
+        prog="ludwig benchmark",
+        usage="%(prog)s [options]",
     )
     parser.add_argument("--config", type=str, help="The benchmarking config.")
     add_contrib_callback_args(parser)

--- a/ludwig/benchmarking/benchmark.py
+++ b/ludwig/benchmarking/benchmark.py
@@ -10,7 +10,6 @@ from ludwig.benchmarking.reporting import create_metrics_report
 from ludwig.benchmarking.utils import export_artifacts, load_from_module
 from ludwig.utils.data_utils import load_yaml
 
-# todo (Wael): to update once api.py PR is merged.
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 

--- a/ludwig/benchmarking/benchmark.py
+++ b/ludwig/benchmarking/benchmark.py
@@ -2,14 +2,13 @@ import importlib
 import logging
 import os
 import shutil
-import traceback
+import argparse
 from typing import Any, Dict, Union
 
 from ludwig.api import LudwigModel
-from ludwig.benchmarking.reporting import create_metrics_report
 from ludwig.benchmarking.utils import export_artifacts, load_from_module
 from ludwig.utils.data_utils import load_yaml
-
+from ludwig.contrib import add_contrib_callback_args
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -20,12 +19,10 @@ def setup_experiment(experiment: Dict[str, str]) -> Dict[Any, Any]:
     experiment: dictionary containing the dataset name, config path, and experiment name.
     Returns a Ludwig config.
     """
-    shutil.rmtree(os.path.join(os.getcwd(), experiment["dataset_name"]), ignore_errors=True)
-    model_config = load_yaml(os.path.join("configs", experiment["config_path"]))
+    shutil.rmtree(os.path.join(experiment["dataset_name"]), ignore_errors=True)
+    model_config = load_yaml(experiment["config_path"])
     model_config["backend"] = {}
     model_config["backend"]["type"] = "local"
-    model_config["backend"]["cache_dir"] = os.path.join(os.getcwd(), experiment["dataset_name"], "cache")
-    os.makedirs(model_config["backend"]["cache_dir"], exist_ok=True)
     return model_config
 
 
@@ -35,32 +32,28 @@ def benchmark_one_local(experiment: Dict[str, str], export_artifacts_dict: Dict[
     experiment: dictionary containing the dataset name, config path, and experiment name.
     export_artifacts_dict: dictionary containing an export boolean flag and a path to export to.
     """
-    print("\nRunning", experiment["dataset_name"] + " " + experiment["experiment_name"])
+    logging.info(f"\nRunning experiment *{experiment['experiment_name']}* on dataset *{experiment['dataset_name']}*")
 
     # configuring backend and paths
     model_config = setup_experiment(experiment)
 
     # loading dataset
-    dataset_module = importlib.import_module("ludwig.datasets.{}".format(experiment["dataset_name"]))
+    dataset_module = importlib.import_module(f"ludwig.datasets.{experiment['dataset_name']}")
     dataset = load_from_module(dataset_module, model_config["output_features"][0])
 
     # running model and capturing metrics
-    experiment_output_directory = os.path.join(os.getcwd(), experiment["dataset_name"])
     model = LudwigModel(config=model_config, logging_level=logging.ERROR)
-    model.experiment(
+    _, _, _, output_directory = model.experiment(
         dataset=dataset,
-        output_directory=experiment_output_directory,
-        track_resource_usage=True,
+        output_directory=experiment["dataset_name"],
+        skip_save_processed_input=True,
+        skip_save_unprocessed_output=True,
+        skip_save_predictions=True,
+        skip_collect_predictions=True,
     )
-
-    # creating full report containing performance metrics (e.g. accuracy) and non-performance metrics (e.g. RAM usage)
-    _, report_path = create_metrics_report(experiment["dataset_name"])
-
-    # exporting the metrics report and experiment config to s3
     if export_artifacts_dict["export_artifacts"]:
-        export_artifacts(
-            experiment, report_path, experiment_output_directory, export_artifacts_dict["export_base_path"]
-        )
+        export_base_path = export_artifacts_dict["export_base_path"]
+        export_artifacts(experiment, output_directory, export_base_path)
 
 
 def benchmark(bench_config_path: str) -> None:
@@ -76,5 +69,17 @@ def benchmark(bench_config_path: str) -> None:
                 experiment["experiment_name"] = config["global_experiment_name"]
             benchmark_one_local(experiment, export_artifacts_dict=config["export"][0])
         except Exception:
-            print("Benchmarking {} {} failed".format(experiment["dataset_name"], experiment["experiment_name"]))
-            print(traceback.format_exc())
+            logging.exception(
+                "Benchmarking {} {} failed".format(experiment["dataset_name"], experiment["experiment_name"]))
+
+
+def cli(sys_argv):
+    parser = argparse.ArgumentParser(
+        description="This script runs a ludwig experiment on datasets specified in the benchmark config and exports "
+                    "the experiment artifact for each of the datasets following the export parameters specified in"
+                    "the benchmarking config.", prog="ludwig benchmark", usage="%(prog)s [options]"
+    )
+    parser.add_argument("--config", type=str, help="The benchmarking config.")
+    add_contrib_callback_args(parser)
+    args = parser.parse_args(sys_argv)
+    benchmark(args.config)

--- a/ludwig/benchmarking/benchmark.py
+++ b/ludwig/benchmarking/benchmark.py
@@ -70,7 +70,7 @@ def benchmark(bench_config_path: str) -> None:
             benchmark_one_local(experiment, export_artifacts_dict=config["export"][0])
         except Exception:
             logging.exception(
-                "Benchmarking {} {} failed".format(experiment["dataset_name"], experiment["experiment_name"])
+                f"Experiment *{experiment['experiment_name']}* on dataset *{experiment['dataset_name']}* failed"
             )
 
 
@@ -82,7 +82,7 @@ def cli(sys_argv):
         prog="ludwig benchmark",
         usage="%(prog)s [options]",
     )
-    parser.add_argument("--config", type=str, help="The benchmarking config.")
+    parser.add_argument("--benchmarking_config", type=str, help="The benchmarking config.")
     add_contrib_callback_args(parser)
     args = parser.parse_args(sys_argv)
     benchmark(args.config)

--- a/ludwig/benchmarking/utils.py
+++ b/ludwig/benchmarking/utils.py
@@ -1,10 +1,10 @@
 import logging
 import os
+from types import ModuleType
+from typing import Any, Dict, Union
+
 import fsspec
 import pandas as pd
-
-from typing import Any, Dict, Union
-from types import ModuleType
 
 from ludwig.constants import CATEGORY
 from ludwig.datasets.base_dataset import BaseDataset
@@ -15,7 +15,7 @@ from ludwig.utils.fs_utils import get_fs_and_path
 
 
 def load_from_module(
-        dataset_module: Union[BaseDataset, ModuleType], output_feature: Dict[str, str], subsample_frac: float = 1
+    dataset_module: Union[BaseDataset, ModuleType], output_feature: Dict[str, str], subsample_frac: float = 1
 ) -> pd.DataFrame:
     """Load the ludwig dataset, optionally subsamples it, and returns a repeatable split. A stratified split is
     used for classification datasets.
@@ -65,4 +65,5 @@ def export_artifacts(experiment: Dict[str, str], experiment_output_directory: st
     except Exception:
         logging.exception(
             f"Failed to upload experiment artifacts for experiment *{experiment['experiment_name']}* on "
-            f"dataset {experiment['dataset_name']}")
+            f"dataset {experiment['dataset_name']}"
+        )

--- a/ludwig/benchmarking/utils.py
+++ b/ludwig/benchmarking/utils.py
@@ -1,25 +1,21 @@
 import logging
 import os
-import shutil
-from typing import Any, Dict
-
 import fsspec
 import pandas as pd
-from botocore.exceptions import ClientError
 
-# todo (Wael): add to ludwig.globals
-from s3fs.errors import translate_boto_error
+from typing import Any, Dict, Union
+from types import ModuleType
 
 from ludwig.constants import CATEGORY
 from ludwig.datasets.base_dataset import BaseDataset
-from ludwig.globals import CONFIG_YAML, EXPERIMENT_RUN, MODEL_HYPERPARAMETERS_FILE_NAME, REPORT_JSON
+from ludwig.globals import CONFIG_YAML
 from ludwig.utils.dataset_utils import get_repeatable_train_val_test_split
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.fs_utils import get_fs_and_path
 
 
 def load_from_module(
-    dataset_module: BaseDataset, output_feature: Dict[str, str], subsample_frac: float = 1
+        dataset_module: Union[BaseDataset, ModuleType], output_feature: Dict[str, str], subsample_frac: float = 1
 ) -> pd.DataFrame:
     """Load the ludwig dataset, optionally subsamples it, and returns a repeatable split. A stratified split is
     used for classification datasets.
@@ -46,46 +42,27 @@ def flatten_dict(d: Dict[str, Any], sep: str = ".") -> Dict[str, Any]:
     return flat_dict
 
 
-def export_artifacts(
-    experiment: Dict[str, str], report_path: str, experiment_output_directory: str, export_base_path: str
-) -> None:
+def export_artifacts(experiment: Dict[str, str], experiment_output_directory: str, export_base_path: str):
     """Save the experiment artifacts to the `bench_export_directory`.
 
-    experiment: experiment dict that contains "dataset_name" (e.g. ames_housing),
+    :param experiment: experiment dict that contains "dataset_name" (e.g. ames_housing),
         "experiment_name" (specified by user), and "config_path" (path to experiment config.
         Relative to ludwig/benchmarks/configs).
-    report_path: path where the experiment metrics report is
-        saved.
-    experiment_output_directory: path where the model, data,
-        and logs of the experiment are saved.
-    export_base_path: remote or local path (directory) where artifacts are
+    :param experiment_output_directory: path where the model, data, and logs of the experiment are saved.
+    :param export_base_path: remote or local path (directory) where artifacts are
         exported. (e.g. s3://benchmarking.us-west-2.ludwig.com/bench/ or your/local/bench/)
     """
     protocol, _ = fsspec.core.split_protocol(export_base_path)
     fs, _ = get_fs_and_path(export_base_path)
     try:
         export_full_path = os.path.join(export_base_path, experiment["dataset_name"], experiment["experiment_name"])
-        fs.put(report_path, os.path.join(export_full_path, REPORT_JSON), recursive=True)
+        fs.put(experiment_output_directory, export_full_path, recursive=True)
         fs.put(
             os.path.join("configs", experiment["config_path"]),
             os.path.join(export_full_path, CONFIG_YAML),
-            recursive=True,
         )
-        fs.put(
-            os.path.join(experiment["dataset_name"], EXPERIMENT_RUN, "model", MODEL_HYPERPARAMETERS_FILE_NAME),
-            os.path.join(export_full_path, MODEL_HYPERPARAMETERS_FILE_NAME),
-            recursive=True,
-        )
-
-        # zip experiment directory to export
-        try:
-            shutil.make_archive("artifacts", "zip", experiment_output_directory)
-            fs.put("artifacts.zip", os.path.join(export_full_path, "artifacts.zip"), recursive=True)
-            os.remove("artifacts.zip")
-        except Exception as e:
-            logging.error(f"Couldn't export '{experiment_output_directory}' to bucket")
-            logging.error(e)
-
-        print("Uploaded metrics report and experiment config to\n\t", export_full_path)
-    except ClientError as e:
-        logging.error(translate_boto_error(e))
+        logging.info(f"Uploaded experiment artifact to\n\t{export_full_path}")
+    except Exception:
+        logging.exception(
+            f"Failed to upload experiment artifacts for experiment *{experiment['experiment_name']}* on "
+            f"dataset {experiment['dataset_name']}")

--- a/ludwig/cli.py
+++ b/ludwig/cli.py
@@ -38,6 +38,7 @@ Available sub-commands:
    evaluate              Evaluate a pretrained model's performance
    experiment            Runs a full experiment training a model and evaluating it
    hyperopt              Perform hyperparameter optimization
+   benchmark             Run and track experiments on a number of datasets and configs, and export experiment artifacts. 
    serve                 Serves a pretrained model
    visualize             Visualizes experimental results
    collect_summary       Prints names of weights and layers activations to use with other collect commands
@@ -89,6 +90,11 @@ Available sub-commands:
         from ludwig import hyperopt_cli
 
         hyperopt_cli.cli(sys.argv[2:])
+
+    def benchmark(self):
+        from ludwig.benchmarking import benchmark
+
+        benchmark.cli(sys.argv[2:])
 
     def serve(self):
         from ludwig import serve

--- a/ludwig/cli.py
+++ b/ludwig/cli.py
@@ -38,7 +38,7 @@ Available sub-commands:
    evaluate              Evaluate a pretrained model's performance
    experiment            Runs a full experiment training a model and evaluating it
    hyperopt              Perform hyperparameter optimization
-   benchmark             Run and track experiments on a number of datasets and configs, and export experiment artifacts. 
+   benchmark             Run and track experiments on a number of datasets and configs, and export experiment artifacts.
    serve                 Serves a pretrained model
    visualize             Visualizes experimental results
    collect_summary       Prints names of weights and layers activations to use with other collect commands

--- a/ludwig/globals.py
+++ b/ludwig/globals.py
@@ -33,7 +33,6 @@ TRAINING_PREPROC_FILE_NAME = "training.hdf5"
 
 HYPEROPT_STATISTICS_FILE_NAME = "hyperopt_statistics.json"
 
-REPORT_JSON = "report.json"
 CONFIG_YAML = "config.yaml"
 
 DISABLE_PROGRESSBAR = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ psutil
 protobuf==3.20.1 # https://github.com/databrickslabs/dbx/issues/257
 experiment_impact_tracker
 gpustat
-s3fs
 
 # new data format support
 xlwt            # excel


### PR DESCRIPTION
In this PR, we simplify the `ludwig.benchmarking.benchmark` API and add a CLI option. Changes include
- Deprecating old way of collecting artifacts. Instead of collecting performance metrics and resource usage metrics, merging them in one file, then uploading, we decouple all tracked metrics. Note that this PR only includes collection and tracking of performance metrics per experiment. Collection and tracking of resource usage metrics will follow in a separate PR once #2363 and #2372 are merged in.
- Adds a CLI option that can be invoked with `ludwig benchmark --benchmarking_config path/to/benchmarking_config.yaml`

This is an example of a benchmarking config
```
global_experiment_name: zscore_normalization
export:
  - export_artifacts: true
    export_base_path: s3://some-bucket.com/bench/    # include the slash at the end. (you can also specify a local path e.g. local/experimental/path)
datasets:
  - dataset_name: ames_housing
    config_path: path/to/configs/ames_housing.yaml
  - dataset_name: protein
    config_path: different/path/protein.yaml
  - dataset_name: mercedes_benz_greener
    config_path: another/path/mercedes_benz_greener.yaml
```