### PR TITLE
Fixed support for distributed datasets in create_auto_config

### DIFF
--- a/ludwig/automl/auto_tune_config.py
+++ b/ludwig/automl/auto_tune_config.py
@@ -13,6 +13,7 @@ except ImportError:
 
 from ludwig.api import LudwigModel
 from ludwig.constants import (
+    AUTO,
     AUTOML_DEFAULT_TEXT_ENCODER,
     AUTOML_LARGE_TEXT_DATASET,
     AUTOML_MAX_ROWS_PER_CHECKPOINT,
@@ -20,6 +21,7 @@ from ludwig.constants import (
     AUTOML_SMALLER_TEXT_LENGTH,
     AUTOML_TEXT_ENCODER_MAX_TOKEN_LEN,
     BATCH_SIZE,
+    DEFAULT_BATCH_SIZE,
     HYPEROPT,
     PREPROCESSING,
     SPACE,
@@ -117,7 +119,10 @@ def compute_memory_usage(config, training_set_metadata, model_category) -> int:
     update_config_with_metadata(config, training_set_metadata)
     lm = LudwigModel.create_model(config)
     model_size = lm.get_model_size()  # number of parameters in model
-    batch_size = config[TRAINER][BATCH_SIZE]
+    batch_size = config[TRAINER].get(BATCH_SIZE, DEFAULT_BATCH_SIZE)
+    if batch_size == AUTO:
+        # Smallest valid batch size that will allow training to complete
+        batch_size = 2
     memory_usage = model_size * (BYTES_PER_WEIGHT + BYTES_OPTIMIZER_PER_WEIGHT) * batch_size
     if model_category == TEXT:
         return _get_text_model_memory_usage(config, training_set_metadata, memory_usage)

--- a/ludwig/automl/auto_tune_config.py
+++ b/ludwig/automl/auto_tune_config.py
@@ -70,9 +70,9 @@ BYTES_PER_WEIGHT = 4  # assumes 32-bit precision = 4 bytes
 BYTES_OPTIMIZER_PER_WEIGHT = 8  # for optimizer m and v vectors
 
 
-def get_trainingset_metadata(config, dataset):
+def get_trainingset_metadata(config, dataset, backend):
     (_, _, _, training_set_metadata) = preprocess_for_training(
-        config, dataset=dataset, preprocessing_params=config[PREPROCESSING]
+        config, dataset=dataset, preprocessing_params=config[PREPROCESSING], backend=backend
     )
     return training_set_metadata
 
@@ -194,11 +194,11 @@ def _update_num_samples(num_samples, hyperparam_search_space):
 
 
 # Note: if run in Ray Cluster, this method is run remote with gpu resources requested if available
-def memory_tune_config(config, dataset, model_category, row_count):
+def memory_tune_config(config, dataset, model_category, row_count, backend):
     fits_in_memory = False
     tried_reduce_seq_len = False
     raw_config = merge_with_defaults(config)
-    training_set_metadata = get_trainingset_metadata(raw_config, dataset)
+    training_set_metadata = get_trainingset_metadata(raw_config, dataset, backend)
     modified_hyperparam_search_space = copy.deepcopy(raw_config[HYPEROPT]["parameters"])
     current_param_values = {}
     param_list = []

--- a/ludwig/automl/auto_tune_config.py
+++ b/ludwig/automl/auto_tune_config.py
@@ -12,6 +12,7 @@ except ImportError:
     raise ImportError(" ray is not installed. In order to use auto_train please run pip install ludwig[ray]")
 
 from ludwig.api import LudwigModel
+from ludwig.backend import initialize_backend
 from ludwig.constants import (
     AUTO,
     AUTOML_DEFAULT_TEXT_ENCODER,
@@ -200,6 +201,8 @@ def _update_num_samples(num_samples, hyperparam_search_space):
 
 # Note: if run in Ray Cluster, this method is run remote with gpu resources requested if available
 def memory_tune_config(config, dataset, model_category, row_count, backend):
+    backend = initialize_backend(backend)
+
     fits_in_memory = False
     tried_reduce_seq_len = False
     raw_config = merge_with_defaults(config)

--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -170,6 +170,11 @@ def get_dataset_info(dataset: Union[str, pd.DataFrame, dd.core.DataFrame]) -> Da
     :return: (List[FieldInfo]) list of FieldInfo objects
     """
     dataframe = load_dataset(dataset)
+    if isinstance(dataset, dd.core.DataFrame):
+        # Limit the dataset to first 10k elements to speed up type inference
+        # TODO(travis): find a more uniform sampling strategy here
+        # Alternatively just use Whylogs for this...
+        dataframe = dataframe.head(10000)
     source = DataframeSource(dataframe)
     return get_dataset_info_from_source(source)
 

--- a/ludwig/utils/automl/type_inference.py
+++ b/ludwig/utils/automl/type_inference.py
@@ -72,7 +72,11 @@ def should_exclude(idx: int, field: FieldInfo, dtype: str, row_count: int, targe
     distinct_value_percent = float(field.num_distinct_values) / row_count
     if distinct_value_percent == 1.0:
         upper_name = field.name.upper()
-        if (idx == 0 and dtype == NUMBER) or upper_name.endswith("ID") or upper_name.startswith("ID"):
+        if (
+            (idx == 0 and "INDEX" in upper_name and dtype == NUMBER)
+            or upper_name.endswith("ID")
+            or upper_name.startswith("ID")
+        ):
             return True
 
     return False

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 # ==============================================================================
 import copy
+import functools
 import os
 import random
+import weakref
 from collections import OrderedDict
 from collections.abc import Mapping
 
@@ -159,3 +161,26 @@ def set_saved_weights_in_checkpoint_flag(config):
 
 def remove_empty_lines(str):
     return "\n".join([line.rstrip() for line in str.split("\n") if line.rstrip()])
+
+
+# TODO(travis): move to cached_property when we drop Python 3.7.
+# https://stackoverflow.com/a/33672499
+def memoized_method(*lru_args, **lru_kwargs):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapped_func(self, *args, **kwargs):
+            # We're storing the wrapped method inside the instance. If we had
+            # a strong reference to self the instance would never die.
+            self_weak = weakref.ref(self)
+
+            @functools.wraps(func)
+            @functools.lru_cache(*lru_args, **lru_kwargs)
+            def cached_method(*args, **kwargs):
+                return func(self_weak(), *args, **kwargs)
+
+            setattr(self, func.__name__, cached_method)
+            return cached_method(*args, **kwargs)
+
+        return wrapped_func
+
+    return decorator

--- a/tests/integration_tests/test_automl.py
+++ b/tests/integration_tests/test_automl.py
@@ -35,11 +35,12 @@ def test_data():
 
 
 @pytest.mark.distributed
-def test_create_auto_config(test_data, ray_cluster_2cpu):
+@pytest.mark.parametrize("tune_for_memory", [True, False])
+def test_create_auto_config(tune_for_memory, test_data, ray_cluster_2cpu):
     input_features, output_features, dataset_csv = test_data
     targets = [feature[NAME] for feature in output_features]
     df = dd.read_csv(dataset_csv)
-    config = create_auto_config(df, targets, time_limit_s=600, tune_for_memory=False)
+    config = create_auto_config(df, targets, time_limit_s=600, tune_for_memory=tune_for_memory, backend="ray")
 
     def to_name_set(features: List[Dict[str, Any]]) -> Set[str]:
         return {feature[NAME] for feature in features}

--- a/tests/integration_tests/test_automl.py
+++ b/tests/integration_tests/test_automl.py
@@ -1,31 +1,57 @@
 import os
+import tempfile
+from typing import Any, Dict, List, Set
 from unittest import mock
 
 import pytest
 
 from ludwig.api import LudwigModel
-from ludwig.constants import TRAINER
+from ludwig.constants import INPUT_FEATURES, NAME, OUTPUT_FEATURES, TRAINER
 from tests.integration_tests.utils import category_feature, generate_data, number_feature
 
 try:
-    from ludwig.automl.automl import train_with_config
+    import dask.dataframe as dd
+
+    from ludwig.automl.automl import create_auto_config, train_with_config
     from ludwig.hyperopt.execution import RayTuneExecutor
 except ImportError:
     pass
 
 
+@pytest.fixture(scope="module")
+def test_data():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_features = [
+            number_feature(),
+            number_feature(),
+            category_feature(encoder={"vocab_size": 3}),
+            category_feature(encoder={"vocab_size": 3}),
+        ]
+        output_features = [category_feature(decoder={"vocab_size": 3})]
+        dataset_csv = generate_data(
+            input_features, output_features, os.path.join(tmpdir, "dataset.csv"), num_examples=100
+        )
+        yield input_features, output_features, dataset_csv
+
+
+@pytest.mark.distributed
+def test_create_auto_config(test_data, ray_cluster_2cpu):
+    input_features, output_features, dataset_csv = test_data
+    targets = [feature[NAME] for feature in output_features]
+    df = dd.read_csv(dataset_csv)
+    config = create_auto_config(df, targets, time_limit_s=600, tune_for_memory=False)
+
+    def to_name_set(features: List[Dict[str, Any]]) -> Set[str]:
+        return {feature[NAME] for feature in features}
+
+    assert to_name_set(config[INPUT_FEATURES]) == to_name_set(input_features)
+    assert to_name_set(config[OUTPUT_FEATURES]) == to_name_set(output_features)
+
+
 @pytest.mark.distributed
 @pytest.mark.parametrize("time_budget", [200, 1], ids=["high", "low"])
-def test_train_with_config(time_budget, ray_cluster_2cpu, tmpdir):
-    input_features = [
-        number_feature(),
-        number_feature(),
-        category_feature(encoder={"vocab_size": 3}),
-        category_feature(encoder={"vocab_size": 3}),
-    ]
-    output_features = [category_feature(decoder={"vocab_size": 3})]
-    dataset = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"))
-
+def test_train_with_config(time_budget, test_data, ray_cluster_2cpu, tmpdir):
+    input_features, output_features, dataset_csv = test_data
     config = {
         "input_features": input_features,
         "output_features": output_features,
@@ -68,7 +94,7 @@ def test_train_with_config(time_budget, ray_cluster_2cpu, tmpdir):
         mock_fn.side_effect = fn
 
         outdir = os.path.join(tmpdir, "output")
-        results = train_with_config(dataset, config, output_directory=outdir)
+        results = train_with_config(dataset_csv, config, output_directory=outdir)
         best_model = results.best_model
 
         if time_budget > 1:

--- a/tests/ludwig/utils/automl/test_type_inference.py
+++ b/tests/ludwig/utils/automl/test_type_inference.py
@@ -68,7 +68,9 @@ def test_infer_type_explicit_date():
     "idx,num_distinct_values,dtype,name,expected",
     [
         (3, ROW_COUNT, NUMBER, "id", True),
-        (0, ROW_COUNT, NUMBER, "foo", True),
+        (0, ROW_COUNT, NUMBER, "index", True),
+        (1, ROW_COUNT, NUMBER, "index", False),
+        (0, ROW_COUNT, NUMBER, "foo", False),
         (3, ROW_COUNT, TEXT, "uuid", True),
         (0, ROW_COUNT, TEXT, "name", False),
         (0, ROW_COUNT, NUMBER, TARGET_NAME, False),


### PR DESCRIPTION
Fixes #2499.
Related #2497.

Also changes exclusion logic to be less restrictive for index-looking fields.