### PR TITLE
Remove extra warnings when images cannot be read.

### DIFF
--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -69,15 +69,13 @@ def get_bytes_obj_from_path(path: str) -> Optional[bytes]:
     if is_http(path):
         try:
             return get_bytes_obj_from_http_path(path)
-        except Exception as e:
-            logger.warning(e)
+        except Exception:
             return None
     else:
         try:
             with open_file(path) as f:
                 return f.read()
-        except OSError as e:
-            logger.warning(e)
+        except OSError:
             return None
 
 

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -52,8 +52,7 @@ def is_image(src_path: str, img_entry: Union[bytes, str], column: str) -> bool:
         if isinstance(bytes_obj, bytes):
             return imghdr.what(None, bytes_obj) is not None
         return imghdr.what(bytes_obj) is not None
-    except Exception as e:
-        logger.warning(f"While assessing potential image in is_image() for column {column}, encountered exception: {e}")
+    except Exception:
         return False
 
 


### PR DESCRIPTION
These warnings are rather verbose when iterating over the values of a dataframe to determine its potential type.