### PR TITLE
Fix Regression Test Configs

### DIFF
--- a/tests/regression_tests/benchmark/configs/adult_census_income.gbm.yaml
+++ b/tests/regression_tests/benchmark/configs/adult_census_income.gbm.yaml
@@ -52,4 +52,4 @@ trainer:
   early_stop: 5
   eval_batch_size: 16384
   evaluate_training_set: false
-type: gbm
+model_type: gbm

--- a/tests/regression_tests/benchmark/configs/ames_housing.gbm.yaml
+++ b/tests/regression_tests/benchmark/configs/ames_housing.gbm.yaml
@@ -182,4 +182,4 @@ trainer:
   early_stop: 5
   eval_batch_size: 16384
   evaluate_training_set: false
-type: gbm
+model_type: gbm

--- a/tests/regression_tests/benchmark/configs/mercedes_benz_greener.gbm.yaml
+++ b/tests/regression_tests/benchmark/configs/mercedes_benz_greener.gbm.yaml
@@ -776,4 +776,4 @@ trainer:
   early_stop: 5
   eval_batch_size: 16384
   evaluate_training_set: false
-type: gbm
+model_type: gbm

--- a/tests/regression_tests/benchmark/configs/sarcos.gbm.yaml
+++ b/tests/regression_tests/benchmark/configs/sarcos.gbm.yaml
@@ -106,4 +106,4 @@ trainer:
   min_sum_hessian_in_leaf: 8
   num_boost_round: 382
   num_leaves: 434
-type: gbm
+model_type: gbm


### PR DESCRIPTION
Regression test configs for gbm had the `model_type` defined in their configs by the key `type`. Switched that to the proper parameter to fix the CI failures.