### PR TITLE
fix: Various schema adjustments

### DIFF
--- a/ludwig/schema/decoders/base.py
+++ b/ludwig/schema/decoders/base.py
@@ -143,12 +143,19 @@ class ProjectorConfig(BaseDecoderConfig):
         description=" Indicates the activation function applied to the output.",
     )
 
-    clip: Union[List[int], Tuple[int]] = schema_utils.FloatRangeTupleDataclassField(
-        n=2,
-        default=None,
+    clip: Union[List[int], Tuple[int]] = schema_utils.OneOfOptionsField(
+        field_options=[
+            schema_utils.FloatRangeTupleDataclassField(
+                n=2,
+                default=None,
+                allow_none=True,
+                min=0,
+                max=999999999,
+            )
+        ],
         allow_none=True,
-        min=0,
-        max=999999999,
+        default=None,
+        parameter_metadata=None,
         description="Clip the output of the decoder to be within the given range.",
     )
 

--- a/ludwig/schema/decoders/base.py
+++ b/ludwig/schema/decoders/base.py
@@ -147,8 +147,7 @@ class ProjectorConfig(BaseDecoderConfig):
         field_options=[
             schema_utils.FloatRangeTupleDataclassField(
                 n=2,
-                default=None,
-                allow_none=True,
+                default=(0, 0),
                 min=0,
                 max=999999999,
             )

--- a/ludwig/schema/encoders/image_encoders.py
+++ b/ludwig/schema/encoders/image_encoders.py
@@ -67,8 +67,13 @@ class Stacked2DCNNEncoderConfig(BaseEncoderConfig):
         "2D convolutional kernel that will be used for each layer. ",
     )
 
-    padding: Optional[Union[int, Tuple[int], str]] = schema_utils.PositiveIntegerOrTupleOrStringOptions(
-        options=["valid", "same"],
+    padding: Optional[Union[int, Tuple[int], str]] = schema_utils.OneOfOptionsField(
+        field_options=[
+            schema_utils.PositiveInteger(description="", default=1),
+            schema_utils.FloatRangeTupleDataclassField(description="", default=(1, 1), min=0, max=99999),
+            schema_utils.StringOptions(description="", options=["valid", "same"], default="valid", allow_none=False),
+        ],
+        allow_none=True,
         default="valid",
         description="An int, pair of ints (h, w), or one of valid, same specifying the padding used for convolution "
         "kernels. ",

--- a/ludwig/schema/features/number_feature.py
+++ b/ludwig/schema/features/number_feature.py
@@ -51,6 +51,7 @@ class NumberOutputFeatureConfig(BaseOutputFeatureConfig):
                 max=999999999,
             )
         ],
+        allow_none=True,
         description="Clip the predicted output to the specified range.",
         default=None,
     )

--- a/ludwig/schema/features/number_feature.py
+++ b/ludwig/schema/features/number_feature.py
@@ -42,13 +42,17 @@ class NumberOutputFeatureConfig(BaseOutputFeatureConfig):
         default=MEAN_SQUARED_ERROR,
     )
 
-    clip: Union[List[int], Tuple[int]] = schema_utils.FloatRangeTupleDataclassField(
-        n=2,
-        default=None,
-        allow_none=True,
-        min=0,
-        max=999999999,
+    clip: Union[List[int], Tuple[int]] = schema_utils.OneOfOptionsField(
+        field_options=[
+            schema_utils.FloatRangeTupleDataclassField(
+                n=2,
+                allow_none=True,
+                min=0,
+                max=999999999,
+            )
+        ],
         description="Clip the predicted output to the specified range.",
+        default=None,
     )
 
     decoder: BaseDecoderConfig = DecoderDataclassField(


### PR DESCRIPTION
* Updates misc. `title`(s) in custom JSON mappings to include the parameter name as part of each option's `title`
* Switches `FloatRangeTupleDataclassField` back to a normal array rather than a `oneOf`.
  * Updates usages of it that require a `null` option to use `OneOfOptionsField` instead
* Makes `min` and `max` optional for `FloatRangeTupleDataclassField`
* Updates `PositiveIntegerOrTupleOrStringOptions` to use `OneOfOptionsField` under the hood.
* Updates `List` field to be more expressive