### PR TITLE
AutoML: stratify imbalanced datasets

### DIFF
--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -127,7 +127,13 @@ def auto_train(
     :return: (AutoTrainResults) results containing hyperopt experiments and best model
     """
     config = create_auto_config(
-        dataset, target, time_limit_s, tune_for_memory, user_config, random_seed, use_reference_config
+        dataset,
+        target,
+        time_limit_s,
+        tune_for_memory,
+        user_config,
+        random_seed,
+        use_reference_config=use_reference_config,
     )
     return train_with_config(dataset, config, output_directory=output_directory, random_seed=random_seed, **kwargs)
 
@@ -139,6 +145,7 @@ def create_auto_config(
     tune_for_memory: bool,
     user_config: Dict = None,
     random_seed: int = default_random_seed,
+    imbalance_threshold: float = 0.9,
     use_reference_config: bool = False,
     backend: Union[Backend, str] = None,
 ) -> dict:
@@ -157,6 +164,7 @@ def create_auto_config(
                         there is a call to a random number generator, including
                         hyperparameter search sampling, as well as data splitting,
                         parameter initialization and training set shuffling
+    :param imbalance_threshold: (float) maximum imbalance ratio (minority / majority) to perform stratified sampling
     :param use_reference_config: (bool) refine hyperopt search space by setting first
                                  search point from reference model config, if any
 
@@ -170,7 +178,7 @@ def create_auto_config(
 
     dataset_info = get_dataset_info(dataset) if not isinstance(dataset, DatasetInfo) else dataset
     default_configs, features_metadata = _create_default_config(
-        dataset_info, target, time_limit_s, random_seed, backend
+        dataset_info, target, time_limit_s, random_seed, imbalance_threshold, backend
     )
     model_config, model_category, row_count = _model_select(
         dataset_info, default_configs, features_metadata, user_config, use_reference_config

--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -13,7 +13,7 @@
 
 import os
 from dataclasses import dataclass
-from typing import List, Set, Union
+from typing import Any, Dict, List, Set, Union
 
 import dask.dataframe as dd
 import numpy as np
@@ -91,7 +91,7 @@ def allocate_experiment_resources(resources: Resources) -> dict:
     return experiment_resources
 
 
-def _get_hyperopt_config(experiment_resources, time_limit_s, random_seed):
+def _get_hyperopt_config(experiment_resources: Dict[str, Any], time_limit_s: Union[int, float], random_seed: int):
     executor = experiment_resources
     executor.update({"time_budget_s": time_limit_s})
     if time_limit_s is not None:

--- a/tests/integration_tests/test_automl.py
+++ b/tests/integration_tests/test_automl.py
@@ -85,8 +85,7 @@ def test_autoconfig_preprocessing_imbalanced():
 
     assert PREPROCESSING in config
     assert SPLIT in config[PREPROCESSING]
-    assert config[PREPROCESSING][SPLIT][TYPE] == "stratify"
-    assert config[PREPROCESSING][SPLIT][COLUMN] == "category"
+    assert config[PREPROCESSING][SPLIT] == {TYPE: "stratify", COLUMN: "category"}
 
 
 @pytest.mark.distributed


### PR DESCRIPTION
Adds stratified splitting to the AutoML generated config if the dataset:
- has a single output feature
- the output feature is categorical or binary
- the output feature's imbalance ratio is below `imbalance_threshold`