### PR TITLE
Adds DeveloperAPI and PublicAPI annotations to AutoML

### DIFF
--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -19,7 +19,7 @@ import pandas as pd
 import yaml
 
 from ludwig.api import LudwigModel
-from ludwig.api_annotations import DeveloperAPI
+from ludwig.api_annotations import PublicAPI
 from ludwig.automl.auto_tune_config import memory_tune_config
 from ludwig.automl.base_config import _create_default_config, _get_reference_configs, DatasetInfo, get_dataset_info
 from ludwig.backend import Backend, initialize_backend
@@ -94,6 +94,7 @@ class AutoTrainResults:
                 return LudwigModel.load(os.path.join(ckpt_path, "model"))
 
 
+@PublicAPI
 def auto_train(
     dataset: Union[str, pd.DataFrame, dd.core.DataFrame],
     target: str,
@@ -143,7 +144,7 @@ def auto_train(
     return train_with_config(dataset, config, output_directory=output_directory, random_seed=random_seed, **kwargs)
 
 
-@DeveloperAPI
+@PublicAPI
 def create_auto_config(
     dataset: Union[str, pd.DataFrame, dd.core.DataFrame, DatasetInfo],
     target: Union[str, List[str]],
@@ -209,7 +210,7 @@ def create_auto_config(
     return model_config
 
 
-@DeveloperAPI
+@PublicAPI
 def train_with_config(
     dataset: Union[str, pd.DataFrame, dd.core.DataFrame],
     config: dict,

--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -19,6 +19,7 @@ import pandas as pd
 import yaml
 
 from ludwig.api import LudwigModel
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.automl.auto_tune_config import memory_tune_config
 from ludwig.automl.base_config import _create_default_config, _get_reference_configs, DatasetInfo, get_dataset_info
 from ludwig.backend import Backend, initialize_backend
@@ -142,6 +143,7 @@ def auto_train(
     return train_with_config(dataset, config, output_directory=output_directory, random_seed=random_seed, **kwargs)
 
 
+@DeveloperAPI
 def create_auto_config(
     dataset: Union[str, pd.DataFrame, dd.core.DataFrame, DatasetInfo],
     target: Union[str, List[str]],
@@ -207,6 +209,7 @@ def create_auto_config(
     return model_config
 
 
+@DeveloperAPI
 def train_with_config(
     dataset: Union[str, pd.DataFrame, dd.core.DataFrame],
     config: dict,

--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 from dataclasses_json import dataclass_json, LetterCase
 
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.backend import Backend
 from ludwig.constants import (
     COLUMN,
@@ -58,6 +59,7 @@ encoder_defaults = {"text": {"bert": os.path.join(CONFIG_DIR, "text/bert_config.
 MAX_DISTINCT_VALUES_TO_RETURN = 10
 
 
+@DeveloperAPI
 @dataclass_json(letter_case=LetterCase.CAMEL)
 @dataclass
 class DatasetInfo:
@@ -210,10 +212,10 @@ def get_dataset_info(df: Union[pd.DataFrame, dd.core.DataFrame]) -> DatasetInfo:
     inference.
 
     # Inputs
-    :param dataset: (str) filepath to dataset.
+    :param df: (Union[pd.DataFrame, dd.core.DataFrame]) Pandas or Dask dataframe.
 
     # Return
-    :return: (List[FieldInfo]) list of FieldInfo objects
+    :return: (DatasetInfo) Structure containing list of FieldInfo objects.
     """
     source = wrap_data_source(df)
     return get_dataset_info_from_source(source)
@@ -236,7 +238,17 @@ def is_field_boolean(source: DataSource, field: str) -> bool:
     return True
 
 
+@DeveloperAPI
 def get_dataset_info_from_source(source: DataSource) -> DatasetInfo:
+    """Constructs FieldInfo objects for each feature in dataset. These objects are used for downstream type
+    inference.
+
+    # Inputs
+    :param source: (DataSource) A wrapper around a data source, which may represent a pandas or Dask dataframe.
+
+    # Return
+    :return: (DatasetInfo) Structure containing list of FieldInfo objects.
+    """
     row_count = len(source)
     fields = []
     for field in source.columns:
@@ -324,6 +336,7 @@ def get_config_from_metadata(metadata: List[FieldMetadata], targets: Set[str] = 
     return config
 
 
+@DeveloperAPI
 def get_field_metadata(
     fields: List[FieldInfo], row_count: int, resources: Resources, targets: Set[str] = None
 ) -> List[FieldMetadata]:

--- a/ludwig/utils/dataset_utils.py
+++ b/ludwig/utils/dataset_utils.py
@@ -3,11 +3,13 @@ from typing import List, Tuple, Union
 import pandas as pd
 from sklearn.model_selection import train_test_split
 
+from ludwig.api_annotations import PublicAPI
 from ludwig.constants import TEST_SPLIT, TRAIN_SPLIT, VALIDATION_SPLIT
 from ludwig.data.dataset.base import Dataset
 from ludwig.utils.defaults import default_random_seed
 
 
+@PublicAPI
 def get_repeatable_train_val_test_split(
     df_input, stratify_colname="", random_seed=default_random_seed, frac_train=0.7, frac_val=0.1, frac_test=0.2
 ):


### PR DESCRIPTION
Also adds `dataset_utils.get_repeatable_train_val_test_split` as public API, since it is referenced in the AutoML user guide.  https://ludwig.ai/latest/user_guide/automl/