### PR TITLE
[cherry-pick] Fixed stratified splitting with Dask (#1883)

### DIFF
--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -23,7 +23,15 @@ from packaging import version
 
 from ludwig.api import LudwigModel
 from ludwig.backend import create_ray_backend, initialize_backend, LOCAL_BACKEND
-from ludwig.constants import BALANCE_PERCENTAGE_TOLERANCE, BFILL, COLUMN, DEFAULT_BATCH_SIZE, NAME, TRAINER
+from ludwig.constants import (
+    BALANCE_PERCENTAGE_TOLERANCE,
+    BFILL,
+    COLUMN,
+    DEFAULT_BATCH_SIZE,
+    NAME,
+    PREPROCESSING,
+    TRAINER,
+)
 from ludwig.data.preprocessing import balance_data
 from ludwig.utils.data_utils import read_parquet
 from tests.integration_tests.utils import (
@@ -155,13 +163,17 @@ def run_test_with_features(
     dataset_type="parquet",
     skip_save_processed_input=True,
     nan_percent=0.0,
+    preprocessing=None,
 ):
+    preprocessing = preprocessing or {}
     config = {
         "input_features": input_features,
         "output_features": output_features,
         "combiner": {"type": "concat", "output_size": 14},
         TRAINER: {"epochs": 2, "batch_size": 8},
     }
+    if preprocessing:
+        config[PREPROCESSING] = preprocessing
 
     backend_config = {**RAY_BACKEND_CONFIG}
     if df_engine:

--- a/tests/ludwig/data/test_split.py
+++ b/tests/ludwig/data/test_split.py
@@ -140,9 +140,24 @@ def test_fixed_split(df_engine):
         last_t = t
 
 
-def test_stratify_split():
-    nrows = 100
-    thresholds = [60, 80, 100]
+@pytest.mark.parametrize(
+    ("df_engine", "nrows", "atol"),
+    [
+        pytest.param(PandasEngine(), 100, 1, id="pandas"),
+        # Splitting with a distributed engine becomes more accurate with more rows.
+        pytest.param(DaskEngine(_use_ray=False), 10000, 10, id="dask", marks=pytest.mark.distributed),
+    ],
+)
+@pytest.mark.parametrize(
+    "class_probs",
+    [
+        pytest.param(np.array([0.33, 0.33, 0.34]), id="balanced"),
+        pytest.param(np.array([0.6, 0.2, 0.2]), id="imbalanced"),
+    ],
+)
+def test_stratify_split(df_engine, nrows, atol, class_probs):
+    npartitions = 10
+    thresholds = np.cumsum((class_probs * nrows).astype(int))
 
     df = pd.DataFrame(np.random.randint(0, 100, size=(nrows, 3)), columns=["A", "B", "C"])
 
@@ -155,6 +170,9 @@ def test_stratify_split():
 
     df["category"] = df.index.map(get_category).astype(np.int8)
 
+    if isinstance(df_engine, DaskEngine):
+        df = df_engine.df_lib.from_pandas(df, npartitions=npartitions)
+
     probs = (0.7, 0.1, 0.2)
     split_params = {
         "type": "stratify",
@@ -164,24 +182,32 @@ def test_stratify_split():
     splitter = get_splitter(**split_params)
 
     backend = Mock()
-    backend.df_engine = PandasEngine()
+    backend.df_engine = df_engine
     splits = splitter.split(df, backend, random_seed=42)
     assert len(splits) == 3
 
-    ratios = [60, 20, 20]
+    ratios = class_probs * nrows
     for split, p in zip(splits, probs):
+        if isinstance(df_engine, DaskEngine):
+            split = split.compute()
         for idx, r in enumerate(ratios):
             actual = np.sum(split["category"] == idx)
             expected = int(r * p)
-            assert np.isclose(actual, expected, atol=1)
+            assert np.isclose(actual, expected, atol=atol)
 
     # Test determinism
     splits2 = splitter.split(df, backend, random_seed=7)
     for s1, s2 in zip(splits, splits2):
+        if isinstance(df_engine, DaskEngine):
+            s1 = s1.compute()
+            s2 = s2.compute()
         assert not s1.equals(s2)
 
     splits3 = splitter.split(df, backend, random_seed=42)
     for s1, s3 in zip(splits, splits3):
+        if isinstance(df_engine, DaskEngine):
+            s1 = s1.compute()
+            s3 = s3.compute()
         assert s1.equals(s3)
 
 


### PR DESCRIPTION
Assumes every partition fits in memory

Given $P$ the set of partitions of dataset $D$, and $S$ the set of unique values in the stratify column. When stratified splitting every partition individually, $\forall s \in S:$

$$
\begin{align}
 &\sum_{p \in P} \\%\_{train} \times | p\_{S = s} | & \\%\_{train} \texttt{ of every partition's } s
\texttt{ values will be in that partition's train} \\
= &\\%\_{train} \times \sum_{p \in P} | p\_{S = s} | & \texttt{which is } \\%\_{train} \texttt{ of the sum of all } s \texttt{ value counts over all partitions} \\
= &\\%\_{train} \times | D\_{S = s} | & \texttt{which is } \\%\_{train} \texttt{ of the total number of } s \texttt{ values} \\
\end{align}
$$

$\\%\_{train}$ of records in $D$ with value $s$ in the stratify column will land in the training set. Equivalent proof for the valid and test split.
