### PR TITLE
Hotfix: features eligible for shared params hyperopt

### DIFF
--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -444,11 +444,11 @@ def get_features_eligible_for_shared_params(
 
         if config_feature_type == INPUT_FEATURES:
             default_encoder = feature_schema().encoder.type
-            if feature.get(ENCODER) and feature.get(ENCODER).get(TYPE, 0) != default_encoder:
+            if feature.get(ENCODER, None) and feature.get(ENCODER).get(TYPE, None) != default_encoder:
                 continue
         else:
             default_decoder = feature_schema().decoder.type
-            if feature.get(DECODER) and feature.get(DECODER).get(TYPE, 0) != default_decoder:
+            if feature.get(DECODER, None) and feature.get(DECODER).get(TYPE, None) != default_decoder:
                 continue
 
         features_eligible_for_shared_params[feature[TYPE]].add(feature[NAME])

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -441,11 +441,17 @@ def get_features_eligible_for_shared_params(
         if config_feature_type == INPUT_FEATURES:
             feature_schema = get_from_registry(feature.get(TYPE), input_type_registry).get_schema_cls()
             default_encoder = feature_schema().encoder.type
+            if not feature.get(ENCODER):
+                continue
+
             if not feature[ENCODER].get(TYPE, 0) or feature[ENCODER].get(TYPE) == default_encoder:
                 features_eligible_for_shared_params[feature[TYPE]].add(feature[NAME])
         else:
             feature_schema = get_from_registry(feature.get(TYPE), output_type_registry).get_schema_cls()
             default_decoder = feature_schema().decoder.type
+            if not feature.get(DECODER):
+                continue
+
             if not feature[DECODER].get(TYPE, 0) or feature[DECODER].get(TYPE) == default_decoder:
                 features_eligible_for_shared_params[feature[TYPE]].add(feature[NAME])
 

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -434,25 +434,23 @@ def get_features_eligible_for_shared_params(
     features_eligible_for_shared_params = defaultdict(set)
 
     features = config_dict.get(config_feature_type)
+    feature_registry = input_type_registry if config_feature_type == INPUT_FEATURES else output_type_registry
 
     for feature in features:
         if TYPE not in feature:
             raise ValueError("Ludwig expects feature types to be defined for each feature within the config.")
+
+        feature_schema = get_from_registry(feature.get(TYPE), feature_registry).get_schema_cls()
+
         if config_feature_type == INPUT_FEATURES:
-            feature_schema = get_from_registry(feature.get(TYPE), input_type_registry).get_schema_cls()
             default_encoder = feature_schema().encoder.type
-            if not feature.get(ENCODER):
+            if feature.get(ENCODER) and feature.get(ENCODER).get(TYPE, 0) != default_encoder:
                 continue
-
-            if not feature[ENCODER].get(TYPE, 0) or feature[ENCODER].get(TYPE) == default_encoder:
-                features_eligible_for_shared_params[feature[TYPE]].add(feature[NAME])
         else:
-            feature_schema = get_from_registry(feature.get(TYPE), output_type_registry).get_schema_cls()
             default_decoder = feature_schema().decoder.type
-            if not feature.get(DECODER):
+            if feature.get(DECODER) and feature.get(DECODER).get(TYPE, 0) != default_decoder:
                 continue
 
-            if not feature[DECODER].get(TYPE, 0) or feature[DECODER].get(TYPE) == default_decoder:
-                features_eligible_for_shared_params[feature[TYPE]].add(feature[NAME])
+        features_eligible_for_shared_params[feature[TYPE]].add(feature[NAME])
 
     return features_eligible_for_shared_params

--- a/tests/ludwig/hyperopt/test_hyperopt.py
+++ b/tests/ludwig/hyperopt/test_hyperopt.py
@@ -7,7 +7,7 @@ from ludwig.hyperopt.run import get_features_eligible_for_shared_params
 def _setup():
     config = {
         INPUT_FEATURES: [{NAME: "title", TYPE: "text"}],
-        OUTPUT_FEATURES: [{NAME: "title", TYPE: "text"}],
+        OUTPUT_FEATURES: [{NAME: "summary", TYPE: "text"}],
     }
     return config
 
@@ -18,8 +18,8 @@ def test_hyperopt_without_encoders_or_decoders():
         INPUT_FEATURES: get_features_eligible_for_shared_params(config, INPUT_FEATURES),
         OUTPUT_FEATURES: get_features_eligible_for_shared_params(config, OUTPUT_FEATURES),
     }
-    assert features_eligible_for_shared_params[INPUT_FEATURES] == {}
-    assert features_eligible_for_shared_params[OUTPUT_FEATURES] == {}
+    assert features_eligible_for_shared_params[INPUT_FEATURES] == {"text": {"title"}}
+    assert features_eligible_for_shared_params[OUTPUT_FEATURES] == {"text": {"summary"}}
 
 
 @pytest.mark.parametrize("encoder", ["parallel_cnn", "stacked_cnn"])

--- a/tests/ludwig/hyperopt/test_hyperopt.py
+++ b/tests/ludwig/hyperopt/test_hyperopt.py
@@ -1,0 +1,35 @@
+import pytest
+
+from ludwig.constants import ENCODER, INPUT_FEATURES, NAME, OUTPUT_FEATURES, TYPE
+from ludwig.hyperopt.run import get_features_eligible_for_shared_params
+
+
+def _setup():
+    config = {
+        INPUT_FEATURES: [{NAME: "title", TYPE: "text"}],
+        OUTPUT_FEATURES: [{NAME: "title", TYPE: "text"}],
+    }
+    return config
+
+
+def test_hyperopt_without_encoders_or_decoders():
+    config = _setup()
+    features_eligible_for_shared_params = {
+        INPUT_FEATURES: get_features_eligible_for_shared_params(config, INPUT_FEATURES),
+        OUTPUT_FEATURES: get_features_eligible_for_shared_params(config, OUTPUT_FEATURES),
+    }
+    assert features_eligible_for_shared_params[INPUT_FEATURES] == {}
+    assert features_eligible_for_shared_params[OUTPUT_FEATURES] == {}
+
+
+@pytest.mark.parametrize("encoder", ["parallel_cnn", "stacked_cnn"])
+def test_hyperopt_default_encoder(encoder: str):
+    config = _setup()
+    config[INPUT_FEATURES][0][ENCODER] = {TYPE: encoder}
+    features_eligible_for_shared_params = get_features_eligible_for_shared_params(config, INPUT_FEATURES)
+    print(features_eligible_for_shared_params)
+    if encoder == "parallel_cnn":
+        assert features_eligible_for_shared_params == {"text": {"title"}}
+    else:
+        # When non-default encoder is passed, there should be no features eligible for shared params
+        assert features_eligible_for_shared_params == {}


### PR DESCRIPTION
After the encoder/decoder refactor, we need to make sure we're checking if an encoder/decoder is specified first before checking if the type of the encoder or decoder is a default encoder or default decoder. This PR makes sure we're checking this with the right level of nesting and also refactors the function to make it simpler. It also adds unit tests for the `get_features_eligible_for_shared_params` function.