### PR TITLE
Add local_rank to BaseTrainer

### DIFF
--- a/ludwig/trainers/base.py
+++ b/ludwig/trainers/base.py
@@ -43,6 +43,10 @@ class BaseTrainer(ABC):
     def shutdown(self):
         pass
 
+    @property
+    def local_rank(self) -> int:
+        return 0
+
     def barrier(self):
         pass
 

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -1390,7 +1390,7 @@ class Trainer(BaseTrainer):
         return self.horovod.rank() == 0
 
     @property
-    def local_rank(self):
+    def local_rank(self) -> int:
         if not self.horovod:
             return 0
         return self.horovod.local_rank()


### PR DESCRIPTION
Previously, GBM trainers lacked this property. In the future, we should figure out a way to get this info from the GBM workers, as some of them may be running on the same node, so it would be useful to know which ones are.