### PR TITLE
GBM bugfix: matching predictions LightGBM, hummingbird

### DIFF
--- a/ludwig/models/gbm.py
+++ b/ludwig/models/gbm.py
@@ -1,6 +1,6 @@
 import copy
 import os
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import lightgbm as lgb
 import numpy as np
@@ -15,6 +15,7 @@ from ludwig.globals import MODEL_WEIGHTS_FILE_NAME
 from ludwig.models.base import BaseModel
 from ludwig.utils import output_feature_utils
 from ludwig.utils.torch_utils import get_torch_device
+from ludwig.utils.types import TorchDevice
 
 
 class GBM(BaseModel):
@@ -141,15 +142,15 @@ class GBM(BaseModel):
             f"Expected inputs to be a 2D tensor of shape (batch_size, {len(self.input_features)}) of type float32, "
             f"but got {inputs.shape} of type {inputs.dtype}"
         )
+        # Predict using PyTorch module, so it is included when converting to TorchScript.
+        preds = self.compiled_model.model(inputs)
 
         if output_feature.type() == NUMBER:
             # regression
-            preds = self.compiled_model.predict(inputs)
-            logits = torch.from_numpy(preds)
+            logits = preds.view(-1)
         else:
             # classification
-            probs = self.compiled_model.predict_proba(inputs)
-            probs = torch.from_numpy(probs)
+            _, probs = preds
 
             if output_feature.type() == BINARY:
                 # keep positive class only for binary feature
@@ -189,6 +190,14 @@ class GBM(BaseModel):
 
         device = torch.device(get_torch_device())
         self.compiled_model.to(device)
+
+    def to_torchscript(self, device: Optional[TorchDevice] = None):
+        """Converts the ECD model as a TorchScript model."""
+
+        # Disable gradient calculation for hummingbird Parameter nodes.
+        self.compiled_model.model.requires_grad_(False)
+
+        return super().to_torchscript(device)
 
     def get_args(self):
         """Returns init arguments for constructing this model."""

--- a/ludwig/models/gbm.py
+++ b/ludwig/models/gbm.py
@@ -33,8 +33,12 @@ class GBM(BaseModel):
         if len(output_features) > 1:
             raise ValueError("Only single task currently supported")
         feat_types = {f[TYPE] for f in output_features + input_features}
-        if len(feat_types - {NUMBER, CATEGORY, BINARY}) != 0:
-            raise ValueError("Model type GBM only supports numerical, categorical, or binary features")
+        unsupported_types = feat_types - {NUMBER, CATEGORY, BINARY}
+        if len(unsupported_types) != 0:
+            raise ValueError(
+                "Model type GBM only supports numerical, categorical, or binary features "
+                f"but got unsupported types {unsupported_types}"
+            )
 
         super().__init__(random_seed=random_seed)
 

--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -726,16 +726,16 @@ class LightGBMTrainer(BaseTrainer):
     def _construct_lgb_params(self) -> Tuple[dict, dict]:
         output_params = {}
         feature = next(iter(self.model.output_features.values()))
-        if feature.type() == CATEGORY:
+        if feature.type() == BINARY or feature.num_classes == 2:
+            output_params = {
+                "objective": "binary",
+                "metric": ["binary_logloss"],
+            }
+        elif feature.type() == CATEGORY:
             output_params = {
                 "objective": "multiclass",
                 "metric": ["multi_logloss"],
                 "num_class": feature.num_classes,
-            }
-        elif feature.type() == BINARY:
-            output_params = {
-                "objective": "binary",
-                "metric": ["binary_logloss"],
             }
         elif feature.type() == NUMBER:
             output_params = {

--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -521,10 +521,6 @@ class LightGBMTrainer(BaseTrainer):
 
         # TODO: construct new datasets by running encoders (for text, image)
 
-        # TODO: only single task currently
-        if len(output_features) > 1:
-            raise ValueError("Only single task currently supported")
-
         metrics_names = get_metric_names(output_features)
 
         # check if validation_field is valid
@@ -726,7 +722,7 @@ class LightGBMTrainer(BaseTrainer):
     def _construct_lgb_params(self) -> Tuple[dict, dict]:
         output_params = {}
         feature = next(iter(self.model.output_features.values()))
-        if feature.type() == BINARY or feature.num_classes == 2:
+        if feature.type() == BINARY or (hasattr(feature, "num_classes") and feature.num_classes == 2):
             output_params = {
                 "objective": "binary",
                 "metric": ["binary_logloss"],

--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -351,18 +351,22 @@ class LightGBMTrainer(BaseTrainer):
     ) -> bool:
         self.callback(lambda c: c.on_batch_start(self, progress_tracker, save_path))
 
-        booster = None
         evals_result = {}
-        booster = self.train_step(
-            params, lgb_train, eval_sets, eval_names, booster, self.boosting_rounds_per_checkpoint, evals_result
+        self.model.lgbm_model = self.train_step(
+            params,
+            lgb_train,
+            eval_sets,
+            eval_names,
+            self.model.lgbm_model,
+            self.boosting_rounds_per_checkpoint,
+            evals_result,
         )
 
         progress_bar.update(self.boosting_rounds_per_checkpoint)
         progress_tracker.steps += self.boosting_rounds_per_checkpoint
-        progress_tracker.last_improvement_steps = booster.best_iteration
+        progress_tracker.last_improvement_steps = self.model.lgbm_model.best_iteration_
 
         # convert to pytorch for inference
-        self.model.lgb_booster = booster
         self.model.compile()
         self.model = self.model.to(self.device)
 
@@ -463,10 +467,10 @@ class LightGBMTrainer(BaseTrainer):
         lgb_train: lgb.Dataset,
         eval_sets: List[lgb.Dataset],
         eval_names: List[str],
-        booster: lgb.Booster,
+        init_model: lgb.LGBMModel,
         boost_rounds_per_train_step: int,
         evals_result: Dict,
-    ) -> lgb.Booster:
+    ) -> lgb.LGBMModel:
         """Trains a LightGBM model.
 
         Args:
@@ -478,18 +482,21 @@ class LightGBMTrainer(BaseTrainer):
         Returns:
             LightGBM Booster model
         """
-        gbm = lgb.train(
-            params,
-            lgb_train,
-            init_model=booster,
-            num_boost_round=boost_rounds_per_train_step,
-            valid_sets=eval_sets,
-            valid_names=eval_names,
-            feature_name=list(self.model.input_features.keys()),
+        output_feature = next(iter(self.model.output_features.values()))
+        gbm_sklearn_cls = lgb.LGBMRegressor if output_feature.type() == NUMBER else lgb.LGBMClassifier
+
+        gbm = gbm_sklearn_cls(n_estimators=boost_rounds_per_train_step, **params).fit(
+            X=lgb_train.get_data(),
+            y=lgb_train.get_label(),
+            init_model=init_model,
+            eval_set=[(ds.get_data(), ds.get_label()) for ds in eval_sets],
+            eval_names=eval_names,
+            # add early stopping callback to populate best_iteration
+            callbacks=[lgb.early_stopping(boost_rounds_per_train_step)],
             # NOTE: hummingbird does not support categorical features
             # categorical_feature=categorical_features,
-            evals_result=evals_result,
         )
+        evals_result.update(gbm.evals_result_)
 
         return gbm
 
@@ -799,15 +806,15 @@ class LightGBMTrainer(BaseTrainer):
         y_train = training_set.to_df(self.model.output_features.values())
 
         # create dataset for lightgbm
-        # if you want to re-use data, remember to set free_raw_data=False
-        lgb_train = lgb.Dataset(X_train, label=y_train)
+        # keep raw data for continued training https://github.com/microsoft/LightGBM/issues/4965#issuecomment-1019344293
+        lgb_train = lgb.Dataset(X_train, label=y_train, free_raw_data=False).construct()
 
         eval_sets = [lgb_train]
         eval_names = [LightGBMTrainer.TRAIN_KEY]
         if validation_set is not None:
             X_val = validation_set.to_df(self.model.input_features.values())
             y_val = validation_set.to_df(self.model.output_features.values())
-            lgb_val = lgb.Dataset(X_val, label=y_val, reference=lgb_train)
+            lgb_val = lgb.Dataset(X_val, label=y_val, reference=lgb_train, free_raw_data=False).construct()
             eval_sets.append(lgb_val)
             eval_names.append(LightGBMTrainer.VALID_KEY)
         else:
@@ -817,7 +824,7 @@ class LightGBMTrainer(BaseTrainer):
         if test_set is not None:
             X_test = test_set.to_df(self.model.input_features.values())
             y_test = test_set.to_df(self.model.output_features.values())
-            lgb_test = lgb.Dataset(X_test, label=y_test, reference=lgb_train)
+            lgb_test = lgb.Dataset(X_test, label=y_test, reference=lgb_train, free_raw_data=False).construct()
             eval_sets.append(lgb_test)
             eval_names.append(LightGBMTrainer.TEST_KEY)
 
@@ -898,10 +905,10 @@ class LightGBMRayTrainer(LightGBMTrainer):
         lgb_train: "RayDMatrix",  # noqa: F821
         eval_sets: List["RayDMatrix"],  # noqa: F821
         eval_names: List[str],
-        booster: lgb.Booster,
+        init_model: lgb.LGBMModel,
         boost_rounds_per_train_step: int,
         evals_result: Dict,
-    ) -> lgb.Booster:
+    ) -> lgb.LGBMModel:
         """Trains a LightGBM model using ray.
 
         Args:
@@ -913,23 +920,26 @@ class LightGBMRayTrainer(LightGBMTrainer):
         Returns:
             LightGBM Booster model
         """
-        from lightgbm_ray import train as lgb_ray_train
+        from lightgbm_ray import RayLGBMClassifier, RayLGBMRegressor
 
-        gbm = lgb_ray_train(
-            params,
-            lgb_train,
-            init_model=booster,
-            num_boost_round=boost_rounds_per_train_step,
-            valid_sets=eval_sets,
-            valid_names=eval_names,
-            feature_name=list(self.model.input_features.keys()),
-            evals_result=evals_result,
+        output_feature = next(iter(self.model.output_features.values()))
+        gbm_sklearn_cls = RayLGBMRegressor if output_feature.type() == NUMBER else RayLGBMClassifier
+
+        gbm = gbm_sklearn_cls(n_estimators=boost_rounds_per_train_step, **params).fit(
+            X=lgb_train,
+            y=None,
+            init_model=init_model,
+            eval_set=[(s, n) for s, n in zip(eval_sets, eval_names)],
+            eval_names=eval_names,
+            # add early stopping callback to populate best_iteration
+            callbacks=[lgb.early_stopping(boost_rounds_per_train_step)],
+            ray_params=_map_to_lgb_ray_params(self.trainer_kwargs),
             # NOTE: hummingbird does not support categorical features
             # categorical_feature=categorical_features,
-            ray_params=_map_to_lgb_ray_params(self.trainer_kwargs),
         )
+        evals_result.update(gbm.evals_result_)
 
-        return gbm.booster_
+        return gbm.to_local()
 
     def _construct_lgb_datasets(
         self,

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -6,7 +6,7 @@ import torch
 from marshmallow import ValidationError
 
 from ludwig.api import LudwigModel
-from ludwig.constants import MODEL_TYPE, TRAINER
+from ludwig.constants import INPUT_FEATURES, MODEL_TYPE, OUTPUT_FEATURES, TRAINER
 from tests.integration_tests.utils import binary_feature, category_feature, generate_data, number_feature, text_feature
 
 
@@ -41,8 +41,8 @@ def _train_and_predict_gbm(input_features, output_features, tmpdir, backend_conf
 
     config = {
         MODEL_TYPE: "gbm",
-        "input_features": input_features,
-        "output_features": output_features,
+        INPUT_FEATURES: input_features,
+        OUTPUT_FEATURES: output_features,
         TRAINER: {"num_boost_round": 2},
     }
 

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -1,11 +1,6 @@
 import os
 
 import pytest
-
-try:
-    import ray as _ray
-except ImportError:
-    _ray = None
 from marshmallow import ValidationError
 
 from ludwig.api import LudwigModel
@@ -38,71 +33,7 @@ def ray_backend():
     }
 
 
-def run_test_gbm_output_not_supported(tmpdir, backend_config):
-    """Test that an error is raised when the output feature is not supported by the model."""
-    input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
-    output_features = [text_feature()]
-
-    csv_filename = os.path.join(tmpdir, "training.csv")
-    dataset_filename = generate_data(input_features, output_features, csv_filename, num_examples=100)
-
-    config = {MODEL_TYPE: "gbm", "input_features": input_features, "output_features": output_features}
-
-    model = LudwigModel(config, backend=backend_config)
-    with pytest.raises(
-        ValueError, match="Model type GBM only supports numerical, categorical, or binary output features"
-    ):
-        model.train(dataset=dataset_filename, output_directory=tmpdir)
-
-
-def test_local_gbm_output_not_supported(tmpdir, local_backend):
-    run_test_gbm_output_not_supported(tmpdir, local_backend)
-
-
-@pytest.mark.distributed
-def test_ray_gbm_output_not_supported(tmpdir, ray_backend, ray_cluster_4cpu):
-    run_test_gbm_output_not_supported(tmpdir, ray_backend)
-
-
-def run_test_gbm_multiple_outputs(tmpdir, backend_config):
-    """Test that an error is raised when the model is trained with multiple outputs."""
-    input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
-    output_features = [
-        category_feature(decoder={"vocab_size": 3}),
-        binary_feature(),
-        category_feature(decoder={"vocab_size": 3}),
-    ]
-
-    csv_filename = os.path.join(tmpdir, "training.csv")
-    dataset_filename = generate_data(input_features, output_features, csv_filename, num_examples=100)
-
-    config = {
-        MODEL_TYPE: "gbm",
-        "input_features": input_features,
-        "output_features": output_features,
-        TRAINER: {"num_boost_round": 2},
-    }
-
-    model = LudwigModel(config, backend=backend_config)
-    with pytest.raises(ValueError, match="Only single task currently supported"):
-        model.train(dataset=dataset_filename, output_directory=tmpdir)
-
-
-def test_local_gbm_multiple_outputs(tmpdir, local_backend):
-    run_test_gbm_multiple_outputs(tmpdir, local_backend)
-
-
-@pytest.mark.distributed
-def test_ray_gbm_multiple_outputs(tmpdir, ray_backend, ray_cluster_4cpu):
-    run_test_gbm_multiple_outputs(tmpdir, ray_backend)
-
-
-def run_test_gbm_binary(tmpdir, backend_config):
-    """Test that the GBM model can train and predict a binary variable (binary classification)."""
-    input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
-    output_feature = binary_feature()
-    output_features = [output_feature]
-
+def _train_and_predict_gbm(input_features, output_features, tmpdir, backend_config):
     csv_filename = os.path.join(tmpdir, "training.csv")
     dataset_filename = generate_data(input_features, output_features, csv_filename, num_examples=100)
 
@@ -123,7 +54,58 @@ def run_test_gbm_binary(tmpdir, backend_config):
         skip_save_log=True,
     )
     model.load(os.path.join(tmpdir, "api_experiment_run", "model"))
-    preds, _ = model.predict(dataset=dataset_filename, output_directory=output_directory)
+    preds, _ = model.predict(dataset=dataset_filename, output_directory=output_directory, split="test")
+
+    return preds, model
+
+
+def run_test_gbm_output_not_supported(tmpdir, backend_config):
+    """Test that an error is raised when the output feature is not supported by the model."""
+    input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
+    output_features = [text_feature()]
+
+    with pytest.raises(ValueError, match="Model type GBM only supports numerical, categorical, or binary features"):
+        _train_and_predict_gbm(input_features, output_features, tmpdir, backend_config)
+
+
+def test_local_gbm_output_not_supported(tmpdir, local_backend):
+    run_test_gbm_output_not_supported(tmpdir, local_backend)
+
+
+@pytest.mark.distributed
+def test_ray_gbm_output_not_supported(tmpdir, ray_backend, ray_cluster_4cpu):
+    run_test_gbm_output_not_supported(tmpdir, ray_backend)
+
+
+def run_test_gbm_multiple_outputs(tmpdir, backend_config):
+    """Test that an error is raised when the model is trained with multiple outputs."""
+    input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
+    output_features = [
+        category_feature(decoder={"vocab_size": 3}),
+        binary_feature(),
+        category_feature(decoder={"vocab_size": 3}),
+    ]
+
+    with pytest.raises(ValueError, match="Only single task currently supported"):
+        _train_and_predict_gbm(input_features, output_features, tmpdir, backend_config)
+
+
+def test_local_gbm_multiple_outputs(tmpdir, local_backend):
+    run_test_gbm_multiple_outputs(tmpdir, local_backend)
+
+
+@pytest.mark.distributed
+def test_ray_gbm_multiple_outputs(tmpdir, ray_backend, ray_cluster_4cpu):
+    run_test_gbm_multiple_outputs(tmpdir, ray_backend)
+
+
+def run_test_gbm_binary(tmpdir, backend_config):
+    """Test that the GBM model can train and predict a binary variable (binary classification)."""
+    input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
+    output_feature = binary_feature()
+    output_features = [output_feature]
+
+    preds, _ = _train_and_predict_gbm(input_features, output_features, tmpdir, backend_config)
 
     prob_col = preds[output_feature["name"] + "_probabilities"]
     if backend_config["type"] == "ray":
@@ -147,27 +129,7 @@ def run_test_gbm_non_number_inputs(tmpdir, backend_config):
     output_feature = binary_feature()
     output_features = [output_feature]
 
-    csv_filename = os.path.join(tmpdir, "training.csv")
-    dataset_filename = generate_data(input_features, output_features, csv_filename, num_examples=100)
-
-    config = {
-        MODEL_TYPE: "gbm",
-        "input_features": input_features,
-        "output_features": output_features,
-        TRAINER: {"num_boost_round": 2},
-    }
-
-    model = LudwigModel(config, backend=backend_config)
-    _, _, output_directory = model.train(
-        dataset=dataset_filename,
-        output_directory=tmpdir,
-        skip_save_processed_input=True,
-        skip_save_progress=True,
-        skip_save_unprocessed_output=True,
-        skip_save_log=True,
-    )
-    model.load(os.path.join(tmpdir, "api_experiment_run", "model"))
-    preds, _ = model.predict(dataset=dataset_filename, output_directory=output_directory)
+    preds, _ = _train_and_predict_gbm(input_features, output_features, tmpdir, backend_config)
 
     prob_col = preds[output_feature["name"] + "_probabilities"]
     if backend_config["type"] == "ray":
@@ -185,35 +147,13 @@ def test_ray_gbm_non_number_inputs(tmpdir, ray_backend, ray_cluster_4cpu):
     run_test_gbm_non_number_inputs(tmpdir, ray_backend)
 
 
-def run_test_gbm_category(tmpdir, backend_config):
+def run_test_gbm_category(vocab_size, tmpdir, backend_config):
     """Test that the GBM model can train and predict a categorical output (multiclass classification)."""
     input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
-    vocab_size = 3
     output_feature = category_feature(decoder={"vocab_size": vocab_size})
     output_features = [output_feature]
 
-    csv_filename = os.path.join(tmpdir, "training.csv")
-    dataset_filename = generate_data(input_features, output_features, csv_filename, num_examples=100)
-
-    config = {
-        MODEL_TYPE: "gbm",
-        "input_features": input_features,
-        "output_features": output_features,
-        TRAINER: {"num_boost_round": 2},
-    }
-
-    model = LudwigModel(config, backend=backend_config)
-
-    _, _, output_directory = model.train(
-        dataset=dataset_filename,
-        output_directory=tmpdir,
-        skip_save_processed_input=True,
-        skip_save_progress=True,
-        skip_save_unprocessed_output=True,
-        skip_save_log=True,
-    )
-    model.load(os.path.join(tmpdir, "api_experiment_run", "model"))
-    preds, _ = model.predict(dataset=dataset_filename, output_directory=output_directory)
+    preds, _ = _train_and_predict_gbm(input_features, output_features, tmpdir, backend_config)
 
     prob_col = preds[output_feature["name"] + "_probabilities"]
     if backend_config["type"] == "ray":
@@ -222,13 +162,15 @@ def run_test_gbm_category(tmpdir, backend_config):
     assert prob_col.apply(sum).mean() == pytest.approx(1.0)
 
 
-def test_local_gbm_category(tmpdir, local_backend):
-    run_test_gbm_category(tmpdir, local_backend)
+@pytest.mark.parametrize("vocab_size", [2, 3])
+def test_local_gbm_category(vocab_size, tmpdir, local_backend):
+    run_test_gbm_category(vocab_size, tmpdir, local_backend)
 
 
 @pytest.mark.distributed
-def test_ray_gbm_category(tmpdir, ray_backend, ray_cluster_4cpu):
-    run_test_gbm_category(tmpdir, ray_backend)
+@pytest.mark.parametrize("vocab_size", [2, 3])
+def test_ray_gbm_category(vocab_size, tmpdir, ray_backend, ray_cluster_4cpu):
+    run_test_gbm_category(vocab_size, tmpdir, ray_backend)
 
 
 def run_test_gbm_number(tmpdir, backend_config):
@@ -238,33 +180,8 @@ def run_test_gbm_number(tmpdir, backend_config):
     output_feature = number_feature()
     output_features = [output_feature]
 
-    csv_filename = os.path.join(tmpdir, "training.csv")
-    dataset_filename = generate_data(input_features, output_features, csv_filename, num_examples=100)
-
-    config = {
-        MODEL_TYPE: "gbm",
-        "input_features": input_features,
-        "output_features": output_features,
-        TRAINER: {"num_boost_round": 2},
-    }
-
-    # When I train a model on the dataset, load the model from the output directory, and
-    # predict on the dataset
-    model = LudwigModel(config, backend=backend_config)
-
-    model.train(
-        dataset=dataset_filename,
-        output_directory=tmpdir,
-        skip_save_processed_input=True,
-        skip_save_progress=True,
-        skip_save_unprocessed_output=True,
-        skip_save_log=True,
-    )
-    model.load(os.path.join(tmpdir, "api_experiment_run", "model"))
-    preds, _ = model.predict(
-        dataset=dataset_filename,
-        output_directory=os.path.join(tmpdir, "predictions"),
-    )
+    # When we train a GBM model on the dataset,
+    preds, _ = _train_and_predict_gbm(input_features, output_features, tmpdir, backend_config)
 
     # Then the predictions should be included in the output
     pred_col = preds[output_feature["name"] + "_predictions"]

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -1,6 +1,8 @@
 import os
 
+import numpy as np
 import pytest
+import torch
 from marshmallow import ValidationError
 
 from ludwig.api import LudwigModel
@@ -145,6 +147,82 @@ def test_local_gbm_non_number_inputs(tmpdir, local_backend):
 @pytest.mark.distributed
 def test_ray_gbm_non_number_inputs(tmpdir, ray_backend, ray_cluster_4cpu):
     run_test_gbm_non_number_inputs(tmpdir, ray_backend)
+
+
+def run_test_hummingbird_conversion_binary(tmpdir, backend_config):
+    input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
+    output_features = [binary_feature()]
+
+    preds_hb, model = _train_and_predict_gbm(input_features, output_features, tmpdir, backend_config)
+
+    _, _, test, _ = model.preprocess(os.path.join(tmpdir, "training.csv"))
+    test_inputs = test.to_df(model.model.input_features.values())
+
+    output_feature = output_features[0]
+
+    probs_hb = preds_hb[f'{output_feature["name"]}_probabilities']
+    probs_lgbm = model.model.lgbm_model.predict_proba(test_inputs)
+
+    # sanity check Hummingbird probabilities equal to LightGBM probabilities
+    assert np.allclose(np.stack(probs_hb.values), probs_lgbm, atol=1e-8)
+
+
+def run_test_hummingbird_conversion_regression(tmpdir, backend_config):
+    input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
+    output_features = [number_feature()]
+
+    preds_hb, model = _train_and_predict_gbm(input_features, output_features, tmpdir, backend_config)
+
+    _, _, test, _ = model.preprocess(os.path.join(tmpdir, "training.csv"))
+    test_inputs = test.to_df(model.model.input_features.values())
+
+    preds_lgbm = model.model.lgbm_model.predict(test_inputs)
+
+    assert np.allclose(preds_hb.values, preds_lgbm)
+
+
+def run_test_hummingbird_conversion_category(vocab_size, tmpdir, backend_config):
+    input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
+    output_features = [category_feature(decoder={"vocab_size": vocab_size})]
+
+    preds_hb, model = _train_and_predict_gbm(input_features, output_features, tmpdir, backend_config)
+
+    _, _, test, _ = model.preprocess(os.path.join(tmpdir, "training.csv"))
+    test_inputs = test.to_df(model.model.input_features.values())
+
+    output_feature = next(iter(model.model.output_features.values()))
+
+    probs_hb = preds_hb[f"{output_feature.column}_probabilities"]
+
+    if output_feature.num_classes == 2:
+        # LightGBM binary classifier transforms logits using sigmoid, so we need to invert the
+        # transformation to get the logits back, and then use softmax to get the probabilities to match
+        # Ludwig's category feature prediction behavior.
+        probs_lgbm = torch.softmax(torch.logit(torch.from_numpy(model.model.lgbm_model.predict_proba(test_inputs))), -1)
+    else:
+        # Otherwise, just compare to the raw probabilities from LightGBM
+        probs_lgbm = model.model.lgbm_model.predict_proba(test_inputs)
+
+    # sanity check Hummingbird probabilities equal to LightGBM probabilities
+    assert np.allclose(np.stack(probs_hb.values), probs_lgbm, atol=1e-4)
+
+
+def test_local_hummingbird_conversion_binary(tmpdir, local_backend):
+    run_test_hummingbird_conversion_binary(tmpdir, local_backend)
+
+
+def test_local_hummingbird_conversion_regression(tmpdir, local_backend):
+    run_test_hummingbird_conversion_regression(tmpdir, local_backend)
+
+
+@pytest.mark.parametrize("vocab_size", [2, 3])
+def test_local_hummingbird_conversion_category(vocab_size, tmpdir, local_backend):
+    run_test_hummingbird_conversion_category(vocab_size, tmpdir, local_backend)
+
+
+# TODO: tests for loss going down
+
+# TODO: saving, loading, continuing training
 
 
 def run_test_gbm_category(vocab_size, tmpdir, backend_config):

--- a/tests/integration_tests/test_model_save_and_load.py
+++ b/tests/integration_tests/test_model_save_and_load.py
@@ -187,8 +187,8 @@ def test_gbm_model_save_reload_api(tmpdir, csv_filename, tmp_path):
             for if1_w, if2_w in zip(if1.encoder_obj.parameters(), if2.encoder_obj.parameters()):
                 assert torch.allclose(if1_w, if2_w)
 
-        tree1 = ludwig_model1.model.compiled_model
-        tree2 = ludwig_model2.model.compiled_model
+        tree1 = ludwig_model1.model.compiled_model.model
+        tree2 = ludwig_model2.model.compiled_model.model
         for t1_w, t2_w in zip(tree1.parameters(), tree2.parameters()):
             assert torch.allclose(t1_w, t2_w)
 


### PR DESCRIPTION
This PR:

1. Fixes a bug where category variable with 2 classes gave wrong predictions
2. Asserts predictions from LightGBM and converted Hummingbird model match
3. Extends test coverage (incl. for the above cases)
4. Uses cleaner sklearn API for LightGBM

There are quite some changes, the PR is best reviewed commit-by-commit