### PR TITLE
Add in-memory dataset size calculation

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -484,7 +484,7 @@ class LudwigModel:
                     os.makedirs(model_dir, exist_ok=True)
                     save_json(os.path.join(model_dir, TRAIN_SET_METADATA_FILE_NAME), training_set_metadata)
 
-                logger.info("\nDataset sizes:")
+                logger.info("\nDataset Sizes (Rows)")
                 logger.info(tabulate(dataset_statistics, headers="firstrow", tablefmt="fancy_grid", floatfmt=".4f"))
 
             for callback in self.callbacks:

--- a/ludwig/data/dataset/base.py
+++ b/ludwig/data/dataset/base.py
@@ -31,6 +31,10 @@ class Dataset(ABC):
     def to_df(self):
         raise NotImplementedError()
 
+    @property
+    def in_memory_size_bytes(self):
+        raise NotImplementedError()
+
 
 class DatasetManager(ABC):
     @abstractmethod

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -74,6 +74,12 @@ class PandasDataset(Dataset):
     def __len__(self):
         return self.size
 
+    @property
+    def in_memory_size_bytes(self):
+        df = self.to_df()
+        memory_usage = df.memory_usage(deep=True).sum() if not None else 0
+        return memory_usage
+
     @contextlib.contextmanager
     def initialize_batcher(self, batch_size=128, should_shuffle=True, seed=0, ignore_last=False, horovod=None):
         sampler = DistributedSampler(len(self), shuffle=should_shuffle, seed=seed, horovod=horovod)

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -130,6 +130,11 @@ class RayDataset(Dataset):
     def size(self):
         return len(self)
 
+    @property
+    def in_memory_size_bytes(self):
+        memory_usage = self.ds.size_bytes() if not None else 0
+        return memory_usage
+
     def to_df(self):
         return self.df_engine.from_ray_dataset(self.ds)
 

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 import torch
+from tabulate import tabulate
 
 from ludwig.backend import Backend, LOCAL_BACKEND
 from ludwig.constants import (
@@ -1662,6 +1663,16 @@ def preprocess_for_training(
                         "preprocessing configuration."
                     )
                     test_dataset = None
+
+        # Surface in-memory dataset sizes
+        dataset_statistics = [
+            ["Dataset", "Size In Bytes"],
+            ["Training", training_dataset.in_memory_size_bytes],
+            ["Validation", validation_dataset.in_memory_size_bytes],
+            ["Test", test_dataset.in_memory_size_bytes],
+        ]
+        logging.info("\nDataset Sizes (In Memory)")
+        logging.info(tabulate(dataset_statistics, headers="firstrow", tablefmt="fancy_grid"))
 
         return (training_dataset, validation_dataset, test_dataset, training_set_metadata)
 


### PR DESCRIPTION
Based on a conversation with an OSS user, it is useful to surface the size of the in-memory dataset to Ludwig users after preprocessing so that they can better estimate their cluster memory. 

This will also be useful for profiling and debugging.

Cost of running `RayDataset.size_bytes()` is O(1), while cost of running `df.memory_usage(deep=True)` should be minimal (can't find a computational complexity approximation anywhere). 

In the future, we can pass a flag to decide whether to compute these values or not if we find this to be a bottleneck. 