### PR TITLE
Fix assertions in training_determinism tests

### DIFF
--- a/tests/ludwig/models/test_training_determinism.py
+++ b/tests/ludwig/models/test_training_determinism.py
@@ -31,8 +31,8 @@ def test_training_determinism_ray_backend(csv_filename, tmpdir):
     eval_stats_1, train_stats_1, _, _ = experiment_output_1
     eval_stats_2, train_stats_2, _, _ = experiment_output_2
 
-    np.testing.assert_equal(eval_stats_1, eval_stats_1)
-    np.testing.assert_equal(train_stats_1, train_stats_1)
+    np.testing.assert_equal(eval_stats_1, eval_stats_2)
+    np.testing.assert_equal(train_stats_1, train_stats_2)
 
 
 def test_training_determinism_local_backend(csv_filename, tmpdir):
@@ -41,8 +41,8 @@ def test_training_determinism_local_backend(csv_filename, tmpdir):
     eval_stats_1, train_stats_1, _, _ = experiment_output_1
     eval_stats_2, train_stats_2, _, _ = experiment_output_2
 
-    np.testing.assert_equal(eval_stats_1, eval_stats_1)
-    np.testing.assert_equal(train_stats_1, train_stats_1)
+    np.testing.assert_equal(eval_stats_1, eval_stats_2)
+    np.testing.assert_equal(train_stats_1, train_stats_2)
 
 
 def train_twice(backend, csv_filename, tmpdir):


### PR DESCRIPTION
These tests should be comparing the values from both of the runs, rather than to themselves.