### PR TITLE
Added storage backend API to allow injecting dynamic credentials

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,8 +44,6 @@ jobs:
       NEUROPOD_VERISON: "0.3.0-rc6"
       TORCHSCRIPT_VERISON: ${{ matrix.torchscript-version }}
       RAY_VERSION: ${{ matrix.ray-version }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.LUDWIG_TESTS_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.LUDWIG_TESTS_AWS_SECRET_ACCESS_KEY }}
 
     name: py${{ matrix.python-version  }}, torch-${{ matrix.pytorch-version }}, ${{ matrix.test-markers }}, ${{ matrix.os }}
     services:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -48,6 +48,14 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.LUDWIG_TESTS_AWS_SECRET_ACCESS_KEY }}
 
     name: py${{ matrix.python-version  }}, torch-${{ matrix.pytorch-version }}, ${{ matrix.test-markers }}, ${{ matrix.os }}
+    services:
+      minio:
+        image: fclairamb/minio-github-actions
+        env:
+          MINIO_ACCESS_KEY: minio
+          MINIO_SECRET_KEY: minio123
+        ports:
+          - 9000:9000
 
     timeout-minutes: 80
     steps:

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -17,13 +17,14 @@
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import numpy as np
 import pandas as pd
 import psutil
 import torch
 
+from ludwig.backend.utils.storage import StorageManager
 from ludwig.data.cache.manager import CacheManager
 from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.data.dataset.base import DatasetManager
@@ -42,17 +43,23 @@ class Backend(ABC):
         self,
         dataset_manager: DatasetManager,
         cache_dir: Optional[str] = None,
-        cache_credentials: Optional[Union[str, dict]] = None,
+        credentials: Optional[Dict[str, Any]] = None,
     ):
+        credentials = credentials or {}
         self._dataset_manager = dataset_manager
-        self._cache_manager = CacheManager(self._dataset_manager, cache_dir, cache_credentials)
+        self._storage_manager = StorageManager(**credentials)
+        self._cache_manager = CacheManager(self._dataset_manager, cache_dir)
 
     @property
-    def cache(self):
+    def storage(self) -> StorageManager:
+        return self._storage_manager
+
+    @property
+    def cache(self) -> CacheManager:
         return self._cache_manager
 
     @property
-    def dataset_manager(self):
+    def dataset_manager(self) -> DatasetManager:
         return self._dataset_manager
 
     @abstractmethod

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -43,7 +43,7 @@ class Backend(ABC):
         self,
         dataset_manager: DatasetManager,
         cache_dir: Optional[str] = None,
-        credentials: Optional[Dict[str, Any]] = None,
+        credentials: Optional[Dict[str, Dict[str, Any]]] = None,
     ):
         credentials = credentials or {}
         self._dataset_manager = dataset_manager

--- a/ludwig/backend/utils/storage.py
+++ b/ludwig/backend/utils/storage.py
@@ -2,7 +2,6 @@ import contextlib
 from typing import Any, Dict, Optional, Union
 
 from ludwig.utils import data_utils
-from ludwig.utils.fs_utils import RemoteFilesystem
 
 CredInputs = Optional[Union[str, Dict[str, Any]]]
 
@@ -17,16 +16,13 @@ class Storage:
     def __init__(self, creds: Optional[Dict[str, Any]]):
         self._creds = creds
 
-    @property
-    def fs(self) -> RemoteFilesystem:
-        return RemoteFilesystem(self._creds)
-
     @contextlib.contextmanager
     def use(self):
         with data_utils.use_credentials(self._creds):
             yield
 
-    def to_dict(self) -> Optional[Dict[str, Any]]:
+    @property
+    def credentials(self) -> Optional[Dict[str, Any]]:
         return self._creds
 
 
@@ -54,10 +50,12 @@ class StorageManager:
 
     @property
     def artifacts(self) -> Storage:
+        """TODO(travis): Currently used for hyperopt, but should be used for all outputs."""
         return self.storages[ARTIFACTS]
 
     @property
     def datasets(self) -> Storage:
+        """TODO(travis): Should be used to read in datasets."""
         return self.storages[DATASETS]
 
     @property

--- a/ludwig/backend/utils/storage.py
+++ b/ludwig/backend/utils/storage.py
@@ -1,0 +1,71 @@
+import contextlib
+from typing import Any, Dict, Optional, Union
+
+from ludwig.utils import data_utils
+from ludwig.utils.fs_utils import RemoteFilesystem
+
+CredInputs = Optional[Union[str, Dict[str, Any]]]
+
+
+DEFAULTS = "defaults"
+ARTIFACTS = "artifacts"
+DATASETS = "datasets"
+CACHE = "cache"
+
+
+class Storage:
+    def __init__(self, creds: Optional[Dict[str, Any]]):
+        self._creds = creds
+
+    @property
+    def fs(self) -> RemoteFilesystem:
+        return RemoteFilesystem(self._creds)
+
+    @contextlib.contextmanager
+    def use(self):
+        with data_utils.use_credentials(self._creds):
+            yield
+
+    def to_dict(self) -> Optional[Dict[str, Any]]:
+        return self._creds
+
+
+class StorageManager:
+    def __init__(
+        self,
+        defaults: CredInputs = None,
+        artifacts: CredInputs = None,
+        datasets: CredInputs = None,
+        cache: CredInputs = None,
+    ):
+        defaults = load_creds(defaults)
+        cred_inputs = {
+            DEFAULTS: defaults,
+            ARTIFACTS: load_creds(artifacts),
+            DATASETS: load_creds(datasets),
+            CACHE: load_creds(cache),
+        }
+
+        self.storages = {k: Storage(v if v is not None else defaults) for k, v in cred_inputs.items()}
+
+    @property
+    def defaults(self) -> Storage:
+        return self.storages[DEFAULTS]
+
+    @property
+    def artifacts(self) -> Storage:
+        return self.storages[ARTIFACTS]
+
+    @property
+    def datasets(self) -> Storage:
+        return self.storages[DATASETS]
+
+    @property
+    def cache(self) -> Storage:
+        return self.storages[CACHE]
+
+
+def load_creds(cred: CredInputs) -> Dict[str, Any]:
+    if isinstance(cred, str):
+        cred = data_utils.load_json(cred)
+    return cred

--- a/ludwig/backend/utils/storage.py
+++ b/ludwig/backend/utils/storage.py
@@ -17,7 +17,7 @@ class Storage:
         self._creds = creds
 
     @contextlib.contextmanager
-    def use(self):
+    def use_credentials(self):
         with data_utils.use_credentials(self._creds):
             yield
 

--- a/ludwig/data/cache/manager.py
+++ b/ludwig/data/cache/manager.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Optional, Union
+from typing import Optional
 
 from ludwig.constants import CHECKSUM, META, TEST, TRAINING, VALIDATION
 from ludwig.data.cache.types import alphanum, CacheableDataset
@@ -87,13 +87,9 @@ class CacheManager:
         self,
         dataset_manager: DatasetManager,
         cache_dir: Optional[str] = None,
-        cache_credentials: Optional[Union[str, dict]] = None,
     ):
         self._dataset_manager = dataset_manager
         self._cache_dir = cache_dir
-        if isinstance(cache_credentials, str):
-            cache_credentials = data_utils.load_json(cache_credentials)
-        self._cache_credentials = cache_credentials
 
     def get_dataset_cache(
         self,
@@ -151,7 +147,3 @@ class CacheManager:
     @property
     def data_format(self) -> str:
         return self._dataset_manager.data_format
-
-    @property
-    def credentials(self) -> Optional[dict]:
-        return self._cache_credentials

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1575,7 +1575,7 @@ def preprocess_for_training(
         test_set = test_set.unwrap() if test_set is not None else None
 
         if data_format in CACHEABLE_FORMATS:
-            with backend.storage.cache.use():
+            with backend.storage.cache.use_credentials():
                 cache_results = cache.get()
                 if cache_results is not None:
                     valid, *cache_values = cache_results
@@ -1602,7 +1602,7 @@ def preprocess_for_training(
         data_format_processor = get_from_registry(data_format, data_format_preprocessor_registry)
 
         if cached or data_format == "hdf5":
-            with backend.storage.cache.use():
+            with backend.storage.cache.use_credentials():
                 # Always interpret hdf5 files as preprocessed, even if missing from the cache
                 processed = data_format_processor.prepare_processed_data(
                     features,
@@ -1637,14 +1637,14 @@ def preprocess_for_training(
 
             # cache the dataset
             if backend.cache.can_cache(skip_save_processed_input):
-                with backend.storage.cache.use():
+                with backend.storage.cache.use_credentials():
                     logger.debug("cache processed data")
                     processed = cache.put(*processed)
                     # set cached=True to ensure credentials are used correctly below
                     cached = True
             training_set, test_set, validation_set, training_set_metadata = processed
 
-        with backend.storage.cache.use() if cached else contextlib.nullcontext():
+        with backend.storage.cache.use_credentials() if cached else contextlib.nullcontext():
             logger.debug("create training dataset")
             training_dataset = backend.dataset_manager.create(training_set, config, training_set_metadata)
             if not len(training_set):
@@ -1913,7 +1913,7 @@ def preprocess_for_prediction(
 
     training_set = test_set = validation_set = None
     if data_format in CACHEABLE_FORMATS and split != FULL:
-        with backend.storage.cache.use():
+        with backend.storage.cache.use_credentials():
             cache_results = cache.get()
             if cache_results is not None:
                 valid, *cache_values = cache_results
@@ -1929,7 +1929,7 @@ def preprocess_for_prediction(
 
     data_format_processor = get_from_registry(data_format, data_format_preprocessor_registry)
     if cached:
-        with backend.storage.cache.use():
+        with backend.storage.cache.use_credentials():
             processed = data_format_processor.prepare_processed_data(
                 features,
                 dataset=dataset,
@@ -1967,7 +1967,7 @@ def preprocess_for_prediction(
         "output_features": output_features,
     }
 
-    with backend.storage.cache.use() if cached else contextlib.nullcontext():
+    with backend.storage.cache.use_credentials() if cached else contextlib.nullcontext():
         dataset = backend.dataset_manager.create(
             dataset,
             config,

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import contextlib
 import logging
 import warnings
 from abc import ABC, abstractmethod
@@ -98,7 +99,6 @@ from ludwig.utils.data_utils import (
     SPSS_FORMATS,
     STATA_FORMATS,
     TSV_FORMATS,
-    use_credentials,
 )
 from ludwig.utils.defaults import default_preprocessing_parameters, default_random_seed
 from ludwig.utils.fs_utils import file_lock, path_exists
@@ -1575,7 +1575,7 @@ def preprocess_for_training(
         test_set = test_set.unwrap() if test_set is not None else None
 
         if data_format in CACHEABLE_FORMATS:
-            with use_credentials(backend.cache.credentials):
+            with backend.storage.cache.use():
                 cache_results = cache.get()
                 if cache_results is not None:
                     valid, *cache_values = cache_results
@@ -1602,7 +1602,7 @@ def preprocess_for_training(
         data_format_processor = get_from_registry(data_format, data_format_preprocessor_registry)
 
         if cached or data_format == "hdf5":
-            with use_credentials(backend.cache.credentials):
+            with backend.storage.cache.use():
                 # Always interpret hdf5 files as preprocessed, even if missing from the cache
                 processed = data_format_processor.prepare_processed_data(
                     features,
@@ -1637,14 +1637,14 @@ def preprocess_for_training(
 
             # cache the dataset
             if backend.cache.can_cache(skip_save_processed_input):
-                with use_credentials(backend.cache.credentials):
+                with backend.storage.cache.use():
                     logger.debug("cache processed data")
                     processed = cache.put(*processed)
                     # set cached=True to ensure credentials are used correctly below
                     cached = True
             training_set, test_set, validation_set, training_set_metadata = processed
 
-        with use_credentials(backend.cache.credentials if cached else None):
+        with backend.storage.cache.use() if cached else contextlib.nullcontext():
             logger.debug("create training dataset")
             training_dataset = backend.dataset_manager.create(training_set, config, training_set_metadata)
             if not len(training_set):
@@ -1913,7 +1913,7 @@ def preprocess_for_prediction(
 
     training_set = test_set = validation_set = None
     if data_format in CACHEABLE_FORMATS and split != FULL:
-        with use_credentials(backend.cache.credentials):
+        with backend.storage.cache.use():
             cache_results = cache.get()
             if cache_results is not None:
                 valid, *cache_values = cache_results
@@ -1929,7 +1929,7 @@ def preprocess_for_prediction(
 
     data_format_processor = get_from_registry(data_format, data_format_preprocessor_registry)
     if cached:
-        with use_credentials(backend.cache.credentials):
+        with backend.storage.cache.use():
             processed = data_format_processor.prepare_processed_data(
                 features,
                 dataset=dataset,
@@ -1967,7 +1967,7 @@ def preprocess_for_prediction(
         "output_features": output_features,
     }
 
-    with use_credentials(backend.cache.credentials if cached else None):
+    with backend.storage.cache.use() if cached else contextlib.nullcontext():
         dataset = backend.dataset_manager.create(
             dataset,
             config,

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -779,7 +779,7 @@ class RayTuneExecutor:
 
         if has_remote_protocol(output_directory):
             if _ray_200:
-                self.sync_client = RemoteSyncer()
+                self.sync_client = RemoteSyncer(creds=backend.storage.artifacts.credentials)
                 self.sync_config = tune.SyncConfig(upload_dir=output_directory, syncer=self.sync_client)
             else:
                 raise ValueError(

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -381,7 +381,7 @@ def hyperopt(
         print_hyperopt_results(hyperopt_results)
 
         if not skip_save_hyperopt_statistics:
-            with backend.storage.artifacts.use():
+            with backend.storage.artifacts.use_credentials():
                 results_directory = os.path.join(output_directory, experiment_name)
                 makedirs(results_directory, exist_ok=True)
 

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -381,16 +381,17 @@ def hyperopt(
         print_hyperopt_results(hyperopt_results)
 
         if not skip_save_hyperopt_statistics:
-            results_directory = os.path.join(output_directory, experiment_name)
-            makedirs(results_directory, exist_ok=True)
+            with backend.storage.artifacts.use():
+                results_directory = os.path.join(output_directory, experiment_name)
+                makedirs(results_directory, exist_ok=True)
 
-            hyperopt_stats = {
-                "hyperopt_config": hyperopt_config,
-                "hyperopt_results": [t.to_dict() for t in hyperopt_results.ordered_trials],
-            }
+                hyperopt_stats = {
+                    "hyperopt_config": hyperopt_config,
+                    "hyperopt_results": [t.to_dict() for t in hyperopt_results.ordered_trials],
+                }
 
-            save_hyperopt_stats(hyperopt_stats, results_directory)
-            logger.info(f"Hyperopt stats saved to: {results_directory}")
+                save_hyperopt_stats(hyperopt_stats, results_directory)
+                logger.info(f"Hyperopt stats saved to: {results_directory}")
 
     for callback in callbacks or []:
         callback.on_hyperopt_end(experiment_name)

--- a/ludwig/hyperopt/syncer.py
+++ b/ludwig/hyperopt/syncer.py
@@ -12,16 +12,25 @@ class RemoteSyncer(_BackgroundSyncer):
         self.creds = creds
 
     def _sync_up_command(self, local_path: str, uri: str, exclude: Optional[List] = None) -> Tuple[Callable, Dict]:
-        with use_credentials(self.creds):
-            return upload, dict(lpath=local_path, rpath=uri)
+        def upload_cmd(*args, **kwargs):
+            with use_credentials(self.creds):
+                return upload(*args, **kwargs)
+
+        return upload_cmd, dict(lpath=local_path, rpath=uri)
 
     def _sync_down_command(self, uri: str, local_path: str) -> Tuple[Callable, Dict]:
-        with use_credentials(self.creds):
-            return download, dict(rpath=uri, lpath=local_path)
+        def download_cmd(*args, **kwargs):
+            with use_credentials(self.creds):
+                return download(*args, **kwargs)
+
+        return download_cmd, dict(rpath=uri, lpath=local_path)
 
     def _delete_command(self, uri: str) -> Tuple[Callable, Dict]:
-        with use_credentials(self.creds):
-            return delete, dict(url=uri, recursive=True)
+        def delete_cmd(*args, **kwargs):
+            with use_credentials(self.creds):
+                return delete(*args, **kwargs)
+
+        return delete_cmd, dict(url=uri, recursive=True)
 
     def __reduce__(self):
         """We need this custom serialization because we can't pickle thread.lock objects that are used by the

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -161,6 +161,22 @@ def _traverse_dicts(config: Any, f: Callable[[Dict], None]):
             _traverse_dicts(v, f)
 
 
+@register_config_transformation("0.6")
+def _update_backend_cache_credentials(config: Dict[str, Any]) -> Dict[str, Any]:
+    backend = config.get("backend", {})
+    if "cache_credentials" in backend:
+        credentials = backend.get("credentials", {})
+        if "cache" in credentials:
+            warnings.warn("`cache` already found in `backend.credentials`, ignoring `cache_credentials`")
+        else:
+            warnings.warn(
+                "`backend.cache_credentials` has been renamed `backend.credentials.cache`", DeprecationWarning
+            )
+            credentials["cache"] = backend.pop("cache_credentials")
+        backend["credentials"] = credentials
+    return config
+
+
 @register_config_transformation("0.6", ["output_features"])
 def update_class_weights_in_features(feature: Dict[str, Any]) -> Dict[str, Any]:
     if LOSS in feature:

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -161,9 +161,8 @@ def _traverse_dicts(config: Any, f: Callable[[Dict], None]):
             _traverse_dicts(v, f)
 
 
-@register_config_transformation("0.6")
-def _update_backend_cache_credentials(config: Dict[str, Any]) -> Dict[str, Any]:
-    backend = config.get("backend", {})
+@register_config_transformation("0.6", "backend")
+def _update_backend_cache_credentials(backend: Dict[str, Any]) -> Dict[str, Any]:
     if "cache_credentials" in backend:
         credentials = backend.get("credentials", {})
         if "cache" in credentials:
@@ -174,7 +173,7 @@ def _update_backend_cache_credentials(config: Dict[str, Any]) -> Dict[str, Any]:
             )
             credentials["cache"] = backend.pop("cache_credentials")
         backend["credentials"] = credentials
-    return config
+    return backend
 
 
 @register_config_transformation("0.6", ["output_features"])

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -192,9 +192,6 @@ def copy(src, tgt, recursive=False):
 def makedirs(url, exist_ok=False):
     fs, path = get_fs_and_path(url)
     fs.makedirs(path, exist_ok=exist_ok)
-    if not path_exists(url):
-        with fsspec.open(url, mode="wb"):
-            pass
 
 
 def delete(url, recursive=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ absl-py
 kaggle
 requests
 tables
-fsspec[http]<2022.8
+fsspec[http]
 dataclasses-json
 jsonschema>=4.5.0,<4.7
 marshmallow

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -40,3 +40,5 @@ scikit-optimize
 
 # search_alg: zoopt
 zoopt
+
+s3fs>=2022.8.2

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,29 @@
+# Test Guide
+
+Assuming your CWD is the Ludwig repo root.
+
+## Basic
+
+```bash
+pytest -vs tests
+```
+
+## Private Tests
+
+These tests connect to services like remote filesystems (Minio / S3), which can be run locally using Docker.
+
+```bash
+# prepare test services
+docker-compose -f tests/docker-compose.yml up
+
+# run all tests
+RUN_PRIVATE=1 pytest -vs tests
+```
+
+## Slow Tests
+
+These tests are very slow, and should typically be run on GPU machines.
+
+```bash
+RUN_SLOW=1 pytest -vs tests
+```

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  minio:
+    image: 'minio/minio:latest'
+    volumes:
+      - minio_storage:/data
+    ports:
+      - 9000:9000
+      - 9001:9001
+    environment:
+      - MINIO_ACCESS_KEY=minio
+      - MINIO_SECRET_KEY=minio123
+    command: server --console-address ":9001" /data
+volumes:
+  minio_storage:

--- a/tests/integration_tests/test_cache_manager.py
+++ b/tests/integration_tests/test_cache_manager.py
@@ -1,4 +1,3 @@
-import json
 import os
 from pathlib import Path
 
@@ -24,22 +23,7 @@ def change_test_dir(tmpdir, monkeypatch):
 def test_cache_dataset(use_cache_dir, use_split, use_df, tmpdir, change_test_dir):
     dataset_manager = PandasDatasetManager(backend=LocalTestBackend())
     cache_dir = os.path.join(tmpdir, "cache") if use_cache_dir else None
-
-    creds_fname = os.path.join(tmpdir, "credentials.json")
-    creds = {
-        "s3": {
-            "client_kwargs": {
-                "endpoint_url": "http://localhost:9000",
-                "aws_access_key_id": "test",
-                "aws_secret_access_key": "test",
-            }
-        }
-    }
-    with open(creds_fname, "w") as f:
-        json.dump(creds, f)
-
-    manager = CacheManager(dataset_manager, cache_dir=cache_dir, cache_credentials=creds_fname)
-    assert manager.credentials == creds
+    manager = CacheManager(dataset_manager, cache_dir=cache_dir)
 
     config = {
         "input_features": [sequence_feature(encoder={"reduce_output": "sum"})],

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -43,7 +43,14 @@ from ludwig.hyperopt.run import hyperopt, update_hyperopt_params_with_defaults
 from ludwig.utils import fs_utils
 from ludwig.utils.data_utils import load_json
 from ludwig.utils.defaults import merge_with_defaults
-from tests.integration_tests.utils import category_feature, generate_data, private_param, remote_tmpdir, text_feature
+from tests.integration_tests.utils import (
+    category_feature,
+    generate_data,
+    minio_test_creds,
+    private_param,
+    remote_tmpdir,
+    text_feature,
+)
 
 ray = pytest.importorskip("ray")
 
@@ -300,8 +307,7 @@ def test_hyperopt_scheduler(
         assert isinstance(raytune_results, HyperoptResults)
 
 
-@pytest.mark.parametrize("search_space", ["random", "grid"])
-def test_hyperopt_run_hyperopt(csv_filename, search_space, tmpdir, ray_cluster):
+def _run_hyperopt_run_hyperopt(csv_filename, search_space, tmpdir, backend, ray_cluster):
     input_features = [
         text_feature(name="utterance", encoder={"reduce_output": "sum"}),
         category_feature(encoder={"vocab_size": 3}),
@@ -316,6 +322,7 @@ def test_hyperopt_run_hyperopt(csv_filename, search_space, tmpdir, ray_cluster):
         OUTPUT_FEATURES: output_features,
         COMBINER: {TYPE: "concat", "num_fc_layers": 2},
         TRAINER: {"epochs": 2, "learning_rate": 0.001},
+        "backend": backend,
     }
 
     output_feature_name = output_features[0][NAME]
@@ -365,7 +372,9 @@ def test_hyperopt_run_hyperopt(csv_filename, search_space, tmpdir, ray_cluster):
     config[HYPEROPT] = hyperopt_configs
 
     experiment_name = f"test_hyperopt_{uuid.uuid4().hex}"
-    hyperopt_results = hyperopt(config, dataset=rel_path, output_directory=tmpdir, experiment_name=experiment_name)
+    hyperopt_results = hyperopt(
+        config, dataset=rel_path, output_directory=tmpdir, experiment_name=experiment_name, backend=backend
+    )
     if search_space == "random":
         assert hyperopt_results.experiment_analysis.results_df.shape[0] == RANDOM_SEARCH_SIZE
     else:
@@ -382,14 +391,27 @@ def test_hyperopt_run_hyperopt(csv_filename, search_space, tmpdir, ray_cluster):
     assert fs_utils.path_exists(os.path.join(tmpdir, experiment_name, HYPEROPT_STATISTICS_FILE_NAME))
 
 
+@pytest.mark.parametrize("search_space", ["random", "grid"])
+def test_hyperopt_run_hyperopt(csv_filename, search_space, tmpdir, ray_cluster):
+    _run_hyperopt_run_hyperopt(csv_filename, search_space, tmpdir, "local", ray_cluster)
+
+
 @pytest.mark.parametrize("fs_protocol,bucket", [private_param(("s3", "ludwig-tests"))], ids=["s3"])
 def test_hyperopt_sync_remote(fs_protocol, bucket, csv_filename, ray_cluster):
+    backend = {
+        "type": "local",
+        "storage": {
+            "artifacts": minio_test_creds(),
+        },
+    }
+
     with remote_tmpdir(fs_protocol, bucket) as tmpdir:
         with pytest.raises(ValueError) if not _ray200 else contextlib.nullcontext():
-            test_hyperopt_run_hyperopt(
+            _run_hyperopt_run_hyperopt(
                 csv_filename,
                 "random",
                 tmpdir,
+                backend,
                 ray_cluster,
             )
 

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -42,7 +42,7 @@ from ludwig.experiment import experiment_cli
 from ludwig.features.feature_utils import compute_feature_hash
 from ludwig.trainers.trainer import Trainer
 from ludwig.utils import fs_utils
-from ludwig.utils.data_utils import read_csv, replace_file_extension
+from ludwig.utils.data_utils import read_csv, replace_file_extension, use_credentials
 
 logger = logging.getLogger(__name__)
 
@@ -889,7 +889,20 @@ def remote_tmpdir(fs_protocol, bucket):
         yield tmpdir
     finally:
         try:
-            fs_utils.delete(tmpdir, recursive=True)
+            with use_credentials(minio_test_creds()):
+                fs_utils.delete(tmpdir, recursive=True)
         except FileNotFoundError as e:
             logging.info(f"failed to delete remote tempdir, does not exist: {str(e)}")
             pass
+
+
+def minio_test_creds():
+    return {
+        "s3": {
+            "client_kwargs": {
+                "endpoint_url": os.environ.get("LUDWIG_MINIO_ENDPOINT", "http://localhost:9000"),
+                "aws_access_key_id": os.environ.get("LUDWIG_MINIO_ACCESS_KEY", "minio"),
+                "aws_secret_access_key": os.environ.get("LUDWIG_MINIO_SECRET_KEY", "minio123"),
+            }
+        }
+    }

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -886,6 +886,8 @@ def remote_tmpdir(fs_protocol, bucket):
     prefix = f"tmp_{uuid.uuid4().hex}"
     tmpdir = f"{fs_protocol}://{bucket}/{prefix}"
     try:
+        with use_credentials(minio_test_creds()):
+            fs_utils.makedirs(f"{fs_protocol}://{bucket}", exist_ok=True)
         yield tmpdir
     finally:
         try:

--- a/tests/ludwig/utils/test_backward_compatibility.py
+++ b/tests/ludwig/utils/test_backward_compatibility.py
@@ -23,6 +23,7 @@ from ludwig.constants import (
 from ludwig.schema import validate_config
 from ludwig.schema.trainer import ECDTrainerConfig
 from ludwig.utils.backward_compatibility import (
+    _update_backend_cache_credentials,
     _upgrade_encoder_decoder_params,
     _upgrade_feature,
     _upgrade_preprocessing_split,
@@ -657,3 +658,13 @@ def test_upgrade_model_progress_already_valid():
 
     unchanged_model_progress = upgrade_model_progress(valid_model_progress)
     assert unchanged_model_progress == valid_model_progress
+
+
+def test_cache_credentials_backward_compatibility():
+    # From v0.6.3.
+    creds = {"s3": {"client_kwargs": {}}}
+    config = {"backend": {"type": "local", "cache_dir": "/foo/bar", "cache_credentials": creds}}
+
+    _update_backend_cache_credentials(config)
+
+    assert config == {"backend": {"type": "local", "cache_dir": "/foo/bar", "credentials": {"cache": creds}}}

--- a/tests/ludwig/utils/test_backward_compatibility.py
+++ b/tests/ludwig/utils/test_backward_compatibility.py
@@ -663,8 +663,8 @@ def test_upgrade_model_progress_already_valid():
 def test_cache_credentials_backward_compatibility():
     # From v0.6.3.
     creds = {"s3": {"client_kwargs": {}}}
-    config = {"backend": {"type": "local", "cache_dir": "/foo/bar", "cache_credentials": creds}}
+    backend = {"type": "local", "cache_dir": "/foo/bar", "cache_credentials": creds}
 
-    _update_backend_cache_credentials(config)
+    _update_backend_cache_credentials(backend)
 
-    assert config == {"backend": {"type": "local", "cache_dir": "/foo/bar", "credentials": {"cache": creds}}}
+    assert backend == {"type": "local", "cache_dir": "/foo/bar", "credentials": {"cache": creds}}


### PR DESCRIPTION
This PR adds a basic structure for specifying different cloud credentials for different entities in the system. Currently supported is the cache and artifacts (for hyperopt), but this will be extended to support all artifacts (outputs) and datasets (inputs) in the future.

This also deprecates the `cache_credentials` backend config param and moves it to `credentials.cache`. The structure is:

```
backend:
  credentials:
    artifacts: ...
    cache: ...
```

Also removes s3 as a test dep and uses an internal minio container instead, so forks can still run tests successfully.