### PR TITLE
[explain] add API annotations

### DIFF
--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -7,6 +7,7 @@ from captum.attr import IntegratedGradients
 from torch.autograd import Variable
 
 from ludwig.api import LudwigModel
+from ludwig.api_annotations import PublicAPI
 from ludwig.data.preprocessing import preprocess_for_prediction
 from ludwig.explain.explainer import Explainer
 from ludwig.explain.explanation import Explanation
@@ -107,6 +108,7 @@ def get_input_tensors(model: LudwigModel, input_set: pd.DataFrame) -> List[Varia
     return data_to_predict
 
 
+@PublicAPI(stability="experimental")
 class IntegratedGradientsExplainer(Explainer):
     def explain(self) -> Tuple[List[Explanation], List[float]]:
         """Explain the model's predictions using Integrated Gradients.

--- a/ludwig/explain/explainer.py
+++ b/ludwig/explain/explainer.py
@@ -4,10 +4,10 @@ from typing import List, Tuple
 import pandas as pd
 
 from ludwig.api import LudwigModel
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import BINARY, CATEGORY, TYPE
 from ludwig.explain.explanation import Explanation
 from ludwig.explain.util import prepare_data
-from ludwig.api_annotations import DeveloperAPI
 
 
 @DeveloperAPI

--- a/ludwig/explain/explainer.py
+++ b/ludwig/explain/explainer.py
@@ -7,8 +7,10 @@ from ludwig.api import LudwigModel
 from ludwig.constants import BINARY, CATEGORY, TYPE
 from ludwig.explain.explanation import Explanation
 from ludwig.explain.util import prepare_data
+from ludwig.api_annotations import DeveloperAPI
 
 
+@DeveloperAPI
 class Explainer(metaclass=ABCMeta):
     def __init__(self, model: LudwigModel, inputs_df: pd.DataFrame, sample_df: pd.DataFrame, target: str):
         """Constructor for the explainer.

--- a/ludwig/explain/explanation.py
+++ b/ludwig/explain/explanation.py
@@ -4,6 +4,8 @@ from typing import List
 import numpy as np
 import numpy.typing as npt
 
+from ludwig.api_annotations import PublicAPI
+
 
 @dataclass
 class LabelExplanation:
@@ -13,6 +15,7 @@ class LabelExplanation:
     feature_attributions: npt.NDArray[np.float64]
 
 
+@PublicAPI(stability="experimental")
 @dataclass
 class Explanation:
     """Stores the explanations for a single row of input data.

--- a/ludwig/explain/gbm.py
+++ b/ludwig/explain/gbm.py
@@ -1,10 +1,12 @@
 from typing import List, Tuple
 
+from ludwig.api_annotations import PublicAPI
 from ludwig.explain.explainer import Explainer
 from ludwig.explain.explanation import Explanation
 from ludwig.models.gbm import GBM
 
 
+@PublicAPI(stability="experimental")
 class GBMExplainer(Explainer):
     def explain(self) -> Tuple[List[Explanation], List[float]]:
         """Explain the model's predictions. Uses the feature importances from the model.


### PR DESCRIPTION
Marks as DeveloperAPI:

- `Explainer`: developers can implement this base class to add a new explanation algorithm

Marks as experimental PublicAPI:

- `Explanation` dataclass stores feature attributions for a single row
- `IntegratedGradientsExplainer`: Implements `Explainer` with Integrated Gradients
- `GBMExplainer`: Implements `Explainer` with GBM feature importance
