### PR TITLE
add customer churn datasets

### DIFF
--- a/ludwig/datasets/configs/customer_churn_prediction.yaml
+++ b/ludwig/datasets/configs/customer_churn_prediction.yaml
@@ -1,0 +1,12 @@
+version: 1.0
+name: customer_churn_prediction
+kaggle_competition: customer-churn-prediction-2020
+archive_filenames: customer-churn-prediction-2020.zip
+train_filenames: train.csv
+test_filenames: test.csv
+sha256:
+  customer-churn-prediction-2020.zip: fb5cbc787081a6a559592230c657a0520a181447da6eb2adc34a3aebbe8ed9ca
+description: |
+  Dataset from a Kaggle competition that is about predicting whether a customer will change 
+  telecommunications provider, something known as "churning".
+  https://www.kaggle.com/c/customer-churn-prediction-2020

--- a/ludwig/datasets/configs/customer_churn_prediction.yaml
+++ b/ludwig/datasets/configs/customer_churn_prediction.yaml
@@ -7,6 +7,6 @@ test_filenames: test.csv
 sha256:
   customer-churn-prediction-2020.zip: fb5cbc787081a6a559592230c657a0520a181447da6eb2adc34a3aebbe8ed9ca
 description: |
-  Dataset from a Kaggle competition that is about predicting whether a customer will change 
+  Dataset from a Kaggle competition that is about predicting whether a customer will change
   telecommunications provider, something known as "churning".
   https://www.kaggle.com/c/customer-churn-prediction-2020

--- a/ludwig/datasets/configs/telco_customer_churn.yaml
+++ b/ludwig/datasets/configs/telco_customer_churn.yaml
@@ -1,0 +1,12 @@
+version: 1.0
+name: telco_customer_churn
+kaggle_dataset_id: blastchar/telco-customer-churn
+archive_filenames: telco-customer-churn.zip
+dataset_filenames: WA_Fn-UseC_-Telco-Customer-Churn.csv
+sha256:
+  telco-customer-churn.zip: cf7e6dcd8a238ecaa841a7d133142525453992d8d5e3ef6d1e5f0d359e7bf444
+description: |
+  The Telco customer churn data contains information about a fictional telco company 
+  that provided home phone and Internet services to customers. Each row represents a 
+  customer, each column contains customer’s attributes described on the column Metadata.
+  https://www.kaggle.com/datasets/blastchar/telco-customer-churn

--- a/ludwig/datasets/configs/telco_customer_churn.yaml
+++ b/ludwig/datasets/configs/telco_customer_churn.yaml
@@ -6,7 +6,7 @@ dataset_filenames: WA_Fn-UseC_-Telco-Customer-Churn.csv
 sha256:
   telco-customer-churn.zip: cf7e6dcd8a238ecaa841a7d133142525453992d8d5e3ef6d1e5f0d359e7bf444
 description: |
-  The Telco customer churn data contains information about a fictional telco company 
-  that provided home phone and Internet services to customers. Each row represents a 
+  The Telco customer churn data contains information about a fictional telco company
+  that provided home phone and Internet services to customers. Each row represents a
   customer, each column contains customer’s attributes described on the column Metadata.
   https://www.kaggle.com/datasets/blastchar/telco-customer-churn


### PR DESCRIPTION
adds two kaggle datasets
- https://www.kaggle.com/datasets/blastchar/telco-customer-churn
- https://www.kaggle.com/competitions/customer-churn-prediction-2020