### PR TITLE
Remove global torchtext version-specific tokenizer availability warnings.

### DIFF
--- a/ludwig/features/feature_utils.py
+++ b/ludwig/features/feature_utils.py
@@ -21,7 +21,7 @@ import torch
 
 from ludwig.constants import NAME, PREPROCESSING, SEQUENCE, TEXT, TIMESERIES
 from ludwig.utils.data_utils import hash_dict
-from ludwig.utils.strings_utils import tokenizer_registry, UNKNOWN_SYMBOL
+from ludwig.utils.strings_utils import get_tokenizer_from_registry, UNKNOWN_SYMBOL
 
 SEQUENCE_TYPES = {SEQUENCE, TEXT, TIMESERIES}
 FEATURE_NAME_SUFFIX = "__ludwig"
@@ -39,7 +39,7 @@ def should_regularize(regularize_layers):
 
 def set_str_to_idx(set_string, feature_dict, tokenizer_name):
     try:
-        tokenizer = tokenizer_registry[tokenizer_name]()
+        tokenizer = get_tokenizer_from_registry(tokenizer_name)()
     except ValueError:
         raise Exception(f"Tokenizer {tokenizer_name} not supported")
 

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -51,16 +51,16 @@ from ludwig.schema.features.sequence_feature import SequenceInputFeatureConfig, 
 from ludwig.schema.features.utils import register_input_feature, register_output_feature
 from ludwig.utils import output_feature_utils
 from ludwig.utils.math_utils import softmax
-from ludwig.utils.misc_utils import get_from_registry, set_default_value, set_default_values
+from ludwig.utils.misc_utils import set_default_value, set_default_values
 from ludwig.utils.strings_utils import (
     build_sequence_matrix,
     create_vocabulary,
     SpecialSymbol,
     START_SYMBOL,
     STOP_SYMBOL,
-    tokenizer_registry,
     UNKNOWN_SYMBOL,
 )
+from ludwig.utils.tokenizers import get_tokenizer_from_registry
 from ludwig.utils.types import DataFrame, TorchscriptPreprocessingInput
 
 logger = logging.getLogger(__name__)
@@ -73,7 +73,7 @@ class _SequencePreprocessing(torch.nn.Module):
         super().__init__()
         self.lowercase = metadata["preprocessing"]["lowercase"]
         self.tokenizer_type = metadata["preprocessing"]["tokenizer"]
-        self.tokenizer = get_from_registry(self.tokenizer_type, tokenizer_registry)(
+        self.tokenizer = get_tokenizer_from_registry(self.tokenizer_type)(
             pretrained_model_name_or_path=metadata["preprocessing"].get("pretrained_model_name_or_path", None)
         )
 

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -46,7 +46,7 @@ from ludwig.schema.features.utils import register_input_feature, register_output
 from ludwig.utils import output_feature_utils
 from ludwig.utils.misc_utils import set_default_value, set_default_values
 from ludwig.utils.strings_utils import create_vocabulary, UNKNOWN_SYMBOL
-from ludwig.utils.tokenizers import TORCHSCRIPT_COMPATIBLE_TOKENIZERS, get_tokenizer_from_registry
+from ludwig.utils.tokenizers import get_tokenizer_from_registry, TORCHSCRIPT_COMPATIBLE_TOKENIZERS
 from ludwig.utils.types import TorchscriptPreprocessingInput
 
 logger = logging.getLogger(__name__)

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -44,9 +44,9 @@ from ludwig.features.feature_utils import set_str_to_idx
 from ludwig.schema.features.set_feature import SetInputFeatureConfig, SetOutputFeatureConfig
 from ludwig.schema.features.utils import register_input_feature, register_output_feature
 from ludwig.utils import output_feature_utils
-from ludwig.utils.misc_utils import get_from_registry, set_default_value, set_default_values
-from ludwig.utils.strings_utils import create_vocabulary, tokenizer_registry, UNKNOWN_SYMBOL
-from ludwig.utils.tokenizers import TORCHSCRIPT_COMPATIBLE_TOKENIZERS
+from ludwig.utils.misc_utils import set_default_value, set_default_values
+from ludwig.utils.strings_utils import create_vocabulary, UNKNOWN_SYMBOL
+from ludwig.utils.tokenizers import TORCHSCRIPT_COMPATIBLE_TOKENIZERS, get_tokenizer_from_registry
 from ludwig.utils.types import TorchscriptPreprocessingInput
 
 logger = logging.getLogger(__name__)
@@ -68,7 +68,7 @@ class _SetPreprocessing(torch.nn.Module):
             )
 
         self.lowercase = metadata["preprocessing"]["lowercase"]
-        self.tokenizer = get_from_registry(metadata["preprocessing"]["tokenizer"], tokenizer_registry)()
+        self.tokenizer = get_tokenizer_from_registry(metadata["preprocessing"]["tokenizer"])()
         self.vocab_size = metadata["vocab_size"]
         self.unknown_symbol = UNKNOWN_SYMBOL
         self.unit_to_id = metadata["str2idx"]

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -25,7 +25,7 @@ from ludwig.features.sequence_feature import SequenceInputFeature
 from ludwig.schema.features.timeseries_feature import TimeseriesInputFeatureConfig
 from ludwig.schema.features.utils import register_input_feature
 from ludwig.utils.misc_utils import set_default_value, set_default_values
-from ludwig.utils.tokenizers import TORCHSCRIPT_COMPATIBLE_TOKENIZERS, get_tokenizer_from_registry
+from ludwig.utils.tokenizers import get_tokenizer_from_registry, TORCHSCRIPT_COMPATIBLE_TOKENIZERS
 from ludwig.utils.types import TorchscriptPreprocessingInput
 
 logger = logging.getLogger(__name__)

--- a/ludwig/schema/features/preprocessing/timeseries.py
+++ b/ludwig/schema/features/preprocessing/timeseries.py
@@ -13,7 +13,7 @@ from ludwig.utils.tokenizers import tokenizer_registry
 class TimeseriesPreprocessingConfig(BasePreprocessingConfig):
 
     tokenizer: str = schema_utils.StringOptions(
-        sorted(list(tokenizer_registry.keys())),
+        tokenizer_registry.keys(),
         default="space",
         allow_none=False,
         description="Defines how to map from the raw string content of the dataset column to a sequence of elements.",

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -26,8 +26,7 @@ from ludwig.data.dataframe.base import DataFrameEngine
 from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.utils.fs_utils import open_file
 from ludwig.utils.math_utils import int_type
-from ludwig.utils.misc_utils import get_from_registry
-from ludwig.utils.tokenizers import tokenizer_registry
+from ludwig.utils.tokenizers import get_tokenizer_from_registry
 from ludwig.utils.types import Series
 
 PANDAS_TRUE_STRS = {"true"}
@@ -254,7 +253,7 @@ def create_vocabulary(
     """
     vocab = None
 
-    tokenizer = get_from_registry(tokenizer_type, tokenizer_registry)(
+    tokenizer = get_tokenizer_from_registry(tokenizer_type)(
         vocab_file=vocab_file,
         pretrained_model_name_or_path=pretrained_model_name_or_path,
     )
@@ -396,7 +395,7 @@ def build_sequence_matrix(
     pretrained_model_name_or_path=None,
     processor=PANDAS,
 ) -> np.ndarray:
-    tokenizer = get_from_registry(tokenizer_type, tokenizer_registry)(
+    tokenizer = get_tokenizer_from_registry(tokenizer_type)(
         vocab_file=tokenizer_vocab_file,
         pretrained_model_name_or_path=pretrained_model_name_or_path,
     )

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -1165,28 +1165,31 @@ tokenizer_registry.update(
 
 
 def get_tokenizer_from_registry(tokenizer_name: str) -> torch.nn.Module:
-    """Returns the appropriate tokenizer from the tokenizer registry."""
+    """Returns the appropriate tokenizer from the tokenizer registry.
+
+    Raises a KeyError if a tokenizer that does not exist in the registry is requested, with additional help text in case
+    the tokenizer would be available for a different version of torchtext.
+    """
+    if tokenizer_name in tokenizer_registry:
+        return tokenizer_registry[tokenizer_name]
+
     if (
         torch.torch_version.TorchVersion(torchtext.__version__) < (0, 12, 0)
         and tokenizer_name in TORCHTEXT_0_12_0_TOKENIZERS
     ):
-        raise ValueError(
-            f"torchtext>=0.12.0 is not installed, so the following tokenizers are not available: "
-            f"{TORCHTEXT_0_12_0_TOKENIZERS}"
+        raise KeyError(
+            f"torchtext>=0.12.0 is not installed, so '{tokenizer_name}' and the following tokenizers are not "
+            f"available: {TORCHTEXT_0_12_0_TOKENIZERS}"
         )
 
     if (
         torch.torch_version.TorchVersion(torchtext.__version__) < (0, 13, 0)
         and tokenizer_name in TORCHTEXT_0_13_0_TOKENIZERS
     ):
-        raise ValueError(
-            f"torchtext>=0.13.0 is not installed, so the following tokenizers are not available: "
-            f"{TORCHTEXT_0_13_0_TOKENIZERS}"
+        raise KeyError(
+            f"torchtext>=0.13.0 is not installed, so '{tokenizer_name}' and the following tokenizers are not "
+            f"available: {TORCHTEXT_0_13_0_TOKENIZERS}"
         )
 
-    if tokenizer_name not in tokenizer_registry:
-        raise ValueError(
-            f"Invalid tokenizer name: '{tokenizer_name}'. Available tokenizers: {tokenizer_registry.keys()}"
-        )
-
-    return tokenizer_registry[tokenizer_name]
+    # Tokenizer does not exist or is unavailable.
+    raise KeyError(f"Invalid tokenizer name: '{tokenizer_name}'. Available tokenizers: {tokenizer_registry.keys()}")

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -1167,8 +1167,8 @@ tokenizer_registry.update(
 def get_tokenizer_from_registry(tokenizer_name: str) -> torch.nn.Module:
     """Returns the appropriate tokenizer from the tokenizer registry.
 
-    Raises a KeyError if a tokenizer that does not exist in the registry is requested, with additional help text if
-    the requested tokenizer would be available for a different version of torchtext.
+    Raises a KeyError if a tokenizer that does not exist in the registry is requested, with additional help text if the
+    requested tokenizer would be available for a different version of torchtext.
     """
     if tokenizer_name in tokenizer_registry:
         return tokenizer_registry[tokenizer_name]

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -1017,10 +1017,7 @@ try:
         raise ImportError
 
 except ImportError:
-    logger.warning(
-        f"torchtext>=0.12.0 is not installed, so the following tokenizers are not available: "
-        f"{TORCHTEXT_0_12_0_TOKENIZERS}"
-    )
+    pass
 
 
 try:
@@ -1126,10 +1123,7 @@ try:
     TORCHSCRIPT_COMPATIBLE_TOKENIZERS.update(TORCHTEXT_0_13_0_TOKENIZERS)
 
 except ImportError:
-    logger.warning(
-        f"torchtext>=0.13.0 is not installed, so the following tokenizers are not available: "
-        f"{TORCHTEXT_0_13_0_TOKENIZERS}"
-    )
+    pass
 
 
 def get_hf_tokenizer(pretrained_model_name_or_path, **kwargs):
@@ -1168,3 +1162,31 @@ tokenizer_registry.update(
         "hf_tokenizer": get_hf_tokenizer,
     }
 )
+
+
+def get_tokenizer_from_registry(tokenizer_name: str) -> torch.nn.Module:
+    """Returns the appropriate tokenizer from the tokenizer registry."""
+    if (
+        torch.torch_version.TorchVersion(torchtext.__version__) < (0, 12, 0)
+        and tokenizer_name in TORCHTEXT_0_12_0_TOKENIZERS
+    ):
+        raise ValueError(
+            f"torchtext>=0.12.0 is not installed, so the following tokenizers are not available: "
+            f"{TORCHTEXT_0_12_0_TOKENIZERS}"
+        )
+
+    if (
+        torch.torch_version.TorchVersion(torchtext.__version__) < (0, 13, 0)
+        and tokenizer_name in TORCHTEXT_0_13_0_TOKENIZERS
+    ):
+        raise ValueError(
+            f"torchtext>=0.13.0 is not installed, so the following tokenizers are not available: "
+            f"{TORCHTEXT_0_13_0_TOKENIZERS}"
+        )
+
+    if tokenizer_name not in tokenizer_registry:
+        raise ValueError(
+            f"Invalid tokenizer name: '{tokenizer_name}'. Available tokenizers: {tokenizer_registry.keys()}"
+        )
+
+    return tokenizer_registry[tokenizer_name]

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -1167,8 +1167,8 @@ tokenizer_registry.update(
 def get_tokenizer_from_registry(tokenizer_name: str) -> torch.nn.Module:
     """Returns the appropriate tokenizer from the tokenizer registry.
 
-    Raises a KeyError if a tokenizer that does not exist in the registry is requested, with additional help text in case
-    the tokenizer would be available for a different version of torchtext.
+    Raises a KeyError if a tokenizer that does not exist in the registry is requested, with additional help text if
+    the requested tokenizer would be available for a different version of torchtext.
     """
     if tokenizer_name in tokenizer_registry:
         return tokenizer_registry[tokenizer_name]


### PR DESCRIPTION
Currently, a tokenizer availability warning is always logged unless `torchtext>=0.13.0` is installed, regardless of what kind of model you have.

Instead, we remove the pan-warning in favor of raising a `KeyError` during tokenizer registry access, with additional help text if the requested tokenizer would be available for a different version of torchtext.

Valid tokenizers are also enforced by the schema.