### PR TITLE
Include split column in explanation df

### DIFF
--- a/ludwig/explain/util.py
+++ b/ludwig/explain/util.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from ludwig.api import LudwigModel
+from ludwig.constants import SPLIT, PREPROCESSING, COLUMN, INPUT_FEATURES
 
 
 def filter_cols(df, cols):
@@ -10,7 +11,9 @@ def filter_cols(df, cols):
 
 
 def prepare_data(model: LudwigModel, inputs_df: pd.DataFrame, sample_df: pd.DataFrame, target: str):
-    feature_cols = [feature["column"] for feature in model.config["input_features"]]
+    feature_cols = [feature[COLUMN] for feature in model.config[INPUT_FEATURES]]
+    if SPLIT in model.config.get(PREPROCESSING, {}) and COLUMN in model.config[PREPROCESSING][SPLIT]:
+        feature_cols.append(model.config[PREPROCESSING][SPLIT][COLUMN])
     target_feature_name = get_feature_name(model, target)
 
     inputs_df = filter_cols(inputs_df, feature_cols)

--- a/ludwig/explain/util.py
+++ b/ludwig/explain/util.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from ludwig.api import LudwigModel
-from ludwig.constants import SPLIT, PREPROCESSING, COLUMN, INPUT_FEATURES
+from ludwig.constants import COLUMN, INPUT_FEATURES, PREPROCESSING, SPLIT
 
 
 def filter_cols(df, cols):


### PR DESCRIPTION
When generating explanations, a call to `prepare_data()` is made which filters out all columns except for input features. This leads to a key error during data preprocessing when Ludwig looks for a split column if a non-random type of splitting has been specified. The proposed fix makes sure that split column is not removed from the df that is sent for preprocessing from the explanations generation.