### PR TITLE
Enforcing a 1 to 1 matching in names between Ludwig datasets and AutoGluon paper

### DIFF
--- a/ludwig/datasets/configs/fake_job_postings2.yaml
+++ b/ludwig/datasets/configs/fake_job_postings2.yaml
@@ -1,5 +1,5 @@
 version: 1.0
-name: fake_job_postings
+name: fake_job_postings2
 download_urls:
   - https://automl-mm-bench.s3.amazonaws.com/fake_job_postings2/train.csv
   - https://automl-mm-bench.s3.amazonaws.com/fake_job_postings2/test.csv

--- a/ludwig/datasets/configs/google_qa_answer_type_reason_explanation.yaml
+++ b/ludwig/datasets/configs/google_qa_answer_type_reason_explanation.yaml
@@ -1,0 +1,18 @@
+version: 1.0
+name: google_qa_answer_type_reason_explanation
+download_urls:
+  - https://automl-mm-bench.s3.amazonaws.com/google_quest_qa/train.pq
+  - https://automl-mm-bench.s3.amazonaws.com/google_quest_qa/dev.pq
+sha256:
+  train.pq: 92274286ffb759c96bfca77001c10eb323b3531db3a0e178813db9b82e80a12a
+  dev.pq: 2e66450215b94dc404eadc7dde83a1eabad9640d946863c298aa2d42c998ed84
+train_filenames: train.pq
+test_filenames: dev.pq
+description: |
+  Google QUEST Q&A Labeling
+  Improving automated understanding of complex question answer content.
+  The data for this competition includes questions and answers from various StackExchange properties.
+  https://www.kaggle.com/c/google-quest-challenge/data
+  Note: this is the same dataset as `google_quest_qa`. It is duplicated here to have a one-to-one mapping
+  with the benchmarking datasets in https://arxiv.org/pdf/2111.02705.pdf
+  In this paper, the column `answer_type_reason_explanation` is used as the output feature.

--- a/ludwig/datasets/configs/google_qa_question_type_reason_explanation.yaml
+++ b/ludwig/datasets/configs/google_qa_question_type_reason_explanation.yaml
@@ -1,0 +1,18 @@
+version: 1.0
+name: google_qa_question_type_reason_explanation
+download_urls:
+  - https://automl-mm-bench.s3.amazonaws.com/google_quest_qa/train.pq
+  - https://automl-mm-bench.s3.amazonaws.com/google_quest_qa/dev.pq
+sha256:
+  train.pq: 92274286ffb759c96bfca77001c10eb323b3531db3a0e178813db9b82e80a12a
+  dev.pq: 2e66450215b94dc404eadc7dde83a1eabad9640d946863c298aa2d42c998ed84
+train_filenames: train.pq
+test_filenames: dev.pq
+description: |
+  Google QUEST Q&A Labeling
+  Improving automated understanding of complex question answer content.
+  The data for this competition includes questions and answers from various StackExchange properties.
+  https://www.kaggle.com/c/google-quest-challenge/data
+  Note: this is the same dataset as `google_quest_qa`. It is duplicated here to have a one-to-one mapping
+  with the benchmarking datasets in https://arxiv.org/pdf/2111.02705.pdf
+  In this paper, the column `question_type_reason_explanation` is used as the output feature.

--- a/ludwig/datasets/configs/jigsaw_unintended_bias100k.yaml
+++ b/ludwig/datasets/configs/jigsaw_unintended_bias100k.yaml
@@ -1,5 +1,5 @@
 version: 1.0
-name: jigsaw_unintended_bias_100k
+name: jigsaw_unintended_bias100K
 download_urls:
   - https://automl-mm-bench.s3.amazonaws.com/jigsaw_unintended_bias100K/train.pq
   - https://automl-mm-bench.s3.amazonaws.com/jigsaw_unintended_bias100K/test.pq

--- a/ludwig/datasets/configs/mercari_price_suggestion100K.yaml
+++ b/ludwig/datasets/configs/mercari_price_suggestion100K.yaml
@@ -1,5 +1,5 @@
 version: 1.0
-name: mercari_price_suggestion_100k
+name: mercari_price_suggestion100K
 download_urls:
   - https://automl-mm-bench.s3.amazonaws.com/mercari_price_suggestion100K/train.pq
   - https://automl-mm-bench.s3.amazonaws.com/mercari_price_suggestion100K/test.pq

--- a/ludwig/datasets/configs/news_channel.yaml
+++ b/ludwig/datasets/configs/news_channel.yaml
@@ -1,0 +1,16 @@
+version: 1.0
+name: news_channel
+download_urls:
+  - https://automl-mm-bench.s3.amazonaws.com/news_channel/train.csv
+  - https://automl-mm-bench.s3.amazonaws.com/news_channel/test.csv
+sha256:
+  test.csv: d48e7261dce69964eb1163c89e05261b8732c676b10de9b40339b2d95559c9c3
+  train.csv: 46e433fcf070ec684cfaf30bada482a73637e8dd954edc3e1fe860de8e661055
+train_filenames: train.csv
+test_filenames: test.csv
+description: |
+  Online News Popularity Data Set
+  This dataset summarizes a heterogeneous set of features about articles
+  published by Mashable in a period of two years. The goal is to predict
+  the number of shares in social networks (popularity).
+  https://archive.ics.uci.edu/ml/datasets/online+news+popularity

--- a/ludwig/datasets/configs/product_sentiment_machine_hack.yaml
+++ b/ludwig/datasets/configs/product_sentiment_machine_hack.yaml
@@ -3,14 +3,11 @@ name: product_sentiment_machine_hack
 download_urls:
   - https://automl-mm-bench.s3.amazonaws.com/machine_hack_product_sentiment/train.csv
   - https://automl-mm-bench.s3.amazonaws.com/machine_hack_product_sentiment/dev.csv
-  - https://automl-mm-bench.s3.amazonaws.com/machine_hack_product_sentiment/test.csv
 sha256:
-  test.csv: 5551bb65502d50bf408162d42073d449a0000c57bd8a82c88018c4637eda1a6d
   dev.csv: 33adff4dba7d9322397b398900c20f678d3fffc5d87b0ea825d9aa497a343150
   train.csv: 85a229e162b6d8c4839d1b27f834c36ae5e244fd027534fe62a888d4f536f0ef
 train_filenames: train.csv
-validation_filenames: dev.csv
-test_filenames: test.csv
+test_filenames: dev.csv
 description: |
   We challenge the machinehackers community to develop a machine learning model
   to accurately classify various products into 4 different classes of sentiments


### PR DESCRIPTION
This PR 
- Modifies some of the YAMLs used to load benchmarking datasets from the AutoGluon [paper](https://arxiv.org/pdf/2111.02705.pdf). For the datasets where they submit to an online competition, they have a `competition` split ([example](https://github.com/sxjscience/automl_multimodal_benchmark/blob/77edc53ef7e8a91ea4cfdaa336b353af66e3db00/multimodal_text_benchmark/src/auto_mm_bench/datasets.py#L89)). However, the scores reported in the paper are on the `test` split. We change the Ludwig `test` split for those datasets to the right file used to report scores in the paper.
- Adds the dataset `news_channel` (`channel` in the paper).
- Adds a few YAML files that allow us to use the same names in their work.