### PR TITLE
[fix] Only drop rows where Nan is not in target column

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1743,7 +1743,7 @@ def _preprocess_file_for_training(
 
         # Data is pre-split, so we override whatever split policy the user specified
         if preprocessing_params["split"]:
-            warnings.warn(
+            logger.debug(
                 'Preprocessing "split" section provided, but pre-split dataset given as input. '
                 "Ignoring split configuration."
             )
@@ -1814,7 +1814,7 @@ def _preprocess_df_for_training(
 
         # Data is pre-split, so we override whatever split policy the user specified
         if preprocessing_params["split"]:
-            warnings.warn(
+            logger.debug(
                 'Preprocessing "split" section provided, but pre-split dataset given as input. '
                 "Ignoring split configuration."
             )


### PR DESCRIPTION
This PR fixes the following bugs in preprocessing. Both bugs exist because we do joint preprocessing of `training_set`, `val_set` and `test_set` by concatenating then and passing them to `build_dataset`.

- While removing `Nan`s,  we drop rows all rows from the test split because the have `Nan`s in the target column.
- After concatenating the 3 dataframes, we don't set the split percentage of the datasets based on their original sizes.