### PR TITLE
Shutdown ray if initialized in _ray_start fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,9 @@ def _ray_start(request, **kwargs):
         yield None
         return
 
+    if ray.is_initialized():
+        ray.shutdown()
+
     init_kwargs = _get_default_ray_kwargs()
     init_kwargs.update(kwargs)
     res = ray.init(**init_kwargs)


### PR DESCRIPTION
This PR adds a check to shutdown ray if it was previously initialized in a separate `_ray_start` call. Occasionally, the teardown code is not executed which causes future `ray.init` cause an error. This PR shuts down ray before calling `ray.init` to avoid that error.