### PR TITLE
Remove hyperopt from config when running train through cli

### DIFF
--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -158,7 +158,8 @@ def train_cli(
         if not query_yes_no(HYPEROPT_WARNING + CONTINUE_PROMPT):
             exit(1)
         # Stop gap: remove hyperopt from the config to prevent interference with training step sizes
-        # TODO: Need to investigate why the presence of hyperopt in the config interferes with training step sizes
+        # TODO: https://github.com/ludwig-ai/ludwig/issues/2633
+        # Need to investigate why the presence of hyperopt in the config interferes with training step sizes
         config.pop(HYPEROPT)
 
     if model_load_path:

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -157,6 +157,8 @@ def train_cli(
     if HYPEROPT in config:
         if not query_yes_no(HYPEROPT_WARNING + CONTINUE_PROMPT):
             exit(1)
+        # Stop gap: remove hyperopt from the config to prevent interference with training step sizes
+        # TODO: Need to investigate why the presence of hyperopt in the config interferes with training step sizes
         config.pop(HYPEROPT)
 
     if model_load_path:

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -157,6 +157,7 @@ def train_cli(
     if HYPEROPT in config:
         if not query_yes_no(HYPEROPT_WARNING + CONTINUE_PROMPT):
             exit(1)
+        config.pop(HYPEROPT)
 
     if model_load_path:
         model = LudwigModel.load(


### PR DESCRIPTION
When hyperopt exists in the Ludwig config, it causes a strange interaction with `model.train()` which results in the very large step sizes/epoch sizes. This is unexpected and something that definitely needs to be looked into more deeply.

In the interim, here's a stopgap solution that removes hyperopt from the config if it is present since a majority of users use Ludwig through the CLI.