### PR TITLE
[TorchScript] Add user-defined HF Bert tokenizers

### DIFF
--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -104,6 +104,12 @@ CROP_OR_PAD = "crop_or_pad"
 INTERPOLATE = "interpolate"
 RESIZE_METHODS = [CROP_OR_PAD, INTERPOLATE]
 
+# Special symbols for text.
+STOP_SYMBOL = "<EOS>"
+START_SYMBOL = "<SOS>"
+PADDING_SYMBOL = "<PAD>"
+UNKNOWN_SYMBOL = "<UNK>"
+
 TRAINER = "trainer"
 LIGHTGBM_TRAINER = "lightgbm_trainer"
 OPTIMIZER = "optimizer"

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -22,6 +22,7 @@ from typing import List, Optional, Set, Union
 
 import numpy as np
 
+from ludwig.constants import PADDING_SYMBOL, START_SYMBOL, STOP_SYMBOL, UNKNOWN_SYMBOL
 from ludwig.data.dataframe.base import DataFrameEngine
 from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.utils.fs_utils import open_file
@@ -34,12 +35,6 @@ PANDAS_FALSE_STRS = {"false"}
 
 BOOL_TRUE_STRS = {"yes", "y", "true", "t", "1", "1.0"}
 BOOL_FALSE_STRS = {"no", "n", "false", "f", "0", "0.0"}
-
-# Special symbols.
-STOP_SYMBOL = "<EOS>"
-START_SYMBOL = "<SOS>"
-PADDING_SYMBOL = "<PAD>"
-UNKNOWN_SYMBOL = "<UNK>"
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -1075,6 +1075,7 @@ try:
             self.unk_token = hf_tokenizer_attrs["unk_token"]  # Used as unknown symbol
             self.cls_token_id = hf_tokenizer_attrs["cls_token_id"]  # Used as start symbol. Only used if HF.
             self.sep_token_id = hf_tokenizer_attrs["sep_token_id"]  # Used as stop symbol. Only used if HF.
+            self.all_special_tokens = hf_tokenizer_attrs["all_special_tokens"]
 
             tokenizer_kwargs = {}
             if "do_lower_case" in kwargs:
@@ -1091,6 +1092,7 @@ try:
                 vocab_path=vocab_file,
                 **tokenizer_kwargs,
                 return_tokens=self.return_tokens,
+                never_split=self.all_special_tokens,
             )
 
         def _init_vocab(self, vocab_file: str) -> Dict[str, int]:
@@ -1186,6 +1188,7 @@ def get_hf_tokenizer(pretrained_model_name_or_path, **kwargs):
                 "unk_token": hf_tokenizer.unk_token,
                 "cls_token_id": hf_tokenizer.cls_token_id,
                 "sep_token_id": hf_tokenizer.sep_token_id,
+                "all_special_tokens": hf_tokenizer.all_special_tokens,
             },
         )
 


### PR DESCRIPTION
This PR enables users to export arbitrary HuggingFace BERT models to TorchScript. Such models include various built-in and community instances of BERT, for example:

```
"bert-base-uncased",
"distilbert-base-uncased",
"google/electra-small-discriminator",
"dbmdz/bert-base-italian-cased",  # Community model
"nreimers/MiniLM-L6-H384-uncased",  # Community model
```
