### PR TITLE
Fixed --gpu_memory_limit in CLI to interpret as fraction of GPU memory

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -200,8 +200,8 @@ class LudwigModel:
         of backend to use to execute preprocessing / training steps.
     :param gpus: (Union[str, int, List[int]], default: `None`) GPUs
         to use (it uses the same syntax of CUDA_VISIBLE_DEVICES)
-    :param gpu_memory_limit: (int: default: `None`) maximum memory in MB to
-        allocate per GPU device.
+    :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
+        [0, 1] allowed to allocate per GPU device.
     :param allow_parallel_threads: (bool, default: `True`) allow Torch
         to use multithreading parallelism to improve performance at the
         cost of determinism.
@@ -263,7 +263,7 @@ class LudwigModel:
         logging_level: int = logging.ERROR,
         backend: Union[Backend, str] = None,
         gpus: Union[str, int, List[int]] = None,
-        gpu_memory_limit: int = None,
+        gpu_memory_limit: Optional[float] = None,
         allow_parallel_threads: bool = True,
         callbacks: List[Callback] = None,
     ) -> None:
@@ -278,8 +278,8 @@ class LudwigModel:
             of backend to use to execute preprocessing / training steps.
         :param gpus: (Union[str, int, List[int]], default: `None`) GPUs
             to use (it uses the same syntax of CUDA_VISIBLE_DEVICES)
-        :param gpu_memory_limit: (int: default: `None`) maximum memory in MB to
-            allocate per GPU device.
+        :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
+            [0, 1] allowed to allocate per GPU device.
         :param allow_parallel_threads: (bool, default: `True`) allow Torch
             to use multithreading parallelism to improve performance at the
             cost of determinism.
@@ -1414,7 +1414,7 @@ class LudwigModel:
         logging_level: int = logging.ERROR,
         backend: Union[Backend, str] = None,
         gpus: Union[str, int, List[int]] = None,
-        gpu_memory_limit: int = None,
+        gpu_memory_limit: Optional[float] = None,
         allow_parallel_threads: bool = True,
         callbacks: List[Callback] = None,
     ) -> "LudwigModel":  # return is an instance of ludwig.api.LudwigModel class
@@ -1431,8 +1431,8 @@ class LudwigModel:
             of backend to use to execute preprocessing / training steps.
         :param gpus: (Union[str, int, List[int]], default: `None`) GPUs
             to use (it uses the same syntax of CUDA_VISIBLE_DEVICES)
-        :param gpu_memory_limit: (int: default: `None`) maximum memory in MB to
-            allocate per GPU device.
+        :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
+            [0, 1] allowed to allocate per GPU device.
         :param allow_parallel_threads: (bool, default: `True`) allow Torch
             to use
             multithreading parallelism to improve performance at the cost of
@@ -1677,7 +1677,7 @@ def kfold_cross_validate(
     output_directory: str = "results",
     random_seed: int = default_random_seed,
     gpus: Union[str, int, List[int]] = None,
-    gpu_memory_limit: int = None,
+    gpu_memory_limit: Optional[float] = None,
     allow_parallel_threads: bool = True,
     backend: Union[Backend, str] = None,
     logging_level: int = logging.INFO,
@@ -1747,8 +1747,8 @@ def kfold_cross_validate(
            splits and any other random function.
     :param gpus: (list, default: `None`) list of GPUs that are available
             for training.
-    :param gpu_memory_limit: (int, default: `None`) maximum memory in MB to
-            allocate per GPU device.
+    :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
+            [0, 1] allowed to allocate per GPU device.
     :param allow_parallel_threads: (bool, default: `True`) allow Torch to
             use multithreading parallelism
            to improve performance at the cost of determinism.

--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -17,7 +17,7 @@ import argparse
 import logging
 import os
 import sys
-from typing import List, Union
+from typing import List, Optional, Union
 
 import numpy as np
 import torchinfo
@@ -43,7 +43,7 @@ def collect_activations(
     batch_size: int = 128,
     output_directory: str = "results",
     gpus: List[str] = None,
-    gpu_memory_limit: int = None,
+    gpu_memory_limit: Optional[float] = None,
     allow_parallel_threads: bool = True,
     callbacks: List[Callback] = None,
     backend: Union[Backend, str] = None,
@@ -75,8 +75,8 @@ def collect_activations(
         model and the training progress files.
     :param gpus: (list, default: `None`) list of GPUs that are available
         for training.
-    :param gpu_memory_limit: (int, default: `None`) maximum memory in MB to
-        allocate per GPU device.
+    :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
+        [0, 1] allowed to allocate per GPU device.
     :param allow_parallel_threads: (bool, default: `True`) allow TensorFlow
         to use multithreading parallelism to improve performance at
         the cost of determinism.
@@ -267,7 +267,11 @@ def cli_collect_activations(sys_argv):
     # ------------------
     parser.add_argument("-g", "--gpus", type=int, default=0, help="list of gpu to use")
     parser.add_argument(
-        "-gml", "--gpu_memory_limit", type=int, default=None, help="maximum memory in MB to allocate per GPU device"
+        "-gml",
+        "--gpu_memory_limit",
+        type=float,
+        default=None,
+        help="maximum memory fraction [0, 1] allowed to allocate per GPU device",
     )
     parser.add_argument(
         "-dpt",

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -108,7 +108,7 @@ class RayDataset(Dataset):
                 self.ds = self.ds.map_batches(lambda x: x, batch_size=None)
 
             # set instance state so calls to __len__ will also use the fully_executed version
-            # self.ds = self.ds.fully_executed()
+            self.ds = self.ds.fully_executed()
 
         if window_size_bytes is None:
             pipe = self.ds.repeat()
@@ -260,7 +260,7 @@ class RayDatasetBatcher(Batcher):
     def _fetch_next_epoch(self):
         pipeline = next(self.dataset_epoch_iterator)
 
-        read_parallelism = 0
+        read_parallelism = 1
         if read_parallelism == 1:
             self.dataset_batch_iter = self._create_async_reader(pipeline)
         elif read_parallelism > 1:
@@ -268,7 +268,6 @@ class RayDatasetBatcher(Batcher):
             #  very good with 1 parallelism
             self.dataset_batch_iter = self._create_async_parallel_reader(pipeline, read_parallelism)
         else:
-            print("!!! CREATE SYNC READER !!!")
             self.dataset_batch_iter = self._create_sync_reader(pipeline)
 
         self._step = 0

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -108,7 +108,7 @@ class RayDataset(Dataset):
                 self.ds = self.ds.map_batches(lambda x: x, batch_size=None)
 
             # set instance state so calls to __len__ will also use the fully_executed version
-            self.ds = self.ds.fully_executed()
+            # self.ds = self.ds.fully_executed()
 
         if window_size_bytes is None:
             pipe = self.ds.repeat()
@@ -260,7 +260,7 @@ class RayDatasetBatcher(Batcher):
     def _fetch_next_epoch(self):
         pipeline = next(self.dataset_epoch_iterator)
 
-        read_parallelism = 1
+        read_parallelism = 0
         if read_parallelism == 1:
             self.dataset_batch_iter = self._create_async_reader(pipeline)
         elif read_parallelism > 1:
@@ -268,6 +268,7 @@ class RayDatasetBatcher(Batcher):
             #  very good with 1 parallelism
             self.dataset_batch_iter = self._create_async_parallel_reader(pipeline, read_parallelism)
         else:
+            print("!!! CREATE SYNC READER !!!")
             self.dataset_batch_iter = self._create_sync_reader(pipeline)
 
         self._step = 0

--- a/ludwig/evaluate.py
+++ b/ludwig/evaluate.py
@@ -16,7 +16,7 @@
 import argparse
 import logging
 import sys
-from typing import List, Union
+from typing import List, Optional, Union
 
 import pandas as pd
 
@@ -44,7 +44,7 @@ def evaluate_cli(
     skip_collect_overall_stats: bool = False,
     output_directory: str = "results",
     gpus: Union[str, int, List[int]] = None,
-    gpu_memory_limit: int = None,
+    gpu_memory_limit: Optional[float] = None,
     allow_parallel_threads: bool = True,
     callbacks: List[Callback] = None,
     backend: Union[Backend, str] = None,
@@ -87,8 +87,8 @@ def evaluate_cli(
          model and the training progress files.
      :param gpus: (list, default: `None`) list of GPUs that are available
          for training.
-     :param gpu_memory_limit: (int, default: `None`) maximum memory in MB to
-         allocate per GPU device.
+     :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
+            [0, 1] allowed to allocate per GPU device.
      :param allow_parallel_threads: (bool, default: `True`) allow TensorFlow
          to use multithreading parallelism to improve performance at
          the cost of determinism.
@@ -212,7 +212,11 @@ def cli(sys_argv):
     # ------------------
     parser.add_argument("-g", "--gpus", type=int, default=0, help="list of gpu to use")
     parser.add_argument(
-        "-gml", "--gpu_memory_limit", type=int, default=None, help="maximum memory in MB to allocate per GPU device"
+        "-gml",
+        "--gpu_memory_limit",
+        type=float,
+        default=None,
+        help="maximum memory fraction [0, 1] allowed to allocate per GPU device",
     )
     parser.add_argument(
         "-dpt",

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -17,7 +17,7 @@ import argparse
 import logging
 import os
 import sys
-from typing import List, Union
+from typing import List, Optional, Union
 
 import pandas as pd
 
@@ -60,7 +60,7 @@ def experiment_cli(
     skip_collect_overall_stats: bool = False,
     output_directory: str = "results",
     gpus: Union[str, int, List[int]] = None,
-    gpu_memory_limit: int = None,
+    gpu_memory_limit: Optional[float] = None,
     allow_parallel_threads: bool = True,
     callbacks: List[Callback] = None,
     backend: Union[Backend, str] = None,
@@ -160,8 +160,8 @@ def experiment_cli(
          model and the training progress files.
      :param gpus: (list, default: `None`) list of GPUs that are available
          for training.
-     :param gpu_memory_limit: (int, default: `None`) maximum memory in MB to
-         allocate per GPU device.
+     :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
+            [0, 1] allowed to allocate per GPU device.
      :param allow_parallel_threads: (bool, default: `True`) allow TensorFlow
          to use multithreading parallelism to improve performance at
          the cost of determinism.
@@ -480,7 +480,11 @@ def cli(sys_argv):
     )
     parser.add_argument("-g", "--gpus", nargs="+", type=int, default=None, help="list of GPUs to use")
     parser.add_argument(
-        "-gml", "--gpu_memory_limit", type=int, default=None, help="maximum memory in MB to allocate per GPU device"
+        "-gml",
+        "--gpu_memory_limit",
+        type=float,
+        default=None,
+        help="maximum memory fraction [0, 1] allowed to allocate per GPU device",
     )
     parser.add_argument(
         "-dpt",

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -82,7 +82,7 @@ def hyperopt(
     skip_save_hyperopt_statistics: bool = False,
     output_directory: str = "results",
     gpus: Union[str, int, List[int]] = None,
-    gpu_memory_limit: int = None,
+    gpu_memory_limit: Optional[float] = None,
     allow_parallel_threads: bool = True,
     callbacks: List[Callback] = None,
     backend: Union[Backend, str] = None,
@@ -173,8 +173,8 @@ def hyperopt(
         model and the training progress files.
     :param gpus: (list, default: `None`) list of GPUs that are available
         for training.
-    :param gpu_memory_limit: (int, default: `None`) maximum memory in MB to
-        allocate per GPU device.
+    :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
+        [0, 1] allowed to allocate per GPU device.
     :param allow_parallel_threads: (bool, default: `True`) allow TensorFlow
         to use multithreading parallelism to improve performance at
         the cost of determinism.

--- a/ludwig/hyperopt_cli.py
+++ b/ludwig/hyperopt_cli.py
@@ -16,7 +16,7 @@
 import argparse
 import logging
 import sys
-from typing import List, Union
+from typing import List, Optional, Union
 
 from ludwig.backend import ALL_BACKENDS, Backend, initialize_backend
 from ludwig.callbacks import Callback
@@ -54,7 +54,7 @@ def hyperopt_cli(
     skip_save_hyperopt_statistics: bool = False,
     output_directory: str = "results",
     gpus: Union[str, int, List[int]] = None,
-    gpu_memory_limit: int = None,
+    gpu_memory_limit: Optional[float] = None,
     allow_parallel_threads: bool = True,
     callbacks: List[Callback] = None,
     backend: Union[Backend, str] = None,
@@ -139,8 +139,8 @@ def hyperopt_cli(
         model and the training progress files.
     :param gpus: (list, default: `None`) list of GPUs that are available
         for training.
-    :param gpu_memory_limit: (int, default: `None`) maximum memory in MB to
-        allocate per GPU device.
+    :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
+        [0, 1] allowed to allocate per GPU device.
     :param allow_parallel_threads: (bool, default: `True`) allow TensorFlow
         to use multithreading parallelism to improve performance at
         the cost of determinism.
@@ -373,7 +373,11 @@ def cli(sys_argv):
     )
     parser.add_argument("-g", "--gpus", nargs="+", type=int, default=None, help="list of gpus to use")
     parser.add_argument(
-        "-gml", "--gpu_memory_limit", type=int, default=None, help="maximum memory in MB to allocate per GPU device"
+        "-gml",
+        "--gpu_memory_limit",
+        type=float,
+        default=None,
+        help="maximum memory fraction [0, 1] allowed to allocate per GPU device",
     )
     parser.add_argument(
         "-b",

--- a/ludwig/predict.py
+++ b/ludwig/predict.py
@@ -16,7 +16,7 @@
 import argparse
 import logging
 import sys
-from typing import List, Union
+from typing import List, Optional, Union
 
 import pandas as pd
 
@@ -41,7 +41,7 @@ def predict_cli(
     skip_save_predictions: bool = False,
     output_directory: str = "results",
     gpus: Union[str, int, List[int]] = None,
-    gpu_memory_limit: int = None,
+    gpu_memory_limit: Optional[float] = None,
     allow_parallel_threads: bool = True,
     callbacks: List[Callback] = None,
     backend: Union[Backend, str] = None,
@@ -78,8 +78,8 @@ def predict_cli(
         model and the training progress files.
     :param gpus: (list, default: `None`) list of GPUs that are available
         for training.
-    :param gpu_memory_limit: (int, default: `None`) maximum memory in MB to
-        allocate per GPU device.
+    :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
+        [0, 1] allowed to allocate per GPU device.
     :param allow_parallel_threads: (bool, default: `True`) allow TensorFlow
         to use multithreading parallelism to improve performance at
         the cost of determinism.
@@ -189,7 +189,11 @@ def cli(sys_argv):
     # ------------------
     parser.add_argument("-g", "--gpus", type=int, default=0, help="list of gpu to use")
     parser.add_argument(
-        "-gml", "--gpu_memory_limit", type=int, default=None, help="maximum memory in MB to allocate per GPU device"
+        "-gml",
+        "--gpu_memory_limit",
+        type=float,
+        default=None,
+        help="maximum memory fraction [0, 1] allowed to allocate per GPU device",
     )
     parser.add_argument(
         "-dpt",

--- a/ludwig/preprocess.py
+++ b/ludwig/preprocess.py
@@ -122,8 +122,8 @@ def preprocess_cli(
         model and the training progress files.
     :param gpus: (list, default: `None`) list of GPUs that are available
         for training.
-    :param gpu_memory_limit: (int, default: `None`) maximum memory in MB to
-        allocate per GPU device.
+    :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
+        [0, 1] allowed to allocate per GPU device.
     :param allow_parallel_threads: (bool, default: `True`) allow TensorFlow
         to use multithreading parallelism to improve performance at
         the cost of determinism.

--- a/ludwig/train.py
+++ b/ludwig/train.py
@@ -16,7 +16,7 @@
 import argparse
 import logging
 import sys
-from typing import List, Union
+from typing import List, Optional, Union
 
 import pandas as pd
 
@@ -53,7 +53,7 @@ def train_cli(
     skip_save_processed_input: bool = False,
     output_directory: str = "results",
     gpus: Union[str, int, List[int]] = None,
-    gpu_memory_limit: int = None,
+    gpu_memory_limit: Optional[float] = None,
     allow_parallel_threads: bool = True,
     callbacks: List[Callback] = None,
     backend: Union[Backend, str] = None,
@@ -136,8 +136,8 @@ def train_cli(
         model and the training progress files.
     :param gpus: (list, default: `None`) list of GPUs that are available
         for training.
-    :param gpu_memory_limit: (int, default: `None`) maximum memory in MB to
-        allocate per GPU device.
+    :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
+        [0, 1] allowed to allocate per GPU device.
     :param allow_parallel_threads: (bool, default: `True`) allow TensorFlow
         to use multithreading parallelism to improve performance at
         the cost of determinism.
@@ -348,7 +348,11 @@ def cli(sys_argv):
     )
     parser.add_argument("-g", "--gpus", nargs="+", type=int, default=None, help="list of gpus to use")
     parser.add_argument(
-        "-gml", "--gpu_memory_limit", type=int, default=None, help="maximum memory in MB to allocate per GPU device"
+        "-gml",
+        "--gpu_memory_limit",
+        type=float,
+        default=None,
+        help="maximum memory fraction [0, 1] allowed to allocate per GPU device",
     )
     parser.add_argument(
         "-dpt",

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -41,7 +41,7 @@ def _run_commands(commands, **ludwig_kwargs):
 
 
 def _run_ludwig(command, **ludwig_kwargs):
-    commands = ["ludwig", command]
+    commands = ["python -m ludwig.cli", command]
     return _run_commands(commands, **ludwig_kwargs)
 
 
@@ -118,6 +118,15 @@ def test_train_cli_dataset(tmpdir, csv_filename):
     config_filename = os.path.join(tmpdir, "config.yaml")
     dataset_filename = _prepare_data(csv_filename, config_filename)
     _run_ludwig("train", dataset=dataset_filename, config=config_filename, output_directory=str(tmpdir))
+
+
+def test_train_cli_gpu_memory_limit(tmpdir, csv_filename):
+    """Test training using `ludwig train --dataset --gpu_memory_limit`."""
+    config_filename = os.path.join(tmpdir, "config.yaml")
+    dataset_filename = _prepare_data(csv_filename, config_filename)
+    _run_ludwig(
+        "train", dataset=dataset_filename, config=config_filename, output_directory=str(tmpdir), gpu_memory_limit="0.5"
+    )
 
 
 def test_train_cli_training_set(tmpdir, csv_filename):

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -41,7 +41,7 @@ def _run_commands(commands, **ludwig_kwargs):
 
 
 def _run_ludwig(command, **ludwig_kwargs):
-    commands = ["python -m ludwig.cli", command]
+    commands = ["ludwig", command]
     return _run_commands(commands, **ludwig_kwargs)
 
 

--- a/tests/integration_tests/test_horovod.py
+++ b/tests/integration_tests/test_horovod.py
@@ -96,5 +96,5 @@ def test_horovod_implicit(csv_filename):
 @pytest.mark.distributed
 def test_horovod_gpu_memory_limit(csv_filename):
     """Test Horovod with explicit GPU memory limit set."""
-    ludwig_kwargs = dict(gpu_memory_limit=128)
+    ludwig_kwargs = dict(gpu_memory_limit="0.5")
     _run_horovod(csv_filename, **ludwig_kwargs)


### PR DESCRIPTION
PyTorch expects `gpu_memory_limit` to be given as the fraction `[0, 1]` of GPU memory to use, not the total amount of GPU memory. We were honoring this correctly in the API (and Hyperopt), but not on the CLI, which was rejecting float values:

```
ludwig train: error: argument -gml/--gpu_memory_limit: invalid int value: '0.5'
```