### PR TITLE
int: bump Dask version

### DIFF
--- a/ludwig/data/dataframe/dask.py
+++ b/ludwig/data/dataframe/dask.py
@@ -23,7 +23,7 @@ import dask.dataframe as dd
 from dask.diagnostics import ProgressBar
 
 from ludwig.data.dataframe.base import DataFrameEngine
-from ludwig.utils.data_utils import split_by_slices
+from ludwig.utils.data_utils import split_by_slices, get_pa_schema
 from ludwig.utils.dataframe_utils import set_index_name
 
 TMP_COLUMN = "__TMP_COLUMN__"
@@ -186,12 +186,13 @@ class DaskEngine(DataFrameEngine):
         return df
 
     def to_parquet(self, df, path, index=False):
+        schema = get_pa_schema(df)
         with ProgressBar():
             df.to_parquet(
                 path,
                 engine="pyarrow",
                 write_index=index,
-                schema="infer",
+                schema=schema,
             )
 
     def to_ray_dataset(self, df):

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -76,7 +76,7 @@ class DateFeatureMixin(BaseFeatureMixin):
                 datetime_obj = parse(date_str)
         except Exception as e:
             logger.error(
-                f"Error parsing date: {date_str} with error {e} "
+                f"Error parsing date: '{date_str}' with error '{e}' "
                 "Please provide a datetime format that parses it "
                 "in the preprocessing section of the date feature "
                 "in the config. "

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -22,7 +22,7 @@ from ludwig.globals import (
 )
 from ludwig.models.base import BaseModel
 from ludwig.progress_bar import LudwigProgressBar
-from ludwig.utils.data_utils import save_csv, save_json
+from ludwig.utils.data_utils import save_csv, save_json, get_pa_schema
 from ludwig.utils.dataframe_utils import flatten_df, from_numpy_dataset
 from ludwig.utils.horovod_utils import return_first
 from ludwig.utils.print_utils import repr_ordered_dict
@@ -317,7 +317,8 @@ def save_prediction_outputs(
     backend,
 ):
     postprocessed_output, column_shapes = flatten_df(postprocessed_output, backend)
-    postprocessed_output.to_parquet(os.path.join(output_directory, PREDICTIONS_PARQUET_FILE_NAME), schema=None)
+    schema = get_pa_schema(postprocessed_output)
+    postprocessed_output.to_parquet(os.path.join(output_directory, PREDICTIONS_PARQUET_FILE_NAME), schema=schema)
     save_json(os.path.join(output_directory, PREDICTIONS_SHAPES_FILE_NAME), column_shapes)
     if not backend.df_engine.partitioned:
         # csv can only be written out for unpartitioned df format (i.e., pandas)

--- a/requirements_distributed.txt
+++ b/requirements_distributed.txt
@@ -1,5 +1,5 @@
 # requirements for dask
-dask[dataframe]>2021.3.1,<2022.1.1
+dask[dataframe,distributed]==2022.8.0
 pyarrow==6.0.1 # https://github.com/ray-project/ray/issues/22310
 
 # requirements for horovod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def hyperopt_results():
 
 @pytest.fixture(scope="module")
 def ray_cluster_2cpu(request):
-    with _ray_start(request, num_cpus=2):
+    with _ray_start(request, num_cpus=None, num_gpus=None, object_store_memory=None, _system_config=None):
         yield
 
 

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -771,6 +771,7 @@ def train_with_backend(
     evaluate=True,
     callbacks=None,
     skip_save_processed_input=True,
+    skip_save_predictions=True,
 ):
     model = LudwigModel(config, backend=backend, callbacks=callbacks)
     output_dir = None
@@ -791,7 +792,7 @@ def train_with_backend(
             dataset = training_set
 
         if predict:
-            preds, _ = model.predict(dataset=dataset)
+            preds, _ = model.predict(dataset=dataset, skip_save_predictions=skip_save_predictions)
             assert preds is not None
 
         if evaluate:


### PR DESCRIPTION
This PR updates the version of Dask and implements PyArrow schema inference so that both cached inputs and predictions can be saved to parquet files. This code path was relatively under-tested, particularly for Dask with Ray, and so this PR also implements a unit test.

Some things worth calling out:
1. The unit test shows that we only have partial coverage for caching inputs and outputs. Notably, the H3 input feature and the sequence and text output features are incompatible with this code path.
2. NaN handling for date input features make them incompatible with the ray test, which does an equality check between the local and ray backends to verify correctness. Because date input features fill using the present time, they cannot be equal.
3. There is no NaN handling for vector input features.