### PR TITLE
Relax test constraint to reduce flakiness in test_ray

### DIFF
--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -865,7 +865,7 @@ def train_with_backend(
                     for (name1, metric1), (name2, metric2) in zip(v1.items(), v2.items()):
                         assert name1 == name2
                         assert np.isclose(
-                            metric1, metric2, rtol=1e-04, atol=1e-5
+                            metric1, metric2, rtol=1e-03, atol=1e-04
                         ), f"metric {name1}: {metric1} != {metric2}"
 
         return model


### PR DESCRIPTION
Seeing some flakiness in some tests I added, so relaxing constraints (to a reasonable amount) to make sure they're no longer flaky. 