### PR TITLE
Surfacing dataset statistics in hyperopt

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -36,7 +36,6 @@ import torch
 from tabulate import tabulate
 
 from ludwig.backend import Backend, initialize_backend, provision_preprocessing_workers
-from ludwig.benchmarking.utils import format_memory
 from ludwig.callbacks import Callback
 from ludwig.constants import (
     AUTO,
@@ -88,6 +87,7 @@ from ludwig.utils.data_utils import (
     load_yaml,
     save_json,
 )
+from ludwig.utils.dataset_utils import generate_dataset_statistics
 from ludwig.utils.defaults import default_random_seed, merge_with_defaults
 from ludwig.utils.fs_utils import makedirs, path_exists, upload_output_directory
 from ludwig.utils.misc_utils import (
@@ -474,16 +474,7 @@ class LudwigModel:
             self.training_set_metadata = training_set_metadata
 
             if self.backend.is_coordinator():
-                dataset_statistics = [["Dataset", "Size (Rows)", "Size (In Memory)"]]
-                dataset_statistics.append(
-                    ["Training", len(training_set), format_memory(training_set.in_memory_size_bytes)]
-                )
-                if validation_set is not None:
-                    dataset_statistics.append(
-                        ["Validation", len(validation_set), format_memory(validation_set.in_memory_size_bytes)]
-                    )
-                if test_set is not None:
-                    dataset_statistics.append(["Test", len(test_set), format_memory(test_set.in_memory_size_bytes)])
+                dataset_statistics = generate_dataset_statistics(training_set, validation_set, test_set)
 
                 if not skip_save_model:
                     # save train set metadata

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Union
 
 import pandas as pd
 import yaml
+from tabulate import tabulate
 
 from ludwig.api import LudwigModel
 from ludwig.backend import Backend, initialize_backend, LocalBackend
@@ -29,6 +30,7 @@ from ludwig.features.feature_registries import output_type_registry
 from ludwig.hyperopt.results import HyperoptResults
 from ludwig.hyperopt.utils import print_hyperopt_results, save_hyperopt_stats, should_tune_preprocessing
 from ludwig.utils.backward_compatibility import upgrade_to_latest_version
+from ludwig.utils.dataset_utils import generate_dataset_statistics
 from ludwig.utils.defaults import default_random_seed, merge_with_defaults
 from ludwig.utils.fs_utils import makedirs, open_file
 from ludwig.utils.misc_utils import get_class_attributes, get_from_registry, set_default_value, set_default_values
@@ -319,6 +321,11 @@ def hyperopt(
             random_seed=random_seed,
         )
         dataset = None
+
+        dataset_statistics = generate_dataset_statistics(training_set, validation_set, test_set)
+
+        logging.info("\nDataset Statistics")
+        logging.info(tabulate(dataset_statistics, headers="firstrow", tablefmt="fancy_grid"))
 
         for callback in callbacks or []:
             callback.on_hyperopt_preprocessing_end(experiment_name)

--- a/ludwig/utils/dataset_utils.py
+++ b/ludwig/utils/dataset_utils.py
@@ -1,7 +1,10 @@
+from typing import List, Tuple, Union
+
 import pandas as pd
 from sklearn.model_selection import train_test_split
 
 from ludwig.constants import TEST_SPLIT, TRAIN_SPLIT, VALIDATION_SPLIT
+from ludwig.data.dataset.base import Dataset
 from ludwig.utils.defaults import default_random_seed
 
 
@@ -85,3 +88,19 @@ def get_repeatable_train_val_test_split(
     df_test["split"] = TEST_SPLIT
     df_split = pd.concat([df_train, df_val, df_test], ignore_index=True)
     return df_split
+
+
+def generate_dataset_statistics(
+    training_set: Dataset, validation_set: Union[Dataset, None], test_set: Union[Dataset, None]
+) -> List[Tuple[str, int, int]]:
+    from ludwig.benchmarking.utils import format_memory
+
+    dataset_statistics = [["Dataset", "Size (Rows)", "Size (In Memory)"]]
+    dataset_statistics.append(["Training", len(training_set), format_memory(training_set.in_memory_size_bytes)])
+    if validation_set is not None:
+        dataset_statistics.append(
+            ["Validation", len(validation_set), format_memory(validation_set.in_memory_size_bytes)]
+        )
+    if test_set is not None:
+        dataset_statistics.append(["Test", len(test_set), format_memory(test_set.in_memory_size_bytes)])
+    return dataset_statistics


### PR DESCRIPTION
Follow up from https://github.com/ludwig-ai/ludwig/commit/39ba54197820e0a33645dc7ccb36a0809ae1a6e8
This ensures that we can see dataset statistics for hyperopt and it also fixes the current issues with the dataloader on master