### PR TITLE
Added eq to fix training determinism failure

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -163,8 +163,11 @@ class TrainingStats:
                     recursive_compare(dict_1[key1], dict_2[key2])
                 elif isinstance(dict_1[key1], EvaluationFrequency) and isinstance(dict_2[key2], EvaluationFrequency):
                     recursive_compare(dataclasses.asdict(dict_1[key1]), dataclasses.asdict(dict_2[key2]))
-                elif isinstance(dict_1[key1], list) and isinstance(dict_2[key2], list) \
-                        and set(dict_1[key1]) == set(dict_2[key2]):
+                elif (
+                    isinstance(dict_1[key1], list)
+                    and isinstance(dict_2[key2], list)
+                    and set(dict_1[key1]) == set(dict_2[key2])
+                ):
                     return False
                 elif dict_1[key1] != dict_2[key2]:
                     return False

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -151,6 +151,29 @@ class TrainingStats:
         # Supports dict-style [] element access for compatibility.
         return {TRAINING: self.training, VALIDATION: self.validation, TEST: self.test}[key]
 
+    def __eq__(self, other):
+        if type(self) != type(other):
+            return NotImplemented
+
+        def recursive_compare(dict_1, dict_2):
+            for key1, key2 in zip(dict_1.keys(), dict_2.keys()):
+                if key1 != key2:
+                    return False
+                elif isinstance(dict_1[key1], dict) and isinstance(dict_2[key2], dict):
+                    recursive_compare(dict_1[key1], dict_2[key2])
+                elif isinstance(dict_1[key1], EvaluationFrequency) and isinstance(dict_2[key2], EvaluationFrequency):
+                    recursive_compare(dataclasses.asdict(dict_1[key1]), dataclasses.asdict(dict_2[key2]))
+                elif isinstance(dict_1[key1], list) and isinstance(dict_2[key2], list) \
+                        and set(dict_1[key1]) == set(dict_2[key2]):
+                    return False
+                elif dict_1[key1] != dict_2[key2]:
+                    return False
+                else:
+                    continue
+            return True
+
+        return recursive_compare(dataclasses.asdict(self), dataclasses.asdict(other))
+
 
 @dataclass
 class PreprocessedDataset:


### PR DESCRIPTION
`test_training_determinism_ray_backend` is failing because the trainstats are now in an object which is technically not equal to the subsequent run even though the contents are. I added a `__eq__` function so that comparing the two classes will compare them based on the contents not the hash of the object. 