### PR TITLE
Testing always() inside expansion in condition

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -176,7 +176,7 @@ jobs:
           RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=3600 pytest -v --timeout 300 --durations 100 -m "($MARKERS) and (not $EXCLUDED_MARKERS)" --junitxml pytest.xml tests
 
       - name: Upload Unit Test Results
-        if: always() && ${{ !env.ACT }}
+        if: ${{ always() && !env.ACT }}
         uses: actions/upload-artifact@v2
         with:
           name: Unit Test Results (Python ${{ matrix.python-version }} ${{ matrix.test-markers }})


### PR DESCRIPTION
Testing to see if this behaves correctly in github runner, because this fixes a bug in act. 

`always() && ${{ !env.ACT }}` always runs upload in `act`, which fails without an upload url and access token, while
`${{always() && !env.ACT }}` correctly skips upload when running `act`