### PR TITLE
Fix: Upgrade ludwig config before schema validation

### DIFF
--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -62,7 +62,8 @@ def validate_config(config):
     # Update config from previous versions to check that backwards compatibility will enable a valid config
     from ludwig.utils.backward_compatibility import upgrade_to_latest_version
 
-    config["ludwig_version"] = "0.4"
+    if "ludwig_version" not in config:
+        config["ludwig_version"] = "0.4"
     updated_config = upgrade_to_latest_version(config)
 
     type_checker = Draft7Validator.TYPE_CHECKER.redefine("array", custom_is_array)

--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -59,6 +59,11 @@ def validate_config(config):
     def custom_is_array(checker, instance):
         return isinstance(instance, list) or isinstance(instance, tuple)
 
+    # Update config from previous versions to check that backwards compatibility will enable a valid config
+    from ludwig.utils.backward_compatibility import upgrade_to_latest_version
+    config['ludwig_version'] = "0.4"
+    updated_config = upgrade_to_latest_version(config)
+
     type_checker = Draft7Validator.TYPE_CHECKER.redefine("array", custom_is_array)
     CustomValidator = extend(Draft7Validator, type_checker=type_checker)
-    validate(instance=config, schema=get_schema(), cls=CustomValidator)
+    validate(instance=updated_config, schema=get_schema(), cls=CustomValidator)

--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -61,10 +61,12 @@ def validate_config(config):
 
     # Update config from previous versions to check that backwards compatibility will enable a valid config
     from ludwig.utils.backward_compatibility import upgrade_to_latest_version
+    from ludwig.utils.defaults import merge_with_defaults
 
     if "ludwig_version" not in config:
         config["ludwig_version"] = "0.4"
     updated_config = upgrade_to_latest_version(config)
+    updated_config = merge_with_defaults(updated_config)
 
     type_checker = Draft7Validator.TYPE_CHECKER.redefine("array", custom_is_array)
     CustomValidator = extend(Draft7Validator, type_checker=type_checker)

--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -61,7 +61,6 @@ def validate_config(config):
 
     # Update config from previous versions to check that backwards compatibility will enable a valid config
     from ludwig.utils.backward_compatibility import upgrade_to_latest_version
-    from ludwig.utils.defaults import merge_with_defaults
 
     if "ludwig_version" not in config:
         config["ludwig_version"] = "0.4"

--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -66,7 +66,6 @@ def validate_config(config):
     if "ludwig_version" not in config:
         config["ludwig_version"] = "0.4"
     updated_config = upgrade_to_latest_version(config)
-    updated_config = merge_with_defaults(updated_config)
 
     type_checker = Draft7Validator.TYPE_CHECKER.redefine("array", custom_is_array)
     CustomValidator = extend(Draft7Validator, type_checker=type_checker)

--- a/ludwig/schema/decoders/utils.py
+++ b/ludwig/schema/decoders/utils.py
@@ -60,7 +60,6 @@ def DecoderDataclassField(feature_type: str, default: str):
                 },
                 "title": "decoder_options",
                 "allOf": get_decoder_conds(feature_type),
-                "required": ["type"],
             }
 
     try:

--- a/ludwig/schema/encoders/utils.py
+++ b/ludwig/schema/encoders/utils.py
@@ -60,7 +60,6 @@ def EncoderDataclassField(feature_type: str, default: str):
                 },
                 "title": "encoder_options",
                 "allOf": get_encoder_conds(feature_type),
-                "required": ["type"],
             }
 
     try:

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -196,6 +196,7 @@ def _upgrade_encoder_decoder_params(feature: Dict[str, Any], input_feature: bool
         "name",
         "type",
         "column",
+        "proc_column",
         "decoder",
         "num_classes",
         "preprocessing",
@@ -244,10 +245,11 @@ def _upgrade_encoder_decoder_params(feature: Dict[str, Any], input_feature: bool
             nested_params.append(k)
             warn = True
 
-    if module_type in feature:
-        feature[module_type].update(module)
-    else:
-        feature[module_type] = module
+    if module:
+        if module_type in feature:
+            feature[module_type].update(module)
+        else:
+            feature[module_type] = module
 
     for k in nested_params:
         del feature[k]

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -246,6 +246,8 @@ def _upgrade_encoder_decoder_params(feature: Dict[str, Any], input_feature: bool
 
     if module_type in feature:
         feature[module_type].update(module)
+    else:
+        feature[module_type] = module
 
     for k in nested_params:
         del feature[k]

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -246,8 +246,6 @@ def _upgrade_encoder_decoder_params(feature: Dict[str, Any], input_feature: bool
 
     if module_type in feature:
         feature[module_type].update(module)
-    else:
-        feature[module_type] = module
 
     for k in nested_params:
         del feature[k]

--- a/tests/ludwig/utils/test_backward_compatibility.py
+++ b/tests/ludwig/utils/test_backward_compatibility.py
@@ -1,4 +1,5 @@
 import pytest
+from marshmallow import ValidationError
 
 from ludwig.constants import (
     EVAL_BATCH_SIZE,
@@ -17,6 +18,7 @@ from ludwig.utils.backward_compatibility import (
     _upgrade_preprocessing_split,
     upgrade_to_latest_version,
 )
+from ludwig.schema import validate_config
 
 
 def test_preprocessing_backward_compatibility():
@@ -362,3 +364,30 @@ def test_deprecated_split_aliases(stratify, force_split):
     else:
         assert split.get(TYPE) == "stratify"
         assert split.get("column") == stratify
+
+
+def test_validate_old_model_config():
+    old_valid_config = {
+        "input_features": [
+            {"name": "feature_1", "type": "category"},
+            {"name": "Sex", "type": "category", "encoder": "dense"}
+            ],
+        "output_features": [
+            {"name": "Survived", "type": "category"},
+        ]
+    }
+
+    old_invalid_config = {
+        "input_features": [
+            {"name": "feature_1", "type": "category"},
+            {"name": "Sex", "type": "category", "encoder": "fake_encoder"}
+            ],
+        "output_features": [
+            {"name": "Survived", "type": "category"},
+        ]
+    }
+
+    validate_config(old_valid_config)
+
+    with pytest.raises(Exception):
+        validate_config(old_invalid_config)

--- a/tests/ludwig/utils/test_backward_compatibility.py
+++ b/tests/ludwig/utils/test_backward_compatibility.py
@@ -1,5 +1,4 @@
 import pytest
-from marshmallow import ValidationError
 
 from ludwig.constants import (
     EVAL_BATCH_SIZE,

--- a/tests/ludwig/utils/test_validate_config_combiner.py
+++ b/tests/ludwig/utils/test_validate_config_combiner.py
@@ -51,7 +51,7 @@ def test_config_bad_combiner():
             category_feature(encoder={"type": "dense", "vocab_size": 2}, reduce_input="sum"),
             number_feature(),
         ],
-        "output_features": [binary_feature(deccoder={"weight_regularization": None})],
+        "output_features": [binary_feature(decoder={"weight_regularization": None})],
         "combiner": {
             "type": "tabnet",
         },

--- a/tests/ludwig/utils/test_validate_config_combiner.py
+++ b/tests/ludwig/utils/test_validate_config_combiner.py
@@ -51,7 +51,7 @@ def test_config_bad_combiner():
             category_feature(encoder={"type": "dense", "vocab_size": 2}, reduce_input="sum"),
             number_feature(),
         ],
-        "output_features": [binary_feature(weight_regularization=None)],
+        "output_features": [binary_feature(deccoder={"weight_regularization": None})],
         "combiner": {
             "type": "tabnet",
         },


### PR DESCRIPTION
This fix adds a backwards compatibility step into the validate config step for the schema. The issue we we're dealing with was the frontend validating for 0.5 configs and Ludwig for 0.6. The solution in this PR is to update the configs in the validation step which will allow the frontend to validate old valid configs. These will get converted by backwards compatibility upon training anyways so we are just updating them before validation so that the frontend can validate without conflicting with Ludwig validation.

Note: the reason for importing `upgrade_to_latest_version` in the `validate_config` function is because circular imports start occurring if we import it at the top. This is something I will fix in the future, but may take a bit longer. If everyones ok with it, I will leave it like this for now.