### PR TITLE
Log warning for calibration if validation set is trivially small

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -46,6 +46,7 @@ from ludwig.constants import (
     HYPEROPT,
     HYPEROPT_WARNING,
     LEARNING_RATE,
+    MIN_VALIDATION_SET_ROWS,
     MODEL_TYPE,
     PREPROCESSING,
     TEST,
@@ -575,11 +576,11 @@ class LudwigModel:
                                 "Recommend providing a validation set when using calibration."
                             )
                             calibrator.train_calibration(training_set, TRAINING)
-                        elif len(validation_set) <= 1:
+                        elif len(validation_set) < MIN_VALIDATION_SET_ROWS:
                             logger.warning(
                                 f"Validation set size ({len(validation_set)} rows) is too small for calibration."
                                 "Will use training set for calibration."
-                                "Recommend providing more examples in validation set."
+                                f"Validation set much have at least {MIN_VALIDATION_SET_ROWS} rows."
                             )
                             calibrator.train_calibration(training_set, TRAINING)
                         else:

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -575,7 +575,7 @@ class LudwigModel:
                                 "Recommend providing a validation set when using calibration."
                             )
                             calibrator.train_calibration(training_set, TRAINING)
-                        elif len(validation_set) <= 1 or len(validation_set) < trainer.eval_batch_size:
+                        elif len(validation_set) <= 1:
                             logger.warning(
                                 f"Validation set size ({len(validation_set)} rows) is too small for calibration."
                                 "Will use training set for calibration."

--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -128,6 +128,7 @@ FULL = "full"
 TRAIN_SPLIT = 0
 VALIDATION_SPLIT = 1
 TEST_SPLIT = 2
+MIN_VALIDATION_SET_ROWS = 3  # The absolute minimum validation set size to ensure metric computation doesn't fail.
 
 META = "meta"
 

--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -128,7 +128,7 @@ FULL = "full"
 TRAIN_SPLIT = 0
 VALIDATION_SPLIT = 1
 TEST_SPLIT = 2
-MIN_VALIDATION_SET_ROWS = 3  # The absolute minimum validation set size to ensure metric computation doesn't fail.
+MIN_VALIDATION_SET_ROWS = 3  # The minimum validation set size to ensure metric computation doesn't fail.
 
 META = "meta"
 


### PR DESCRIPTION
If the validation set has only one row (which may occur in some of our tests) then calibration will fail with nan metrics.