### PR TITLE
Pin ray nightly to October 25 2022

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -125,10 +125,10 @@ jobs:
           if [ "$MARKERS" == "distributed" ]; then
             if [ "$RAY_VERSION" == "nightly" ]; then
               # NOTE: hardcoded for python 3.9 on Linux
-              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+              # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
 
-              # NOTE: Pinned Ray nightly version to September 20, 2022 to get tests to pass
-              # pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/fa182d3c9e478ef4c169ccf7459764768996110f/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
+              # NOTE: Pinned Ray nightly version to October 25, 2022 since Ray nightly has unrelated tensorflow import errors
+              pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/37de814a8598e0ea3dea23d5ae0caf9df54fa0e6/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl
             else
               pip install ray==$RAY_VERSION
             fi


### PR DESCRIPTION
Seeing the following stack trace on our CI

```
___________ ERROR collecting tests/integration_tests/test_automl.py ____________
ImportError while importing test module '/home/runner/work/ludwig/ludwig/tests/integration_tests/test_automl.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/ray/train/tensorflow/__init__.py:3: in <module>
    import tensorflow as tf  # noqa: F401
E   ModuleNotFoundError: No module named 'tensorflow'

During handling of the above exception, another exception occurred:
/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/integration_tests/test_automl.py:[29](https://github.com/ludwig-ai/ludwig/actions/runs/3340881834/jobs/5531486974#step:12:30): in <module>
    from ludwig.automl.automl import create_auto_config, train_with_config  # noqa
ludwig/automl/__init__.py:1: in <module>
    from ludwig.automl.automl import auto_train, cli_init_config, create_auto_config, train_with_config  # noqa
ludwig/automl/automl.py:40: in <module>
    from ludwig.utils.automl.ray_utils import _ray_init
ludwig/utils/automl/ray_utils.py:3: in <module>
    from ludwig.backend.ray import initialize_ray
ludwig/backend/ray.py:[36](https://github.com/ludwig-ai/ludwig/actions/runs/3340881834/jobs/5531486974#step:12:37): in <module>
    from ray.train.horovod import HorovodConfig
/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/ray/train/horovod/__init__.py:10: in <module>
    from ray.train.horovod.horovod_trainer import HorovodTrainer
/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/ray/train/horovod/horovod_trainer.py:9: in <module>
    from ray.train.horovod.config import HorovodConfig
/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/ray/train/horovod/config.py:16: in <module>
    from ray.train.tensorflow.tensorflow_checkpoint import TensorflowCheckpoint
/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/ray/train/tensorflow/__init__.py:5: in <module>
    raise ModuleNotFoundError(
E   ModuleNotFoundError: TensorFlow isn't installed. To install TensorFlow, run 'pip install tensorflow'
```