### PR TITLE
fix: Fix metadata object-to-JSON serialization for oneOf fields and add full schema serialization test.

### DIFF
--- a/ludwig/schema/metadata/parameter_metadata.py
+++ b/ludwig/schema/metadata/parameter_metadata.py
@@ -1,4 +1,3 @@
-import copy
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, List, Union
@@ -72,7 +71,7 @@ def convert_metadata_to_json(pm: ParameterMetadata):
     NOTE: Without the json.loads call, to_json() returns
     a string repr that is improperly parsed.
     """
-    return copy.deepcopy(pm).to_json()
+    return pm.to_json()
 
 
 # This is a quick way to flag schema parameters as internal only via the `parameter_metadata` argument

--- a/ludwig/schema/metadata/parameter_metadata.py
+++ b/ludwig/schema/metadata/parameter_metadata.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, List, Union
@@ -71,7 +72,7 @@ def convert_metadata_to_json(pm: ParameterMetadata):
     NOTE: Without the json.loads call, to_json() returns
     a string repr that is improperly parsed.
     """
-    return pm.to_json()
+    return json.loads(pm.to_json())
 
 
 # This is a quick way to flag schema parameters as internal only via the `parameter_metadata` argument

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -921,7 +921,7 @@ def OneOfOptionsField(
                 "description": description,
                 "default": default,
                 "title": self.name,
-                "parameter_metadata": parameter_metadata,
+                "parameter_metadata": convert_metadata_to_json(parameter_metadata) if parameter_metadata else None,
             }
 
             for idx, option in enumerate(field_options):
@@ -965,6 +965,9 @@ def OneOfOptionsField(
         default_kwarg["default"] = default
     else:
         default_kwarg["default_factory"] = lambda: default
+
+    print(parameter_metadata)
+    print(convert_metadata_to_json(parameter_metadata))
 
     return field(
         metadata={

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -966,9 +966,6 @@ def OneOfOptionsField(
     else:
         default_kwarg["default_factory"] = lambda: default
 
-    print(parameter_metadata)
-    print(convert_metadata_to_json(parameter_metadata))
-
     return field(
         metadata={
             "marshmallow_field": OneOfOptionsCombinatorialField(

--- a/tests/ludwig/schema/test_validate_config_misc.py
+++ b/tests/ludwig/schema/test_validate_config_misc.py
@@ -379,3 +379,15 @@ def test_schema_no_duplicates():
                 "allOf"
             ][0]["then"]["properties"]
         )
+
+
+@pytest.mark.parametrize("model_type", [MODEL_ECD, MODEL_GBM])
+def test_ludwig_schema_serialization(model_type):
+    import json
+
+    schema = get_schema(model_type)
+
+    try:
+        json.dumps(schema)
+    except TypeError as e:
+        raise TypeError(f"Ludwig schema cannot be represented by valid JSON. See further details: {e}")

--- a/tests/ludwig/schema/test_validate_config_misc.py
+++ b/tests/ludwig/schema/test_validate_config_misc.py
@@ -391,5 +391,5 @@ def test_ludwig_schema_serialization(model_type):
         json.dumps(schema)
     except TypeError as e:
         raise TypeError(
-            f"Ludwig schema of model_type `{model_type}` cannot be represented by valid JSON. See further details: {e}"
+            f"Ludwig schema of type `{model_type}` cannot be represented by valid JSON. See further details: {e}"
         )

--- a/tests/ludwig/schema/test_validate_config_misc.py
+++ b/tests/ludwig/schema/test_validate_config_misc.py
@@ -390,4 +390,6 @@ def test_ludwig_schema_serialization(model_type):
     try:
         json.dumps(schema)
     except TypeError as e:
-        raise TypeError(f"Ludwig schema cannot be represented by valid JSON. See further details: {e}")
+        raise TypeError(
+            f"Ludwig schema of model_type `{model_type}` cannot be represented by valid JSON. See further details: {e}"
+        )


### PR DESCRIPTION
I also removed the `deepcopy` call that occurred when metadata dicts are serialized because it is unnecessary.