### PR TITLE
Log warning for failed ray imports

### DIFF
--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -55,7 +55,7 @@ try:
 
     _ray_113 = parse_version(ray.__version__) >= parse_version("1.13.0")
 except ImportError:
-    raise ImportError(" ray is not installed. In order to use auto_train please run pip install ludwig[ray]")
+    raise ImportError("ray is not installed. In order to use auto_train please run pip install ludwig[ray]")
 
 
 logger = logging.getLogger(__name__)

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -42,15 +42,18 @@ from ludwig.utils.defaults import default_random_seed, merge_with_defaults
 from ludwig.utils.fs_utils import makedirs, open_file
 from ludwig.utils.misc_utils import get_class_attributes, get_from_registry, set_default_value, set_default_values
 
+logger = logging.getLogger(__name__)
+
 try:
     from ludwig.backend.ray import RayBackend
-except ImportError:
+except ImportError as e:
+    logger.warning(
+        f"ImportError (run.py) failed to import RayBackend with error: \n\t{e}. "
+        "The LocalBackend will be used instead. If you want to use the RayBackend, please install ludwig[distributed]."
+    )
 
     class RayBackend:
         pass
-
-
-logger = logging.getLogger(__name__)
 
 
 def hyperopt(

--- a/ludwig/progress_bar.py
+++ b/ludwig/progress_bar.py
@@ -1,12 +1,16 @@
+import logging
 import uuid
 from typing import Dict
 
 import tqdm
 
+logger = logging.getLogger(__name__)
+
 try:
     import ray.train as rt
 except ImportError:
     rt = None
+    logger.warning("Failed to import ray train. ray may not be installed. Run pip install ludwig[ray]")
 
 
 class LudwigProgressBarActions:

--- a/tests/integration_tests/test_class_imbalance_feature.py
+++ b/tests/integration_tests/test_class_imbalance_feature.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 import os
 import shutil
 
@@ -10,11 +11,18 @@ from ludwig.api import LudwigModel
 from ludwig.backend import LocalBackend
 from tests.integration_tests.utils import create_data_set_to_use, spawn
 
+logger = logging.getLogger(__name__)
+
 try:
     import ray
 
     from ludwig.backend.ray import RayBackend
-except ImportError:
+except ImportError as e:
+    logger.warning(
+        f"ImportError (test_class_imbalance_feature.py) failed to import RayBackend with error: \n\t{e}. "
+        "The LocalBackend will be used instead. If you want to use the RayBackend, please install ludwig[distributed]. "
+        "Setting ray import to none."
+    )
     ray = None
 
 rs = np.random.RandomState(42)

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 import contextlib
 import json
+import logging
 import os.path
 from typing import Any, Dict, Optional, Tuple, Union
 
@@ -43,6 +44,8 @@ from ludwig.utils.data_utils import load_json
 from ludwig.utils.defaults import merge_with_defaults
 from tests.integration_tests.utils import category_feature, generate_data, text_feature
 
+logger = logging.getLogger(__name__)
+
 try:
     import ray
 
@@ -51,6 +54,9 @@ try:
     _ray113 = version.parse(ray.__version__) > version.parse("1.13")
 
 except ImportError:
+    logger.warning(
+        "ray is not installed. In order to use ray please run pip install ludwig[ray]." "Setting ray import to none."
+    )
     ray = None
     _ray113 = None
 

--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -30,17 +30,20 @@ from ludwig.hyperopt.run import hyperopt, update_hyperopt_params_with_defaults
 from ludwig.utils.defaults import merge_with_defaults
 from tests.integration_tests.utils import category_feature, generate_data, text_feature
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logging.getLogger("ludwig").setLevel(logging.INFO)
+
 try:
     import ray
 
     from ludwig.hyperopt.execution import get_build_hyperopt_executor
 except ImportError:
+    logger.warning(
+        "ray is not installed. In order to use ray please run pip install ludwig[ray]." "Setting ray import to none."
+    )
     ray = None
 
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-logging.getLogger("ludwig").setLevel(logging.INFO)
 
 HYPEROPT_CONFIG = {
     "parameters": {

--- a/tests/integration_tests/test_hyperopt_ray_horovod.py
+++ b/tests/integration_tests/test_hyperopt_ray_horovod.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import logging
 import os.path
 import shutil
 import uuid
@@ -29,6 +30,8 @@ from ludwig.hyperopt.run import hyperopt, update_hyperopt_params_with_defaults
 from ludwig.utils.defaults import merge_with_defaults
 from tests.integration_tests.utils import binary_feature, create_data_set_to_use, generate_data, number_feature
 
+logger = logging.getLogger(__name__)
+
 try:
     import ray
 
@@ -42,12 +45,16 @@ try:
 
     from ludwig.backend.ray import RayBackend
     from ludwig.hyperopt.execution import _get_relative_checkpoints_dir_parts, RayTuneExecutor
-except ImportError:
+except ImportError as e:
+    logger.warning(
+        f"ImportError (test_hyperopt_ray_horovod.py) failed to import RayBackend with error: \n\t{e}. "
+        "The LocalBackend will be used instead. If you want to use the RayBackend, please install ludwig[distributed]. "
+        "Setting ray import to none."
+    )
     ray = None
     _ray_nightly = False
     RayTuneExecutor = object
 
-# Ray mocks
 
 # Dummy sync templates
 LOCAL_SYNC_TEMPLATE = "echo {source}/ {target}/"

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import logging
 import os
 import tempfile
 
@@ -55,6 +56,8 @@ from tests.integration_tests.utils import (
     vector_feature,
 )
 
+logger = logging.getLogger(__name__)
+
 try:
     import modin
     import ray
@@ -80,6 +83,9 @@ try:
     ) >= version.parse("1.13.0")
 
 except ImportError:
+    logger.warning(
+        "ray is not installed. In order to use ray please run pip install ludwig[ray]." "Setting ray import to none."
+    )
     modin = None
     ray = None
 

--- a/tests/integration_tests/test_trainer.py
+++ b/tests/integration_tests/test_trainer.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 from unittest import mock
@@ -8,6 +9,8 @@ from ludwig.api import LudwigModel
 from ludwig.callbacks import Callback
 from ludwig.constants import BATCH_SIZE, EVAL_BATCH_SIZE, LEARNING_RATE, TRAINER
 from tests.integration_tests.utils import category_feature, generate_data, LocalTestBackend, sequence_feature
+
+logger = logging.getLogger(__name__)
 
 try:
     import ray
@@ -39,6 +42,9 @@ try:
         return callback.lr
 
 except ImportError:
+    logger.warning(
+        "ray is not installed. In order to use ray please run pip install ludwig[ray]." "Setting ray import to none."
+    )
     ray = None
 
 

--- a/tests/integration_tests/test_whylogs.py
+++ b/tests/integration_tests/test_whylogs.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 import os
 import shutil
 
@@ -9,9 +10,14 @@ from ludwig.constants import TRAINER
 from ludwig.contribs import WhyLogsCallback
 from tests.integration_tests.utils import category_feature, generate_data, sequence_feature, spawn
 
+logger = logging.getLogger(__name__)
+
 try:
     import ray
 except ImportError:
+    logger.warning(
+        "ray is not installed. In order to use ray please run pip install ludwig[ray]." "Setting ray import to none."
+    )
     ray = None
 
 


### PR DESCRIPTION
I started running into some bespoke test failures and figured out it was because the version of Ray I was using in my container was different from the version now officially supported by Ludwig (Ray >= 1.13). 

I realized that we don't actually log warnings when an import to ray fails and we also set this to None, which often causes downstream issues for tests in particular when we do a `ray.init()` call using test fixtures.

This PR logs warnings to make sure users running their tests are made of ray import failures.