### PR TITLE
Infer single distinct value columns as category instead of binary

### DIFF
--- a/ludwig/utils/automl/type_inference.py
+++ b/ludwig/utils/automl/type_inference.py
@@ -63,8 +63,6 @@ def should_exclude(idx: int, field: FieldInfo, dtype: str, row_count: int, targe
     if field.key == "PRI":
         return True
 
-    print(field.name)
-    print(targets)
     if field.name in targets:
         return False
 

--- a/ludwig/utils/automl/type_inference.py
+++ b/ludwig/utils/automl/type_inference.py
@@ -24,10 +24,12 @@ def infer_type(field: FieldInfo, missing_value_percent: float, row_count: int) -
         return DATE
 
     num_distinct_values = field.num_distinct_values
-    if num_distinct_values == 0:
-        return CATEGORY
     distinct_values = field.distinct_values
-    if num_distinct_values <= 2 and missing_value_percent == 0:
+
+    if num_distinct_values <= 1:
+        return CATEGORY
+
+    if num_distinct_values == 2 and missing_value_percent == 0:
         # Check that all distinct values are conventional bools.
         if strings_utils.are_conventional_bools(distinct_values):
             return BINARY
@@ -61,10 +63,12 @@ def should_exclude(idx: int, field: FieldInfo, dtype: str, row_count: int, targe
     if field.key == "PRI":
         return True
 
+    print(field.name)
+    print(targets)
     if field.name in targets:
         return False
 
-    if field.num_distinct_values == 0:
+    if field.num_distinct_values <= 1:
         return True
 
     distinct_value_percent = float(field.num_distinct_values) / row_count

--- a/tests/ludwig/automl/test_data_source.py
+++ b/tests/ludwig/automl/test_data_source.py
@@ -2,6 +2,7 @@ import tempfile
 
 import pytest
 
+from ludwig.constants import TEXT
 from ludwig.utils.data_utils import read_csv
 
 try:
@@ -28,9 +29,8 @@ def test_mixed_csv_data_source():
         ds = read_csv(temp.name, dtype=None)
         df = dd.from_pandas(ds, npartitions=1)
         config = create_auto_config(dataset=df, target=[], time_limit_s=3600, tune_for_memory=False)
-        assert len(config["input_features"]) == 3
-        assert config["input_features"][0]["type"] == "text"
-        assert config["input_features"][1]["type"] == "text"
-        assert config["input_features"][2]["type"] == "binary"
+        assert len(config["input_features"]) == 2
+        assert config["input_features"][0]["type"] == TEXT
+        assert config["input_features"][1]["type"] == TEXT
     finally:
         temp.close()

--- a/tests/ludwig/utils/automl/test_type_inference.py
+++ b/tests/ludwig/utils/automl/test_type_inference.py
@@ -78,4 +78,12 @@ def test_infer_type_explicit_date():
 )
 def test_should_exclude(idx, num_distinct_values, dtype, name, expected):
     field = FieldInfo(name=name, dtype=dtype, num_distinct_values=num_distinct_values)
-    assert should_exclude(idx, field, dtype, ROW_COUNT, TARGET_NAME) == expected
+    assert should_exclude(idx, field, dtype, ROW_COUNT, {TARGET_NAME}) == expected
+
+
+def test_auto_type_inference_single_value_binary_feature():
+    field = FieldInfo(
+        name="foo", dtype="object", num_distinct_values=1, distinct_values=["1" for i in range(ROW_COUNT)]
+    )
+    assert infer_type(field=field, missing_value_percent=0, row_count=ROW_COUNT) == CATEGORY
+    assert should_exclude(idx=3, field=field, dtype="object", row_count=ROW_COUNT, targets={TARGET_NAME})


### PR DESCRIPTION
This fixes an issue where we were seeing that columns with single distinct values (say all 1s) were being inferred as a binary value which caused downstream problems when trying to precompute the fille value with the following error:

```
Unable to determine False value for column X with distinct values: [1].
```

This fix changes these types of features to be inferred as categorical features, and also for them to be excluded from the dataset since a categorical feature with the same value doesn't add anything to a machine learning model.