### PR TITLE
Bump Ludwig to Ray 2.0

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
           - python-version: 3.7
             pytorch-version: 1.11.0
             torchscript-version: 1.10.2
-            ray-version: 1.13.0
+            ray-version: 2.0.0
           - python-version: 3.8
             pytorch-version: 1.12.1
             torchscript-version: 1.10.2

--- a/requirements_distributed.txt
+++ b/requirements_distributed.txt
@@ -5,7 +5,7 @@ pyarrow==6.0.1 # https://github.com/ray-project/ray/issues/22310
 # requirements for horovod
 horovod[pytorch]>=0.24.0,!=0.26.0
 # requirements for ray
-ray[default,data,serve,tune]>=1.13.0
+ray[default,data,serve,tune]>=2.0.0
 pickle5; python_version <= '3.7'
 tensorboardX<2.3
 GPUtil

--- a/requirements_hyperopt.txt
+++ b/requirements_hyperopt.txt
@@ -1,4 +1,4 @@
-ray[default,tune]>=1.13.0
+ray[default,tune]>=2.0.0
 
 # required for Ray Tune Search Algorithm support for AutoML
 #search_alg: hyperopt


### PR DESCRIPTION
This PR drops support for Ray 1.x and moves Ludwig to Ray 2.0. It also ensures the CI uses Ray 2.0 for all of Ludwig's tests.