### PR TITLE
Fix example values for max_batch_size in trainer parameter metadata

### DIFF
--- a/ludwig/schema/metadata/trainer_metadata.py
+++ b/ludwig/schema/metadata/trainer_metadata.py
@@ -26,7 +26,7 @@ TRAINER_METADATA = (
                                      internal_only=False),
      'max_batch_size': ParameterMetadata(ui_display_name='Max Batch Size',
                                          default_value_reasoning='Not typically required.',
-                                         example_value=1024,
+                                         example_value=[1024],
                                          related_parameters=['batch_size', 'increase_batch_size_on_plateau'],
                                          description_implications='Value used to manually limit the batch '
                                                                   'sizes explored by auto batch size tuning '


### PR DESCRIPTION
Small fix in trainer metadata