### PR TITLE
Adds annotation to download_one method in benchmarks

### DIFF
--- a/ludwig/benchmarking/utils.py
+++ b/ludwig/benchmarking/utils.py
@@ -12,6 +12,7 @@ import fsspec
 import pandas as pd
 import yaml
 
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import BINARY, CATEGORY
 from ludwig.datasets import model_configs_for_dataset
 from ludwig.datasets.loaders.dataset_loader import DatasetLoader
@@ -125,6 +126,9 @@ def download_artifacts(
     ), "Experiments not downloaded to the same path"
 
     return local_dir, dataset_names
+
+
+DeveloperAPI
 
 
 async def download_one(

--- a/ludwig/benchmarking/utils.py
+++ b/ludwig/benchmarking/utils.py
@@ -128,9 +128,7 @@ def download_artifacts(
     return local_dir, dataset_names
 
 
-DeveloperAPI
-
-
+@DeveloperAPI
 async def download_one(
     fs, download_base_path: str, dataset_name: str, experiment_name: str, local_dir: str
 ) -> Tuple[str, str]:


### PR DESCRIPTION
used in `model_baselines/utils.py` in Predibase.