### PR TITLE
Fix AimCallback to model_name as Run.name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: pyupgrade
         args: [--py36-plus]
   - repo: https://github.com/myint/docformatter
-    rev: v1.5.0-rc1
+    rev: v1.5.0
     hooks:
       - id: docformatter
         args: [--in-place, --wrap-summaries=115, --wrap-descriptions=120]


### PR DESCRIPTION
Starting from `3.13` version Aim SDK rejects `Run.hash` values other than auto-generated ones. Implementation of AimCallback sets the `model_name` as `aim.Run.hash`, which started to fail with an exception.
Fix includes the following changes:
- set `model_name` as `aim.Run.name`
- when the callback is initialized, check the `aim.Repo` for the Run with name == "model_name" and use it for tracking, otherwise, create a new `aim.Run`.