### PR TITLE
Disables `batch_size: auto` for CPU-only training

### DIFF
--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -161,6 +161,7 @@ SRC = "dataset_src"
 EPOCHS = "epochs"
 BATCH_SIZE = "batch_size"
 EVAL_BATCH_SIZE = "eval_batch_size"
+DEFAULT_BATCH_SIZE = 128
 LEARNING_RATE = "learning_rate"
 USE_BIAS = "use_bias"
 BIAS = "bias"

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 
 from marshmallow_dataclass import dataclass
 
-from ludwig.constants import COMBINED, LOSS, MODEL_ECD, MODEL_GBM, TRAINING, TYPE
+from ludwig.constants import COMBINED, DEFAULT_BATCH_SIZE, LOSS, MODEL_ECD, MODEL_GBM, TRAINING, TYPE
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.metadata.trainer_metadata import TRAINER_METADATA
 from ludwig.schema.optimizers import (
@@ -147,7 +147,7 @@ class ECDTrainerConfig(BaseTrainerConfig):
     )
 
     batch_size: Union[int, str] = schema_utils.OneOfOptionsField(
-        default=128,
+        default=DEFAULT_BATCH_SIZE,
         allow_none=False,
         description=(
             "The number of training examples utilized in one training step of the model. If ’auto’, the "
@@ -155,7 +155,7 @@ class ECDTrainerConfig(BaseTrainerConfig):
         ),
         parameter_metadata=TRAINER_METADATA["batch_size"],
         field_options=[
-            schema_utils.PositiveInteger(default=128, description=""),
+            schema_utils.PositiveInteger(default=DEFAULT_BATCH_SIZE, description=""),
             schema_utils.StringOptions(options=["auto"], default="auto", allow_none=False),
         ],
     )

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -32,7 +32,7 @@ import torch
 from tabulate import tabulate
 from torch.utils.tensorboard import SummaryWriter
 
-from ludwig.constants import COMBINED, LOSS, MODEL_ECD, TEST, TRAINING, VALIDATION
+from ludwig.constants import COMBINED, DEFAULT_BATCH_SIZE, LOSS, MODEL_ECD, TEST, TRAINING, VALIDATION
 from ludwig.data.dataset.base import Dataset
 from ludwig.globals import (
     is_progressbar_disabled,
@@ -445,46 +445,54 @@ class Trainer(BaseTrainer):
     ) -> int:
         logger.info("Tuning batch size...")
 
-        def _is_valid_batch_size(batch_size):
-            # make sure that batch size is valid (e.g. less than size of ds)
-            return batch_size < len(training_set)
+        if torch.device(self.device) == torch.device("cpu"):
+            logger.warn(
+                f'Batch size tuning is not supported on CPU, setting batch size from "auto" to default value '
+                f"{DEFAULT_BATCH_SIZE}"
+            )
+            best_batch_size = DEFAULT_BATCH_SIZE
+        else:
 
-        # TODO (ASN) : Circle back on how we want to set default placeholder value
-        # Currently, since self.batch_size is originally set to auto, we provide a
-        # placeholder starting value
-        batch_size = 2
-        skip_save_model = self.skip_save_model
-        skip_save_progress = self.skip_save_progress
-        skip_save_log = self.skip_save_log
-        # Set temporary values
-        self.skip_save_model = True
-        self.skip_save_progress = True
-        self.skip_save_log = True
+            def _is_valid_batch_size(batch_size):
+                # make sure that batch size is valid (e.g. less than size of ds)
+                return batch_size < len(training_set)
 
-        best_batch_size = None
-        try:
-            count = 0
-            while count < max_trials and _is_valid_batch_size(batch_size):
-                logger.info(f"Exploring batch_size={batch_size}")
-                gc.collect()
+            # TODO (ASN) : Circle back on how we want to set default placeholder value
+            # Currently, since self.batch_size is originally set to auto, we provide a
+            # placeholder starting value
+            batch_size = 2
+            skip_save_model = self.skip_save_model
+            skip_save_progress = self.skip_save_progress
+            skip_save_log = self.skip_save_log
+            # Set temporary values
+            self.skip_save_model = True
+            self.skip_save_progress = True
+            self.skip_save_log = True
 
-                try:
-                    self.train_for_tuning(training_set, batch_size, total_steps=3)
-                    best_batch_size = batch_size
-                    count += 1
-
-                    # double batch size
-                    batch_size *= 2
-                except RuntimeError:
-                    # PyTorch only generates Runtime errors for CUDA OOM.
+            best_batch_size = None
+            try:
+                count = 0
+                while count < max_trials and _is_valid_batch_size(batch_size):
+                    logger.info(f"Exploring batch_size={batch_size}")
                     gc.collect()
-                    logger.info(f"OOM at batch_size={batch_size}")
-                    break
-        finally:
-            # Restore original parameters to defaults
-            self.skip_save_model = skip_save_model
-            self.skip_save_progress = skip_save_progress
-            self.skip_save_log = skip_save_log
+
+                    try:
+                        self.train_for_tuning(training_set, batch_size, total_steps=3)
+                        best_batch_size = batch_size
+                        count += 1
+
+                        # double batch size
+                        batch_size *= 2
+                    except RuntimeError:
+                        # PyTorch only generates Runtime errors for CUDA OOM.
+                        gc.collect()
+                        logger.info(f"OOM at batch_size={batch_size}")
+                        break
+            finally:
+                # Restore original parameters to defaults
+                self.skip_save_model = skip_save_model
+                self.skip_save_progress = skip_save_progress
+                self.skip_save_log = skip_save_log
 
         logger.info(f"Selected batch_size={best_batch_size}")
         return best_batch_size

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -450,6 +450,7 @@ class Trainer(BaseTrainer):
                 f'Batch size tuning is not supported on CPU, setting batch size from "auto" to default value '
                 f"{DEFAULT_BATCH_SIZE}"
             )
+            # TODO(geoffrey): Add support for batch size tuning on CPU
             best_batch_size = DEFAULT_BATCH_SIZE
         else:
 

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -23,7 +23,7 @@ from packaging import version
 
 from ludwig.api import LudwigModel
 from ludwig.backend import create_ray_backend, initialize_backend, LOCAL_BACKEND
-from ludwig.constants import BACKFILL, BALANCE_PERCENTAGE_TOLERANCE, COLUMN, NAME, TRAINER
+from ludwig.constants import BACKFILL, BALANCE_PERCENTAGE_TOLERANCE, COLUMN, DEFAULT_BATCH_SIZE, NAME, TRAINER
 from ludwig.data.preprocessing import balance_data
 from ludwig.utils.data_utils import read_parquet
 from tests.integration_tests.utils import (
@@ -520,8 +520,9 @@ def _run_train_gpu_load_cpu(config, data_parquet):
         ray.get(predict_cpu.remote(model_dir, data_parquet))
 
 
+# TODO(geoffrey): add a GPU test for batch size tuning
 @pytest.mark.distributed
-def test_tune_batch_size_lr(tmpdir, ray_cluster_2cpu):
+def test_tune_batch_size_lr_cpu(tmpdir, ray_cluster_2cpu):
     config = {
         "input_features": [
             number_feature(normalization="zscore"),
@@ -536,10 +537,12 @@ def test_tune_batch_size_lr(tmpdir, ray_cluster_2cpu):
     backend_config = {**RAY_BACKEND_CONFIG}
 
     csv_filename = os.path.join(tmpdir, "dataset.csv")
-    dataset_csv = generate_data(config["input_features"], config["output_features"], csv_filename, num_examples=100)
+    dataset_csv = generate_data(config["input_features"], config["output_features"], csv_filename, num_examples=200)
     dataset_parquet = create_data_set_to_use("parquet", dataset_csv)
     model = run_api_experiment(config, dataset=dataset_parquet, backend_config=backend_config)
-    assert model.config[TRAINER]["batch_size"] != "auto"
+    assert (
+        model.config[TRAINER]["batch_size"] == DEFAULT_BATCH_SIZE
+    )  # On CPU, batch size tuning is disabled, so assert it is equal to default
     assert model.config[TRAINER]["learning_rate"] != "auto"
 
 


### PR DESCRIPTION
If batch_size is set to `auto`, this PR implements a change that (1) detects whether or not the device is CPU, (2) logs a warning if it is, then (3) sets the batch size to the default 128.

Before this change, the batch size tuner would never OOM or hit any other runtime Exception on CPU-only machines, leading to arbitrarily high batch sizes– often, the batch size would be the max possible batch size, which was some value `0.5 * len(training_dataset) < batch_size < len(training_dataset)`. Such a large batch size would lead to OOMs downstream, particularly when training using a Ray cluster.

Future work includes re-enabling batch size tuning for CPU-only machines, possibly by using some memory limit values introduced by either Ray or the system itself.