### PR TITLE
Fixing SettingWithCopyWarning when using `get_repeatable_train_val_test_split`

### DIFF
--- a/ludwig/utils/dataset_utils.py
+++ b/ludwig/utils/dataset_utils.py
@@ -58,9 +58,9 @@ def get_repeatable_train_val_test_split(
             df_input["split"] = 0  # set up for non-stratified split path
 
     if "split" in df_input.columns:
-        df_train = df_input[df_input["split"] == TRAIN_SPLIT]
-        df_val = df_input[df_input["split"] == VALIDATION_SPLIT]
-        df_test = df_input[df_input["split"] == TEST_SPLIT]
+        df_train = df_input[df_input["split"] == TRAIN_SPLIT].copy()
+        df_val = df_input[df_input["split"] == VALIDATION_SPLIT].copy()
+        df_test = df_input[df_input["split"] == TEST_SPLIT].copy()
         if not do_stratify_split or len(df_val) != 0 or len(df_test) != 0:
             if len(df_val) == 0:
                 df_val = df_train.sample(frac=frac_val, replace=False, random_state=random_seed)


### PR DESCRIPTION
Fixes the following warning
```
ludwig/ludwig/utils/dataset_utils.py:91: SettingWithCopyWarning:  A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead
```
when running
```
from ludwig.datasets import ames_housing
from ludwig.utils.dataset_utils import get_repeatable_train_val_test_split

dataset = ames_housing.load(split=False)
get_repeatable_train_val_test_split(dataset)
```

