### PR TITLE
ZScore Normalization Failure When Using Constant Value Number Feature

### DIFF
--- a/ludwig/features/number_feature.py
+++ b/ludwig/features/number_feature.py
@@ -62,7 +62,7 @@ class ZScoreTransformer(nn.Module):
         self.mu = float(mean) if mean is not None else mean
         self.sigma = float(std) if std is not None else std
         self.feature_name = kwargs.get(NAME, "")
-        if not self.sigma:
+        if self.sigma == 0:
             raise RuntimeError(
                 f"Cannot apply zscore normalization to `{self.feature_name}` since it has a standard deviation of 0. "
                 f"This is most likely because `{self.feature_name}` has a constant value of {self.mu} for all rows in "

--- a/tests/integration_tests/test_number_feature.py
+++ b/tests/integration_tests/test_number_feature.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import pytest
+
+from ludwig.api import LudwigModel
+from tests.integration_tests.utils import generate_data, number_feature
+
+
+def test_number_feature_zscore_normalization_error():
+    input_features = [number_feature(name="num_input", preprocessing={"normalization": "zscore"})]
+    output_features = [number_feature(name="num_output")]
+
+    df = pd.read_csv(generate_data(input_features, output_features))
+    df["num_input"] = 1.0
+    df["num_input"] = df["num_input"].astype("float32")
+
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+    }
+
+    model = LudwigModel(config, backend="local")
+
+    with pytest.raises(RuntimeError):
+        model.preprocess(dataset=df)

--- a/tests/integration_tests/test_number_feature.py
+++ b/tests/integration_tests/test_number_feature.py
@@ -10,8 +10,9 @@ def test_number_feature_zscore_normalization_error():
     output_features = [number_feature(name="num_output")]
 
     df = pd.read_csv(generate_data(input_features, output_features))
-    df["num_input"] = 1.0
-    df["num_input"] = df["num_input"].astype("float32")
+
+    # Override input number feature to have a constant value
+    df["num_input"] = 1
 
     config = {
         "input_features": input_features,


### PR DESCRIPTION
This PR raises a warning when a number feature is being used that has a constant value across all rows of the dataset, along with preprocessing being set to `zscore`. This results in a std deviation of 0 and a divide by zero error. This results in the feature being processed as NaNs, the downstream metrics to be NaNs, etc. which isn't a good outcome. 

Questions:
- Is this a good enough reason to raise a RuntimeError and cause the model execution to stop?
- Would it instead make sense to:
    - Log a warning stating the reason why zscore normalization failed
    - Just return the same value back, i.e., `self.mu` which is the average of the column == the value itself?