### PR TITLE
Added tests for init_config and render_config CLI commands

### DIFF
--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -20,13 +20,13 @@ import numpy as np
 import pandas as pd
 from dataclasses_json import dataclass_json, LetterCase
 
+from ludwig.backend import Backend
 from ludwig.constants import COMBINER, EXECUTOR, HYPEROPT, SCHEDULER, SEARCH_ALG, TEXT, TYPE
 from ludwig.utils.automl.data_source import DataSource, wrap_data_source
 from ludwig.utils.automl.field_info import FieldConfig, FieldInfo, FieldMetadata
-from ludwig.utils.automl.ray_utils import get_available_resources
 from ludwig.utils.automl.type_inference import infer_type, should_exclude
 from ludwig.utils.data_utils import load_yaml
-from ludwig.utils.defaults import default_random_seed
+from ludwig.utils.system_utils import Resources
 
 PATH_HERE = os.path.abspath(os.path.dirname(__file__))
 CONFIG_DIR = os.path.join(PATH_HERE, "defaults")
@@ -54,7 +54,7 @@ class DatasetInfo:
     size_bytes: int = -1
 
 
-def allocate_experiment_resources(resources: dict) -> dict:
+def allocate_experiment_resources(resources: Resources) -> dict:
     """Allocates ray trial resources based on available resources.
 
     # Inputs
@@ -69,7 +69,7 @@ def allocate_experiment_resources(resources: dict) -> dict:
     # (2) add support for kubernetes namespace (if applicable)
     # (3) add support for smarter allocation based on size of GPU memory
     experiment_resources = {"cpu_resources_per_trial": 1}
-    gpu_count, cpu_count = resources["gpu"], resources["cpu"]
+    gpu_count, cpu_count = resources.gpus, resources.cpus
     if gpu_count > 0:
         experiment_resources.update({"gpu_resources_per_trial": 1})
         if cpu_count > 1:
@@ -81,9 +81,10 @@ def allocate_experiment_resources(resources: dict) -> dict:
 
 def _create_default_config(
     dataset_info: DatasetInfo,
-    target_name: Union[str, List[str]] = None,
-    time_limit_s: Union[int, float] = None,
-    random_seed: int = default_random_seed,
+    target_name: Union[str, List[str]],
+    time_limit_s: Union[int, float],
+    random_seed: int,
+    backend: Backend = None,
 ) -> dict:
     """Returns auto_train configs for three available combiner models. Coordinates the following tasks:
 
@@ -108,7 +109,7 @@ def _create_default_config(
     :return: (dict) dictionaries contain auto train config files for all available
     combiner types
     """
-    resources = get_available_resources()
+    resources = backend.get_available_resources()
     experiment_resources = allocate_experiment_resources(resources)
 
     input_and_output_feature_config, features_metadata = get_features_config(
@@ -310,7 +311,7 @@ def get_field_metadata(
     input_count = sum(not meta.excluded and meta.mode == "input" and meta.config.type != TEXT for meta in metadata) - 1
 
     # Exclude text fields if no GPUs are available
-    if resources["gpu"] == 0:
+    if resources.gpus == 0:
         for meta in metadata:
             if input_count > 2 and meta.config.type == TEXT:
                 # By default, exclude text inputs when there are other candidate inputs

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -21,6 +21,8 @@ from typing import Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
+import psutil
+import torch
 
 from ludwig.data.cache.manager import CacheManager
 from ludwig.data.dataframe.pandas import PANDAS
@@ -30,6 +32,7 @@ from ludwig.models.base import BaseModel
 from ludwig.schema.trainer import ECDTrainerConfig, GBMTrainerConfig
 from ludwig.utils.fs_utils import get_bytes_obj_from_path
 from ludwig.utils.misc_utils import get_from_registry
+from ludwig.utils.system_utils import Resources
 from ludwig.utils.torch_utils import initialize_pytorch
 from ludwig.utils.types import Series
 
@@ -98,6 +101,10 @@ class Backend(ABC):
     @property
     @abstractmethod
     def num_nodes(self) -> int:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_available_resources(self) -> Resources:
         raise NotImplementedError()
 
 
@@ -187,3 +194,6 @@ class LocalBackend(LocalPreprocessingMixin, LocalTrainingMixin, Backend):
     @property
     def num_nodes(self) -> int:
         return 1
+
+    def get_available_resources(self) -> Resources:
+        return Resources(cpus=psutil.cpu_count(), gpus=torch.cuda.device_count())

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -53,6 +53,7 @@ from ludwig.utils.dataframe_utils import set_index_name
 from ludwig.utils.fs_utils import get_fs_and_path
 from ludwig.utils.horovod_utils import initialize_horovod
 from ludwig.utils.misc_utils import get_from_registry
+from ludwig.utils.system_utils import Resources
 from ludwig.utils.torch_utils import get_torch_device, initialize_pytorch
 from ludwig.utils.types import Series
 
@@ -982,6 +983,10 @@ class RayBackend(RemoteTrainingMixin, Backend):
         if not ray.is_initialized():
             return 1
         return len(ray.nodes())
+
+    def get_available_resources(self) -> Resources:
+        resources = ray.cluster_resources()
+        return Resources(cpus=resources.get("CPU", 0), gpus=resources.get("GPU", 0))
 
 
 def initialize_ray():

--- a/ludwig/utils/system_utils.py
+++ b/ludwig/utils/system_utils.py
@@ -1,0 +1,23 @@
+#! /usr/bin/env python
+# Copyright (c) 2022 Predibase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Resources:
+    cpus: int
+    gpus: int

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -25,7 +25,7 @@ import pytest
 import yaml
 
 from ludwig.constants import INPUT_FEATURES, NAME, OUTPUT_FEATURES, TRAINER
-from ludwig.utils.data_utils import load_json
+from ludwig.utils.data_utils import load_yaml
 from tests.integration_tests.utils import category_feature, generate_data, number_feature, sequence_feature
 
 
@@ -396,7 +396,7 @@ def test_init_config(tmpdir):
 
     _run_ludwig("init_config", dataset=dataset_csv, target=output_features[0][NAME], output=output_config_path)
 
-    config = load_json(output_config_path)
+    config = load_yaml(output_config_path)
 
     def to_name_set(features: List[Dict[str, Any]]) -> Set[str]:
         return {feature[NAME] for feature in features}

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -382,6 +382,7 @@ def test_reproducible_cli_runs(
             assert test1 != test2
 
 
+@pytest.mark.distributed
 def test_init_config(tmpdir):
     """Test initializing a config from a dataset and a target."""
     input_features = [

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -346,6 +346,9 @@ def test_ray_audio(tmpdir, dataset_type, ray_cluster_2cpu):
 @pytest.mark.parametrize("dataset_type", ["csv", "parquet", "pandas+numpy_images"])
 @pytest.mark.distributed
 def test_ray_image(tmpdir, dataset_type, ray_cluster_2cpu):
+    if dataset_type == "pandas+numpy_images":
+        pytest.skip("https://github.com/ludwig-ai/ludwig/issues/2452")
+
     image_dest_folder = os.path.join(tmpdir, "generated_images")
     input_features = [
         image_feature(


### PR DESCRIPTION
Adds tests to check `init_config` and `render_config` CLI commands are working correctly.

See #2448.

Also fixes `init_config` to work without a running Ray cluster.