### PR TITLE
Allow Ray Tune callbacks to be passed into hyperopt and log model config

### DIFF
--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -449,16 +449,13 @@ class RayTuneExecutor:
         trial_id = tune.get_trial_id()
         trial_dir = Path(tune.get_trial_dir())
 
-        # Write out the unmerged config to the trial's local directory.
-        with open(os.path.join(trial_dir, 'user_hyperparameters.json'), 'w') as f:
-            json.dump(hyperopt_dict['config'], f)
-
         modified_config = substitute_parameters(copy.deepcopy(hyperopt_dict["config"]), config)
 
-        modified_config = ModelConfig.from_dict(modified_config).to_dict()
+        # Write out the unmerged config to the trial's local directory.
+        with open(os.path.join(trial_dir, "trial_hyperparameters.json"), "w") as f:
+            json.dump(hyperopt_dict["config"], f)
 
-        with open(os.path.join(trial_dir, 'model_hyperparameters.json'), 'w') as f:
-            json.dump(hyperopt_dict['config'], f)
+        modified_config = ModelConfig.from_dict(modified_config).to_dict()
 
         hyperopt_dict["config"] = modified_config
         hyperopt_dict["experiment_name "] = f'{hyperopt_dict["experiment_name"]}_{trial_id}'
@@ -770,7 +767,6 @@ class RayTuneExecutor:
             )
 
         tune_config = {}
-        # tune_callbacks = []
         for callback in callbacks or []:
             run_experiment_trial, tune_config = callback.prepare_ray_tune(
                 run_experiment_trial,
@@ -816,7 +812,7 @@ class RayTuneExecutor:
         # https://docs.ray.io/en/latest/tune/tutorials/tune-stopping.html
         should_resume = "AUTO" if resume is None else resume
 
-        raise_on_failed_trial = kwargs.get('raise_on_failed_trial', True)
+        raise_on_failed_trial = kwargs.get("raise_on_failed_trial", True)
 
         try:
             analysis = tune.run(

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -451,7 +451,7 @@ class RayTuneExecutor:
 
         modified_config = substitute_parameters(copy.deepcopy(hyperopt_dict["config"]), config)
 
-        # Write out the unmerged config to the trial's local directory.
+        # Write out the unmerged config with sampled hyperparameters to the trial's local directory.
         with open(os.path.join(trial_dir, "trial_hyperparameters.json"), "w") as f:
             json.dump(hyperopt_dict["config"], f)
 
@@ -812,8 +812,6 @@ class RayTuneExecutor:
         # https://docs.ray.io/en/latest/tune/tutorials/tune-stopping.html
         should_resume = "AUTO" if resume is None else resume
 
-        raise_on_failed_trial = kwargs.get("raise_on_failed_trial", True)
-
         try:
             analysis = tune.run(
                 f"trainable_func_f{hash_dict(config).decode('ascii')}",
@@ -840,7 +838,6 @@ class RayTuneExecutor:
                 verbose=hyperopt_log_verbosity,
                 resume=should_resume,
                 log_to_file=True,
-                raise_on_failed_trial=raise_on_failed_trial,
             )
         except Exception as e:
             # Explicitly raise a RuntimeError if an error is encountered during a Ray trial.

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -5,6 +5,7 @@ from pprint import pformat
 from typing import List, Optional, Union
 
 import pandas as pd
+from ray.tune import Callback as TuneCallback
 import yaml
 from tabulate import tabulate
 
@@ -86,6 +87,7 @@ def hyperopt(
     gpu_memory_limit: Optional[float] = None,
     allow_parallel_threads: bool = True,
     callbacks: List[Callback] = None,
+    tune_callbacks: List[TuneCallback] = None,
     backend: Union[Backend, str] = None,
     random_seed: int = default_random_seed,
     hyperopt_log_verbosity: int = 3,
@@ -387,6 +389,7 @@ def hyperopt(
         gpu_memory_limit=gpu_memory_limit,
         allow_parallel_threads=allow_parallel_threads,
         callbacks=callbacks,
+        tune_callbacks=tune_callbacks,
         backend=backend,
         random_seed=random_seed,
         hyperopt_log_verbosity=hyperopt_log_verbosity,

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -5,7 +5,6 @@ from pprint import pformat
 from typing import List, Optional, Union
 
 import pandas as pd
-from ray.tune import Callback as TuneCallback
 import yaml
 from tabulate import tabulate
 
@@ -51,11 +50,15 @@ from ludwig.utils.fs_utils import makedirs, open_file
 from ludwig.utils.misc_utils import get_from_registry
 
 try:
+    from ray.tune import Callback as TuneCallback
+
     from ludwig.backend.ray import RayBackend
 except ImportError:
 
     class RayBackend:
         pass
+
+    TuneCallback = object
 
 
 logger = logging.getLogger(__name__)
@@ -87,7 +90,7 @@ def hyperopt(
     gpu_memory_limit: Optional[float] = None,
     allow_parallel_threads: bool = True,
     callbacks: List[Callback] = None,
-    tune_callbacks: List[TuneCallback] = None,
+    tune_callbacks: List["TuneCallback"] = None,
     backend: Union[Backend, str] = None,
     random_seed: int = default_random_seed,
     hyperopt_log_verbosity: int = 3,

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -90,7 +90,7 @@ def hyperopt(
     gpu_memory_limit: Optional[float] = None,
     allow_parallel_threads: bool = True,
     callbacks: List[Callback] = None,
-    tune_callbacks: List["TuneCallback"] = None,
+    tune_callbacks: List[TuneCallback] = None,
     backend: Union[Backend, str] = None,
     random_seed: int = default_random_seed,
     hyperopt_log_verbosity: int = 3,

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -54,11 +54,10 @@ try:
 
     from ludwig.backend.ray import RayBackend
 except ImportError:
+    TuneCallback = object
 
     class RayBackend:
         pass
-
-    TuneCallback = object
 
 
 logger = logging.getLogger(__name__)

--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -37,7 +37,7 @@ from tests.integration_tests.utils import category_feature, generate_data, text_
 
 try:
     import ray
-    from ray.tune import TuneCallback
+    from ray.tune import Callback as TuneCallback
     from ray.tune.trial import Trial
 
     from ludwig.hyperopt.execution import get_build_hyperopt_executor

--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -155,7 +155,8 @@ class HyperoptTestCallback(TuneCallback):
         if os.path.isfile(model_hyperparameters):
             try:
                 with open(model_hyperparameters) as f:
-                    json.load(f)
+                    config = json.load(f)
+                    assert config, f"Trial {trial} rendered config was empty."
                 self.rendered_config[trial.trial_id] = True
             except OSError:
                 logging.exception("Could not load rendered config from trial logdir.")
@@ -164,7 +165,8 @@ class HyperoptTestCallback(TuneCallback):
         if os.path.isfile(model_hyperparameters):
             try:
                 with open(model_hyperparameters) as f:
-                    json.load(f)
+                    config = json.load(f)
+                    assert config, "Trial {trial} user config was empty."
                 self.rendered_config[trial.trial_id] = True
             except OSError:
                 logging.exception("Could not load rendered config from trial logdir.")

--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -145,7 +145,7 @@ class HyperoptTestCallback(TuneCallback):
         super().on_trial_start(iteration, trials, trial, **info)
         self.trial_ids.add(trial.trial_id)
 
-    def on_trial_complete(self, iteration: int, trials: List["Trial"], trial: "Trial", **info):
+    def on_trial_complete(self, iteration: int, trials: List["Trial"], trial: "Trial", **info):  # noqa
         super().on_trial_complete(iteration, trials, trial, **info)
         self.trial_status[trial.trial_id] = trial.status
 


### PR DESCRIPTION
This update makes three changes to hyperopt in Ludwig:

1.  Adds the `tune_callbacks` parameter to hyperopt to allow passing [Ray Tune Callbacks](https://docs.ray.io/en/latest/tune/api_docs/internals.html#callbacks) into Ray Tune
2. Updates the logic of the RayTuneExecutor to pass the callbacks into Ray Tune
3. Logs user-supplied and rendered model configs to trial logdirs

These changes support error surfacing, as well as #2343 and #2344
