### PR TITLE
Downgrade to Ray 2.0 in CI to get green Ludwig CIs again.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,11 +32,11 @@ jobs:
           - python-version: 3.8
             pytorch-version: 1.12.1
             torchscript-version: 1.10.2
-            ray-version: 2.0.0
+            ray-version: 2.0.0 # TODO: Upgrade to 2.1.0.
           - python-version: 3.9
             pytorch-version: nightly
             torchscript-version: 1.10.2
-            ray-version: nightly
+            ray-version: 2.0.0 # TODO: Upgrade to nightly.
     env:
       PYTORCH: ${{ matrix.pytorch-version }}
       MARKERS: ${{ matrix.test-markers }}


### PR DESCRIPTION
Ludwig will upgrade to Ray 2.1 in #2709, and a separate PR will upgrade Ludwig to ray-nightly.