### PR TITLE
Fixes calibration and adds example scripts

### DIFF
--- a/examples/calibration/README.md
+++ b/examples/calibration/README.md
@@ -1,0 +1,22 @@
+# Calibration Examples
+
+Drawing on the methods in
+On Calibration of Modern Neural Networks (Chuan Guo, Geoff Pleiss, Yu Sun, Kilian Q. Weinberger), Ludwig supports
+temperature scaling for binary and category output features. Temperature scaling brings a model’s output probabilities
+closer to the true likelihood while preserving the same accuracy and top k predictions.
+
+To enable calibration, add calibration: True to any binary or category feature:
+
+```
+output_features:
+ - name: Cover_Type
+   type: category
+   calibration: True
+```
+
+With calibration enabled, Ludwig will attempt to find a scale factor (temperature) which will bring the probabilities
+closer to the true likelihoods using the validation set. This calibration phase is run after training is complete. If
+no validation set is provided, the training set is used for calibration.
+
+To visualize the effects of calibration in Ludwig, you can use Calibration Plots, which bin the data based on model
+probability and plot the model probability (X) versus the observed rate (Y) for each bin.

--- a/examples/calibration/train_forest_cover_calibrated.py
+++ b/examples/calibration/train_forest_cover_calibrated.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+import copy
+import logging
+import shutil
+
+import numpy as np
+import yaml
+
+import ludwig.visualize
+from ludwig.api import LudwigModel
+from ludwig.datasets import forest_cover
+
+# clean out prior results
+shutil.rmtree("./results_forest_cover", ignore_errors=True)
+shutil.rmtree("./visualizations_forest_cover", ignore_errors=True)
+
+# Download and prepare the dataset
+dataset = forest_cover.load()
+
+config_yaml = """
+input_features:
+  - name: Elevation
+    type: number
+  - name: Aspect
+    type: number
+  - name: Slope
+    type: number
+  - name: Horizontal_Distance_To_Hydrology
+    type: number
+  - name: Vertical_Distance_To_Hydrology
+    type: number
+  - name: Horizontal_Distance_To_Roadways
+    type: number
+  - name: Hillshade_9am
+    type: number
+  - name: Hillshade_Noon
+    type: number
+  - name: Hillshade_3pm
+    type: number
+  - name: Horizontal_Distance_To_Fire_Points
+    type: number
+  - name: Wilderness_Area
+    type: category
+  - name: Soil_Type
+    type: category
+output_features:
+  - name: Cover_Type
+    type: category
+combiner:
+  type: transformer
+  num_layers: 1
+  num_heads: 8
+  hidden_size: 32
+  dropout: 0.1
+  fc_dropout: 0.2
+  num_fc_layers: 1
+trainer:
+  batch_size: 256
+  learning_rate: .001
+  epochs: 5
+"""
+
+uncalibrated_config = yaml.safe_load(config_yaml)
+
+scaled_config = copy.deepcopy(uncalibrated_config)
+scaled_config["output_features"][0]["calibration"] = True
+
+uncalibrated_model = LudwigModel(config=uncalibrated_config, logging_level=logging.INFO)
+uncalibrated_model.train(
+    dataset,
+    model_name="uncalibrated",
+    experiment_name="forest_cover_calibration",
+    output_directory="results_forest_cover",
+)
+
+scaled_model = LudwigModel(config=scaled_config, logging_level=logging.INFO)
+scaled_model.train(
+    dataset, model_name="scaled", experiment_name="forest_cover_calibration", output_directory="results_forest_cover"
+)
+
+# Generates predictions and performance statistics for the test set.
+uncalibrated_test_stats, uncalibrated_test_predictions, _ = uncalibrated_model.evaluate(
+    dataset, collect_predictions=True, collect_overall_stats=True
+)
+
+scaled_test_stats, scaled_test_predictions, _ = scaled_model.evaluate(
+    dataset, collect_predictions=True, collect_overall_stats=True
+)
+
+uncalibrated_probs = np.stack(uncalibrated_test_predictions["Cover_Type_probabilities"], axis=0)
+scaled_probs = np.stack(scaled_test_predictions["Cover_Type_probabilities"], axis=0)
+
+ludwig.visualize.calibration_1_vs_all(
+    probabilities_per_model=[uncalibrated_probs, scaled_probs],
+    model_names=["Uncalibrated", "Calibrated"],
+    ground_truth=dataset["Cover_Type"],
+    metadata=uncalibrated_model.training_set_metadata,
+    output_feature_name="Cover_Type",
+    top_n_classes=[7, 7],
+    labels_limit=7,
+    output_directory="visualizations_forest_cover",
+    file_format="png",
+)

--- a/examples/calibration/train_forest_cover_calibrated.py
+++ b/examples/calibration/train_forest_cover_calibrated.py
@@ -49,16 +49,10 @@ output_features:
     type: category
 combiner:
   type: transformer
-  num_layers: 1
-  num_heads: 8
-  hidden_size: 32
-  dropout: 0.1
-  fc_dropout: 0.2
-  num_fc_layers: 1
 trainer:
   batch_size: 256
   learning_rate: .001
-  epochs: 5
+  epochs: 1
 """
 
 uncalibrated_config = yaml.safe_load(config_yaml)

--- a/examples/calibration/train_mushroom_edibility_calibrated.py
+++ b/examples/calibration/train_mushroom_edibility_calibrated.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+
+import copy
+import logging
+import shutil
+
+import numpy as np
+import yaml
+
+import ludwig.visualize
+from ludwig.api import LudwigModel
+from ludwig.datasets import mushroom_edibility
+
+# clean out prior results
+shutil.rmtree("./results_mushroom_edibility", ignore_errors=True)
+shutil.rmtree("./visualizations_mushroom_edibility", ignore_errors=True)
+
+# Download and prepare the dataset
+dataset = mushroom_edibility.load()
+
+# This dataset has no split, so add a split column
+dataset.split = np.random.choice(3, len(dataset), p=(0.7, 0.1, 0.2))
+
+config_yaml = """
+output_features:
+  - name: class
+    type: category
+input_features:
+  - name: cap-shape
+    type: category
+  - name: cap-surface
+    type: category
+  - name: cap-color
+    type: category
+  - name: bruises?
+    type: category
+  - name: odor
+    type: category
+  - name: gill-attachment
+    type: category
+  - name: gill-spacing
+    type: category
+  - name: gill-size
+    type: category
+  - name: gill-color
+    type: category
+  - name: stalk-shape
+    type: category
+  - name: stalk-root
+    type: category
+  - name: stalk-surface-above-ring
+    type: category
+  - name: stalk-surface-below-ring
+    type: category
+  - name: stalk-color-above-ring
+    type: category
+  - name: stalk-color-below-ring
+    type: category
+  - name: veil-type
+    type: category
+  - name: veil-color
+    type: category
+  - name: ring-number
+    type: category
+  - name: ring-type
+    type: category
+  - name: spore-print-color
+    type: category
+  - name: population
+    type: category
+  - name: habitat
+    type: category
+combiner:
+  type: concat
+trainer:
+  batch_size: 256
+  learning_rate: .0001
+  epochs: 10
+"""
+
+uncalibrated_config = yaml.safe_load(config_yaml)
+
+scaled_config = copy.deepcopy(uncalibrated_config)
+scaled_config["output_features"][0]["calibration"] = True
+
+uncalibrated_model = LudwigModel(config=uncalibrated_config, logging_level=logging.INFO)
+uncalibrated_model.train(
+    dataset,
+    model_name="uncalibrated",
+    experiment_name="mushroom_edibility_calibration",
+    output_directory="results_mushroom_edibility",
+)
+
+scaled_model = LudwigModel(config=scaled_config, logging_level=logging.INFO)
+scaled_model.train(
+    dataset,
+    model_name="scaled",
+    experiment_name="mushroom_edibility_calibration",
+    output_directory="results_mushroom_edibility",
+)
+
+# Generates predictions and performance statistics for the test set.
+uncalibrated_test_stats, uncalibrated_test_predictions, _ = uncalibrated_model.evaluate(
+    dataset, collect_predictions=True, collect_overall_stats=True
+)
+
+scaled_test_stats, scaled_test_predictions, _ = scaled_model.evaluate(
+    dataset, collect_predictions=True, collect_overall_stats=True
+)
+
+uncalibrated_probs = np.stack(uncalibrated_test_predictions["class_probabilities"], axis=0)
+scaled_probs = np.stack(scaled_test_predictions["class_probabilities"], axis=0)
+
+ludwig.visualize.calibration_1_vs_all(
+    probabilities_per_model=[uncalibrated_probs, scaled_probs],
+    model_names=["Uncalibrated", "Calibrated"],
+    ground_truth=dataset["class"],
+    metadata=uncalibrated_model.training_set_metadata,
+    output_feature_name="class",
+    top_n_classes=[3, 3],
+    labels_limit=3,
+    output_directory="visualizations_mushroom_edibility",
+    file_format="png",
+)

--- a/examples/calibration/train_mushroom_edibility_calibrated.py
+++ b/examples/calibration/train_mushroom_edibility_calibrated.py
@@ -22,9 +22,6 @@ dataset = mushroom_edibility.load()
 dataset.split = np.random.choice(3, len(dataset), p=(0.7, 0.1, 0.2))
 
 config_yaml = """
-output_features:
-  - name: class
-    type: category
 input_features:
   - name: cap-shape
     type: category
@@ -69,6 +66,9 @@ input_features:
   - name: population
     type: category
   - name: habitat
+    type: category
+output_features:
+  - name: class
     type: category
 combiner:
   type: concat

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -223,7 +223,7 @@ class OutputFeature(BaseFeature, LudwigModule, ABC):
             default_activation=feature.decoder.fc_activation,
             default_dropout=feature.decoder.fc_dropout,
         )
-        self._calibration_module = self.create_calibration_module(kwargs)
+        self._calibration_module = self.create_calibration_module(feature)
         self._prediction_module = self.create_predict_module()
 
         # set up two sequence reducers, one for inputs and other for dependencies
@@ -293,7 +293,7 @@ class OutputFeature(BaseFeature, LudwigModule, ABC):
             },
         }
 
-    def create_calibration_module(self, feature) -> CalibrationModule:
+    def create_calibration_module(self, feature: BaseOutputFeatureConfig) -> CalibrationModule:
         """Creates and returns a CalibrationModule that converts logits to a probability distribution."""
         return None
 

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -302,13 +302,13 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
             confidence_penalty=self.loss["confidence_penalty"],
         )
 
-    def create_calibration_module(self, feature) -> torch.nn.Module:
+    def create_calibration_module(self, feature: BinaryOutputFeatureConfig) -> torch.nn.Module:
         """Creates the appropriate calibration module based on the feature config.
 
         Today, only one type of calibration ("temperature_scaling") is available, but more options may be supported in
         the future.
         """
-        if feature.get("calibration"):
+        if feature.calibration:
             calibration_cls = calibration.get_calibration_cls(BINARY, "temperature_scaling")
             return calibration_cls(binary=True)
         return None

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -247,13 +247,13 @@ class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):
         # hidden: shape [batch_size, size of final fully connected layer]
         return {LOGITS: self.decoder_obj(hidden), PROJECTION_INPUT: hidden}
 
-    def create_calibration_module(self, feature) -> torch.nn.Module:
+    def create_calibration_module(self, feature: CategoryOutputFeatureConfig) -> torch.nn.Module:
         """Creates the appropriate calibration module based on the feature config.
 
         Today, only one type of calibration ("temperature_scaling") is available, but more options may be supported in
         the future.
         """
-        if feature.get("calibration"):
+        if feature.calibration:
             calibration_cls = calibration.get_calibration_cls(CATEGORY, "temperature_scaling")
             return calibration_cls(num_classes=self.num_classes)
         return None

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -230,12 +230,12 @@ class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):
         **kwargs,
     ):
         output_feature_config = self.load_config(output_feature_config)
+        self.num_classes = output_feature_config.num_classes
+        self.top_k = output_feature_config.top_k
         super().__init__(output_feature_config, output_features, **kwargs)
         if hasattr(output_feature_config.decoder, "num_classes"):
             output_feature_config.decoder.num_classes = output_feature_config.num_classes
         self.decoder_obj = self.initialize_decoder(output_feature_config.decoder)
-        self.num_classes = output_feature_config.num_classes
-        self.top_k = output_feature_config.top_k
         self._setup_loss()
         self._setup_metrics()
 

--- a/ludwig/schema/features/binary_feature.py
+++ b/ludwig/schema/features/binary_feature.py
@@ -72,3 +72,8 @@ class BinaryOutputFeatureConfig(BaseOutputFeatureConfig):
         default="sum",
         description="How to reduce the dependencies of the output feature.",
     )
+
+    calibration: bool = schema_utils.Boolean(
+        default=False,
+        description="Calibrate the model's output probabilities using temperature scaling.",
+    )

--- a/ludwig/schema/features/category_feature.py
+++ b/ludwig/schema/features/category_feature.py
@@ -74,3 +74,8 @@ class CategoryOutputFeatureConfig(BaseOutputFeatureConfig):
         "measure. It computes accuracy but considering as a match if the true category appears in the "
         "first k predicted categories ranked by decoder's confidence.",
     )
+
+    calibration: bool = schema_utils.Boolean(
+        default=False,
+        description="Calibrate the model's output probabilities using temperature scaling.",
+    )

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -195,6 +195,7 @@ def _upgrade_encoder_decoder_params(feature: Dict[str, Any], input_feature: bool
     output_feature_keys = [
         "name",
         "type",
+        "calibration",
         "column",
         "proc_column",
         "decoder",

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -961,6 +961,7 @@ def brier_plot(
     filename=None,
     callbacks=None,
 ):
+    plt.figure()
     sns.set_style("whitegrid")
 
     if title is not None:
@@ -1123,6 +1124,7 @@ def plot_matrix(
     filename=None,
     callbacks=None,
 ):
+    plt.figure()
     plt.matshow(matrix, cmap=cmap)
     visualize_callbacks(callbacks, plt.gcf())
     if filename:


### PR DESCRIPTION
- Adds calibration to binary and category output feature schemas
- Fixes bug in brier plot which causes class probabilities plot to overshadow brier score
- Adds forest cover and mushroom edibility calibration examples



Brier plot:

![calibration_1_vs_all_brier](https://user-images.githubusercontent.com/687280/187344765-4258de08-f587-4ea9-8642-9288820cc021.png)
