### PR TITLE
Hotfix: Proc column missing in output feature schema

### DIFF
--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -196,6 +196,7 @@ def _upgrade_encoder_decoder_params(feature: Dict[str, Any], input_feature: bool
         "name",
         "type",
         "column",
+        "proc_column",
         "decoder",
         "num_classes",
         "preprocessing",


### PR DESCRIPTION
This column is missing in the output feature schema, which causes the wrong proc_column to be used occasionally during model load/prediction which causes further downstream failures. 