### PR TITLE
Adds minimum split size, ensures random split is never smaller than split size.

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -45,7 +45,7 @@ from ludwig.constants import (
     HYPEROPT,
     HYPEROPT_WARNING,
     LEARNING_RATE,
-    MIN_VALIDATION_SET_ROWS,
+    MIN_DATASET_SPLIT_ROWS,
     MODEL_TYPE,
     PREPROCESSING,
     TEST,
@@ -577,11 +577,11 @@ class LudwigModel:
                                     "Recommend providing a validation set when using calibration."
                                 )
                                 calibrator.train_calibration(training_set, TRAINING)
-                            elif len(validation_set) < MIN_VALIDATION_SET_ROWS:
+                            elif len(validation_set) < MIN_DATASET_SPLIT_ROWS:
                                 logger.warning(
                                     f"Validation set size ({len(validation_set)} rows) is too small for calibration."
                                     "Will use training set for calibration."
-                                    f"Validation set much have at least {MIN_VALIDATION_SET_ROWS} rows."
+                                    f"Validation set much have at least {MIN_DATASET_SPLIT_ROWS} rows."
                                 )
                                 calibrator.train_calibration(training_set, TRAINING)
                             else:

--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -128,7 +128,7 @@ FULL = "full"
 TRAIN_SPLIT = 0
 VALIDATION_SPLIT = 1
 TEST_SPLIT = 2
-MIN_VALIDATION_SET_ROWS = 3  # The minimum validation set size to ensure metric computation doesn't fail.
+MIN_DATASET_SPLIT_ROWS = 3  # The minimum number of rows in a split. Splits smaller than this size are treated as empty.
 
 META = "meta"
 

--- a/ludwig/data/dataset_synthesizer.py
+++ b/ludwig/data/dataset_synthesizer.py
@@ -172,7 +172,7 @@ def build_synthetic_dataset(dataset_size: int, features: List[dict], outdir: str
 
     :param dataset_size: (int) size of the dataset
     :param features: (List[dict]) list of features to generate in YAML format.
-        Provide a list contaning one dictionary for each feature,
+        Provide a list containing one dictionary for each feature,
         each dictionary must include a name, a type
         and can include some generation parameters depending on the type
     :param outdir: (str) Path to an output directory. Used for saving synthetic image and audio files.

--- a/tests/ludwig/data/test_split.py
+++ b/tests/ludwig/data/test_split.py
@@ -16,6 +16,46 @@ except ImportError:
     DaskEngine = Mock
 
 
+def test_make_fractions_ensure_minimum_rows():
+    from ludwig.data.split import _make_fractions_ensure_minimum_rows
+
+    # With 100 examples, the function should make no change to fractions.
+    fractions = _make_fractions_ensure_minimum_rows((0.7, 0.1, 0.2), 100, min_rows=3)
+    assert sum(fractions) == pytest.approx(1.0)
+    assert fractions[0] == pytest.approx(0.7)
+    assert fractions[1] == pytest.approx(0.1)
+    assert fractions[2] == pytest.approx(0.2)
+    # With 25 examples, the expected number of validation set rows is 2.5
+    fractions = _make_fractions_ensure_minimum_rows((0.7, 0.1, 0.2), 25, min_rows=3)
+    assert sum(fractions) == pytest.approx(1.0)
+    assert fractions[0] == pytest.approx(0.68)
+    assert fractions[1] == pytest.approx(0.12)
+    assert fractions[2] == pytest.approx(0.2)
+    # With 25 examples, the expected number of val and test set rows is 2.5
+    fractions = _make_fractions_ensure_minimum_rows((0.8, 0.1, 0.1), 25, min_rows=3)
+    assert sum(fractions) == pytest.approx(1.0)
+    assert fractions[0] == pytest.approx(0.76)
+    assert fractions[1] == pytest.approx(0.12)
+    assert fractions[2] == pytest.approx(0.12)
+
+
+def test_make_divisions_ensure_minimum_rows():
+    from ludwig.data.split import _make_divisions_ensure_minimum_rows
+
+    # In this case, the function should make no change to fractions.
+    divisions = _make_divisions_ensure_minimum_rows((70, 80), 100, min_rows=3)
+    assert divisions[0] == 70
+    assert divisions[1] == 80
+    # The number of rows in validation set is too small.
+    divisions = _make_divisions_ensure_minimum_rows((17, 19), 25, min_rows=3)
+    assert divisions[0] == 16
+    assert divisions[1] == 19
+    # The number of rows in validation and test sets are both too small.
+    divisions = _make_divisions_ensure_minimum_rows((20, 22), 25, min_rows=3)
+    assert divisions[0] == 19
+    assert divisions[1] == 22
+
+
 @pytest.mark.parametrize(
     ("df_engine",),
     [


### PR DESCRIPTION
Should fix NaN metrics caused by too-small validation set.

Problem: if the validation set is too small (1 row, for example) some metrics evaluate to NaN, which causes tests to fail.

This situation is mainly encountered in test cases where we use small synthetic datasets with random splits.

The solution here is to add a constant `MIN_DATASET_SPLIT_ROWS`, and ensure that each nonempty split contains at least `MIN_DATASET_SPLIT_ROWS`