### PR TITLE
Fix InputDataError to be serializeable

### DIFF
--- a/ludwig/error.py
+++ b/ludwig/error.py
@@ -44,3 +44,6 @@ class InputDataError(LudwigError, ValueError):
 
     def __str__(self):
         return f'Column "{self.column_name}" as {self.feature_type} feature: {self.message}'
+
+    def __reduce__(self):
+        return type(self), (self.column_name, self.feature_type, self.message)

--- a/tests/ludwig/utils/test_errors.py
+++ b/tests/ludwig/utils/test_errors.py
@@ -1,0 +1,16 @@
+import pickle
+
+from ludwig.error import InputDataError
+
+
+def test_input_data_error_serializeable():
+    err = InputDataError(
+        "location", "category", "At least 2 distinct values are required, column only contains ['here']"
+    )
+
+    loaded_err: InputDataError = pickle.loads(pickle.dumps(err))
+
+    assert loaded_err.column_name == err.column_name
+    assert loaded_err.feature_type == err.feature_type
+    assert loaded_err.message == err.message
+    assert str(err) == str(loaded_err)


### PR DESCRIPTION
This results in Ray being unable to surface the error to the user when sending it back to the driver from the worker processes.

See https://stackoverflow.com/questions/49715881/how-to-pickle-inherited-exceptions