### PR TITLE
Quick fix: Don't show calibration validation set warnings unless calibration is actually enabled

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -569,22 +569,23 @@ class LudwigModel:
                             self.backend,
                             batch_size=trainer.eval_batch_size,
                         )
-                        if validation_set is None:
-                            logger.warning(
-                                "Calibration uses validation set, but no validation split specified."
-                                "Will use training set for calibration."
-                                "Recommend providing a validation set when using calibration."
-                            )
-                            calibrator.train_calibration(training_set, TRAINING)
-                        elif len(validation_set) < MIN_VALIDATION_SET_ROWS:
-                            logger.warning(
-                                f"Validation set size ({len(validation_set)} rows) is too small for calibration."
-                                "Will use training set for calibration."
-                                f"Validation set much have at least {MIN_VALIDATION_SET_ROWS} rows."
-                            )
-                            calibrator.train_calibration(training_set, TRAINING)
-                        else:
-                            calibrator.train_calibration(validation_set, VALIDATION)
+                        if calibrator.calibration_enabled():
+                            if validation_set is None:
+                                logger.warning(
+                                    "Calibration uses validation set, but no validation split specified."
+                                    "Will use training set for calibration."
+                                    "Recommend providing a validation set when using calibration."
+                                )
+                                calibrator.train_calibration(training_set, TRAINING)
+                            elif len(validation_set) < MIN_VALIDATION_SET_ROWS:
+                                logger.warning(
+                                    f"Validation set size ({len(validation_set)} rows) is too small for calibration."
+                                    "Will use training set for calibration."
+                                    f"Validation set much have at least {MIN_VALIDATION_SET_ROWS} rows."
+                                )
+                                calibrator.train_calibration(training_set, TRAINING)
+                            else:
+                                calibrator.train_calibration(validation_set, VALIDATION)
                         if not skip_save_model:
                             self.model.save(model_dir)
 

--- a/ludwig/models/calibrator.py
+++ b/ludwig/models/calibrator.py
@@ -28,12 +28,15 @@ class Calibrator:
         self.backend = backend
         self.batch_size = batch_size
 
+    def calibration_enabled(self):
+        return not all(o.calibration_module is None for o in self.model.output_features.values())
+
     def train_calibration(self, dataset, dataset_name: str):
         """Calibrates model output probabilities on validation set after training.
 
         This works well for most datasets, though it may fail for some difficult or extremely imbalanced datasets.
         """
-        if all(o.calibration_module is None for o in self.model.output_features.values()):
+        if not self.calibration_enabled():
             # Early out if no output features have calibration enabled.
             return
         with self.backend.create_predictor(self.model, batch_size=self.batch_size) as predictor:

--- a/ludwig/models/calibrator.py
+++ b/ludwig/models/calibrator.py
@@ -29,7 +29,11 @@ class Calibrator:
         self.batch_size = batch_size
 
     def calibration_enabled(self):
-        return not all(o.calibration_module is None for o in self.model.output_features.values())
+        """Calibration is enabled if the config requests calibration for any output feature.
+
+        If no output features have calibration enabled, the calibration phase should be skipped.
+        """
+        return any(o.calibration_module is not None for o in self.model.output_features.values())
 
     def train_calibration(self, dataset, dataset_name: str):
         """Calibrates model output probabilities on validation set after training.


### PR DESCRIPTION
The "Calibration uses validation set, but no validation split specified..." warning gets logged even if no output features have calibration enabled, and that is confusing.

This fix checks first to see if any output features are using calibration, and only logs these messages if so.