### PR TITLE
Migrate to Raincloud plots for hyperopt report

### DIFF
--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -21,6 +21,7 @@ from sys import platform
 
 import numpy as np
 import pandas as pd
+import ptitprince as pt
 from packaging import version
 
 from ludwig.constants import SPACE, TRAINING, VALIDATION
@@ -1369,7 +1370,27 @@ def hyperopt_float_plot(hyperopt_results_df, hp_name, metric, title, filename, l
 def hyperopt_category_plot(hyperopt_results_df, hp_name, metric, title, filename, log_scale=True):
     sns.set_style("whitegrid")
     plt.figure()
-    seaborn_figure = sns.violinplot(x=hp_name, y=metric, data=hyperopt_results_df, fit_reg=False)
+
+    # Ensure that all parameter values have at least 2 trials, otherwise the Raincloud Plot will create awkward
+    # looking "flat clouds" in the cloud part of the plot (the "rain" part is ok with 1 trial). In this case,
+    # just use stripplots since they are categorical scatter plots.
+    parameter_to_trial_count = hyperopt_results_df[hp_name].value_counts()
+    parameter_to_trial_count = parameter_to_trial_count[parameter_to_trial_count < 2]
+
+    if len(parameter_to_trial_count) != 0:
+        seaborn_figure = sns.stripplot(x=hp_name, y=metric, data=hyperopt_results_df, size=5)
+    else:
+        seaborn_figure = pt.RainCloud(
+            x=hp_name,
+            y=metric,
+            data=hyperopt_results_df,
+            palette="Set2",
+            bw=0.2,
+            width_viol=0.7,
+            point_size=6,
+            cut=1,
+        )
+
     seaborn_figure.set_title(title)
     seaborn_figure.set(ylabel=metric)
     sns.despine()

--- a/requirements_viz.txt
+++ b/requirements_viz.txt
@@ -1,5 +1,5 @@
 matplotlib>=3.4; python_version > '3.6'
 matplotlib>=3.0,<3.4; python_version <= '3.6'
-seaborn>=0.7
+seaborn>=0.7,<0.12
 hiplot
 ptitprince

--- a/requirements_viz.txt
+++ b/requirements_viz.txt
@@ -2,3 +2,4 @@ matplotlib>=3.4; python_version > '3.6'
 matplotlib>=3.0,<3.4; python_version <= '3.6'
 seaborn>=0.7
 hiplot
+ptitprince


### PR DESCRIPTION
This fixes an issue where the violinplots produced in the hyperopt_report were occasionally "flat lines" / "squashed violins" because there was only 1 trial associated with each parameter (violinplots are used to show a distribution which doesn't make sense when there's only 1 point). This happens in the case of parameters sampled from `choice` or `grid_search` spaces and the number of trials is very small (for e.g., < 5).

This PR makes two changes:

1. Create `stripplots` when all parameter values for the parameter have < 2 trials associated with them. This is because these will end up looking very awkward in a plot that's meant to show distributions. 
2. In the case that all sampled parameters have at least 2 trials associated with them, create a [RainCloud plot](https://wellcomeopenresearch.org/articles/4-63#:~:text=The%20raincloud%20plot%20combines%20an,code%20to%20generate%20this%20figure.) instead of a Violinplot. These “raincloud plots” can visualize raw data, probability density, and key summary statistics such as median, mean, and relevant confidence intervals in an appealing and flexible format with minimal redundancy.

![working_raincloud](https://user-images.githubusercontent.com/106701836/192653506-f2fc3b0b-f19c-40df-975f-efce896fb911.png)

