### PR TITLE
Downgrade to PyTorch 1.12.1 in Docker to due to NCCL + CUDA compatibility

### DIFF
--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM rayproject/ray:2.0.0-py38-cu116
+FROM rayproject/ray:2.0.0-py38-cu113
 
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
 RUN sudo apt-key del 7fa2af80 && \
@@ -32,12 +32,15 @@ RUN pip install -U pip
 
 WORKDIR /ludwig
 
+# TODO(travis): remove this once we fix CUDA 11.6 NCCL version in base image
+RUN pip install torch==1.12.1 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+
 COPY . .
 RUN HOROVOD_GPU_OPERATIONS=NCCL \
     HOROVOD_WITH_PYTORCH=1 \
     HOROVOD_WITHOUT_MPI=1 \
     HOROVOD_WITHOUT_TENSORFLOW=1 \
     HOROVOD_WITHOUT_MXNET=1 \
-    pip install --no-cache-dir '.[full]' --extra-index-url https://download.pytorch.org/whl/cu116 && \
+    pip install --no-cache-dir '.[full]' --extra-index-url https://download.pytorch.org/whl/cu113 && \
     horovodrun --check-build && \
     python -c "import horovod.torch; horovod.torch.init()"

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -25,6 +25,9 @@ RUN pip install -U pip
 
 WORKDIR /ludwig
 
+# TODO(travis): remove this once we fix CUDA 11.6 NCCL version in base image
+RUN pip install torch==1.12.1 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
+
 COPY . .
 RUN HOROVOD_WITH_PYTORCH=1 \
 	HOROVOD_WITHOUT_MPI=1 \


### PR DESCRIPTION
Existing Ray base image seems to have an invalid version of NCCL for CUDA 11.6:

```
>>> import torch
>>> torch.__version__
'1.13.0+cu116'
>>> torch.cuda.is_available()
True
>>> import horovod.torch as hvd
>>> hvd.init()
>>> torch.tensor([1])
tensor([1])
>>> t = torch.tensor([1])
>>> hvd.allreduce(t)
tensor([1])
>>> t = t.to("cuda")
>>> t
tensor([1], device='cuda:0')
>>> hvd.allreduce(t)
Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.8/site-packages/horovod/torch/mpi_ops.py", line 1253, in synchronize
    mpi_lib.horovod_torch_wait_and_clear(handle)
RuntimeError: ncclCommInitRank failed: unhandled cuda error

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ray/anaconda3/lib/python3.8/site-packages/horovod/torch/mpi_ops.py", line 254, in allreduce
    summed_tensor_compressed = HorovodAllreduce.apply(tensor_compressed, average, name, op,
  File "/home/ray/anaconda3/lib/python3.8/site-packages/horovod/torch/mpi_ops.py", line 205, in forward
    return synchronize(handle)
  File "/home/ray/anaconda3/lib/python3.8/site-packages/horovod/torch/mpi_ops.py", line 1258, in synchronize
    raise HorovodInternalError(e)
horovod.common.exceptions.HorovodInternalError: ncclCommInitRank failed: unhandled cuda error
```