### PR TITLE
Only create hyperopt pair plots when there is more than 1 parameter

### DIFF
--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -1402,7 +1402,7 @@ def hyperopt_pair_plot(hyperopt_results_df, metric, title, filename):
     params.remove(metric)
     num_param = len(params)
 
-    # Can't create a pair plot with only 1 parameter
+    # Pair plot is empty if there's only 1 parameter, so skip creating a pair plot
     if num_param == 1:
         return
 

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -1402,6 +1402,10 @@ def hyperopt_pair_plot(hyperopt_results_df, metric, title, filename):
     params.remove(metric)
     num_param = len(params)
 
+    # Can't create a pair plot with only 1 parameter
+    if num_param == 1:
+        return
+
     sns.set_style("white")
     fig = plt.figure(figsize=(20, 20))
     fig.suptitle(title)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,11 @@ def yaml_filename():
 
 @pytest.fixture(scope="module")
 def hyperopt_results(request):
-    """This function generates hyperopt results."""
+    """This function generates hyperopt results.
+
+    The request argument is used to allow indirect passing of parameters. In this test, it is a boolean that indicates
+    whether to use a single parameter or multiple parameters.
+    """
     input_features = [
         text_feature(name="utterance", encoder={"cell_type": "lstm", "reduce_output": "sum"}),
         category_feature(encoder={"vocab_size": 2}, reduce_input="sum"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,8 @@ def hyperopt_results_single_parameter():
             "type": "variant_generator",
         },
     }
-    hyperopt(config, dataset=rel_path, output_directory="results", experiment_name="hyperopt_test")
+    # Prevent resume from failure since this results in failures in other tests
+    hyperopt(config, dataset=rel_path, output_directory="results", experiment_name="hyperopt_test", resume=False)
     return os.path.join(os.path.abspath("results"), "hyperopt_test")
 
 
@@ -106,7 +107,8 @@ def hyperopt_results_multiple_parameters():
             "type": "variant_generator",
         },
     }
-    hyperopt(config, dataset=rel_path, output_directory="results", experiment_name="hyperopt_test")
+    # Prevent resume from failure since this results in failures in other tests
+    hyperopt(config, dataset=rel_path, output_directory="results", experiment_name="hyperopt_test", resume=False)
     return os.path.join(os.path.abspath("results"), "hyperopt_test")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def yaml_filename():
 
 
 @pytest.fixture(scope="module")
-def hyperopt_results():
+def hyperopt_results(request):
     """This function generates hyperopt results."""
     input_features = [
         text_feature(name="utterance", encoder={"cell_type": "lstm", "reduce_output": "sum"}),
@@ -77,16 +77,23 @@ def hyperopt_results():
 
     output_feature_name = output_features[0][NAME]
 
-    hyperopt_configs = {
-        "parameters": {
-            "trainer.learning_rate": {
-                "space": "loguniform",
-                "lower": 0.0001,
-                "upper": 0.01,
-            },
-            output_feature_name + ".decoder.output_size": {"space": "choice", "categories": [32, 64, 128, 256]},
-            output_feature_name + ".decoder.num_fc_layers": {"space": "randint", "lower": 1, "upper": 6},
+    parameters = {
+        "trainer.learning_rate": {
+            "space": "loguniform",
+            "lower": 0.0001,
+            "upper": 0.01,
         },
+    }
+    if not request.param:
+        parameters.update(
+            {
+                output_feature_name + ".decoder.output_size": {"space": "choice", "categories": [32, 64, 128, 256]},
+                output_feature_name + ".decoder.num_fc_layers": {"space": "randint", "lower": 1, "upper": 6},
+            }
+        )
+
+    hyperopt_configs = {
+        "parameters": parameters,
         "goal": "minimize",
         "output_feature": output_feature_name,
         "validation_metrics": "loss",

--- a/tests/integration_tests/test_visualization_api.py
+++ b/tests/integration_tests/test_visualization_api.py
@@ -844,11 +844,12 @@ def test_frequency_vs_f1_vis_api(experiment_to_use):
 
 
 @pytest.mark.distributed
-@pytest.mark.parametrize("hyperopt_results", [False], indirect=True)
-def test_hyperopt_report_vis_api(hyperopt_results, tmpdir):
+def test_hyperopt_report_vis_api(hyperopt_results_multiple_parameters, tmpdir):
     vis_dir = os.path.join(tmpdir, "visualizations")
 
-    visualize.hyperopt_report(os.path.join(hyperopt_results, HYPEROPT_STATISTICS_FILE_NAME), output_directory=vis_dir)
+    visualize.hyperopt_report(
+        os.path.join(hyperopt_results_multiple_parameters, HYPEROPT_STATISTICS_FILE_NAME), output_directory=vis_dir
+    )
 
     # test for creation of output directory
     assert os.path.isdir(vis_dir)
@@ -858,11 +859,12 @@ def test_hyperopt_report_vis_api(hyperopt_results, tmpdir):
 
 
 @pytest.mark.distributed
-@pytest.mark.parametrize("hyperopt_results", [False], indirect=True)
-def test_hyperopt_hiplot_vis_api(hyperopt_results, tmpdir):
+def test_hyperopt_hiplot_vis_api(hyperopt_results_multiple_parameters, tmpdir):
     vis_dir = os.path.join(tmpdir, "visualizations")
 
-    visualize.hyperopt_hiplot(os.path.join(hyperopt_results, HYPEROPT_STATISTICS_FILE_NAME), output_directory=vis_dir)
+    visualize.hyperopt_hiplot(
+        os.path.join(hyperopt_results_multiple_parameters, HYPEROPT_STATISTICS_FILE_NAME), output_directory=vis_dir
+    )
 
     # test for creation of output directory
     assert os.path.isdir(vis_dir)
@@ -872,11 +874,12 @@ def test_hyperopt_hiplot_vis_api(hyperopt_results, tmpdir):
 
 
 @pytest.mark.distributed
-@pytest.mark.parametrize("hyperopt_results", [True], indirect=True)
-def test_hyperopt_report_vis_api_no_pairplot(hyperopt_results, tmpdir):
+def test_hyperopt_report_vis_api_no_pairplot(hyperopt_results_single_parameter, tmpdir):
     vis_dir = os.path.join(tmpdir, "visualizations")
 
-    visualize.hyperopt_report(os.path.join(hyperopt_results, HYPEROPT_STATISTICS_FILE_NAME), output_directory=vis_dir)
+    visualize.hyperopt_report(
+        os.path.join(hyperopt_results_single_parameter, HYPEROPT_STATISTICS_FILE_NAME), output_directory=vis_dir
+    )
 
     figure_cnt = glob.glob(os.path.join(vis_dir, "*"))
 

--- a/tests/integration_tests/test_visualization_api.py
+++ b/tests/integration_tests/test_visualization_api.py
@@ -847,6 +847,11 @@ def test_frequency_vs_f1_vis_api(experiment_to_use):
 def test_hyperopt_report_vis_api(hyperopt_results_multiple_parameters, tmpdir):
     vis_dir = os.path.join(tmpdir, "visualizations")
 
+    # Ensure visualizations directory is empty before creating plots
+    if os.path.exists(vis_dir):
+        for f in os.listdir(vis_dir):
+            os.remove(os.path.join(vis_dir, f))
+
     visualize.hyperopt_report(
         os.path.join(hyperopt_results_multiple_parameters, HYPEROPT_STATISTICS_FILE_NAME), output_directory=vis_dir
     )
@@ -862,6 +867,11 @@ def test_hyperopt_report_vis_api(hyperopt_results_multiple_parameters, tmpdir):
 def test_hyperopt_hiplot_vis_api(hyperopt_results_multiple_parameters, tmpdir):
     vis_dir = os.path.join(tmpdir, "visualizations")
 
+    # Ensure visualizations directory is empty before creating plots
+    if os.path.exists(vis_dir):
+        for f in os.listdir(vis_dir):
+            os.remove(os.path.join(vis_dir, f))
+
     visualize.hyperopt_hiplot(
         os.path.join(hyperopt_results_multiple_parameters, HYPEROPT_STATISTICS_FILE_NAME), output_directory=vis_dir
     )
@@ -876,6 +886,11 @@ def test_hyperopt_hiplot_vis_api(hyperopt_results_multiple_parameters, tmpdir):
 @pytest.mark.distributed
 def test_hyperopt_report_vis_api_no_pairplot(hyperopt_results_single_parameter, tmpdir):
     vis_dir = os.path.join(tmpdir, "visualizations")
+
+    # Ensure visualizations directory is empty before creating plots
+    if os.path.exists(vis_dir):
+        for f in os.listdir(vis_dir):
+            os.remove(os.path.join(vis_dir, f))
 
     visualize.hyperopt_report(
         os.path.join(hyperopt_results_single_parameter, HYPEROPT_STATISTICS_FILE_NAME), output_directory=vis_dir

--- a/tests/integration_tests/test_visualization_api.py
+++ b/tests/integration_tests/test_visualization_api.py
@@ -844,6 +844,7 @@ def test_frequency_vs_f1_vis_api(experiment_to_use):
 
 
 @pytest.mark.distributed
+@pytest.mark.parametrize("hyperopt_results", [False], indirect=True)
 def test_hyperopt_report_vis_api(hyperopt_results, tmpdir):
     vis_dir = os.path.join(tmpdir, "visualizations")
 
@@ -857,6 +858,7 @@ def test_hyperopt_report_vis_api(hyperopt_results, tmpdir):
 
 
 @pytest.mark.distributed
+@pytest.mark.parametrize("hyperopt_results", [False], indirect=True)
 def test_hyperopt_hiplot_vis_api(hyperopt_results, tmpdir):
     vis_dir = os.path.join(tmpdir, "visualizations")
 
@@ -867,3 +869,16 @@ def test_hyperopt_hiplot_vis_api(hyperopt_results, tmpdir):
 
     # test for generatated html page
     assert os.path.isfile(os.path.join(vis_dir, "hyperopt_hiplot.html"))
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize("hyperopt_results", [True], indirect=True)
+def test_hyperopt_report_vis_api_no_pairplot(hyperopt_results, tmpdir):
+    vis_dir = os.path.join(tmpdir, "visualizations")
+
+    visualize.hyperopt_report(os.path.join(hyperopt_results, HYPEROPT_STATISTICS_FILE_NAME), output_directory=vis_dir)
+
+    figure_cnt = glob.glob(os.path.join(vis_dir, "*"))
+
+    # Only create plot for single parameter and skip pairplot creation
+    assert len(figure_cnt) == 1


### PR DESCRIPTION
This ensures that hyperopt pair plots are only created if there is > 1 parameter in the hyperopt parameter search space. Otherwise, in the case of only a single parameter, this creates an empty pair plot. 