### PR TITLE
Check for nans before testing equality in test_training_determinism

### DIFF
--- a/ludwig/utils/numerical_test_utils.py
+++ b/ludwig/utils/numerical_test_utils.py
@@ -23,7 +23,7 @@ def _dict_like(x):
     """Returns true if an object is a dict or convertible to one, false if not."""
     try:
         _ = dict(x)
-    except TypeError:
+    except (TypeError, ValueError):
         return False
     return True
 
@@ -32,7 +32,7 @@ def _enumerable(x):
     """Returns true if an object is enumerable, false if not."""
     try:
         _ = enumerate(x)
-    except TypeError:
+    except (TypeError, ValueError):
         return False
     return True
 

--- a/ludwig/utils/numerical_test_utils.py
+++ b/ludwig/utils/numerical_test_utils.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 # Copyright (c) 2022 Predibase, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +37,7 @@ def _enumerable(x):
 
 
 def assert_all_finite(x: Any, keypath=""):
-    """Ensures that all scalars at all levels of the dictionary, list, tensor, or scalar are finite.
+    """Ensures that all scalars at all levels of the dictionary, list, array, or scalar are finite.
 
     keypath is only used for logging error messages, to indicate where the non-finite value was detected.
     """
@@ -57,7 +56,7 @@ def assert_all_finite(x: Any, keypath=""):
         for k, v in dict(x).items():
             assert_all_finite(v, keypath=keypath + "." + str(k) if keypath else str(k))
     elif _enumerable(x):
-        # x is a list, set, or other enumerable type, but not a string or dict.
+        # x is a list, set or other enumerable type, but not a string, dict, or numpy array.
         for i, v in enumerate(x):
             assert_all_finite(v, keypath=keypath + f"[{i}]")
     else:

--- a/ludwig/utils/numerical_test_utils.py
+++ b/ludwig/utils/numerical_test_utils.py
@@ -1,0 +1,64 @@
+#! /usr/bin/env python
+# Copyright (c) 2022 Predibase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from typing import Any
+
+import numpy as np
+
+
+def _dict_like(x):
+    """Returns true if an object is a dict or convertible to one, false if not."""
+    try:
+        _ = dict(x)
+    except TypeError:
+        return False
+    return True
+
+
+def _enumerable(x):
+    """Returns true if an object is enumerable, false if not."""
+    try:
+        _ = enumerate(x)
+    except TypeError:
+        return False
+    return True
+
+
+def assert_all_finite(x: Any, keypath=""):
+    """Ensures that all scalars at all levels of the dictionary, list, tensor, or scalar are finite.
+
+    keypath is only used for logging error messages, to indicate where the non-finite value was detected.
+    """
+    path_description = f" at {keypath} " if keypath else " "
+    if np.isscalar(x):
+        assert np.isfinite(x), f"Value{path_description}should be finite, but is {str(x)}."
+    elif isinstance(x, np.ndarray):
+        non_finite_indices = np.nonzero(~np.isfinite(x))
+        non_finite_values = x[non_finite_indices]
+        assert np.all(np.isfinite(x)), (
+            f"All values{path_description}should be finite, but found {str(non_finite_values)} "
+            "at positions {str(np.array(non_finite_indices).flatten())}."
+        )
+    elif _dict_like(x):
+        # x is either a dict or convertible to one
+        for k, v in dict(x).items():
+            assert_all_finite(v, keypath=keypath + "." + str(k) if keypath else str(k))
+    elif _enumerable(x):
+        # x is a list, set, or other enumerable type, but not a string or dict.
+        for i, v in enumerate(x):
+            assert_all_finite(v, keypath=keypath + f"[{i}]")
+    else:
+        assert False, f"Unhandled type {str(type(x))} for value{path_description}"

--- a/tests/ludwig/models/test_training_determinism.py
+++ b/tests/ludwig/models/test_training_determinism.py
@@ -6,6 +6,7 @@ import pytest
 
 from ludwig.api import LudwigModel
 from ludwig.constants import TRAINER
+from ludwig.utils.numerical_test_utils import assert_all_finite
 from tests.integration_tests.utils import (
     audio_feature,
     bag_feature,
@@ -31,6 +32,11 @@ def test_training_determinism_ray_backend(csv_filename, tmpdir, ray_cluster_4cpu
     eval_stats_1, train_stats_1, _, _ = experiment_output_1
     eval_stats_2, train_stats_2, _, _ = experiment_output_2
 
+    assert_all_finite(eval_stats_1)
+    assert_all_finite(eval_stats_2)
+    assert_all_finite(train_stats_1)
+    assert_all_finite(train_stats_2)
+
     np.testing.assert_equal(eval_stats_1, eval_stats_2)
     np.testing.assert_equal(train_stats_1, train_stats_2)
 
@@ -40,6 +46,11 @@ def test_training_determinism_local_backend(csv_filename, tmpdir):
 
     eval_stats_1, train_stats_1, _, _ = experiment_output_1
     eval_stats_2, train_stats_2, _, _ = experiment_output_2
+
+    assert_all_finite(eval_stats_1)
+    assert_all_finite(eval_stats_2)
+    assert_all_finite(train_stats_1)
+    assert_all_finite(train_stats_2)
 
     np.testing.assert_equal(eval_stats_1, eval_stats_2)
     np.testing.assert_equal(train_stats_1, train_stats_2)

--- a/tests/ludwig/utils/test_numerical_test_utils.py
+++ b/tests/ludwig/utils/test_numerical_test_utils.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+
+from ludwig.utils.numerical_test_utils import assert_all_finite
+
+
+@pytest.fixture
+def finite_valued_dict():
+    return {
+        "scalar": 1,
+        "metrics": {"val": 0.2, "series": [0.1, 0.2, 0.3], "ndarray": np.ones((8, 4, 2))},
+    }
+
+
+def test_assert_all_finite(finite_valued_dict):
+    assert_all_finite(finite_valued_dict)
+
+
+def test_fail_with_nan(finite_valued_dict):
+    finite_valued_dict["scalar"] = float("nan")
+    with pytest.raises(Exception):
+        assert_all_finite(finite_valued_dict)
+
+
+def test_fail_with_inf(finite_valued_dict):
+    finite_valued_dict["scalar"] = float("inf")
+    with pytest.raises(Exception):
+        assert_all_finite(finite_valued_dict)
+
+
+def test_fail_with_nan_in_list(finite_valued_dict):
+    finite_valued_dict["scalar"] = float("nan")
+    with pytest.raises(Exception):
+        assert_all_finite(finite_valued_dict)
+
+
+def test_fail_with_nan_in_ndarray(finite_valued_dict):
+    finite_valued_dict["metrics"]["ndarray"][0, 0, 1] = np.nan
+    with pytest.raises(Exception):
+        assert_all_finite(finite_valued_dict)


### PR DESCRIPTION
If nans appear in metrics, the equality check fails `(nan == nan) == False`, but this gives an error which may be misleading.

This adds checks for nans and infinite values first, and provides an informative error message showing where the nan was encountered