### PR TITLE
Fix: explicit keyword args for seaborn plot fn

### DIFF
--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -926,8 +926,8 @@ def calibration_plot(
         order = min(3, len(mean_predicted_values[i]) - 1)
 
         sns.regplot(
-            mean_predicted_values[i],
-            fraction_positives[i],
+            x=mean_predicted_values[i],
+            y=fraction_positives[i],
             order=order,
             x_estimator=np.mean,
             color=colors[i],


### PR DESCRIPTION
seaborn 0.12 got released 9hr ago. keyword arguments are now required for plotting functions:
https://seaborn.pydata.org/whatsnew/v0.12.0.html#keyword-only-arguments