### PR TITLE
Fix flaky ray nightly image test

### DIFF
--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -175,7 +175,7 @@ class ImageFeatureMixin(BaseFeatureMixin):
         if isinstance(img_entry, bytes):
             img = read_image_from_bytes_obj(img_entry, num_channels)
         elif isinstance(img_entry, np.ndarray):
-            img = torch.from_numpy(img_entry).permute(2, 0, 1)
+            img = torch.from_numpy(np.array(img_entry, copy=True)).permute(2, 0, 1)
         else:
             img = img_entry
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ torch>=1.10.0
 torchaudio
 torchtext
 torchvision>=0.10.1
-transformers>=4.10.1
+transformers>=4.10.1,<4.22
 spacy>=2.3
 PyYAML>=3.12
 absl-py

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -346,9 +346,6 @@ def test_ray_audio(tmpdir, dataset_type, ray_cluster_2cpu):
 @pytest.mark.parametrize("dataset_type", ["csv", "parquet", "pandas+numpy_images"])
 @pytest.mark.distributed
 def test_ray_image(tmpdir, dataset_type, ray_cluster_2cpu):
-    # if _ray_nightly and dataset_type == "pandas+numpy_images":
-    #     pytest.skip("https://github.com/ludwig-ai/ludwig/issues/2452")
-
     image_dest_folder = os.path.join(tmpdir, "generated_images")
     input_features = [
         image_feature(

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -334,8 +334,8 @@ def test_ray_audio(tmpdir, dataset_type, ray_cluster_2cpu):
 @pytest.mark.parametrize("dataset_type", ["csv", "parquet", "pandas+numpy_images"])
 @pytest.mark.distributed
 def test_ray_image(tmpdir, dataset_type, ray_cluster_2cpu):
-    if _ray_nightly and dataset_type == "pandas+numpy_images":
-        pytest.skip("https://github.com/ludwig-ai/ludwig/issues/2452")
+    # if _ray_nightly and dataset_type == "pandas+numpy_images":
+    #     pytest.skip("https://github.com/ludwig-ai/ludwig/issues/2452")
 
     image_dest_folder = os.path.join(tmpdir, "generated_images")
     input_features = [


### PR DESCRIPTION
When we create a tensor directly from a numpy array instead of from a copy, it creates unpredictable behavior and results in the creation of ragged tensors downstream which causes weird type mismatch issues that Ray doesn't like. This change ensures we create the tensor from a copy of the numpy array so that we don't run into this issue. 