### PR TITLE
fix: Add explicit schema in to_parquet() during saving predictions

### DIFF
--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -317,7 +317,7 @@ def save_prediction_outputs(
     backend,
 ):
     postprocessed_output, column_shapes = flatten_df(postprocessed_output, backend)
-    postprocessed_output.to_parquet(os.path.join(output_directory, PREDICTIONS_PARQUET_FILE_NAME))
+    postprocessed_output.to_parquet(os.path.join(output_directory, PREDICTIONS_PARQUET_FILE_NAME), schema=None)
     save_json(os.path.join(output_directory, PREDICTIONS_SHAPES_FILE_NAME), column_shapes)
     if not backend.df_engine.partitioned:
         # csv can only be written out for unpartitioned df format (i.e., pandas)

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -324,7 +324,13 @@ def save_prediction_outputs(
         import pyarrow as pa
 
         prob_cols = [feature + "_probabilities" for feature in output_features]
-        schema = pa.schema({feature: pa.list_(pa.float64()) for feature in prob_cols if feature in postprocessed_output.columns.tolist()})
+        schema = pa.schema(
+            {
+                feature: pa.list_(pa.float64())
+                for feature in prob_cols
+                if feature in postprocessed_output.columns.tolist()
+            }
+        )
     except ImportError:
         logger.warning("Could not import pyarrow in save_prediction_outputs()")
 

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -322,6 +322,7 @@ def save_prediction_outputs(
     try:
         # Schema is needed for Dask 2022.6+ otherwise probabilities columns will be inferred as strings
         import pyarrow as pa
+
         schema = pa.schema({feature + "_probabilities": pa.list_(pa.float64()) for feature in output_features})
     except ImportError:
         logger.warning("Could not import pyarrow in save_prediction_outputs()")

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -317,24 +317,7 @@ def save_prediction_outputs(
     backend,
 ):
     postprocessed_output, column_shapes = flatten_df(postprocessed_output, backend)
-
-    schema = "infer"
-    try:
-        # Schema is needed for Dask 2022.6+ otherwise probabilities columns will be inferred as strings
-        import pyarrow as pa
-
-        prob_cols = [feature + "_probabilities" for feature in output_features]
-        schema = pa.schema(
-            {
-                feature: pa.list_(pa.float64())
-                for feature in prob_cols
-                if feature in postprocessed_output.columns.tolist()
-            }
-        )
-    except ImportError:
-        logger.warning("Could not import pyarrow in save_prediction_outputs()")
-
-    postprocessed_output.to_parquet(os.path.join(output_directory, PREDICTIONS_PARQUET_FILE_NAME), schema=schema)
+    postprocessed_output.to_parquet(os.path.join(output_directory, PREDICTIONS_PARQUET_FILE_NAME), schema=None)
     save_json(os.path.join(output_directory, PREDICTIONS_SHAPES_FILE_NAME), column_shapes)
     if not backend.df_engine.partitioned:
         # csv can only be written out for unpartitioned df format (i.e., pandas)

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -323,7 +323,8 @@ def save_prediction_outputs(
         # Schema is needed for Dask 2022.6+ otherwise probabilities columns will be inferred as strings
         import pyarrow as pa
 
-        schema = pa.schema({feature + "_probabilities": pa.list_(pa.float64()) for feature in output_features})
+        prob_cols = [feature + "_probabilities" for feature in output_features]
+        schema = pa.schema({feature: pa.list_(pa.float64()) for feature in prob_cols if feature in postprocessed_output.columns.tolist()})
     except ImportError:
         logger.warning("Could not import pyarrow in save_prediction_outputs()")
 


### PR DESCRIPTION
dask 2022.6+ changes the schema behavior to `schema="infer"`, which mistakenly infers that `<Output_feature>_probabilities` is a string (since it's an object) instead of a list of numbers. To fix, change back to `schema=None`, which was the behavior in 2022.5 and before

alternatively, we can enforce the schema only on this column, but we would need custom logic to do something like
```
        import pyarrow as pa
        postprocessed_output.to_parquet(os.path.join(output_directory, PREDICTIONS_PARQUET_FILE_NAME),
                                        schema={probabilities_col: pa.list_(pa.int64())})
```

but that could get messy since the expected schema types are different based on the parquet engine (pyarrow vs fastparquet etc...)

![image](https://user-images.githubusercontent.com/85463385/187789422-edf02ad0-04b6-47a1-9790-d5cf3135ddd2.png)

![image](https://user-images.githubusercontent.com/85463385/187789465-f0acf53a-d7c2-4a24-bb8c-dd8b6cb7dd15.png)




https://github.com/dask/dask/issues/9211

