### PR TITLE
Ensure bfill/ffill leave no residual NaNs in the dataset during preprocessing

### DIFF
--- a/ludwig/utils/dataframe_utils.py
+++ b/ludwig/utils/dataframe_utils.py
@@ -17,16 +17,6 @@ def is_dask_backend(backend: Optional["Backend"]) -> bool:  # noqa: F821
     return backend is not None and is_dask_lib(backend.df_engine.df_lib)
 
 
-def is_dask_series(series) -> bool:
-    """Returns whether the series is a dask series."""
-    try:
-        import dask.dataframe as dd
-
-        return isinstance(series, dd.Series)
-    except ImportError:
-        return False
-
-
 def is_dask_series_or_df(df: DataFrame, backend: Optional["Backend"]) -> bool:  # noqa: F821
     if is_dask_backend(backend):
         import dask.dataframe as dd

--- a/ludwig/utils/dataframe_utils.py
+++ b/ludwig/utils/dataframe_utils.py
@@ -17,6 +17,16 @@ def is_dask_backend(backend: Optional["Backend"]) -> bool:  # noqa: F821
     return backend is not None and is_dask_lib(backend.df_engine.df_lib)
 
 
+def is_dask_series(series) -> bool:
+    """Returns whether the series is a dask series."""
+    try:
+        import dask.dataframe as dd
+
+        return isinstance(series, dd.Series)
+    except ImportError:
+        return False
+
+
 def is_dask_series_or_df(df: DataFrame, backend: Optional["Backend"]) -> bool:  # noqa: F821
     if is_dask_backend(backend):
         import dask.dataframe as dd

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -183,6 +183,8 @@ def run_test_with_features(
         csv_filename = os.path.join(tmpdir, "dataset.csv")
         dataset_csv = generate_data(input_features, output_features, csv_filename, num_examples=num_examples)
         dataset = create_data_set_to_use(dataset_type, dataset_csv, nan_percent=nan_percent)
+        # cols = dataset.columns
+        # dataset.iloc[-1, dataset.columns.get_loc(cols[0])] = np.nan
 
         if expect_error:
             with pytest.raises(ValueError):
@@ -363,6 +365,11 @@ def test_ray_image(tmpdir, dataset_type, ray_cluster_2cpu):
         skip_save_processed_input=False,
         nan_percent=0.1,
     )
+
+
+# @pytest.mark.distributed
+# def test_ray_image_with_bfill_last_row_nan(tmpdir, dataset_type, ray_cluster_2cpu):
+#     pass
 
 
 # TODO(geoffrey): Fold modin tests into test_ray_image as @pytest.mark.parametrized once tests are optimized

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -183,6 +183,8 @@ def run_test_with_features(
         csv_filename = os.path.join(tmpdir, "dataset.csv")
         dataset_csv = generate_data(input_features, output_features, csv_filename, num_examples=num_examples)
         dataset = create_data_set_to_use(dataset_type, dataset_csv, nan_percent=nan_percent)
+        # cols = dataset.columns
+        # dataset.iloc[-1, dataset.columns.get_loc(cols[0])] = np.nan
 
         if expect_error:
             with pytest.raises(ValueError):
@@ -346,8 +348,8 @@ def test_ray_audio(tmpdir, dataset_type, ray_cluster_2cpu):
 @pytest.mark.parametrize("dataset_type", ["csv", "parquet", "pandas+numpy_images"])
 @pytest.mark.distributed
 def test_ray_image(tmpdir, dataset_type, ray_cluster_2cpu):
-    if dataset_type == "pandas+numpy_images":
-        pytest.skip("https://github.com/ludwig-ai/ludwig/issues/2452")
+    # if dataset_type == "pandas+numpy_images":
+    #     pytest.skip("https://github.com/ludwig-ai/ludwig/issues/2452")
 
     image_dest_folder = os.path.join(tmpdir, "generated_images")
     input_features = [

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -183,8 +183,6 @@ def run_test_with_features(
         csv_filename = os.path.join(tmpdir, "dataset.csv")
         dataset_csv = generate_data(input_features, output_features, csv_filename, num_examples=num_examples)
         dataset = create_data_set_to_use(dataset_type, dataset_csv, nan_percent=nan_percent)
-        # cols = dataset.columns
-        # dataset.iloc[-1, dataset.columns.get_loc(cols[0])] = np.nan
 
         if expect_error:
             with pytest.raises(ValueError):
@@ -348,9 +346,6 @@ def test_ray_audio(tmpdir, dataset_type, ray_cluster_2cpu):
 @pytest.mark.parametrize("dataset_type", ["csv", "parquet", "pandas+numpy_images"])
 @pytest.mark.distributed
 def test_ray_image(tmpdir, dataset_type, ray_cluster_2cpu):
-    # if dataset_type == "pandas+numpy_images":
-    #     pytest.skip("https://github.com/ludwig-ai/ludwig/issues/2452")
-
     image_dest_folder = os.path.join(tmpdir, "generated_images")
     input_features = [
         image_feature(

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -760,6 +760,18 @@ def create_data_set_to_use(data_format, raw_data, nan_percent=0.0):
     return dataset_to_use
 
 
+def augment_dataset_with_none(
+    df: pd.DataFrame, first_row_none: bool = False, last_row_none: bool = False, nan_cols: List = []
+) -> pd.DataFrame:
+    if first_row_none:
+        for col in nan_cols:
+            df.iloc[0, df.columns.get_loc(col)] = np.nan
+    if last_row_none:
+        for col in nan_cols:
+            df.iloc[-1, df.columns.get_loc(col)] = np.nan
+    return df
+
+
 def train_with_backend(
     backend,
     config,

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -763,6 +763,16 @@ def create_data_set_to_use(data_format, raw_data, nan_percent=0.0):
 def augment_dataset_with_none(
     df: pd.DataFrame, first_row_none: bool = False, last_row_none: bool = False, nan_cols: List = []
 ) -> pd.DataFrame:
+    """
+    :param df: dataframe containg input features/output features
+    :type df: pd.DataFrame
+    :param first_row_none: indicates whether to set the first rowin the dataframe to np.nan
+    :type first_row_none: bool
+    :param last_row_none: indicates whether to set the last row in the dataframe to np.nan
+    :type last_row_none: bool
+    :param nan_cols: a list of columns in the dataframe to explicitly set the first or last rows to np.nan
+    :type nan_cols: list
+    """
     if first_row_none:
         for col in nan_cols:
             df.iloc[0, df.columns.get_loc(col)] = np.nan

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -763,7 +763,8 @@ def create_data_set_to_use(data_format, raw_data, nan_percent=0.0):
 def augment_dataset_with_none(
     df: pd.DataFrame, first_row_none: bool = False, last_row_none: bool = False, nan_cols: List = []
 ) -> pd.DataFrame:
-    """
+    """Optionally sets the first and last rows of nan_cols of the given dataframe to nan.
+
     :param df: dataframe containg input features/output features
     :type df: pd.DataFrame
     :param first_row_none: indicates whether to set the first rowin the dataframe to np.nan


### PR DESCRIPTION
If the dataset has the first few rows or last few rows as NaNs (especially the first row in the case of ffill, or last row in case of bfill), it can result in a dataset where there are NaNs even after we try to handle the missing value strategy. This causes ragged tensors downstream (particularly in the case of image or audio features) where the missing value strategy is `bfill` by default.

This fix adds a conditional check to see if there are still rows with NaNs, and then applies a secondary missing value strategy to fix it. For e.g., if `bfill` doesn't get rid of all of the NaNs, we're going also apply `ffill` since this will guarantee all rows are non-None. The same is true if the primary missing_value_strategy is `ffill` and there are NaNs left over, which will then create a secondary call to `bfill`. 

This is a good measure to ensure that we don't have NaNs anymore, and also prevents issues like https://github.com/ludwig-ai/ludwig/issues/2452 from showing up in the future because of this.