### PR TITLE
Adds class names to calibration plot title, reformats Brier scores as grouped bar chart

### DIFF
--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -934,7 +934,7 @@ def calibration_plot(
             color=colors[i],
             marker="o",
             scatter_kws={"s": 40},
-            label=algorithm_names[i] if algorithm_names is not None and i < len(algorithm_names) else "",
+            label=algorithm_names[i] if algorithm_names is not None and i < len(algorithm_names) else f"Model {i}",
         )
 
     ticks = np.linspace(0.0, 1.0, num=11)

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -898,6 +898,7 @@ def calibration_plot(
     fraction_positives,
     mean_predicted_values,
     algorithm_names=None,
+    class_name=None,
     filename=None,
     callbacks=None,
 ):
@@ -944,7 +945,10 @@ def calibration_plot(
     plt.ylim([-0.05, 1.05])
     plt.yticks(ticks)
     plt.legend(loc="lower right")
-    plt.title("Calibration (reliability curve)")
+    if class_name is not None:
+        plt.title(f"{class_name}: Calibration (reliability curve)")
+    else:
+        plt.title("Calibration (reliability curve)")
 
     plt.tight_layout()
     visualize_callbacks(callbacks, plt.gcf())

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -959,13 +959,15 @@ def calibration_plot(
 
 
 def brier_plot(
-    brier_scores,
+    brier_scores,  # Expected to be organized as [score, score]
     algorithm_names=None,
+    class_names=None,
     title=None,
     filename=None,
     callbacks=None,
 ):
-    plt.figure()
+
+    fig, ax = plt.subplots()
     sns.set_style("whitegrid")
 
     if title is not None:
@@ -973,22 +975,29 @@ def brier_plot(
 
     colors = plt.get_cmap("tab10").colors
 
-    plt.grid(which="both")
-    plt.grid(which="minor", alpha=0.5)
-    plt.grid(which="major", alpha=0.75)
-    plt.xlabel("class")
-    plt.ylabel("brier")
+    n_algorithms = brier_scores.shape[1]
+    n_classes = brier_scores.shape[0]
+    x = np.arange(n_classes)
 
-    for i in range(brier_scores.shape[1]):
-        plt.plot(
-            brier_scores[:, i],
-            label=algorithm_names[i] + " " if algorithm_names is not None and i < len(algorithm_names) else "",
-            color=colors[i],
-            linewidth=3,
-        )
+    max_width = 0.35
+    bar_width = min(0.5 / n_algorithms, max_width)
+    bar_left = -bar_width * (n_algorithms // 2) + (bar_width / 2)
 
-    plt.legend()
-    plt.tight_layout()
+    ax.grid(which="both")
+    ax.grid(which="minor", alpha=0.5)
+    ax.grid(which="major", alpha=0.75)
+    ax.set_xlabel("class")
+    ax.set_ylabel("brier score")
+    if class_names is not None:
+        ax.set_xticks(x, class_names)
+
+    for i in range(n_algorithms):
+        # Plot bar for each class
+        label = algorithm_names[i] if algorithm_names is not None else None
+        ax.bar(x + bar_left + (bar_width * i), brier_scores[:, i], bar_width, color=colors[i], label=label)
+
+    ax.legend()
+    fig.tight_layout()
     visualize_callbacks(callbacks, plt.gcf())
     if filename:
         plt.savefig(filename)

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -981,7 +981,7 @@ def brier_plot(
 
     max_width = 0.35
     bar_width = min(0.5 / n_algorithms, max_width)
-    bar_left = -bar_width * (n_algorithms // 2) + (bar_width / 2)
+    bar_left = -bar_width * (n_algorithms // 2) + ((bar_width / 2) if (n_algorithms % 2) == 0 else 0)
 
     ax.grid(which="both")
     ax.grid(which="minor", alpha=0.5)
@@ -990,6 +990,8 @@ def brier_plot(
     ax.set_ylabel("brier score")
     if class_names is not None:
         ax.set_xticks(x, class_names)
+    else:
+        ax.set_xticks(x, [str(i) for i in range(n_classes)])
 
     for i in range(n_algorithms):
         # Plot bar for each class

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -959,7 +959,7 @@ def calibration_plot(
 
 
 def brier_plot(
-    brier_scores,  # Expected to be organized as [score, score]
+    brier_scores,
     algorithm_names=None,
     class_names=None,
     title=None,
@@ -995,7 +995,7 @@ def brier_plot(
 
     for i in range(n_algorithms):
         # Plot bar for each class
-        label = algorithm_names[i] if algorithm_names is not None else None
+        label = algorithm_names[i] if algorithm_names is not None and i < len(algorithm_names) else f"Model {i}"
         ax.bar(x + bar_left + (bar_width * i), brier_scores[:, i], bar_width, color=colors[i], label=label)
 
     ax.legend()

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -3254,6 +3254,7 @@ def calibration_1_vs_all(
     brier_scores = []
 
     classes = min(num_classes, top_n_classes[0]) if top_n_classes[0] > 0 else num_classes
+    class_names = [feature_metadata["idx2str"][i] for i in range(classes)]
 
     for class_idx in range(classes):
         fraction_positives_class = []
@@ -3293,12 +3294,11 @@ def calibration_1_vs_all(
             os.makedirs(output_directory, exist_ok=True)
             filename = filename_template_path.format(class_idx)
 
-        class_name = feature_metadata["idx2str"][class_idx]
         visualization_utils.calibration_plot(
             fraction_positives_class,
             mean_predicted_vals_class,
             model_names_list,
-            class_name=class_name,
+            class_name=class_names[class_idx],
             filename=filename,
         )
 
@@ -3314,7 +3314,13 @@ def calibration_1_vs_all(
         os.makedirs(output_directory, exist_ok=True)
         filename = filename_template_path.format("brier")
 
-    visualization_utils.brier_plot(np.array(brier_scores), model_names_list, filename=filename)
+    visualization_utils.brier_plot(
+        np.array(brier_scores),
+        algorithm_names=model_names_list,
+        class_names=class_names,
+        title="Brier scores for each class",
+        filename=filename,
+    )
 
 
 def calibration_multiclass(

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -3232,9 +3232,9 @@ def calibration_1_vs_all(
 
     :return: (None)
     """
+    feature_metadata = metadata[output_feature_name]
     if not isinstance(ground_truth, np.ndarray):
         # not np array, assume we need to translate raw value to encoded value
-        feature_metadata = metadata[output_feature_name]
         ground_truth = _vectorize_ground_truth(ground_truth, feature_metadata["str2idx"], ground_truth_apply_idx)
 
     probs = probabilities_per_model
@@ -3261,7 +3261,7 @@ def calibration_1_vs_all(
         probs_class = []
         brier_scores_class = []
         for prob in probs:
-            # ground_truth is an vector of integers, each integer is a class
+            # ground_truth is a vector of integers, each integer is a class
             # index to have a [0,1] vector we have to check if the value equals
             # the input class index and convert the resulting boolean vector
             # into an integer vector probabilities is a n x c matrix, n is the
@@ -3293,8 +3293,13 @@ def calibration_1_vs_all(
             os.makedirs(output_directory, exist_ok=True)
             filename = filename_template_path.format(class_idx)
 
+        class_name = feature_metadata["idx2str"][class_idx]
         visualization_utils.calibration_plot(
-            fraction_positives_class, mean_predicted_vals_class, model_names_list, filename=filename
+            fraction_positives_class,
+            mean_predicted_vals_class,
+            model_names_list,
+            class_name=class_name,
+            filename=filename,
         )
 
         filename = None


### PR DESCRIPTION
This is the result of running `train_mushroom_edibility_calibrated.py`, which generates two models "Uncalibrated" and "Calibrated" for the dataset with two classes "e" and "p" (edible and poisonous)

Before:
![calibration_1_vs_all_0](https://user-images.githubusercontent.com/687280/191865195-19cd6b7c-69ea-4965-9d0a-59bbc88052bf.png)
![calibration_1_vs_all_1](https://user-images.githubusercontent.com/687280/191865197-0a62e1e2-7b02-4d3a-a0c7-349f99a76e5a.png)
![calibration_1_vs_all_brier](https://user-images.githubusercontent.com/687280/191865198-37bfc988-7dfe-4a51-9e34-fcd7717da28b.png)

---

After:

![calibration_1_vs_all_0](https://user-images.githubusercontent.com/687280/191865227-53bae057-38ed-4d91-8b14-89af6e18e6a5.png)
![calibration_1_vs_all_1](https://user-images.githubusercontent.com/687280/191865232-122a2226-6964-4fe0-b072-92738ac5aaef.png)
![calibration_1_vs_all_brier](https://user-images.githubusercontent.com/687280/191865234-bf9c03ea-16b8-4296-a5e4-20e5c8e0de51.png)
