### PR TITLE
Add splitter that deterministically splits on an ID column

### DIFF
--- a/ludwig/data/split.py
+++ b/ludwig/data/split.py
@@ -279,7 +279,7 @@ class HashSplitter(Splitter):
         thresholds = [v * max_value for v in self.probabilities]
 
         def hash_column(x):
-            value = hash_dict({"value": x})
+            value = hash_dict({"value": x}, max_length=None)
             hash_value = crc32(value)
             if hash_value < thresholds[0]:
                 return 0

--- a/ludwig/data/split.py
+++ b/ludwig/data/split.py
@@ -16,14 +16,21 @@
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple
+from zlib import crc32
 
 import numpy as np
 from sklearn.model_selection import train_test_split
 
 from ludwig.backend.base import Backend
 from ludwig.constants import BINARY, CATEGORY, COLUMN, DATE, SPLIT, TYPE
-from ludwig.schema.split import DateTimeSplitConfig, FixedSplitConfig, RandomSplitConfig, StratifySplitConfig
-from ludwig.utils.data_utils import split_dataset_ttv
+from ludwig.schema.split import (
+    DateTimeSplitConfig,
+    FixedSplitConfig,
+    HashSplitConfig,
+    RandomSplitConfig,
+    StratifySplitConfig,
+)
+from ludwig.utils.data_utils import hash_dict, split_dataset_ttv
 from ludwig.utils.registry import Registry
 from ludwig.utils.types import DataFrame
 
@@ -251,6 +258,51 @@ class DatetimeSplitter(Splitter):
     @staticmethod
     def get_schema_cls():
         return DateTimeSplitConfig
+
+
+@split_registry.register("hash")
+class HashSplitter(Splitter):
+    def __init__(
+        self,
+        column: str,
+        probabilities: List[float] = DEFAULT_PROBABILITIES,
+        **kwargs,
+    ):
+        self.column = column
+        self.probabilities = probabilities
+
+    def split(
+        self, df: DataFrame, backend: Backend, random_seed: float = default_random_seed
+    ) -> Tuple[DataFrame, DataFrame, DataFrame]:
+        # Maximum value of the hash function crc32
+        max_value = 2**32
+        thresholds = [v * max_value for v in self.probabilities]
+
+        def hash_column(x):
+            value = hash_dict({"value": x})
+            hash_value = crc32(value)
+            if hash_value < thresholds[0]:
+                return 0
+            elif hash_value < (thresholds[0] + thresholds[1]):
+                return 1
+            else:
+                return 2
+
+        df[TMP_SPLIT_COL] = backend.df_engine.map_objects(df[self.column], hash_column).astype(np.int8)
+        dfs = split_dataset_ttv(df, TMP_SPLIT_COL)
+        train, test, val = tuple(df.drop(columns=TMP_SPLIT_COL) if df is not None else None for df in dfs)
+        return train, val, test
+
+    def has_split(self, split_index: int) -> bool:
+        return self.probabilities[split_index] > 0
+
+    @property
+    def required_columns(self) -> List[str]:
+        return [self.column]
+
+    @staticmethod
+    def get_schema_cls():
+        return HashSplitConfig
 
 
 def get_splitter(type: Optional[str] = None, **kwargs) -> Splitter:

--- a/ludwig/schema/split.py
+++ b/ludwig/schema/split.py
@@ -94,6 +94,35 @@ class DateTimeSplitConfig(BaseSplitConfig):
         description="The column name to perform datetime splitting on.",
     )
 
+    probabilities: list = schema_utils.List(
+        list_type=float,
+        default=DEFAULT_PROBABILITIES,
+        description="Proportion of data to split into train, validation, and test sets.",
+    )
+
+
+@split_config_registry.register("hash")
+@dataclass
+class HashSplitConfig(BaseSplitConfig):
+    """This Dataclass generates a schema for the fixed splitting config."""
+
+    type: str = schema_utils.StringOptions(
+        ["hash"],
+        default="hash",
+        allow_none=False,
+        description="Type of splitting to use during preprocessing.",
+    )
+
+    column: str = schema_utils.String(
+        description="The column name to perform hash splitting on.",
+    )
+
+    probabilities: list = schema_utils.List(
+        list_type=float,
+        default=DEFAULT_PROBABILITIES,
+        description="Proportion of data to split into train, validation, and test sets.",
+    )
+
 
 def get_split_conds():
     """Returns a JSON schema of conditionals to validate against optimizer types defined in

--- a/ludwig/schema/split.py
+++ b/ludwig/schema/split.py
@@ -104,7 +104,16 @@ class DateTimeSplitConfig(BaseSplitConfig):
 @split_config_registry.register("hash")
 @dataclass
 class HashSplitConfig(BaseSplitConfig):
-    """This Dataclass generates a schema for the fixed splitting config."""
+    """This Dataclass generates a schema for the hash splitting config.
+
+    This is useful for deterministically splitting on a unique ID. Even when additional rows are added to the dataset
+    in the future, each ID will retain its original split assignment.
+
+    This approach does not guarantee that the split proportions will be assigned exactly, but the larger the dataset,
+    the more closely the assignment should match the given proportions.
+
+    This approach can be used on a column with duplicates, but it will further skew the assignments of rows to splits.
+    """
 
     type: str = schema_utils.StringOptions(
         ["hash"],

--- a/tests/ludwig/data/test_split.py
+++ b/tests/ludwig/data/test_split.py
@@ -292,7 +292,7 @@ def test_hash_split(df_engine, ray_cluster_2cpu):
     assert len(splits) == 3
     if isinstance(df_engine, DaskEngine):
         splits = [split.compute() for split in splits]
-        
+
     # IDs should not overlap between splits
     assert all([set(split1["id"]).isdisjoint(set(split2["id"])) for split1, split2 in combinations(splits, 2)])
 

--- a/tests/ludwig/data/test_split.py
+++ b/tests/ludwig/data/test_split.py
@@ -288,18 +288,13 @@ def test_hash_split(df_engine, ray_cluster_2cpu):
     backend = Mock()
     backend.df_engine = df_engine
     splits = splitter.split(df, backend)
-
     assert len(splits) == 3
-
     if isinstance(df_engine, DaskEngine):
         splits = [split.compute() for split in splits]
+    
     for split, p in zip(splits, probabilities):
-
         # Should be approximately the same size as the desired proportion
         assert nrows * p - 5 <= len(split["id"]) <= nrows * p + 5
-
-    # IDs should not overlap between splits
-    assert all([set(split1["id"]).isdisjoint(set(split2["id"])) for split1, split2 in combinations(splits, 2)])
 
     # Need to ensure deterministic splitting even as we append data
     df2 = pd.DataFrame(np.random.randint(0, 100, size=(nrows, 3)), columns=["A", "B", "C"])
@@ -307,12 +302,16 @@ def test_hash_split(df_engine, ray_cluster_2cpu):
 
     nrows *= 2
     df = df.append(df2)
+    
     splits2 = splitter.split(df, backend)
+    assert len(splits2) == 3
+    if isinstance(df_engine, DaskEngine):
+        splits2 = [split.compute() for split in splits2]
+        
+    # IDs should not overlap between splits
+    assert all([set(split1["id"]).isdisjoint(set(split2["id"])) for split1, split2 in combinations(splits, 2)])
+    
     for split1, split2, p in zip(splits, splits2, probabilities):
-        if isinstance(df_engine, DaskEngine):
-            split1 = split1.compute()
-            split2 = split2.compute()
-
         ids1 = set(split1["id"].values.tolist())
         ids2 = set(split2["id"].values.tolist())
 

--- a/tests/ludwig/data/test_split.py
+++ b/tests/ludwig/data/test_split.py
@@ -291,7 +291,7 @@ def test_hash_split(df_engine, ray_cluster_2cpu):
     assert len(splits) == 3
     if isinstance(df_engine, DaskEngine):
         splits = [split.compute() for split in splits]
-    
+
     for split, p in zip(splits, probabilities):
         # Should be approximately the same size as the desired proportion
         assert nrows * p - 5 <= len(split["id"]) <= nrows * p + 5
@@ -302,15 +302,15 @@ def test_hash_split(df_engine, ray_cluster_2cpu):
 
     nrows *= 2
     df = df.append(df2)
-    
+
     splits2 = splitter.split(df, backend)
     assert len(splits2) == 3
     if isinstance(df_engine, DaskEngine):
         splits2 = [split.compute() for split in splits2]
-        
+
     # IDs should not overlap between splits
     assert all([set(split1["id"]).isdisjoint(set(split2["id"])) for split1, split2 in combinations(splits, 2)])
-    
+
     for split1, split2, p in zip(splits, splits2, probabilities):
         ids1 = set(split1["id"].values.tolist())
         ids2 = set(split2["id"].values.tolist())

--- a/tests/ludwig/data/test_split.py
+++ b/tests/ludwig/data/test_split.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from itertools import combinations
 from random import randrange
 from unittest.mock import Mock
 
@@ -291,6 +292,9 @@ def test_hash_split(df_engine, ray_cluster_2cpu):
     assert len(splits) == 3
     if isinstance(df_engine, DaskEngine):
         splits = [split.compute() for split in splits]
+        
+    # IDs should not overlap between splits
+    assert all([set(split1["id"]).isdisjoint(set(split2["id"])) for split1, split2 in combinations(splits, 2)])
 
     for split, p in zip(splits, probabilities):
         # Should be approximately the same size as the desired proportion
@@ -309,7 +313,7 @@ def test_hash_split(df_engine, ray_cluster_2cpu):
         splits2 = [split.compute() for split in splits2]
 
     # IDs should not overlap between splits
-    assert all([set(split1["id"]).isdisjoint(set(split2["id"])) for split1, split2 in combinations(splits, 2)])
+    assert all([set(split1["id"]).isdisjoint(set(split2["id"])) for split1, split2 in combinations(splits2, 2)])
 
     for split1, split2, p in zip(splits, splits2, probabilities):
         ids1 = set(split1["id"].values.tolist())


### PR DESCRIPTION
This is useful for deterministically splitting on a unique ID. Even when additional rows are added to the dataset in the future, each ID will retain its original split assignment.

This approach does not guarantee that the split proportions will be assigned exactly, but the larger the dataset, the more closely the assignment should match the given proportions.

This approach can be used on a column with duplicates, but it will further skew the assignments of rows to splits. However, this may be useful if you need to ensure that the particular ID only appears in a single split (for example, a user ID with multiple rows, where we want to ensure the user isn't in both train and test sets).

The CRC32 approach was from: https://towardsdatascience.com/improve-the-train-test-split-with-the-hashing-function-f38f32b721fb