### PR TITLE
Treat dataset columns as object dtype during first pass of handle_missing_values

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1140,6 +1140,16 @@ def build_dataset(
 
     # Happens after preprocessing parameters are built so we can use precomputed fill values.
     logging.debug("handle missing values")
+
+    # In some cases, there can be a (temporary) mismatch between the dtype of the column and the type expected by the
+    # preprocessing config (e.g., a categorical feature represented as an int-like column). In particular, Dask
+    # may raise an error even when there are no missing values in the column itself.
+    #
+    # Since we immediately cast all columns in accordance with their expected feature types after filling missing
+    # values, we work around the above issue by temporarily treating all columns as object dtype.
+    for col_key in dataset_cols:
+        dataset_cols[col_key] = dataset_cols[col_key].astype(object)
+
     for feature_config in feature_configs:
         preprocessing_parameters = feature_name_to_preprocessing_parameters[feature_config[NAME]]
         handle_missing_values(dataset_cols, feature_config, preprocessing_parameters)

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -263,6 +263,29 @@ def test_number_feature_wrong_dtype(csv_filename, tmpdir):
     assert np.all(concatenated_df[num_feat[PROC_COLUMN]] == 0.0)
 
 
+def test_column_feature_type_mismatch_fill():
+    """Tests that we are able to fill missing values even in columns where the column dtype and desired feature
+    dtype do not match."""
+    cat_feat = category_feature()
+    bin_feat = binary_feature()
+    input_features = [cat_feat]
+    output_features = [bin_feat]
+    config = {"input_features": input_features, "output_features": output_features}
+
+    # Construct dataframe with int-like column representing a categorical feature
+    df = pd.DataFrame(
+        {
+            cat_feat[NAME]: pd.Series(pd.array([None] + [1] * 24, dtype=pd.Int64Dtype())),
+            bin_feat[NAME]: pd.Series([True] * 25),
+        }
+    )
+
+    # run preprocessing
+    backend = LocalTestBackend()
+    ludwig_model = LudwigModel(config, backend=backend)
+    train_ds, val_ds, test_ds, _ = ludwig_model.preprocess(dataset=df)
+
+
 @pytest.mark.parametrize("format", ["file", "df"])
 def test_presplit_override(format, tmpdir):
     """Tests that provising a pre-split file or dataframe overrides the user's split config."""


### PR DESCRIPTION
An example of errors we could see before this PR:

Suppose there is a categorical feature represented in the dataset as a nullable int column (`dtype == pd.Int64Dtype()`). Since the feature itself is categorical, the default fill value is a string (`'<UNK>'`). This leads to a `ValueError`. Additionally, it turns out that, if the dataset is a Dask DataFrame, this error will be raised even if no values are missing and there is nothing to actually fill.

There is a second invocation of `handle_missing_values` in `build_data`. However, in that case all columns should have already been cast to their intended feature-compatible dtypes, so type compatibility should no longer be a column.