### PR TITLE
[Annotations] Callbacks

### DIFF
--- a/ludwig/api_annotations.py
+++ b/ludwig/api_annotations.py
@@ -5,7 +5,7 @@ def PublicAPI(*args, **kwargs):
     """Annotation for documenting public APIs. Public APIs are classes and methods exposed to end users of Ludwig.
 
     If stability="stable", the APIs will remain backwards compatible across minor Ludwig releases
-    (e.g., Ludwig 0.6 -> Ludwig 0.5).
+    (e.g., Ludwig 0.6 -> Ludwig 0.7).
 
     If stability="experimental", the APIs can be used by advanced users who are tolerant to and expect
     breaking changes. This will likely be seen in the case of incremental new feature development.

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -41,6 +41,7 @@ from ray.util.placement_group import placement_group, remove_placement_group
 if TYPE_CHECKING:
     from ludwig.api import LudwigModel
 
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.backend.base import Backend, RemoteTrainingMixin
 from ludwig.backend.datasource import BinaryIgnoreNoneTypeDatasource
 from ludwig.constants import MODEL_ECD, MODEL_GBM, NAME, PREPROCESSING, PROC_COLUMN, TYPE
@@ -293,6 +294,7 @@ def tune_learning_rate_fn(
         hvd.shutdown()
 
 
+@DeveloperAPI
 class TqdmCallback(rt.TrainingCallback):
     """Class for a custom ray callback that updates tqdm progress bars in the driver process."""
 

--- a/ludwig/benchmarking/profiler_callbacks.py
+++ b/ludwig/benchmarking/profiler_callbacks.py
@@ -1,10 +1,13 @@
 from typing import Any, Dict
 
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.benchmarking.profiler import LudwigProfiler
 from ludwig.callbacks import Callback
 from ludwig.constants import EVALUATION, PREPROCESSING, TRAINING
 
 
+# Bump to PublicAPI once Ludwig 0.7 is released
+@DeveloperAPI
 class LudwigProfilerCallback(Callback):
     """Class that defines the methods necessary to hook into process."""
 

--- a/ludwig/benchmarking/profiler_callbacks.py
+++ b/ludwig/benchmarking/profiler_callbacks.py
@@ -6,7 +6,7 @@ from ludwig.callbacks import Callback
 from ludwig.constants import EVALUATION, PREPROCESSING, TRAINING
 
 
-# Bump to PublicAPI once Ludwig 0.7 is released
+# TODO: Change annotation to PublicAPI once Ludwig 0.7 is released
 @DeveloperAPI
 class LudwigProfilerCallback(Callback):
     """Class that defines the methods necessary to hook into process."""

--- a/ludwig/callbacks.py
+++ b/ludwig/callbacks.py
@@ -17,7 +17,10 @@
 from abc import ABC
 from typing import Any, Callable, Dict, List, Union
 
+from ludwig.api_annotations import PublicAPI
 
+
+@PublicAPI
 class Callback(ABC):
     def on_cmdline(self, cmd: str, *args: List[str]):
         """Called when Ludwig is run on the command line with the callback enabled.

--- a/ludwig/contribs/aim.py
+++ b/ludwig/contribs/aim.py
@@ -1,7 +1,7 @@
 import json
 import logging
 
-from ludwig.api import PublicAPI
+from ludwig.api_annotations import PublicAPI
 from ludwig.callbacks import Callback
 from ludwig.utils.data_utils import NumpyEncoder
 from ludwig.utils.package_utils import LazyLoader

--- a/ludwig/contribs/aim.py
+++ b/ludwig/contribs/aim.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from ludwig.api import PublicAPI
 from ludwig.callbacks import Callback
 from ludwig.utils.data_utils import NumpyEncoder
 from ludwig.utils.package_utils import LazyLoader
@@ -10,6 +11,7 @@ aim = LazyLoader("aim", globals(), "aim")
 logger = logging.getLogger(__name__)
 
 
+@PublicAPI
 class AimCallback(Callback):
     """Class that defines the methods necessary to hook into process."""
 

--- a/ludwig/contribs/comet.py
+++ b/ludwig/contribs/comet.py
@@ -16,6 +16,7 @@ import logging
 import os
 from datetime import datetime
 
+from ludwig.api import PublicAPI
 from ludwig.callbacks import Callback
 from ludwig.utils.package_utils import LazyLoader
 
@@ -24,6 +25,7 @@ comet_ml = LazyLoader("comet_ml", globals(), "comet_ml")
 logger = logging.getLogger(__name__)
 
 
+@PublicAPI
 class CometCallback(Callback):
     """Class that defines the methods necessary to hook into process."""
 

--- a/ludwig/contribs/comet.py
+++ b/ludwig/contribs/comet.py
@@ -16,7 +16,7 @@ import logging
 import os
 from datetime import datetime
 
-from ludwig.api import PublicAPI
+from ludwig.api_annotations import PublicAPI
 from ludwig.callbacks import Callback
 from ludwig.utils.package_utils import LazyLoader
 

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -4,6 +4,7 @@ import queue
 import threading
 from typing import Any, Dict
 
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.callbacks import Callback
 from ludwig.constants import TRAINER
 from ludwig.data.dataset.base import Dataset
@@ -27,6 +28,7 @@ def _get_or_create_experiment_id(experiment_name, artifact_uri: str = None):
     return mlflow.create_experiment(name=experiment_name, artifact_location=artifact_uri)
 
 
+@DeveloperAPI
 class MlflowCallback(Callback):
     def __init__(self, tracking_uri=None, log_artifacts: bool = True):
         self.experiment_id = None

--- a/ludwig/contribs/wandb.py
+++ b/ludwig/contribs/wandb.py
@@ -15,6 +15,7 @@
 import logging
 import os
 
+from ludwig.api_annotations import PublicAPI
 from ludwig.callbacks import Callback
 from ludwig.utils.package_utils import LazyLoader
 
@@ -23,6 +24,7 @@ wandb = LazyLoader("wandb", globals(), "wandb")
 logger = logging.getLogger(__name__)
 
 
+@PublicAPI
 class WandbCallback(Callback):
     """Class that defines the methods necessary to hook into process."""
 

--- a/ludwig/contribs/whylogs/__init__.py
+++ b/ludwig/contribs/whylogs/__init__.py
@@ -1,9 +1,11 @@
+from ludwig.api_annotations import PublicAPI
 from ludwig.callbacks import Callback
 from ludwig.utils.package_utils import LazyLoader
 
 whylogs = LazyLoader("whylogs", globals(), "whylogs")
 
 
+@PublicAPI
 class WhyLogsCallback(Callback):
     def __init__(self, path_to_config=None):
         self.path_to_config = path_to_config

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -26,6 +26,7 @@ from ray.tune.utils.placement_groups import PlacementGroupFactory
 from ray.util.queue import Queue as RayQueue
 
 from ludwig.api import LudwigModel
+from ludwig.api_annotations import PublicAPI
 from ludwig.backend import initialize_backend, RAY
 from ludwig.backend.ray import initialize_ray
 from ludwig.callbacks import Callback
@@ -889,6 +890,7 @@ class RayTuneExecutor:
         return HyperoptResults(ordered_trials=ordered_trials, experiment_analysis=analysis)
 
 
+@PublicAPI
 class CallbackStopper(Stopper):
     """Ray Tune Stopper that triggers the entire job to stop if one callback returns True."""
 


### PR DESCRIPTION
This PR adds annotations for callbacks in Ludwig. In particular, it adds:

- DeveloperAPI to Callbacks that have changed recently or are exclusively for developers
- PublicAPI to callbacks that have been stable and have not had any recent changes

This ignores annotating callbacks that only exist within the scope of functions (like `UploadOnEpochEndCallback` within `api.py`), as well as those within tests.