### PR TITLE
Fixed backwards compatibility for training_set_metadata and bfill

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -762,7 +762,6 @@ class LudwigModel:
 
         # preprocessing
         logger.debug("Preprocessing")
-        print("PREPROCESSING", self.config["input_features"][3]["preprocessing"])
         dataset, _ = preprocess_for_prediction(
             self.config,
             dataset=dataset,

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -762,6 +762,7 @@ class LudwigModel:
 
         # preprocessing
         logger.debug("Preprocessing")
+        print("PREPROCESSING", self.config["input_features"][3]["preprocessing"])
         dataset, _ = preprocess_for_prediction(
             self.config,
             dataset=dataset,

--- a/ludwig/data/dataset_synthesizer.py
+++ b/ludwig/data/dataset_synthesizer.py
@@ -20,9 +20,10 @@ import random
 import string
 import sys
 import uuid
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
+import pandas as pd
 import torch
 import torchaudio
 import yaml
@@ -37,8 +38,10 @@ from ludwig.constants import (
     ENCODER,
     H3,
     IMAGE,
+    INPUT_FEATURES,
     NAME,
     NUMBER,
+    OUTPUT_FEATURES,
     PREPROCESSING,
     SEQUENCE,
     SET,
@@ -155,6 +158,13 @@ parameters_builders_registry = {
     "h3": return_none,
     VECTOR: return_none,
 }
+
+
+def build_synthetic_dataset_df(dataset_size: int, config: Dict[str, Any]) -> pd.DataFrame:
+    features = config[INPUT_FEATURES] + config[OUTPUT_FEATURES]
+    df = build_synthetic_dataset(dataset_size, features)
+    data = [next(df) for _ in range(dataset_size + 1)]
+    return pd.DataFrame(data[1:], columns=data[0])
 
 
 def build_synthetic_dataset(dataset_size: int, features: List[dict], outdir: str = "."):

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1499,7 +1499,7 @@ def load_hdf5(hdf5_file_path, preprocessing_params, backend, split_data=True, sh
     return training_set, test_set, validation_set
 
 
-def load_metadata(metadata_file_path):
+def load_metadata(metadata_file_path: str) -> Dict[str, Any]:
     logging.info(f"Loading metadata from: {metadata_file_path}")
     training_set_metadata = data_utils.load_json(metadata_file_path)
     # TODO(travis): decouple config from training_set_metadata so we don't need to

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -56,6 +56,7 @@ from ludwig.encoders.registry import get_encoder_cls
 from ludwig.features.feature_registries import base_type_registry
 from ludwig.features.feature_utils import compute_feature_hash
 from ludwig.utils import data_utils, strings_utils
+from ludwig.utils.backward_compatibility import upgrade_metadata
 from ludwig.utils.config_utils import merge_config_preprocessing_with_feature_specific_defaults
 from ludwig.utils.data_utils import (
     CACHEABLE_FORMATS,
@@ -1500,7 +1501,11 @@ def load_hdf5(hdf5_file_path, preprocessing_params, backend, split_data=True, sh
 
 def load_metadata(metadata_file_path):
     logging.info(f"Loading metadata from: {metadata_file_path}")
-    return data_utils.load_json(metadata_file_path)
+    training_set_metadata = data_utils.load_json(metadata_file_path)
+    # TODO(travis): decouple config from training_set_metadata so we don't need to
+    #  upgrade it over time.
+    training_set_metadata = upgrade_metadata(training_set_metadata)
+    return training_set_metadata
 
 
 def preprocess_for_training(

--- a/tests/regression_tests/model/test_old_models.py
+++ b/tests/regression_tests/model/test_old_models.py
@@ -40,12 +40,22 @@ def test_model_loaded_from_old_config_prediction_works(tmpdir):
 
 @pytest.mark.parametrize(
     "model_url",
-    ["/Users/tgaddair/data/twitter_bots/twitter_bots_v05", "/Users/tgaddair/data/respiratory/respiratory_v05/model"],
+    [
+        "https://predibase-public-us-west-2.s3.us-west-2.amazonaws.com/ludwig_unit_tests/twitter_bots_v05.zip",
+        "https://predibase-public-us-west-2.s3.us-west-2.amazonaws.com/ludwig_unit_tests/respiratory_v05.zip",
+    ],
     ids=["twitter_bots", "respiratory"],
 )
 def test_predict_deprecated_model(model_url, tmpdir):
-    ludwig_model = LudwigModel.load(model_url)
-    config = ludwig_model.config
-    df = build_synthetic_dataset_df(NUM_EXAMPLES, config)
+    model_dir = os.path.join(tmpdir, "model")
+    os.makedirs(model_dir)
+
+    archive_path = wget.download(model_url, tmpdir)
+    with zipfile.ZipFile(archive_path, "r") as zip_ref:
+        zip_ref.extractall(model_dir)
+
+    ludwig_model = LudwigModel.load(model_dir)
+    df = build_synthetic_dataset_df(NUM_EXAMPLES, ludwig_model.config)
+
     pred_df = ludwig_model.predict(df)
     assert len(pred_df) > 0

--- a/tests/regression_tests/model/test_old_models.py
+++ b/tests/regression_tests/model/test_old_models.py
@@ -2,9 +2,13 @@ import os
 import zipfile
 
 import pandas as pd
+import pytest
 import wget
 
 from ludwig.api import LudwigModel
+from ludwig.data.dataset_synthesizer import build_synthetic_dataset_df
+
+NUM_EXAMPLES = 25
 
 
 def test_model_loaded_from_old_config_prediction_works(tmpdir):
@@ -32,3 +36,16 @@ def test_model_loaded_from_old_config_prediction_works(tmpdir):
     predictions, _ = ludwig_model.predict(dataset=test_set)
 
     assert predictions.to_dict()["Survived_predictions"] == {0: False}
+
+
+@pytest.mark.parametrize(
+    "model_url",
+    ["/Users/tgaddair/data/twitter_bots/twitter_bots_v05", "/Users/tgaddair/data/respiratory/respiratory_v05/model"],
+    ids=["twitter_bots", "respiratory"],
+)
+def test_predict_deprecated_model(model_url, tmpdir):
+    ludwig_model = LudwigModel.load(model_url)
+    config = ludwig_model.config
+    df = build_synthetic_dataset_df(NUM_EXAMPLES, config)
+    pred_df = ludwig_model.predict(df)
+    assert len(pred_df) == NUM_EXAMPLES

--- a/tests/regression_tests/model/test_old_models.py
+++ b/tests/regression_tests/model/test_old_models.py
@@ -48,4 +48,4 @@ def test_predict_deprecated_model(model_url, tmpdir):
     config = ludwig_model.config
     df = build_synthetic_dataset_df(NUM_EXAMPLES, config)
     pred_df = ludwig_model.predict(df)
-    assert len(pred_df) == NUM_EXAMPLES
+    assert len(pred_df) > 0


### PR DESCRIPTION
Also adds new tests for old model versions.

We should, very soon, find a way to decouple the config from the training set metadata to avoid these sorts of situations in the future.