### PR TITLE
Annotate MLFlow callback, and utility functions

### DIFF
--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -4,7 +4,7 @@ import queue
 import threading
 from typing import Any, Dict
 
-from ludwig.api_annotations import DeveloperAPI
+from ludwig.api_annotations import DeveloperAPI, PublicAPI
 from ludwig.callbacks import Callback
 from ludwig.constants import TRAINER
 from ludwig.data.dataset.base import Dataset
@@ -35,7 +35,7 @@ def get_or_create_experiment_id(experiment_name, artifact_uri: str = None):
 _get_or_create_experiment_id = get_or_create_experiment_id
 
 
-@DeveloperAPI
+@PublicAPI
 class MlflowCallback(Callback):
     def __init__(self, tracking_uri=None, log_artifacts: bool = True):
         self.experiment_id = None

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -21,11 +21,18 @@ def _get_runs(experiment_id: str):
     return mlflow.tracking.client.MlflowClient().search_runs([experiment_id])
 
 
-def _get_or_create_experiment_id(experiment_name, artifact_uri: str = None):
+@DeveloperAPI
+def get_or_create_experiment_id(experiment_name, artifact_uri: str = None):
+    """Gets experiment id from mlflow."""
     experiment = mlflow.get_experiment_by_name(experiment_name)
     if experiment is not None:
         return experiment.experiment_id
     return mlflow.create_experiment(name=experiment_name, artifact_location=artifact_uri)
+
+
+# Included for backwards compatibility, Deprecated.
+# TODO(daniel): delete this.
+_get_or_create_experiment_id = get_or_create_experiment_id
 
 
 @DeveloperAPI
@@ -46,7 +53,7 @@ class MlflowCallback(Callback):
             mlflow.set_tracking_uri(tracking_uri)
 
     def get_experiment_id(self, experiment_name):
-        return _get_or_create_experiment_id(experiment_name)
+        return get_or_create_experiment_id(experiment_name)
 
     def on_preprocess_end(
         self, training_set: Dataset, validation_set: Dataset, test_set: Dataset, training_set_metadata: Dict[str, Any]

--- a/ludwig/contribs/mlflow/model.py
+++ b/ludwig/contribs/mlflow/model.py
@@ -15,6 +15,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.globals import MODEL_HYPERPARAMETERS_FILE_NAME
 from ludwig.utils.data_utils import load_json
 
@@ -286,7 +287,12 @@ def export_model(model_path, output_path, registered_model_name=None):
         )
 
 
+@DeveloperAPI
 def log_saved_model(lpath):
+    """Log a saved Ludwig model as an MLflow artifact.
+
+    :param lpath: Path to saved Ludwig model.
+    """
     log_model(
         _CopyModel(lpath),
         artifact_path="model",


### PR DESCRIPTION
Upgrades `_get_or_create_experiment_id`, `log_saved_model` to developer API.

Makes MLFlowCallback Public API, for consistency with other callbacks.