### PR TITLE
Adds minimum split size, ensures random split is never smaller than minimum for local backend

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -45,7 +45,7 @@ from ludwig.constants import (
     HYPEROPT,
     HYPEROPT_WARNING,
     LEARNING_RATE,
-    MIN_VALIDATION_SET_ROWS,
+    MIN_DATASET_SPLIT_ROWS,
     MODEL_TYPE,
     PREPROCESSING,
     TEST,
@@ -577,11 +577,11 @@ class LudwigModel:
                                     "Recommend providing a validation set when using calibration."
                                 )
                                 calibrator.train_calibration(training_set, TRAINING)
-                            elif len(validation_set) < MIN_VALIDATION_SET_ROWS:
+                            elif len(validation_set) < MIN_DATASET_SPLIT_ROWS:
                                 logger.warning(
                                     f"Validation set size ({len(validation_set)} rows) is too small for calibration."
                                     "Will use training set for calibration."
-                                    f"Validation set much have at least {MIN_VALIDATION_SET_ROWS} rows."
+                                    f"Validation set much have at least {MIN_DATASET_SPLIT_ROWS} rows."
                                 )
                                 calibrator.train_calibration(training_set, TRAINING)
                             else:

--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -128,7 +128,7 @@ FULL = "full"
 TRAIN_SPLIT = 0
 VALIDATION_SPLIT = 1
 TEST_SPLIT = 2
-MIN_VALIDATION_SET_ROWS = 3  # The minimum validation set size to ensure metric computation doesn't fail.
+MIN_DATASET_SPLIT_ROWS = 3  # The minimum number of rows in a split. Splits smaller than this size are treated as empty.
 
 META = "meta"
 

--- a/ludwig/data/dataset_synthesizer.py
+++ b/ludwig/data/dataset_synthesizer.py
@@ -172,7 +172,7 @@ def build_synthetic_dataset(dataset_size: int, features: List[dict], outdir: str
 
     :param dataset_size: (int) size of the dataset
     :param features: (List[dict]) list of features to generate in YAML format.
-        Provide a list contaning one dictionary for each feature,
+        Provide a list containing one dictionary for each feature,
         each dictionary must include a name, a type
         and can include some generation parameters depending on the type
     :param outdir: (str) Path to an output directory. Used for saving synthetic image and audio files.

--- a/ludwig/data/split.py
+++ b/ludwig/data/split.py
@@ -103,13 +103,13 @@ class RandomSplitter(Splitter):
     def split(
         self, df: DataFrame, backend: Backend, random_seed: float = default_random_seed
     ) -> Tuple[DataFrame, DataFrame, DataFrame]:
-        probabilities = _make_fractions_ensure_minimum_rows(self.probabilities, len(df))
         if backend.df_engine.partitioned:
             # The below approach is very inefficient for partitioned backends, which
             # can split by partition. This may not be exact in all cases, but is much more efficient.
-            return df.random_split(probabilities, random_state=random_seed)
+            return df.random_split(self.probabilities, random_state=random_seed)
 
         n = len(df)
+        probabilities = _make_fractions_ensure_minimum_rows(self.probabilities, n)
         d1 = int(probabilities[0] * n)
         if probabilities[-1] > 0:
             n2 = int(probabilities[1] * n)
@@ -118,7 +118,7 @@ class RandomSplitter(Splitter):
             # If the last probability is 0, then use the entire remaining dataset for validation.
             d2 = n
 
-        divisions = _make_divisions_ensure_minimum_rows((d1, d2), len(df))
+        divisions = _make_divisions_ensure_minimum_rows((d1, d2), n)
         return np.split(df.sample(frac=1, random_state=random_seed), divisions)
 
     def has_split(self, split_index: int) -> bool:

--- a/ludwig/data/split.py
+++ b/ludwig/data/split.py
@@ -153,12 +153,6 @@ class RandomSplitter(Splitter):
             )
             min_test_rows_by_partition[chosen_partitions] = min_split_rows_each_partition
 
-        print("-------------- min_split_rows_each_partition: " + str(min_split_rows_each_partition))
-        print("-------------- df.npartitions: " + str(df.npartitions))
-        print("-------------- quotient: " + str(MIN_DATASET_SPLIT_ROWS / df.npartitions))
-        print("-------------- min_val_rows_by_partition: " + str(min_val_rows_by_partition))
-        print("-------------- min_test_rows_by_partition: " + str(min_test_rows_by_partition))
-
         def random_split_partition(partition: DataFrame, partition_info=None) -> DataFrame:
             """Splits a single partition into train, val, test.
 
@@ -172,7 +166,6 @@ class RandomSplitter(Splitter):
                 min_val_rows=min_val_rows_by_partition[partition_index],
                 min_test_rows=min_test_rows_by_partition[partition_index],
             )
-            print(f"LLLLLLLLLLLLLL  partition:{partition_index}  divisions: " + str(divisions))
             shuffled = partition.sample(frac=1, random_state=random_seed)
             # Split column defaults to train, so only need to update val and test
             split_col = shuffled.columns.get_loc(TMP_SPLIT_COL)

--- a/ludwig/data/split.py
+++ b/ludwig/data/split.py
@@ -142,16 +142,17 @@ class RandomSplitter(Splitter):
         # The number of partitions for which we must enforce the min constraint in order to guarantee min_rows.
         n_guaranteed_partitions = int(np.ceil(MIN_DATASET_SPLIT_ROWS / min_split_rows_each_partition))
         # Selects n_guaranteed_partitions at random. We'll require each to return min_split_rows_each_partition.
-        min_val_rows_by_partition = np.zeros(df.npartitions, dtype=int)
-        if probabilities[1] > 0:
-            chosen_partitions = np.random.choice(np.arange(df.npartitions), size=n_guaranteed_partitions, replace=False)
-            min_val_rows_by_partition[chosen_partitions] = min_split_rows_each_partition
         min_test_rows_by_partition = np.zeros(df.npartitions, dtype=int)
         if probabilities[2] > 0:
-            chosen_partitions = np.random.choice(
-                np.where(min_val_rows_by_partition == 0)[0], size=n_guaranteed_partitions, replace=False
-            )
+            chosen_partitions = np.random.choice(np.arange(df.npartitions), size=n_guaranteed_partitions, replace=False)
             min_test_rows_by_partition[chosen_partitions] = min_split_rows_each_partition
+        min_val_rows_by_partition = np.zeros(df.npartitions, dtype=int)
+        if probabilities[1] > 0:
+            partition_indices = np.where(min_test_rows_by_partition == 0)[0]
+            chosen_partitions = np.random.choice(
+                partition_indices, size=min(n_guaranteed_partitions, partition_indices), replace=False
+            )
+            min_val_rows_by_partition[chosen_partitions] = min_split_rows_each_partition
 
         def random_split_partition(partition: DataFrame, partition_info=None) -> DataFrame:
             """Splits a single partition into train, val, test.

--- a/ludwig/data/split.py
+++ b/ludwig/data/split.py
@@ -141,8 +141,7 @@ class RandomSplitter(Splitter):
         min_split_rows_each_partition = int(np.ceil(MIN_DATASET_SPLIT_ROWS / df.npartitions))
         # The number of partitions for which we must enforce the min constraint in order to guarantee min_rows.
         n_guaranteed_partitions = int(np.ceil(MIN_DATASET_SPLIT_ROWS / min_split_rows_each_partition))
-        # Select n_guaranteed_partitions at random. We'll require each of these to return min_split_rows_each_partition,
-        # and randomly split the rest.
+        # Selects n_guaranteed_partitions at random. We'll require each to return min_split_rows_each_partition.
         min_val_rows_by_partition = np.zeros(df.npartitions, dtype=int)
         if probabilities[1] > 0:
             chosen_partitions = np.random.choice(np.arange(df.npartitions), size=n_guaranteed_partitions, replace=False)

--- a/ludwig/data/split.py
+++ b/ludwig/data/split.py
@@ -150,7 +150,7 @@ class RandomSplitter(Splitter):
         if probabilities[1] > 0:
             partition_indices = np.where(min_test_rows_by_partition == 0)[0]
             chosen_partitions = np.random.choice(
-                partition_indices, size=min(n_guaranteed_partitions, partition_indices), replace=False
+                partition_indices, size=min(n_guaranteed_partitions, len(partition_indices)), replace=False
             )
             min_val_rows_by_partition[chosen_partitions] = min_split_rows_each_partition
 

--- a/ludwig/data/split.py
+++ b/ludwig/data/split.py
@@ -78,8 +78,8 @@ def _make_divisions_ensure_minimum_rows(divisions, n_examples, min_val_rows, min
 def _split_divisions_with_min_rows(
     n_rows: int, probabilities: List[float], min_val_rows: int, min_test_rows: int
 ) -> List[int]:
-    """Splits a dataframe into train, validation, and test sets according to split probabilities, also ensuring
-    that at least min_val_rows or min_test_rows are present in each nonempty split.
+    """Generates splits for a dataset of n_rows into train, validation, and test sets according to split
+    probabilities, also ensuring that at least min_val_rows or min_test_rows are present in each nonempty split.
 
     Returns division indices to split on.
     """

--- a/tests/ludwig/data/test_split.py
+++ b/tests/ludwig/data/test_split.py
@@ -20,19 +20,19 @@ def test_make_fractions_ensure_minimum_rows():
     from ludwig.data.split import _make_fractions_ensure_minimum_rows
 
     # With 100 examples, the function should make no change to fractions.
-    fractions = _make_fractions_ensure_minimum_rows((0.7, 0.1, 0.2), 100, min_rows=3)
+    fractions = _make_fractions_ensure_minimum_rows((0.7, 0.1, 0.2), 100, min_val_rows=3, min_test_rows=3)
     assert sum(fractions) == pytest.approx(1.0)
     assert fractions[0] == pytest.approx(0.7)
     assert fractions[1] == pytest.approx(0.1)
     assert fractions[2] == pytest.approx(0.2)
     # With 25 examples, the expected number of validation set rows is 2.5
-    fractions = _make_fractions_ensure_minimum_rows((0.7, 0.1, 0.2), 25, min_rows=3)
+    fractions = _make_fractions_ensure_minimum_rows((0.7, 0.1, 0.2), 25, min_val_rows=3, min_test_rows=3)
     assert sum(fractions) == pytest.approx(1.0)
     assert fractions[0] == pytest.approx(0.68)
     assert fractions[1] == pytest.approx(0.12)
     assert fractions[2] == pytest.approx(0.2)
     # With 25 examples, the expected number of val and test set rows is 2.5
-    fractions = _make_fractions_ensure_minimum_rows((0.8, 0.1, 0.1), 25, min_rows=3)
+    fractions = _make_fractions_ensure_minimum_rows((0.8, 0.1, 0.1), 25, min_val_rows=3, min_test_rows=3)
     assert sum(fractions) == pytest.approx(1.0)
     assert fractions[0] == pytest.approx(0.76)
     assert fractions[1] == pytest.approx(0.12)
@@ -42,16 +42,20 @@ def test_make_fractions_ensure_minimum_rows():
 def test_make_divisions_ensure_minimum_rows():
     from ludwig.data.split import _make_divisions_ensure_minimum_rows
 
-    # In this case, the function should make no change to fractions.
-    divisions = _make_divisions_ensure_minimum_rows((70, 80), 100, min_rows=3)
+    # Constraints are satisfied, the function should make no change to fractions.
+    divisions = _make_divisions_ensure_minimum_rows((70, 80), 100, min_val_rows=3, min_test_rows=3)
     assert divisions[0] == 70
     assert divisions[1] == 80
+    # Constraints are satisfied, the function should make no change to fractions.
+    divisions = _make_divisions_ensure_minimum_rows((20, 22), 25, min_val_rows=0, min_test_rows=0)
+    assert divisions[0] == 20
+    assert divisions[1] == 22
     # The number of rows in validation set is too small.
-    divisions = _make_divisions_ensure_minimum_rows((17, 19), 25, min_rows=3)
+    divisions = _make_divisions_ensure_minimum_rows((17, 19), 25, min_val_rows=3, min_test_rows=3)
     assert divisions[0] == 16
     assert divisions[1] == 19
     # The number of rows in validation and test sets are both too small.
-    divisions = _make_divisions_ensure_minimum_rows((20, 22), 25, min_rows=3)
+    divisions = _make_divisions_ensure_minimum_rows((20, 22), 25, min_val_rows=3, min_test_rows=3)
     assert divisions[0] == 19
     assert divisions[1] == 22
 

--- a/tests/ludwig/data/test_split.py
+++ b/tests/ludwig/data/test_split.py
@@ -16,6 +16,46 @@ except ImportError:
     DaskEngine = Mock
 
 
+def test_make_fractions_ensure_minimum_rows():
+    from ludwig.data.split import _make_fractions_ensure_minimum_rows
+
+    # With 100 examples, the function should make no change to fractions.
+    fractions = _make_fractions_ensure_minimum_rows((0.7, 0.1, 0.2), 100, min_rows=3)
+    assert sum(fractions) == pytest.approx(1.0)
+    assert fractions[0] == pytest.approx(0.7)
+    assert fractions[1] == pytest.approx(0.1)
+    assert fractions[2] == pytest.approx(0.2)
+    # With 25 examples, the expected number of validation set rows is 2.5
+    fractions = _make_fractions_ensure_minimum_rows((0.7, 0.1, 0.2), 25, min_rows=3)
+    assert sum(fractions) == pytest.approx(1.0)
+    assert fractions[0] == pytest.approx(0.68)
+    assert fractions[1] == pytest.approx(0.12)
+    assert fractions[2] == pytest.approx(0.2)
+    # With 25 examples, the expected number of val and test set rows is 2.5
+    fractions = _make_fractions_ensure_minimum_rows((0.8, 0.1, 0.1), 25, min_rows=3)
+    assert sum(fractions) == pytest.approx(1.0)
+    assert fractions[0] == pytest.approx(0.76)
+    assert fractions[1] == pytest.approx(0.12)
+    assert fractions[2] == pytest.approx(0.12)
+
+
+def test_make_divisions_ensure_minimum_rows():
+    from ludwig.data.split import _make_divisions_ensure_minimum_rows
+
+    # In this case, the function should make no change to fractions.
+    divisions = _make_divisions_ensure_minimum_rows((70, 80), 100, min_rows=3)
+    assert divisions[0] == 70
+    assert divisions[1] == 80
+    # The number of rows in validation set is too small.
+    divisions = _make_divisions_ensure_minimum_rows((17, 19), 25, min_rows=3)
+    assert divisions[0] == 16
+    assert divisions[1] == 19
+    # The number of rows in validation and test sets are both too small.
+    divisions = _make_divisions_ensure_minimum_rows((20, 22), 25, min_rows=3)
+    assert divisions[0] == 19
+    assert divisions[1] == 22
+
+
 @pytest.mark.parametrize(
     ("df_engine",),
     [

--- a/tests/ludwig/data/test_split.py
+++ b/tests/ludwig/data/test_split.py
@@ -16,33 +16,6 @@ except ImportError:
     DaskEngine = Mock
 
 
-def test_make_fractions_ensure_minimum_rows():
-    from ludwig.data.split import _make_fractions_ensure_minimum_rows
-
-    # With 100 examples, the function should make no change to fractions.
-    fractions = _make_fractions_ensure_minimum_rows((0.7, 0.1, 0.2), 100, min_val_rows=3, min_test_rows=3)
-    assert fractions[0] == pytest.approx(0.7)
-    assert fractions[1] == pytest.approx(0.1)
-    assert fractions[2] == pytest.approx(0.2)
-    # Constraints are satisfied, the function should make no change to fractions.
-    fractions = _make_fractions_ensure_minimum_rows((0.8, 0.1, 0.1), 25, min_val_rows=0, min_test_rows=0)
-    assert fractions[0] == pytest.approx(0.8)
-    assert fractions[1] == pytest.approx(0.1)
-    assert fractions[2] == pytest.approx(0.1)
-    # With 25 examples, the expected number of validation set rows is 2.5
-    fractions = _make_fractions_ensure_minimum_rows((0.7, 0.1, 0.2), 25, min_val_rows=3, min_test_rows=3)
-    assert sum(fractions) == pytest.approx(1.0)
-    assert fractions[0] == pytest.approx(0.68)
-    assert fractions[1] == pytest.approx(0.12)
-    assert fractions[2] == pytest.approx(0.2)
-    # With 25 examples, the expected number of val and test set rows is 2.5
-    fractions = _make_fractions_ensure_minimum_rows((0.8, 0.1, 0.1), 25, min_val_rows=3, min_test_rows=3)
-    assert sum(fractions) == pytest.approx(1.0)
-    assert fractions[0] == pytest.approx(0.76)
-    assert fractions[1] == pytest.approx(0.12)
-    assert fractions[2] == pytest.approx(0.12)
-
-
 def test_make_divisions_ensure_minimum_rows():
     from ludwig.data.split import _make_divisions_ensure_minimum_rows
 

--- a/tests/ludwig/data/test_split.py
+++ b/tests/ludwig/data/test_split.py
@@ -21,10 +21,14 @@ def test_make_fractions_ensure_minimum_rows():
 
     # With 100 examples, the function should make no change to fractions.
     fractions = _make_fractions_ensure_minimum_rows((0.7, 0.1, 0.2), 100, min_val_rows=3, min_test_rows=3)
-    assert sum(fractions) == pytest.approx(1.0)
     assert fractions[0] == pytest.approx(0.7)
     assert fractions[1] == pytest.approx(0.1)
     assert fractions[2] == pytest.approx(0.2)
+    # Constraints are satisfied, the function should make no change to fractions.
+    fractions = _make_fractions_ensure_minimum_rows((0.8, 0.1, 0.1), 25, min_val_rows=0, min_test_rows=0)
+    assert fractions[0] == pytest.approx(0.8)
+    assert fractions[1] == pytest.approx(0.1)
+    assert fractions[2] == pytest.approx(0.1)
     # With 25 examples, the expected number of validation set rows is 2.5
     fractions = _make_fractions_ensure_minimum_rows((0.7, 0.1, 0.2), 25, min_val_rows=3, min_test_rows=3)
     assert sum(fractions) == pytest.approx(1.0)
@@ -42,11 +46,11 @@ def test_make_fractions_ensure_minimum_rows():
 def test_make_divisions_ensure_minimum_rows():
     from ludwig.data.split import _make_divisions_ensure_minimum_rows
 
-    # Constraints are satisfied, the function should make no change to fractions.
+    # Constraints are satisfied, the function should make no change to divisions.
     divisions = _make_divisions_ensure_minimum_rows((70, 80), 100, min_val_rows=3, min_test_rows=3)
     assert divisions[0] == 70
     assert divisions[1] == 80
-    # Constraints are satisfied, the function should make no change to fractions.
+    # Constraints are satisfied, the function should make no change to divisions.
     divisions = _make_divisions_ensure_minimum_rows((20, 22), 25, min_val_rows=0, min_test_rows=0)
     assert divisions[0] == 20
     assert divisions[1] == 22


### PR DESCRIPTION
Should fix NaN metrics caused by too-small validation set.

Problem: if the validation set is too small (1 row, for example) some metrics evaluate to NaN, which causes tests to fail.

This situation is mainly encountered in test cases where we use small synthetic datasets with random splits.

The solution here is to add a constant `MIN_DATASET_SPLIT_ROWS`, and ensure that each nonempty split contains at least `MIN_DATASET_SPLIT_ROWS`