### PR TITLE
Pin ray nightly version to avoid new test failures

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -106,7 +106,10 @@ jobs:
           if [ "$MARKERS" == "distributed" ]; then
             if [ "$RAY_VERSION" == "nightly" ]; then
               # NOTE: hardcoded for python 3.9 on Linux
-              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+              # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+
+              # Pin version to September 20, 2022 to get tests to pass
+              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/a182d3c9e478ef4c169ccf7459764768996110f/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
             else
               pip install ray==$RAY_VERSION
             fi

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -108,7 +108,7 @@ jobs:
               # NOTE: hardcoded for python 3.9 on Linux
               # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
 
-              # Pin version to September 20, 2022 to get tests to pass
+              # NOTE: Pinned Ray nightly version to September 20, 2022 to get tests to pass
               pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/a182d3c9e478ef4c169ccf7459764768996110f/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
             else
               pip install ray==$RAY_VERSION

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -109,7 +109,7 @@ jobs:
               # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
 
               # NOTE: Pinned Ray nightly version to September 20, 2022 to get tests to pass
-              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/a182d3c9e478ef4c169ccf7459764768996110f/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/fa182d3c9e478ef4c169ccf7459764768996110f/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
             else
               pip install ray==$RAY_VERSION
             fi


### PR DESCRIPTION
We started seeing a lot of test failures related to TensorDType in Ray nightly on September 22nd. It seems like this is related to changes made on September 21st. This pins Ray nightly to the last commit made on September 20th so that we don't see these failures.

It appears that there's been stronger conditions added for type inference, specifically related to ragged tensors.