### PR TITLE
Add API Annotations to Ludwig

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,20 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+--------------------------------------------------------------------------
+
+Code in ludwig/api_annotations.py adapted from
+https://github.com/ray-project/ray (Apache-2.0 License)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ludwig/api_annotations.py
+++ b/ludwig/api_annotations.py
@@ -1,0 +1,185 @@
+#! /usr/bin/env python
+#
+# Code in api_annotations.py adapted from https://github.com/ray-project/ray (Apache-2.0 License)
+#
+# ==============================================================================
+
+
+from typing import Optional
+
+
+def PublicAPI(*args, **kwargs):
+    """Annotation for documenting public APIs. Public APIs are classes and methods exposed to end users of Ludwig.
+
+    If 'stability="stable"', the APIs will remain backwards compatible across minor Ludwig releases
+    (e.g., Ludwig 0.6 -> Ludwig 0.5).
+
+    If 'stability="experimental"', the APIs can be used by advanced users who are tolerant to and expect
+    breaking changes. This will likely be seen in the case of incremental new feature development.
+
+    Args:
+        stability: One of {"stable", "experimental"}.
+        message: A message to help users understand the reason for the deprecation, and provide a migration path.
+    Examples:
+        >>> from api_annotations import PublicAPI
+        >>> @PublicAPI
+        ... def func1(x):
+        ...     return x
+        >>> @PublicAPI(stability="beta")
+        ... def func2(y):
+        ...     return y
+        >>> @PublicAPI(message="")
+        ... def func3(z):
+        ...     return z
+    """
+    if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+        return PublicAPI(stability="stable")(args[0])
+
+    if "stability" in kwargs:
+        stability = kwargs["stability"]
+        assert stability in ["stable", "experimental"], stability
+    elif kwargs:
+        raise ValueError(f"Unknown kwargs: {kwargs.keys()}")
+    else:
+        stability = "stable"
+
+    def wrap(obj):
+        if stability == "experimental":
+            message = f"PublicAPI ({stability}): This API is in {stability} " "and may change before becoming stable."
+        else:
+            message = "PublicAPI: This API is stable across Ludwig releases."
+
+        _append_doc(obj, message=message)
+        _mark_annotated(obj)
+        return obj
+
+    return wrap
+
+
+def DeveloperAPI(*args, **kwargs):
+    """Annotation for documenting developer APIs. Developer APIs are lower-level methods explicitly exposed to
+    advanced Ludwig users and library developers. Their interfaces may change across minor Ludwig releases (for
+    e.g., Ludwig 0.6.1 and Ludwig 0.6.2).
+
+    Args:
+        message: a message to help users understand the reason for the deprecation, and provide a migration path.
+    Examples:
+        >>> from api_annotations import DeveloperAPI
+        >>> @DeveloperAPI
+        ... def func(x):
+        ...     return x
+    """
+    if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+        return DeveloperAPI()(args[0])
+
+    def wrap(obj):
+        _append_doc(obj, message="DeveloperAPI: This API may change across minor Ludwig releases.")
+        _mark_annotated(obj)
+        return obj
+
+    return wrap
+
+
+def Deprecated(*args, **kwargs):
+    """Annotation for documenting a deprecated API.
+    Deprecated APIs may be removed in future releases of Ludwig (e.g., Ludwig 0.7 to Ludwig 0.8).
+    Args:
+        message: A message to help users understand the reason for the deprecation, and provide a migration path.
+    Examples:
+        >>> from api_annotations import Deprecated
+        >>> @Deprecated
+        ... def func(x):
+        ...     return x
+        >>> @Deprecated(message="g() is deprecated because the API is error prone. Please call h() instead.")
+        ... def g(y):
+        ...     return y
+    """
+    if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+        return Deprecated()(args[0])
+
+    message = "**DEPRECATED:** This API is deprecated and may be removed in a future Ludwig release."
+
+    if "message" in kwargs:
+        message += " " + kwargs["message"]
+        del kwargs["message"]
+
+    if kwargs:
+        raise ValueError(f"Unknown kwargs: {kwargs.keys()}")
+
+    def inner(obj):
+        _append_doc(obj, message=message, directive="warning")
+        _mark_annotated(obj)
+        return obj
+
+    return inner
+
+
+def _append_doc(obj, *, message: str, directive: Optional[str] = None) -> str:
+    if not obj.__doc__:
+        obj.__doc__ = ""
+
+    obj.__doc__ = obj.__doc__.rstrip()
+
+    indent = _get_indent(obj.__doc__)
+    obj.__doc__ += "\n\n"
+    if directive is not None:
+        obj.__doc__ += f"{' ' * indent}.. {directive}::\n"
+        obj.__doc__ += f"{' ' * (indent + 4)}{message}"
+    else:
+        obj.__doc__ += f"{' ' * indent}{message}"
+    obj.__doc__ += f"\n{' ' * indent}"
+
+
+def _get_indent(docstring: str) -> int:
+    """
+    Example:
+        >>> def f():
+        ...     '''Docstring summary.'''
+        >>> f.__doc__
+        'Docstring summary.'
+        >>> _get_indent(f.__doc__)
+        0
+        >>> def g(foo):
+        ...     '''Docstring summary.
+        ...
+        ...     Args:
+        ...         foo: Does bar.
+        ...     '''
+        >>> g.__doc__
+        'Docstring summary.\\n\\n    Args:\\n        foo: Does bar.\\n    '
+        >>> _get_indent(g.__doc__)
+        4
+        >>> class A:
+        ...     def h():
+        ...         '''Docstring summary.
+        ...
+        ...         Returns:
+        ...             None.
+        ...         '''
+        >>> A.h.__doc__
+        'Docstring summary.\\n\\n        Returns:\\n            None.\\n        '
+        >>> _get_indent(A.h.__doc__)
+        8
+    """
+    if not docstring:
+        return 0
+
+    non_empty_lines = list(filter(bool, docstring.splitlines()))
+    if len(non_empty_lines) == 1:
+        # Docstring contains summary only.
+        return 0
+
+    # The docstring summary isn't indented, so check the indentation of the second
+    # non-empty line.
+    return len(non_empty_lines[1]) - len(non_empty_lines[1].lstrip())
+
+
+def _mark_annotated(obj) -> None:
+    # Set magic token for check_api_annotations linter.
+    if hasattr(obj, "__name__"):
+        obj._annotated = obj.__name__
+
+
+def _is_annotated(obj) -> bool:
+    # Check the magic token exists and applies to this class (not a subclass).
+    return hasattr(obj, "_annotated") and obj._annotated == obj.__name__

--- a/ludwig/api_annotations.py
+++ b/ludwig/api_annotations.py
@@ -1,6 +1,7 @@
-#! /usr/bin/env python
+# ==============================================================================
 #
 # Code in api_annotations.py adapted from https://github.com/ray-project/ray (Apache-2.0 License)
+# Link to file: https://github.com/ray-project/ray/blob/master/python/ray/util/annotations.py
 #
 # ==============================================================================
 from typing import Optional
@@ -16,8 +17,7 @@ def PublicAPI(*args, **kwargs):
     breaking changes. This will likely be seen in the case of incremental new feature development.
 
     Args:
-        stability: One of {"stable", "experimental"}.
-        message: A message to help users understand the reason for the deprecation, and provide a migration path.
+        stability: One of {"stable", "experimental"}
 
     Examples:
         >>> from api_annotations import PublicAPI
@@ -27,9 +27,6 @@ def PublicAPI(*args, **kwargs):
         >>> @PublicAPI(stability="beta")
         ... def func2(y):
         ...     return y
-        >>> @PublicAPI(message="")
-        ... def func3(z):
-        ...     return z
     """
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
         return PublicAPI(stability="stable")(args[0])
@@ -61,7 +58,7 @@ def DeveloperAPI(*args, **kwargs):
     e.g., Ludwig 0.6.1 and Ludwig 0.6.2).
 
     Args:
-        message: A message to help users understand the reason for the deprecation, and provide a migration path.
+        message: A message to indicate what might change with the API definition, or provide a migration path.
 
     Examples:
         >>> from api_annotations import DeveloperAPI
@@ -116,7 +113,13 @@ def Deprecated(*args, **kwargs):
     return inner
 
 
-def _append_doc(obj, *, message: str, directive: Optional[str] = None) -> str:
+def _append_doc(obj, message: str, directive: Optional[str] = None) -> str:
+    """
+    Args:
+        message: An additional message to append to the end of docstring for a class
+                 or method that uses one of the API annotations
+        directive:
+    """
     if not obj.__doc__:
         obj.__doc__ = ""
 

--- a/ludwig/api_annotations.py
+++ b/ludwig/api_annotations.py
@@ -18,7 +18,7 @@ def PublicAPI(*args, **kwargs):
         >>> @PublicAPI
         ... def func1(x):
         ...     return x
-        >>> @PublicAPI(stability="beta")
+        >>> @PublicAPI(stability="experimental")
         ... def func2(y):
         ...     return y
     """

--- a/ludwig/api_annotations.py
+++ b/ludwig/api_annotations.py
@@ -109,7 +109,8 @@ def _append_doc(obj, message: str, directive: Optional[str] = None) -> str:
     Args:
         message: An additional message to append to the end of docstring for a class
                  or method that uses one of the API annotations
-        directive:
+        directive: A shorter message that provides contexts for the message and indents it.
+                For example, this could be something like 'warning' or 'info'.
     """
     if not obj.__doc__:
         obj.__doc__ = ""

--- a/ludwig/api_annotations.py
+++ b/ludwig/api_annotations.py
@@ -51,9 +51,6 @@ def DeveloperAPI(*args, **kwargs):
     advanced Ludwig users and library developers. Their interfaces may change across minor Ludwig releases (for
     e.g., Ludwig 0.6.1 and Ludwig 0.6.2).
 
-    Args:
-        message: A message to indicate what might change with the API definition, or provide a migration path.
-
     Examples:
         >>> from api_annotations import DeveloperAPI
         >>> @DeveloperAPI

--- a/ludwig/api_annotations.py
+++ b/ludwig/api_annotations.py
@@ -1,9 +1,3 @@
-# ==============================================================================
-#
-# Code in api_annotations.py adapted from https://github.com/ray-project/ray (Apache-2.0 License)
-# Link to file: https://github.com/ray-project/ray/blob/master/python/ray/util/annotations.py
-#
-# ==============================================================================
 from typing import Optional
 
 

--- a/ludwig/api_annotations.py
+++ b/ludwig/api_annotations.py
@@ -3,23 +3,22 @@
 # Code in api_annotations.py adapted from https://github.com/ray-project/ray (Apache-2.0 License)
 #
 # ==============================================================================
-
-
 from typing import Optional
 
 
 def PublicAPI(*args, **kwargs):
     """Annotation for documenting public APIs. Public APIs are classes and methods exposed to end users of Ludwig.
 
-    If 'stability="stable"', the APIs will remain backwards compatible across minor Ludwig releases
+    If stability="stable", the APIs will remain backwards compatible across minor Ludwig releases
     (e.g., Ludwig 0.6 -> Ludwig 0.5).
 
-    If 'stability="experimental"', the APIs can be used by advanced users who are tolerant to and expect
+    If stability="experimental", the APIs can be used by advanced users who are tolerant to and expect
     breaking changes. This will likely be seen in the case of incremental new feature development.
 
     Args:
         stability: One of {"stable", "experimental"}.
         message: A message to help users understand the reason for the deprecation, and provide a migration path.
+
     Examples:
         >>> from api_annotations import PublicAPI
         >>> @PublicAPI
@@ -45,7 +44,7 @@ def PublicAPI(*args, **kwargs):
 
     def wrap(obj):
         if stability == "experimental":
-            message = f"PublicAPI ({stability}): This API is in {stability} " "and may change before becoming stable."
+            message = f"PublicAPI ({stability}): This API is {stability} and may change before becoming stable."
         else:
             message = "PublicAPI: This API is stable across Ludwig releases."
 
@@ -62,7 +61,8 @@ def DeveloperAPI(*args, **kwargs):
     e.g., Ludwig 0.6.1 and Ludwig 0.6.2).
 
     Args:
-        message: a message to help users understand the reason for the deprecation, and provide a migration path.
+        message: A message to help users understand the reason for the deprecation, and provide a migration path.
+
     Examples:
         >>> from api_annotations import DeveloperAPI
         >>> @DeveloperAPI
@@ -81,10 +81,12 @@ def DeveloperAPI(*args, **kwargs):
 
 
 def Deprecated(*args, **kwargs):
-    """Annotation for documenting a deprecated API.
-    Deprecated APIs may be removed in future releases of Ludwig (e.g., Ludwig 0.7 to Ludwig 0.8).
+    """Annotation for documenting a deprecated API. Deprecated APIs may be removed in future releases of Ludwig
+    (e.g., Ludwig 0.7 to Ludwig 0.8).
+
     Args:
         message: A message to help users understand the reason for the deprecation, and provide a migration path.
+
     Examples:
         >>> from api_annotations import Deprecated
         >>> @Deprecated
@@ -130,6 +132,17 @@ def _append_doc(obj, *, message: str, directive: Optional[str] = None) -> str:
     obj.__doc__ += f"\n{' ' * indent}"
 
 
+def _mark_annotated(obj) -> None:
+    # Set magic token for check_api_annotations linter.
+    if hasattr(obj, "__name__"):
+        obj._annotated = obj.__name__
+
+
+def _is_annotated(obj) -> bool:
+    # Check the magic token exists and applies to this class (not a subclass).
+    return hasattr(obj, "_annotated") and obj._annotated == obj.__name__
+
+
 def _get_indent(docstring: str) -> int:
     """
     Example:
@@ -169,17 +182,5 @@ def _get_indent(docstring: str) -> int:
         # Docstring contains summary only.
         return 0
 
-    # The docstring summary isn't indented, so check the indentation of the second
-    # non-empty line.
+    # The docstring summary isn't indented, so check the indentation of the second non-empty line.
     return len(non_empty_lines[1]) - len(non_empty_lines[1].lstrip())
-
-
-def _mark_annotated(obj) -> None:
-    # Set magic token for check_api_annotations linter.
-    if hasattr(obj, "__name__"):
-        obj._annotated = obj.__name__
-
-
-def _is_annotated(obj) -> bool:
-    # Check the magic token exists and applies to this class (not a subclass).
-    return hasattr(obj, "_annotated") and obj._annotated == obj.__name__


### PR DESCRIPTION
This PR introduces `api_annotations.py` that can be used to delineate the boundary of Ludwig APIs that are public, for developers, and those that are deprecated.

Co-authored-by: Daniel Treiman <daniel@predibase.com> (@dantreiman)