### PR TITLE
Adds Ray implementation of IntegratedGradientsExplainer that distributes across cluster resources

### DIFF
--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -237,7 +237,7 @@ def train_fn(
     return train_results
 
 
-@ray.remote
+@ray.remote(max_calls=1)
 def tune_batch_size_fn(
     dataset: RayDataset = None,
     data_loader_kwargs: Dict[str, Any] = None,
@@ -270,7 +270,7 @@ def tune_batch_size_fn(
         hvd.shutdown()
 
 
-@ray.remote
+@ray.remote(max_calls=1)
 def tune_learning_rate_fn(
     dataset: RayDataset,
     config: Dict[str, Any],

--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -163,16 +163,18 @@ class IntegratedGradientsExplainer(Explainer):
 
                 if total_attribution is not None:
                     if self.use_global:
-                        total_attribution += attribution.sum(dim=0)
+                        total_attribution += attribution.sum(axis=0, keepdims=True)
                     else:
                         total_attribution = np.concatenate([total_attribution, attribution], axis=0)
                 else:
                     if self.use_global:
-                        total_attribution = attribution.sum(dim=0)
+                        total_attribution = attribution.sum(axis=0, keepdims=True)
                     else:
                         total_attribution = attribution
 
-            total_attribution /= len(self.inputs_df)
+            if self.use_global:
+                total_attribution /= len(self.inputs_df)
+            print(total_attribution.shape)
 
             for feature_attributions, explanation in zip(total_attribution, self.explanations):
                 # Add the feature attributions to the explanation object for this row.

--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -65,7 +65,6 @@ def get_input_tensors(model: LudwigModel, input_set: pd.DataFrame) -> List[Varia
 
     :return: A list of variables, one for each input feature. Shape of each variable is [batch size, embedding size].
     """
-
     # Convert raw input data into preprocessed tensor data
     dataset, _ = preprocess_for_prediction(
         model.config_obj.to_dict(),

--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -129,52 +129,20 @@ class IntegratedGradientsExplainer(Explainer):
         # Convert input data into embedding tensors from the output of the model encoders.
         inputs_encoded = get_input_tensors(self.model, self.inputs_df)
         sample_encoded = get_input_tensors(self.model, self.sample_df)
-
-        # For a robust baseline, we take the mean of all embeddings in the sample from the training data.
-        # TODO(travis): pre-compute this during training from the full training dataset.
-        baseline = [torch.unsqueeze(torch.mean(t, dim=0), 0).to(DEVICE) for t in sample_encoded]
-
-        # Configure the explainer, which includes wrapping the model so its interface conforms to
-        # the format expected by Captum.
-        explanation_model = WrapperModule(self.model.model, self.target_feature_name)
-        explainer = IntegratedGradients(explanation_model)
-
-        inputs_encoded_splits = [ipt.split(self.model.config_obj.trainer.batch_size) for ipt in inputs_encoded]
+        baseline = get_baseline(sample_encoded)
 
         # Compute attribution for each possible output feature label separately.
         expected_values = []
         for target_idx in tqdm(range(self.vocab_size), desc="Explain"):
-            total_attribution = None
-            for input_batch in zip(*inputs_encoded_splits):
-                input_batch = [ipt.to(DEVICE) for ipt in input_batch]
-                attribution = explainer.attribute(
-                    tuple(input_batch),
-                    baselines=tuple(baseline),
-                    target=target_idx if self.is_category_target else None,
-                )
-
-                # Attribution over the feature embeddings returns a vector with the same dimensions of
-                # shape [batch_size, embedding_size], so take the sum over this vector in order to return a single
-                # floating point attribution value per input feature.
-                attribution = np.array([t.detach().cpu().numpy().sum(1) for t in attribution])
-
-                # Transpose to [batch_size, num_input_features]
-                attribution = attribution.T
-
-                if total_attribution is not None:
-                    if self.use_global:
-                        total_attribution += attribution.sum(axis=0, keepdims=True)
-                    else:
-                        total_attribution = np.concatenate([total_attribution, attribution], axis=0)
-                else:
-                    if self.use_global:
-                        total_attribution = attribution.sum(axis=0, keepdims=True)
-                    else:
-                        total_attribution = attribution
-
-            if self.use_global:
-                total_attribution /= len(self.inputs_df)
-            print(total_attribution.shape)
+            total_attribution = get_total_attribution(
+                self.model,
+                self.target_feature_name,
+                target_idx if self.is_category_target else None,
+                inputs_encoded,
+                baseline,
+                self.use_global,
+                len(self.inputs_df),
+            )
 
             for feature_attributions, explanation in zip(total_attribution, self.explanations):
                 # Add the feature attributions to the explanation object for this row.
@@ -197,3 +165,61 @@ class IntegratedGradientsExplainer(Explainer):
             expected_values.append(0.0)
 
         return self.explanations, expected_values
+
+
+def get_baseline(sample_encoded: List[Variable]) -> List[Variable]:
+    # For a robust baseline, we take the mean of all embeddings in the sample from the training data.
+    # TODO(travis): pre-compute this during training from the full training dataset.
+    return [torch.unsqueeze(torch.mean(t, dim=0), 0) for t in sample_encoded]
+
+
+def get_total_attribution(
+    model: LudwigModel,
+    target_feature_name: str,
+    target_idx: Optional[int],
+    inputs_encoded: List[Variable],
+    baseline: List[Variable],
+    use_global: bool,
+    nsamples: int,
+) -> np.array:
+
+    # Configure the explainer, which includes wrapping the model so its interface conforms to
+    # the format expected by Captum.
+    explanation_model = WrapperModule(model.model, target_feature_name)
+    explainer = IntegratedGradients(explanation_model)
+
+    inputs_encoded_splits = [ipt.split(model.config_obj.trainer.batch_size) for ipt in inputs_encoded]
+    baseline = [t.to(DEVICE) for t in baseline]
+
+    total_attribution = None
+    for input_batch in zip(*inputs_encoded_splits):
+        input_batch = [ipt.to(DEVICE) for ipt in input_batch]
+        attribution = explainer.attribute(
+            tuple(input_batch),
+            baselines=tuple(baseline),
+            target=target_idx,
+        )
+
+        # Attribution over the feature embeddings returns a vector with the same dimensions of
+        # shape [batch_size, embedding_size], so take the sum over this vector in order to return a single
+        # floating point attribution value per input feature.
+        attribution = np.array([t.detach().cpu().numpy().sum(1) for t in attribution])
+
+        # Transpose to [batch_size, num_input_features]
+        attribution = attribution.T
+
+        if total_attribution is not None:
+            if use_global:
+                total_attribution += attribution.sum(axis=0, keepdims=True)
+            else:
+                total_attribution = np.concatenate([total_attribution, attribution], axis=0)
+        else:
+            if use_global:
+                total_attribution = attribution.sum(axis=0, keepdims=True)
+            else:
+                total_attribution = attribution
+
+    if use_global:
+        total_attribution /= nsamples
+
+    return total_attribution

--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -162,12 +162,12 @@ class IntegratedGradientsExplainer(Explainer):
                 attribution = attribution.T
 
                 if total_attribution is not None:
-                    if self.average:
+                    if self.use_global:
                         total_attribution += attribution.sum(dim=0)
                     else:
                         total_attribution = np.concatenate([total_attribution, attribution], axis=0)
                 else:
-                    if self.average:
+                    if self.use_global:
                         total_attribution = attribution.sum(dim=0)
                     else:
                         total_attribution = attribution

--- a/ludwig/explain/captum_ray.py
+++ b/ludwig/explain/captum_ray.py
@@ -15,9 +15,9 @@ from ludwig.utils.torch_utils import get_torch_device
 
 @PublicAPI(stability="experimental")
 class RayIntegratedGradientsExplainer(IntegratedGradientsExplainer):
-    def __init__(self, resources_per_task: Dict[str, Any], num_workers: int, *args, **kwargs):
+    def __init__(self, *args, resources_per_task: Dict[str, Any] = None, num_workers: int = 1, **kwargs):
         super().__init__(*args, **kwargs)
-        self.resources_per_task = resources_per_task
+        self.resources_per_task = resources_per_task or {}
         self.num_workers = num_workers
 
     def explain(self) -> Tuple[List[Explanation], List[float]]:

--- a/ludwig/explain/captum_ray.py
+++ b/ludwig/explain/captum_ray.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -10,14 +10,15 @@ from ludwig.api import LudwigModel
 from ludwig.api_annotations import PublicAPI
 from ludwig.explain.captum import get_baseline, get_input_tensors, get_total_attribution, IntegratedGradientsExplainer
 from ludwig.explain.explanation import Explanation
-from ludwig.utils.torch_utils import DEVICE
+from ludwig.utils.torch_utils import get_torch_device
 
 
 @PublicAPI(stability="experimental")
 class RayIntegratedGradientsExplainer(IntegratedGradientsExplainer):
-    def __init__(self, resources_per_task: Dict[str, Any], *args, **kwargs):
+    def __init__(self, resources_per_task: Dict[str, Any], num_workers: int, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.resources_per_task = resources_per_task
+        self.num_workers = num_workers
 
     def explain(self) -> Tuple[List[Explanation], List[float]]:
         """Explain the model's predictions using Integrated Gradients.
@@ -32,47 +33,61 @@ class RayIntegratedGradientsExplainer(IntegratedGradientsExplainer):
             `expected_values`: (List[float]) of length [output feature cardinality] Average convergence delta for each
             label in the target feature's vocab.
         """
-        self.model.model.to(DEVICE)
+        self.model.model.cpu()
+        model_ref = ray.put(self.model)
 
         # Convert input data into embedding tensors from the output of the model encoders.
         inputs_encoded_ref = get_input_tensors_task.options(**self.resources_per_task).remote(
-            ray.put(self.model), ray.put(self.inputs_df)
+            model_ref, ray.put(self.inputs_df)
         )
         sample_encoded_ref = get_input_tensors_task.options(**self.resources_per_task).remote(
-            ray.put(self.model), ray.put(self.sample_df)
+            model_ref, ray.put(self.sample_df)
         )
 
         inputs_encoded = ray.get(inputs_encoded_ref)
         sample_encoded = ray.get(sample_encoded_ref)
         baseline = get_baseline(sample_encoded)
 
+        inputs_encoded_ref = ray.put(inputs_encoded)
+        baseline_ref = ray.put(baseline)
+
+        if self.is_category_target:
+            # Evenly divide the list of labels among the desired number of workers (Ray tasks).
+            # For example, 4 GPUs -> 4 workers. We do this instead of creating nlabels tasks because
+            # there is significant overhead to spawning a Ray task.
+            target_splits = split_list(list(range(self.vocab_size)), self.num_workers)
+        else:
+            target_splits = [[None]]
+
+        if self.is_binary_target:
+            # For binary targets, we only need to compute attribution for the positive class (see below).
+            target_splits = [target_splits[0][0]]
+
         # Compute attribution for each possible output feature label separately.
         total_attribution_refs = []
-        for target_idx in range(self.vocab_size):
+        for target_indices in target_splits:
             total_attribution_ref = get_total_attribution_task.options(**self.resources_per_task).remote(
-                ray.put(self.model),
+                model_ref,
                 self.target_feature_name,
-                target_idx if self.is_category_target else None,
-                ray.put(inputs_encoded),
-                ray.put(baseline),
+                target_indices,
+                inputs_encoded_ref,
+                baseline_ref,
                 self.use_global,
                 len(self.inputs_df),
             )
             total_attribution_refs.append(total_attribution_ref)
 
-            if self.is_binary_target:
-                # For binary targets, we only need to compute attribution for the positive class (see below).
-                break
-
+        # Await the completion of our Ray tasks, then merge the results.
         expected_values = []
         for total_attribution_ref in tqdm(total_attribution_refs, desc="Explain"):
-            total_attribution = ray.get(total_attribution_ref)
-            for feature_attributions, explanation in zip(total_attribution, self.explanations):
-                # Add the feature attributions to the explanation object for this row.
-                explanation.add(feature_attributions)
+            total_attributions = ray.get(total_attribution_ref)
+            for total_attribution in total_attributions:
+                for feature_attributions, explanation in zip(total_attribution, self.explanations):
+                    # Add the feature attributions to the explanation object for this row.
+                    explanation.add(feature_attributions)
 
-            # TODO(travis): for force plots, need something similar to SHAP E[X]
-            expected_values.append(0.0)
+                # TODO(travis): for force plots, need something similar to SHAP E[X]
+                expected_values.append(0.0)
 
         # For binary targets, add an extra attribution for the negative class (false).
         if self.is_binary_target:
@@ -86,13 +101,47 @@ class RayIntegratedGradientsExplainer(IntegratedGradientsExplainer):
         return self.explanations, expected_values
 
 
-@ray.remote
+@ray.remote(max_calls=1)
 def get_input_tensors_task(model: LudwigModel, df: pd.DataFrame) -> List[Variable]:
-    model.model.to(DEVICE)
-    return ray.put(get_input_tensors(model, df))
+    model.model.to(get_torch_device())
+    try:
+        return get_input_tensors(model, df)
+    finally:
+        model.model.cpu()
 
 
-@ray.remote
-def get_total_attribution_task(model: LudwigModel, *args, **kwargs) -> np.array:
-    model.model.to(DEVICE)
-    return ray.put(get_total_attribution(*args, **kwargs))
+@ray.remote(max_calls=1)
+def get_total_attribution_task(
+    model: LudwigModel,
+    target_feature_name: str,
+    target_indices: List[Optional[int]],
+    inputs_encoded: List[Variable],
+    baseline: List[Variable],
+    use_global: bool,
+    nsamples: int,
+) -> List[np.array]:
+    model.model.to(get_torch_device())
+    try:
+        return [
+            get_total_attribution(
+                model=model,
+                target_feature_name=target_feature_name,
+                target_idx=target_idx,
+                inputs_encoded=inputs_encoded,
+                baseline=baseline,
+                use_global=use_global,
+                nsamples=nsamples,
+            )
+            for target_idx in tqdm(target_indices, desc="Explain")
+        ]
+    finally:
+        model.model.cpu()
+
+
+def split_list(v, n):
+    """Splits a list into n roughly equal sub-lists.
+
+    Source: https://stackoverflow.com/a/2135920
+    """
+    k, m = divmod(len(v), n)
+    return (v[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)] for i in range(n))

--- a/ludwig/explain/captum_ray.py
+++ b/ludwig/explain/captum_ray.py
@@ -1,0 +1,98 @@
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+import ray
+from torch.autograd import Variable
+from tqdm import tqdm
+
+from ludwig.api import LudwigModel
+from ludwig.api_annotations import PublicAPI
+from ludwig.explain.captum import get_baseline, get_input_tensors, get_total_attribution, IntegratedGradientsExplainer
+from ludwig.explain.explanation import Explanation
+from ludwig.utils.torch_utils import DEVICE
+
+
+@PublicAPI(stability="experimental")
+class RayIntegratedGradientsExplainer(IntegratedGradientsExplainer):
+    def __init__(self, resources_per_task: Dict[str, Any], *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.resources_per_task = resources_per_task
+
+    def explain(self) -> Tuple[List[Explanation], List[float]]:
+        """Explain the model's predictions using Integrated Gradients.
+
+        # Return
+
+        :return: (Tuple[List[Explanation], List[float]]) `(explanations, expected_values)`
+            `explanations`: (List[Explanation]) A list of explanations, one for each row in the input data. Each
+            explanation contains the integrated gradients for each label in the target feature's vocab with respect to
+            each input feature.
+
+            `expected_values`: (List[float]) of length [output feature cardinality] Average convergence delta for each
+            label in the target feature's vocab.
+        """
+        self.model.model.to(DEVICE)
+
+        # Convert input data into embedding tensors from the output of the model encoders.
+        inputs_encoded_ref = get_input_tensors_task.options(**self.resources_per_task).remote(
+            ray.put(self.model), ray.put(self.inputs_df)
+        )
+        sample_encoded_ref = get_input_tensors_task.options(**self.resources_per_task).remote(
+            ray.put(self.model), ray.put(self.sample_df)
+        )
+
+        inputs_encoded = ray.get(inputs_encoded_ref)
+        sample_encoded = ray.get(sample_encoded_ref)
+        baseline = get_baseline(sample_encoded)
+
+        # Compute attribution for each possible output feature label separately.
+        total_attribution_refs = []
+        for target_idx in range(self.vocab_size):
+            total_attribution_ref = get_total_attribution_task.options(**self.resources_per_task).remote(
+                ray.put(self.model),
+                self.target_feature_name,
+                target_idx if self.is_category_target else None,
+                ray.put(inputs_encoded),
+                ray.put(baseline),
+                self.use_global,
+                len(self.inputs_df),
+            )
+            total_attribution_refs.append(total_attribution_ref)
+
+            if self.is_binary_target:
+                # For binary targets, we only need to compute attribution for the positive class (see below).
+                break
+
+        expected_values = []
+        for total_attribution_ref in tqdm(total_attribution_refs, desc="Explain"):
+            total_attribution = ray.get(total_attribution_ref)
+            for feature_attributions, explanation in zip(total_attribution, self.explanations):
+                # Add the feature attributions to the explanation object for this row.
+                explanation.add(feature_attributions)
+
+            # TODO(travis): for force plots, need something similar to SHAP E[X]
+            expected_values.append(0.0)
+
+        # For binary targets, add an extra attribution for the negative class (false).
+        if self.is_binary_target:
+            for explanation in self.explanations:
+                le_true = explanation.label_explanations[0]
+                explanation.add(le_true.feature_attributions * -1)
+
+            # TODO(travis): for force plots, need something similar to SHAP E[X]
+            expected_values.append(0.0)
+
+        return self.explanations, expected_values
+
+
+@ray.remote
+def get_input_tensors_task(model: LudwigModel, df: pd.DataFrame) -> List[Variable]:
+    model.model.to(DEVICE)
+    return ray.put(get_input_tensors(model, df))
+
+
+@ray.remote
+def get_total_attribution_task(model: LudwigModel, *args, **kwargs) -> np.array:
+    model.model.to(DEVICE)
+    return ray.put(get_total_attribution(*args, **kwargs))

--- a/ludwig/explain/explainer.py
+++ b/ludwig/explain/explainer.py
@@ -39,7 +39,10 @@ class Explainer(metaclass=ABCMeta):
             model, inputs_df, sample_df, target
         )
 
-        self.explanations = [Explanation(self.target_feature_name) for _ in self.inputs_df.index]
+        if self.use_global:
+            self.explanations = [Explanation(self.target_feature_name)]
+        else:
+            self.explanations = [Explanation(self.target_feature_name) for _ in self.inputs_df.index]
 
         # Lookup from column name to output feature
         config = self.model.config

--- a/ludwig/explain/explainer.py
+++ b/ludwig/explain/explainer.py
@@ -13,7 +13,12 @@ from ludwig.explain.util import prepare_data
 @DeveloperAPI
 class Explainer(metaclass=ABCMeta):
     def __init__(
-        self, model: LudwigModel, inputs_df: pd.DataFrame, sample_df: pd.DataFrame, target: str, average: bool = False
+        self,
+        model: LudwigModel,
+        inputs_df: pd.DataFrame,
+        sample_df: pd.DataFrame,
+        target: str,
+        use_global: bool = False,
     ):
         """Constructor for the explainer.
 
@@ -23,13 +28,13 @@ class Explainer(metaclass=ABCMeta):
         :param inputs_df: (pd.DataFrame) The input data to explain.
         :param sample_df: (pd.DataFrame) A sample of the ground truth data.
         :param target: (str) The name of the target to explain.
-        :param average: (bool) Return average explanation for all rows if True (default: False).
+        :param use_global: (bool) Return global explanation aggregated over all rows if True (default: False).
         """
         self.model = model
         self.inputs_df = inputs_df
         self.sample_df = sample_df
         self.target = target
-        self.average = average
+        self.use_global = use_global
         self.inputs_df, self.sample_df, self.feature_cols, self.target_feature_name = prepare_data(
             model, inputs_df, sample_df, target
         )

--- a/ludwig/explain/explainer.py
+++ b/ludwig/explain/explainer.py
@@ -12,7 +12,9 @@ from ludwig.explain.util import prepare_data
 
 @DeveloperAPI
 class Explainer(metaclass=ABCMeta):
-    def __init__(self, model: LudwigModel, inputs_df: pd.DataFrame, sample_df: pd.DataFrame, target: str):
+    def __init__(
+        self, model: LudwigModel, inputs_df: pd.DataFrame, sample_df: pd.DataFrame, target: str, average: bool = False
+    ):
         """Constructor for the explainer.
 
         # Inputs
@@ -21,11 +23,13 @@ class Explainer(metaclass=ABCMeta):
         :param inputs_df: (pd.DataFrame) The input data to explain.
         :param sample_df: (pd.DataFrame) A sample of the ground truth data.
         :param target: (str) The name of the target to explain.
+        :param average: (bool) Return average explanation for all rows if True (default: False).
         """
         self.model = model
         self.inputs_df = inputs_df
         self.sample_df = sample_df
         self.target = target
+        self.average = average
         self.inputs_df, self.sample_df, self.feature_cols, self.target_feature_name = prepare_data(
             model, inputs_df, sample_df, target
         )

--- a/ludwig/explain/gbm.py
+++ b/ludwig/explain/gbm.py
@@ -30,7 +30,7 @@ class GBMExplainer(Explainer):
         # Scale the feature importance to sum to 1.
         feat_imp = feat_imp / feat_imp.sum() if feat_imp.sum() > 0 else feat_imp
 
-        if self.average:
+        if self.use_global:
             feat_imp = feat_imp.mean(axis=0)
 
         expected_values = []

--- a/ludwig/explain/gbm.py
+++ b/ludwig/explain/gbm.py
@@ -31,7 +31,7 @@ class GBMExplainer(Explainer):
         feat_imp = feat_imp / feat_imp.sum() if feat_imp.sum() > 0 else feat_imp
 
         if self.use_global:
-            feat_imp = feat_imp.mean(axis=0)
+            feat_imp = feat_imp.mean(axis=0, keepdims=True)
 
         expected_values = []
         for _ in range(self.vocab_size):

--- a/ludwig/explain/gbm.py
+++ b/ludwig/explain/gbm.py
@@ -26,12 +26,11 @@ class GBMExplainer(Explainer):
             raise ValueError("Model has not been trained yet.")
 
         # Get global feature importance from the model, use it for each row in the batch.
+        # TODO(travis): support local feature importance
         feat_imp = gbm.booster_.feature_importance(importance_type="gain")
+
         # Scale the feature importance to sum to 1.
         feat_imp = feat_imp / feat_imp.sum() if feat_imp.sum() > 0 else feat_imp
-
-        if self.use_global:
-            feat_imp = feat_imp.mean(axis=0, keepdims=True)
 
         expected_values = []
         for _ in range(self.vocab_size):

--- a/ludwig/explain/gbm.py
+++ b/ludwig/explain/gbm.py
@@ -30,6 +30,9 @@ class GBMExplainer(Explainer):
         # Scale the feature importance to sum to 1.
         feat_imp = feat_imp / feat_imp.sum() if feat_imp.sum() > 0 else feat_imp
 
+        if self.average:
+            feat_imp = feat_imp.mean(axis=0)
+
         expected_values = []
         for _ in range(self.vocab_size):
             for explanation in self.explanations:

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -802,7 +802,7 @@ class RayTuneExecutor:
 
         run_experiment_trial_params = tune.with_parameters(run_experiment_trial, local_hyperopt_dict=hyperopt_dict)
 
-        @ray.remote
+        @ray.remote(num_cpus=0)
         def _register(name, trainable):
             register_trainable(name, trainable)
 


### PR DESCRIPTION
- Adds `RayIntegratedGradientsExplainer` to do label-parallel explanations (as datasets tend not to be the bottleneck in most cases)
- Adds support for doing global explanations, which returns a single explanation in the list: the mean explanation across all rows
- Sets `max_calls=1` for Ray tasks that use GPUs due to https://docs.ray.io/en/latest/ray-core/tasks/using-ray-with-gpus.html?highlight=max_calls#workers-not-releasing-gpu-resources