### PR TITLE
fix: refactor `IntegerOptions` field

### DIFF
--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -548,7 +548,7 @@ class GBMTrainerConfig(BaseTrainerConfig):
     )
 
     verbose: int = schema_utils.IntegerOptions(
-        options=list(range(-1, 3)), default=-1, description="Verbosity level for GBM trainer."
+        options=list(range(-1, 3)), allow_none=False, default=-1, description="Verbosity level for GBM trainer."
     )
 
     # LightGBM IO params


### PR DESCRIPTION
Simplifies impl. and adds optional `allow_none` and default-value validation back to this field.