### PR TITLE
Hyperopt Backwards Compatibility

### DIFF
--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -30,6 +30,7 @@ from ludwig.constants import (
 from ludwig.data.split import get_splitter
 from ludwig.features.feature_registries import input_type_registry, output_type_registry
 from ludwig.hyperopt.results import HyperoptResults
+from ludwig.utils.backward_compatibility import upgrade_to_latest_version
 from ludwig.hyperopt.utils import print_hyperopt_results, save_hyperopt_stats, should_tune_preprocessing
 from ludwig.utils.defaults import default_random_seed, merge_with_defaults
 from ludwig.utils.fs_utils import makedirs, open_file
@@ -193,8 +194,11 @@ def hyperopt(
         OUTPUT_FEATURES: get_features_eligible_for_shared_params(config_dict, OUTPUT_FEATURES),
     }
 
+    # backwards compatibility
+    config = upgrade_to_latest_version(config_dict)
+
     # merge config with defaults
-    config = merge_with_defaults(config_dict)
+    config = merge_with_defaults(config)
 
     if HYPEROPT not in config:
         raise ValueError("Hyperopt Section not present in config")

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -91,9 +91,8 @@ def upgrade_to_latest_version(config: Dict):
             "ludwig_version".
     """
     if "ludwig_version" in config:
-        to_version = re.findall(r".*\d", LUDWIG_VERSION)[0]
         return config_transformation_registry.update_config(
-            config, from_version=config["ludwig_version"], to_version=to_version
+            config, from_version=config["ludwig_version"], to_version=LUDWIG_VERSION
         )
     else:
         return config

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -16,6 +16,7 @@
 
 import warnings
 from typing import Any, Callable, Dict, List, Union
+import re
 
 from ludwig.constants import (
     AUDIO,
@@ -90,8 +91,9 @@ def upgrade_to_latest_version(config: Dict):
             "ludwig_version".
     """
     if "ludwig_version" in config:
+        to_version = re.findall(r".*\d", LUDWIG_VERSION)[0]
         return config_transformation_registry.update_config(
-            config, from_version=config["ludwig_version"], to_version=LUDWIG_VERSION
+            config, from_version=config["ludwig_version"], to_version=to_version
         )
     else:
         return config

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-import re
 import warnings
 from typing import Any, Callable, Dict, List, Union
 

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -461,6 +461,7 @@ def test_hyperopt_with_shared_params(csv_filename, tmpdir):
     )
 
 
+@pytest.mark.distributed
 def test_hyperopt_old_config(csv_filename, tmpdir):
     old_config = {
         "ludwig_version": "0.4",

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -463,15 +463,15 @@ def test_hyperopt_with_shared_params(csv_filename, tmpdir):
 
 def test_hyperopt_old_config(csv_filename, tmpdir):
     old_config = {
-        'ludwig_version': "0.4",
-        'input_features': [
-            {'name': 'cat1', 'type': 'category', 'encoder': {'vocab_size': 2}},
-            {'name': 'num1', 'type': 'number'},
+        "ludwig_version": "0.4",
+        "input_features": [
+            {"name": "cat1", "type": "category", "encoder": {"vocab_size": 2}},
+            {"name": "num1", "type": "number"},
         ],
-        'output_features': [
-            {'name': 'bin1', 'type': 'binary'},
+        "output_features": [
+            {"name": "bin1", "type": "binary"},
         ],
-        'trainer': {'epochs': 2},
+        "trainer": {"epochs": 2},
         "hyperopt": {
             "executor": {
                 "type": "ray",
@@ -503,12 +503,12 @@ def test_hyperopt_old_config(csv_filename, tmpdir):
                     "lower": 0.001,
                     "upper": 0.1,
                 },
-            }
+            },
         },
     }
 
-    input_features = old_config['input_features']
-    output_features = old_config['output_features']
+    input_features = old_config["input_features"]
+    output_features = old_config["output_features"]
     rel_path = generate_data(input_features, output_features, csv_filename)
 
     hyperopt(old_config, dataset=rel_path, output_directory=tmpdir, experiment_name="test_hyperopt")


### PR DESCRIPTION
Since @dantreiman's changes to backwards compatibility, hyperopt flow wasn't calling back compat logic. I added that in. There was also an issue where the back compat logic uses the global ludwig version to determine which updates to make, but the ludwig version may contain a 'dev' or an 'rc' so added a regex pattern to grab that. Only change in predibase needed is a Ludwig version corresponding to that config.