### PR TITLE
Categorical passthrough encoder training failure fix

### DIFF
--- a/ludwig/encoders/category_encoders.py
+++ b/ludwig/encoders/category_encoders.py
@@ -22,9 +22,42 @@ from ludwig.constants import CATEGORY
 from ludwig.encoders.base import Encoder
 from ludwig.encoders.registry import register_encoder
 from ludwig.modules.embedding_modules import Embed
-from ludwig.schema.encoders.category_encoders import CategoricalEmbedConfig, CategoricalSparseConfig
+from ludwig.schema.encoders.category_encoders import (
+    CategoricalEmbedConfig,
+    CategoricalPassthroughEncoderConfig,
+    CategoricalSparseConfig,
+)
 
 logger = logging.getLogger(__name__)
+
+
+@register_encoder("passthrough", [CATEGORY])
+class CategoricalPassthroughEncoder(Encoder):
+    def __init__(self, input_size=1, encoder_config=None, **kwargs):
+        super().__init__()
+        self.config = encoder_config
+
+        logger.debug(f" {self.name}")
+        self.input_size = input_size
+
+    def forward(self, inputs, mask=None):
+        """
+        :param inputs: The inputs fed into the encoder.
+               Shape: [batch x 1]
+        """
+        return inputs.float()
+
+    @staticmethod
+    def get_schema_cls():
+        return CategoricalPassthroughEncoderConfig
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size([self.input_size])
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return self.input_shape
 
 
 @register_encoder("dense", CATEGORY)

--- a/ludwig/encoders/generic_encoders.py
+++ b/ludwig/encoders/generic_encoders.py
@@ -17,7 +17,7 @@ import logging
 
 import torch
 
-from ludwig.constants import BINARY, CATEGORY, NUMBER, VECTOR
+from ludwig.constants import BINARY, NUMBER, VECTOR
 from ludwig.encoders.base import Encoder
 from ludwig.encoders.registry import register_encoder
 from ludwig.modules.fully_connected_modules import FCStack
@@ -26,7 +26,7 @@ from ludwig.schema.encoders.base import DenseEncoderConfig, PassthroughEncoderCo
 logger = logging.getLogger(__name__)
 
 
-@register_encoder("passthrough", [CATEGORY, NUMBER, VECTOR])
+@register_encoder("passthrough", [NUMBER, VECTOR])
 class PassthroughEncoder(Encoder):
     def __init__(self, input_size=1, encoder_config=None, **kwargs):
         super().__init__()

--- a/ludwig/schema/encoders/base.py
+++ b/ludwig/schema/encoders/base.py
@@ -3,7 +3,7 @@ from typing import List, Union
 
 from marshmallow_dataclass import dataclass
 
-from ludwig.constants import BINARY, CATEGORY, NUMBER, VECTOR
+from ludwig.constants import BINARY, NUMBER, VECTOR
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.utils import register_encoder_config
 
@@ -19,7 +19,7 @@ class BaseEncoderConfig(schema_utils.BaseMarshmallowConfig, ABC):
     "Name corresponding to an encoder."
 
 
-@register_encoder_config("passthrough", [CATEGORY, NUMBER, VECTOR])
+@register_encoder_config("passthrough", [NUMBER, VECTOR])
 @dataclass
 class PassthroughEncoderConfig(BaseEncoderConfig):
     """PassthroughEncoderConfig is a dataclass that configures the parameters used for a passthrough encoder."""

--- a/ludwig/schema/encoders/category_encoders.py
+++ b/ludwig/schema/encoders/category_encoders.py
@@ -9,6 +9,20 @@ from ludwig.schema.encoders.utils import register_encoder_config
 from ludwig.schema.metadata.encoder_metadata import ENCODER_METADATA
 
 
+@register_encoder_config("passthrough", CATEGORY)
+@dataclass
+class CategoricalPassthroughEncoderConfig(BaseEncoderConfig):
+    """CategoricalPassthroughEncoderConfig is a dataclass that configures the parameters used for a categorical
+    passthrough encoder."""
+
+    type: str = schema_utils.StringOptions(
+        ["passthrough"],
+        default="passthrough",
+        allow_none=False,
+        description="Type of encoder.",
+    )
+
+
 @register_encoder_config("dense", CATEGORY)
 @dataclass
 class CategoricalEmbedConfig(BaseEncoderConfig):

--- a/tests/ludwig/models/test_training_success.py
+++ b/tests/ludwig/models/test_training_success.py
@@ -1,4 +1,5 @@
 from contextlib import nullcontext as no_error_raised
+
 from ludwig.api import LudwigModel
 from ludwig.constants import TRAINER
 from tests.integration_tests.utils import category_feature, generate_data
@@ -7,8 +8,12 @@ from tests.integration_tests.utils import category_feature, generate_data
 def test_category_passthrough_encoder(csv_filename):
     input_features = [category_feature(), category_feature()]
     output_features = [category_feature(output_feature=True)]
-    config = {"input_features": input_features, "output_features": output_features, TRAINER: {"train_steps": 1},
-              "defaults": {"category": {"encoder": {"type": "passthrough"}}}}
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        TRAINER: {"train_steps": 1},
+        "defaults": {"category": {"encoder": {"type": "passthrough"}}},
+    }
 
     # Generate training data
     training_data_csv_path = generate_data(input_features, output_features, csv_filename)

--- a/tests/ludwig/models/test_training_success.py
+++ b/tests/ludwig/models/test_training_success.py
@@ -1,0 +1,28 @@
+from contextlib import nullcontext as no_error_raised
+from ludwig.api import LudwigModel
+from ludwig.constants import TRAINER
+from tests.integration_tests.utils import category_feature, generate_data
+
+
+def test_category_passthrough_encoder(csv_filename):
+    input_features = [category_feature(), category_feature()]
+    output_features = [category_feature(output_feature=True)]
+    config = {"input_features": input_features, "output_features": output_features, TRAINER: {"train_steps": 1},
+              "defaults": {"category": {"encoder": {"type": "passthrough"}}}}
+
+    # Generate training data
+    training_data_csv_path = generate_data(input_features, output_features, csv_filename)
+
+    # Train Ludwig (Pythonic) model:
+    ludwig_model = LudwigModel(config)
+
+    with no_error_raised():
+        ludwig_model.experiment(
+            dataset=training_data_csv_path,
+            skip_save_training_description=True,
+            skip_save_training_statistics=True,
+            skip_save_model=True,
+            skip_save_progress=True,
+            skip_save_log=True,
+            skip_save_processed_input=True,
+        )


### PR DESCRIPTION
Fix for ECD training failure when we set
```
defaults:
  category:
    encoder:
      type: passthrough
```