### PR TITLE
Switch defaults to use mixins and improve test

### DIFF
--- a/ludwig/schema/defaults/utils.py
+++ b/ludwig/schema/defaults/utils.py
@@ -3,7 +3,7 @@ from dataclasses import field
 from marshmallow import fields, ValidationError
 
 import ludwig.schema.utils as schema_utils
-from ludwig.schema.features.utils import input_config_registry, output_config_registry
+from ludwig.schema.features.utils import input_mixin_registry, output_mixin_registry
 
 
 def DefaultsDataclassField(feature_type: str):
@@ -21,8 +21,8 @@ def DefaultsDataclassField(feature_type: str):
             if value is None:
                 return None
             if isinstance(value, dict):
-                input_feature_class = input_config_registry[feature_type]
-                output_feature_class = output_config_registry.get(feature_type, None)
+                input_feature_class = input_mixin_registry[feature_type]
+                output_feature_class = output_mixin_registry.get(feature_type, None)
                 try:
                     input_schema = input_feature_class.Schema().load(value)
                     if output_feature_class:
@@ -37,8 +37,8 @@ def DefaultsDataclassField(feature_type: str):
 
         @staticmethod
         def _jsonschema_type_mapping():
-            input_feature_cls = input_config_registry.get(feature_type)
-            output_feature_cls = output_config_registry.get(feature_type, None)
+            input_feature_cls = input_mixin_registry.get(feature_type)
+            output_feature_cls = output_mixin_registry.get(feature_type, None)
             input_props = schema_utils.unload_jsonschema_from_marshmallow_class(input_feature_cls)["properties"]
             if output_feature_cls:
                 output_props = schema_utils.unload_jsonschema_from_marshmallow_class(output_feature_cls)["properties"]
@@ -48,12 +48,13 @@ def DefaultsDataclassField(feature_type: str):
             return {
                 "type": "object",
                 "properties": combined_props,
+                "additionalProperties": False,
                 "title": "defaults_options",
             }
 
     try:
-        input_cls = input_config_registry[feature_type]
-        output_cls = output_config_registry.get(feature_type, None)
+        input_cls = input_mixin_registry[feature_type]
+        output_cls = output_mixin_registry.get(feature_type, None)
         dump_default = input_cls.Schema().dump({"type": feature_type})
         if output_cls:
             output_dump = output_cls.Schema().dump({"type": feature_type})

--- a/tests/ludwig/schema/test_validate_config_misc.py
+++ b/tests/ludwig/schema/test_validate_config_misc.py
@@ -1,7 +1,19 @@
 import pytest
 from jsonschema.exceptions import ValidationError
 
-from ludwig.constants import DECODER, ENCODER, LOSS, MODEL_ECD, MODEL_GBM, MODEL_TYPE, PREPROCESSING, TRAINER
+from ludwig.constants import (
+    CATEGORY,
+    DECODER,
+    DEFAULTS,
+    ENCODER,
+    LOSS,
+    MODEL_ECD,
+    MODEL_GBM,
+    MODEL_TYPE,
+    NAME,
+    PREPROCESSING,
+    TRAINER,
+)
 from ludwig.features.audio_feature import AudioFeatureMixin
 from ludwig.features.bag_feature import BagFeatureMixin
 from ludwig.features.binary_feature import BinaryFeatureMixin
@@ -300,6 +312,11 @@ def test_validate_defaults_schema():
     }
 
     validate_config(config)
+
+    config[DEFAULTS][CATEGORY][NAME] = "TEST"
+
+    with pytest.raises(ValidationError):
+        validate_config(config)
 
 
 def test_validate_no_trainer_type():


### PR DESCRIPTION
Forgot to switch the registry the defaults is composed of in the [defaults factor PR](https://github.com/ludwig-ai/ludwig/pull/2628). This fixes that mistake and improves the test so it will catch it next time.