### PR TITLE
Add support for running pytest github action locally with act

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,1 @@
+-P ubuntu-latest=ludwigai/ludwig-ray

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Setup macOS
         if: runner.os == 'macOS'
         run: |
-          brew install node libuv
+          brew install libuv
 
       - name: pip cache
         uses: actions/cache@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,6 +60,13 @@ jobs:
 
     timeout-minutes: 80
     steps:
+      - name: Hack container for local development
+        if: ${{ env.ACT }}
+        run: |
+          curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+          sudo apt-get install -y nodejs
+          sudo mkdir -p /opt/hostedtoolcache/
+          sudo chmod 777 -R /opt/hostedtoolcache/
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -74,7 +81,7 @@ jobs:
       - name: Setup macOS
         if: runner.os == 'macOS'
         run: |
-          brew install libuv
+          brew install node libuv
 
       - name: pip cache
         uses: actions/cache@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,7 +60,7 @@ jobs:
 
     timeout-minutes: 80
     steps:
-      - name: Hack container for local development
+      - name: Setup ludwigai/ludwig-ray container for local testing with act.
         if: ${{ env.ACT }}
         run: |
           curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -


### PR DESCRIPTION
Testing the `act` CLI tool for running pytest locally.  This PR adds configuration to run our github actions using the `ludwigai/ludwig-ray` docker image. 

To try this out:

1. Install act
https://github.com/nektos/act

2. Run tests
From the ludwig project root:
`act -j pytest`