### PR TITLE
Add custom to_dask() to infer Dask metadata from Datasets schema.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,6 @@ repos:
           - mdformat_frontmatter
         exclude: CHANGELOG.md
   - repo: https://github.com/yoheimuta/protolint
-    rev: v0.40.0
+    rev: v0.41.0
     hooks:
       - id: protolint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
           - mdformat-gfm
           - mdformat_frontmatter
         exclude: CHANGELOG.md
-  # - repo: https://github.com/yoheimuta/protolint
-  #   rev: v0.40.0
-  #   hooks:
-  #     - id: protolint
+  - repo: https://github.com/yoheimuta/protolint
+    rev: v0.40.0
+    hooks:
+      - id: protolint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
           - mdformat-gfm
           - mdformat_frontmatter
         exclude: CHANGELOG.md
-  - repo: https://github.com/yoheimuta/protolint
-    rev: v0.41.0
-    hooks:
-      - id: protolint
+  # - repo: https://github.com/yoheimuta/protolint
+  #   rev: v0.40.0
+  #   hooks:
+  #     - id: protolint

--- a/ludwig/data/dataframe/dask.py
+++ b/ludwig/data/dataframe/dask.py
@@ -14,20 +14,25 @@
 # limitations under the License.
 # ==============================================================================
 
+import collections
 import logging
 import os
-from typing import Dict
+from typing import Any, Dict, Iterable, Tuple, Union
 
 import dask
 import dask.array as da
 import dask.dataframe as dd
+import numpy as np
 import pandas as pd
+import pyarrow as pa
 import ray
 from dask.diagnostics import ProgressBar
 from packaging import version
 from pyarrow.fs import FSSpecHandler, PyFileSystem
-from ray.data import read_parquet
-from ray.data.extensions import TensorArray
+from ray.data import Dataset, read_parquet
+from ray.data.block import Block, BlockAccessor
+from ray.data.extensions import ArrowTensorType, TensorArray, TensorDtype
+from ray.util.client.common import ClientObjectRef
 
 from ludwig.data.dataframe.base import DataFrameEngine
 from ludwig.globals import PREDICTIONS_SHAPES_FILE_NAME
@@ -39,6 +44,8 @@ _ray200 = version.parse(ray.__version__) >= version.parse("2.0")
 
 TMP_COLUMN = "__TMP_COLUMN__"
 
+# This is to be compatible with pyarrow.lib.schema
+PandasBlockSchema = collections.namedtuple("PandasBlockSchema", ["names", "types"])
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +160,7 @@ class DaskEngine(DataFrameEngine):
 
         ds = ray.data.from_dask(series)
         ds = ds.map_batches(map_fn, batch_format="pandas")
-        return ds.to_dask()
+        return self._to_dask(ds)
 
     def apply_objects(self, df, apply_fn, meta=None):
         meta = meta if meta is not None else ("data", "object")
@@ -248,10 +255,67 @@ class DaskEngine(DataFrameEngine):
         return from_dask(df)
 
     def from_ray_dataset(self, dataset) -> dd.DataFrame:
-        return dataset.to_dask()
+        return self._to_dask(dataset)
 
     def reset_index(self, df):
         return reset_index_across_all_partitions(df)
+
+    def _to_dask(
+        self,
+        dataset: Dataset,
+        meta: Union[
+            pd.DataFrame,
+            pd.Series,
+            Dict[str, Any],
+            Iterable[Any],
+            Tuple[Any],
+            None,
+        ] = None,
+    ) -> dd.DataFrame:
+        """Custom Ray to_dask() conversion implementation with meta inference added for compatibility with Ray 2.0
+        and Ray 2.1. Useful for Ray Datasets that have image and audio features.
+
+        TODO(Arnav): Remove in Ray 2.2
+        """
+
+        @dask.delayed
+        def block_to_df(block: Block):
+            if isinstance(block, (ray.ObjectRef, ClientObjectRef)):
+                raise ValueError(
+                    "Dataset.to_dask() must be used with Dask-on-Ray, please "
+                    "set the Dask scheduler to ray_dask_get (located in "
+                    "ray.util.dask)."
+                )
+            block = BlockAccessor.for_block(block)
+            return block.to_pandas()
+
+        # Infer Dask metadata from Datasets schema.
+        schema = dataset.schema()
+        if isinstance(schema, PandasBlockSchema):
+            meta = pd.DataFrame(
+                {
+                    col: pd.Series(dtype=(dtype if not isinstance(dtype, TensorDtype) else np.object_))
+                    for col, dtype in zip(schema.names, schema.types)
+                }
+            )
+        elif pa is not None and isinstance(schema, pa.Schema):
+            if any(isinstance(type_, ArrowTensorType) for type_ in schema.types):
+                meta = pd.DataFrame(
+                    {
+                        col: pd.Series(
+                            dtype=(dtype.to_pandas_dtype() if not isinstance(dtype, ArrowTensorType) else np.object_)
+                        )
+                        for col, dtype in zip(schema.names, schema.types)
+                    }
+                )
+            else:
+                meta = schema.empty_table().to_pandas()
+
+        ddf = dd.from_delayed(
+            [block_to_df(block) for block in dataset.get_internal_block_refs()],
+            meta=meta,
+        )
+        return ddf
 
     @property
     def array_lib(self):

--- a/ludwig/data/dataframe/dask.py
+++ b/ludwig/data/dataframe/dask.py
@@ -298,7 +298,7 @@ class DaskEngine(DataFrameEngine):
                     for col, dtype in zip(schema.names, schema.types)
                 }
             )
-        elif pa is not None and isinstance(schema, pa.Schema):
+        elif isinstance(schema, pa.Schema):
             if any(isinstance(type_, ArrowTensorType) for type_ in schema.types):
                 meta = pd.DataFrame(
                     {


### PR DESCRIPTION
This PR adds a custom implementation of `to_dask()` to ensure forward compatibility with Ray 2.0/Ray 2.1 schema inference. This ensures that Ray 2.1 will work correctly even with image/audio datasets.