### PR TITLE
Add backwards-compatibility logic for model progress tracker

### DIFF
--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -100,6 +100,11 @@ def upgrade_to_latest_version(config: Dict) -> Dict:
 
 
 def upgrade_model_progress(model_progress: Dict) -> Dict:
+    """Updates model progress info to be compatible with latest ProgressTracker implementation.
+
+    Notably, we convert epoch-based stats to their step-based equivalents and reformat metrics into `TrainerMetric`
+    tuples.
+    """
     ret = copy.deepcopy(model_progress)
 
     if "last_improvement_epoch" in ret:
@@ -122,7 +127,8 @@ def upgrade_model_progress(model_progress: Dict) -> Dict:
         for tgt in ret[metric_group]:
             for metric in ret[metric_group][tgt]:
                 ret[metric_group][tgt][metric] = [
-                    TrainerMetric(ret["epoch"], ret["steps"], val) for val in ret[metric_group][tgt][metric]
+                    TrainerMetric(i + 1, (i + 1) * ret["batch_size"], val)
+                    for i, val in enumerate(ret[metric_group][tgt][metric])
                 ]
 
     if "tune_checkpoint_num" not in ret:

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -126,6 +126,11 @@ def upgrade_model_progress(model_progress: Dict) -> Dict:
     for metric_group in ("train_metrics", "test_metrics", "validation_metrics"):
         for tgt in ret[metric_group]:
             for metric in ret[metric_group][tgt]:
+                if len(ret[metric_group][tgt][metric]) == 0 or isinstance(
+                    ret[metric_group][tgt][metric][0], (tuple, list)
+                ):
+                    continue
+
                 ret[metric_group][tgt][metric] = [
                     TrainerMetric(i + 1, (i + 1) * ret["batch_size"], val)
                     for i, val in enumerate(ret[metric_group][tgt][metric])

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -117,6 +117,11 @@ class ProgressTracker:
     @staticmethod
     def load(filepath):
         loaded = load_json(filepath)
+
+        from ludwig.utils.backward_compatibility import upgrade_model_progress
+
+        loaded = upgrade_model_progress(loaded)
+
         return ProgressTracker(**loaded)
 
     def log_metrics(self):

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -147,6 +147,8 @@ class ProgressTracker:
                     if metrics_tuples:
                         # For logging, get the latest metrics. The second "-1" indexes into the TrainerMetric
                         # namedtuple. The last element of the TrainerMetric namedtuple is the actual metric value.
+                        #
+                        # TODO: when loading an existing model, this loses metric values for all but the last epoch.
                         log_metrics[f"{metrics_dict_name}.{feature_name}.{metric_name}"] = metrics_tuples[-1][-1]
 
         return log_metrics

--- a/tests/ludwig/utils/test_backward_compatibility.py
+++ b/tests/ludwig/utils/test_backward_compatibility.py
@@ -546,13 +546,7 @@ def test_upgrade_model_progress():
     # To do so, we modify the batch size value and re-run the upgrade on the otherwise-valid `new_model_progress` dict.
     new_model_progress["batch_size"] = 1
     unchanged_model_progress = upgrade_model_progress(new_model_progress)
-
-    for stat in ("improvement", "increase_batch_size", "learning_rate_reduction"):
-        assert unchanged_model_progress[f"last_{stat}_steps"] == new_model_progress[f"last_{stat}_steps"]
-
-    unchanged_metric = unchanged_model_progress["validation_metrics"]["combined"]["loss"][0]
-    new_metric = new_model_progress["validation_metrics"]["combined"]["loss"][0]
-    assert unchanged_metric == new_metric
+    assert unchanged_model_progress == new_model_progress
 
 
 def test_upgrade_model_progress_already_valid():
@@ -591,10 +585,4 @@ def test_upgrade_model_progress_already_valid():
     }
 
     unchanged_model_progress = upgrade_model_progress(valid_model_progress)
-
-    for stat in ("improvement", "increase_batch_size", "learning_rate_reduction"):
-        assert unchanged_model_progress[f"last_{stat}_steps"] == valid_model_progress[f"last_{stat}_steps"]
-
-    unchanged_metric = unchanged_model_progress["validation_metrics"]["combined"]["loss"][0]
-    new_metric = valid_model_progress["validation_metrics"]["combined"]["loss"][0]
-    assert unchanged_metric == new_metric
+    assert unchanged_model_progress == valid_model_progress

--- a/tests/ludwig/utils/test_backward_compatibility.py
+++ b/tests/ludwig/utils/test_backward_compatibility.py
@@ -1,4 +1,5 @@
 import copy
+import math
 
 import pytest
 
@@ -23,6 +24,7 @@ from ludwig.utils.backward_compatibility import (
     _upgrade_feature,
     _upgrade_preprocessing_split,
     upgrade_missing_value_strategy,
+    upgrade_model_progress,
     upgrade_to_latest_version,
 )
 from ludwig.utils.defaults import merge_with_defaults
@@ -490,3 +492,64 @@ def test_update_missing_value_strategy(missing_value_strategy: str):
         expected_config["input_features"][0]["preprocessing"]["missing_value_strategy"] == "ffill"
 
     assert updated_config == expected_config
+
+
+def test_upgrade_model_progress():
+    old_model_progress = {
+        "batch_size": 64,
+        "best_eval_metric": 0.5,
+        "best_increase_batch_size_eval_metric": math.inf,
+        "best_reduce_learning_rate_eval_metric": math.inf,
+        "epoch": 2,
+        "last_improvement": 1,
+        "last_improvement_epoch": 1,
+        "last_increase_batch_size": 0,
+        "last_increase_batch_size_epoch": 0,
+        "last_increase_batch_size_eval_metric_improvement": 0,
+        "last_learning_rate_reduction": 0,
+        "last_learning_rate_reduction_epoch": 0,
+        "last_reduce_learning_rate_eval_metric_improvement": 0,
+        "learning_rate": 0.001,
+        "num_increases_batch_size": 0,
+        "num_reductions_learning_rate": 0,
+        "steps": 224,
+        "test_metrics": {
+            "combined": {"loss": [0.59, 0.56]},
+            "delinquent": {
+                "accuracy": [0.77, 0.78],
+            },
+        },
+        "train_metrics": {"combined": {"loss": [0.58, 0.55]}, "delinquent": {"roc_auc": [0.53, 0.54]}},
+        "vali_metrics": {"combined": {"loss": [0.59, 0.60]}, "delinquent": {"roc_auc": [0.53, 0.44]}},
+    }
+
+    new_model_progress = upgrade_model_progress(old_model_progress)
+
+    for stat in ("improvement", "increase_batch_size", "learning_rate_reduction"):
+        assert f"last_{stat}_epoch" not in new_model_progress
+        assert f"last_{stat}_steps" in new_model_progress
+        assert (
+            new_model_progress[f"last_{stat}_steps"]
+            == old_model_progress[f"last_{stat}_epoch"] * old_model_progress["batch_size"]
+        )
+
+    assert "tune_checkpoint_num" in new_model_progress
+
+    assert "vali_metrics" not in new_model_progress
+    assert "validation_metrics" in new_model_progress
+
+    metric = new_model_progress["validation_metrics"]["combined"]["loss"][0]
+    assert len(metric) == 3
+    assert metric[-1] == 0.59
+
+    # Verify that we don't make changes to already-valid model progress dicts.
+    # To do so, we modify the batch size value and re-run the upgrade on the otherwise-valid `new_model_progress` dict.
+    new_model_progress["batch_size"] = 1
+    unchanged_model_progress = upgrade_model_progress(new_model_progress)
+
+    for stat in ("improvement", "increase_batch_size", "learning_rate_reduction"):
+        assert unchanged_model_progress[f"last_{stat}_steps"] == new_model_progress[f"last_{stat}_steps"]
+
+    unchanged_metric = unchanged_model_progress["validation_metrics"]["combined"]["loss"][0]
+    new_metric = new_model_progress["validation_metrics"]["combined"]["loss"][0]
+    assert unchanged_metric == new_metric

--- a/tests/ludwig/utils/test_backward_compatibility.py
+++ b/tests/ludwig/utils/test_backward_compatibility.py
@@ -553,3 +553,48 @@ def test_upgrade_model_progress():
     unchanged_metric = unchanged_model_progress["validation_metrics"]["combined"]["loss"][0]
     new_metric = new_model_progress["validation_metrics"]["combined"]["loss"][0]
     assert unchanged_metric == new_metric
+
+
+def test_upgrade_model_progress_already_valid():
+    # Verify that we don't make changes to already-valid model progress dicts.
+    valid_model_progress = {
+        "batch_size": 128,
+        "best_eval_metric": 5.541325569152832,
+        "best_increase_batch_size_eval_metric": math.inf,
+        "best_reduce_learning_rate_eval_metric": math.inf,
+        "epoch": 5,
+        "last_improvement": 0,
+        "last_improvement_steps": 25,
+        "last_increase_batch_size": 0,
+        "last_increase_batch_size_eval_metric_improvement": 0,
+        "last_increase_batch_size_steps": 0,
+        "last_learning_rate_reduction": 0,
+        "last_learning_rate_reduction_steps": 0,
+        "last_reduce_learning_rate_eval_metric_improvement": 0,
+        "learning_rate": 0.001,
+        "num_increases_batch_size": 0,
+        "num_reductions_learning_rate": 0,
+        "steps": 25,
+        "test_metrics": {
+            "Survived": {"accuracy": [[0, 5, 0.39], [1, 10, 0.38]], "loss": [[0, 5, 7.35], [1, 10, 7.08]]},
+            "combined": {"loss": [[0, 5, 7.35], [1, 10, 6.24]]},
+        },
+        "train_metrics": {
+            "Survived": {"accuracy": [[0, 5, 0.39], [1, 10, 0.40]], "loss": [[0, 5, 7.67], [1, 10, 6.57]]},
+            "combined": {"loss": [[0, 5, 7.67], [1, 10, 6.57]]},
+        },
+        "validation_metrics": {
+            "Survived": {"accuracy": [[0, 5, 0.38], [1, 10, 0.38]], "loss": [[0, 5, 6.56], [1, 10, 5.54]]},
+            "combined": {"loss": [[0, 5, 6.56], [1, 10, 5.54]]},
+        },
+        "tune_checkpoint_num": 0,
+    }
+
+    unchanged_model_progress = upgrade_model_progress(valid_model_progress)
+
+    for stat in ("improvement", "increase_batch_size", "learning_rate_reduction"):
+        assert unchanged_model_progress[f"last_{stat}_steps"] == valid_model_progress[f"last_{stat}_steps"]
+
+    unchanged_metric = unchanged_model_progress["validation_metrics"]["combined"]["loss"][0]
+    new_metric = valid_model_progress["validation_metrics"]["combined"]["loss"][0]
+    assert unchanged_metric == new_metric


### PR DESCRIPTION
* Convert epoch-based stats into steps-based stats for compatibility with #1803. Epoch to steps conversion is approximate, as we don't have access to the full history of any batch size increases.
* Reformat train/test/validation metrics into `TrainerMetric` tuples, also with estimated epoch and step values.

