### PR TITLE
Enh: quality-of-life improvements for `export_torchscript`

### DIFF
--- a/ludwig/export.py
+++ b/ludwig/export.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 def export_torchscript(
-    model_path: str, model_only: bool = False, output_path: str = "torchscript", device: Optional[str] = None, **kwargs
+    model_path: str, model_only: bool = False, output_path: Optional[str] = None, device: Optional[str] = None, **kwargs
 ) -> None:
     """Exports a model to torchscript.
 
@@ -38,13 +38,17 @@ def export_torchscript(
 
     :param model_path: (str) filepath to pre-trained model.
     :param model_only: (bool, default: `False`) If true, scripts and exports the model only.
-    :param output_path: (str, default: `'torchscript'`) directory to store torchscript
+    :param output_path: directory to store torchscript. If `None`, defaults to model_path
 
     # Return
     :returns: (`None`)
     """
     logger.info(f"Model path: {model_path}")
     logger.info(f"Saving model only: {model_only}")
+
+    if output_path is None:
+        logger.info("output_path is None, defaulting to model_path")
+        output_path = model_path
     logger.info(f"Output path: {output_path}")
     logger.info("\n")
 
@@ -167,7 +171,13 @@ def cli_export_torchscript(sys_argv):
     # -----------------
     # Output parameters
     # -----------------
-    parser.add_argument("op", "--output_path", type=str, help="path where to save the export model", required=True)
+    parser.add_argument(
+        "-op",
+        "--output_path",
+        type=str,
+        help="path where to save the export model. If not specified, defaults to model_path.",
+        default=None,
+    )
 
     # ------------------
     # Runtime parameters

--- a/ludwig/models/inference.py
+++ b/ludwig/models/inference.py
@@ -13,7 +13,7 @@ from ludwig.features.feature_registries import input_type_registry
 from ludwig.features.feature_utils import get_module_dict_key_from_name, get_name_from_module_dict_key
 from ludwig.globals import MODEL_HYPERPARAMETERS_FILE_NAME, TRAIN_SET_METADATA_FILE_NAME
 from ludwig.utils import output_feature_utils
-from ludwig.utils.data_utils import load_json
+from ludwig.utils.data_utils import load_json, save_json
 from ludwig.utils.inference_utils import get_filename_from_stage, to_inference_module_input_from_dataframe
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.output_feature_utils import get_feature_name_from_concat_name, get_tensor_name_from_concat_name
@@ -250,6 +250,16 @@ def save_ludwig_model_for_inference(
     if model_only:
         stage_to_module[PREDICTOR].save(os.path.join(save_path, stage_to_filenames[PREDICTOR]))
     else:
+        config_path = os.path.join(save_path, MODEL_HYPERPARAMETERS_FILE_NAME)
+        if not os.path.exists(config_path):
+            save_json(config_path, config)
+            logging.info(f"Saved model config to {config_path}")
+
+        training_set_metadata_path = os.path.join(save_path, TRAIN_SET_METADATA_FILE_NAME)
+        if not os.path.exists(training_set_metadata_path):
+            save_json(training_set_metadata_path, training_set_metadata)
+            logging.info(f"Saved training set metadata to {training_set_metadata_path}")
+
         for stage, module in stage_to_module.items():
             module.save(os.path.join(save_path, stage_to_filenames[stage]))
             logging.info(f"Saved torchscript module for {stage} to {stage_to_filenames[stage]}.")

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -628,14 +628,12 @@ def test_api_save_torchscript(tmpdir):
         "combiner": {"type": "concat", "output_size": 14},
     }
     model = LudwigModel(config)
-    _, _, output_dir = model.train(
-        training_set=data_csv, validation_set=val_csv, test_set=test_csv, output_directory=tmpdir
-    )
+    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv, output_directory=tmpdir)
 
     test_df = pd.read_csv(test_csv)
     output_df_expected, _ = model.predict(test_df, return_type=pd.DataFrame)
 
-    save_path = os.path.join(output_dir, "model")
+    save_path = os.path.join(tmpdir, "torchscript")
     os.makedirs(save_path, exist_ok=True)
     model.save_torchscript(save_path)
     inference_module = InferenceModule.from_directory(save_path)

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -169,6 +169,18 @@ def test_export_neuropod_cli(tmpdir, csv_filename):
     )
 
 
+def test_export_torchscript_cli(tmpdir, csv_filename):
+    """Test exporting Ludwig model to torchscript format."""
+    config_filename = os.path.join(tmpdir, "config.yaml")
+    dataset_filename = _prepare_data(csv_filename, config_filename)
+    _run_ludwig("train", dataset=dataset_filename, config=config_filename, output_directory=str(tmpdir))
+    _run_ludwig(
+        "export_torchscript",
+        model_path=os.path.join(tmpdir, "experiment_run", "model"),
+        output_path=os.path.join(tmpdir, "torchscript"),
+    )
+
+
 def test_export_mlflow_cli(tmpdir, csv_filename):
     """Test export_mlflow cli."""
     config_filename = os.path.join(tmpdir, "config.yaml")


### PR DESCRIPTION
This PR implements small improvements for the `export_torchscript` CLI command. Notable behavior changes are the following:

- `--output_path` is now an optional command line argument. If none, then the `output_path` defaults to being the same as `model_path`. This is in contrast to its initial implementation, which placed models in some `torchscript/` directory. The downside of using `torchscript/` as the default was that artifacts could be overridden if multiple torchscript arguments were passed in.
- `model_hyperparameters.json` and `training_set_metadata.json` are now copied into the resulting torchscript export directory. This makes it possible to use the `InferenceModule.predict` function– which requires `model_hyperparameters.json`– regardless of where the inference modules are saved.

