### PR TITLE
Add image files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,13 @@ coverage.xml
 *.meta.json
 *.parquet
 
+# Images
+*.jpg
+*.jpeg
+*.png
+*.gif
+*.bmp
+
 # Translations
 *.mo
 *.pot


### PR DESCRIPTION
Running the Ludwig twitter bots example downloads O(1000)s of images, which overloads VSCode's source control.