### PR TITLE
Move preprocess callbacks inside model.preprocess

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -522,34 +522,27 @@ class LudwigModel:
                         print_boxed("LUDWIG CONFIG")
                         logger.info(pformat(self.config_obj.to_dict(), indent=4))
 
-                for callback in self.callbacks:
-                    callback.on_preprocess_start(self.config_obj.to_dict())
-
-                try:
-                    preprocessed_data = self.preprocess(
-                        dataset=dataset,
-                        training_set=training_set,
-                        validation_set=validation_set,
-                        test_set=test_set,
-                        training_set_metadata=training_set_metadata,
-                        data_format=data_format,
-                        experiment_name=experiment_name,
-                        model_name=model_name,
-                        model_resume_path=model_resume_path,
-                        skip_save_training_description=skip_save_training_description,
-                        skip_save_training_statistics=skip_save_training_statistics,
-                        skip_save_model=skip_save_model,
-                        skip_save_progress=skip_save_progress,
-                        skip_save_log=skip_save_log,
-                        skip_save_processed_input=skip_save_processed_input,
-                        output_directory=output_directory,
-                        random_seed=random_seed,
-                        **kwargs,
-                    )
-                    (training_set, validation_set, test_set, training_set_metadata) = preprocessed_data
-                finally:
-                    for callback in self.callbacks:
-                        callback.on_preprocess_end(training_set, validation_set, test_set, training_set_metadata)
+                preprocessed_data = self.preprocess(
+                    dataset=dataset,
+                    training_set=training_set,
+                    validation_set=validation_set,
+                    test_set=test_set,
+                    training_set_metadata=training_set_metadata,
+                    data_format=data_format,
+                    experiment_name=experiment_name,
+                    model_name=model_name,
+                    model_resume_path=model_resume_path,
+                    skip_save_training_description=skip_save_training_description,
+                    skip_save_training_statistics=skip_save_training_statistics,
+                    skip_save_model=skip_save_model,
+                    skip_save_progress=skip_save_progress,
+                    skip_save_log=skip_save_log,
+                    skip_save_processed_input=skip_save_processed_input,
+                    output_directory=output_directory,
+                    random_seed=random_seed,
+                    **kwargs,
+                )
+                (training_set, validation_set, test_set, training_set_metadata) = preprocessed_data
 
             self.training_set_metadata = training_set_metadata
 
@@ -1384,28 +1377,35 @@ class LudwigModel:
         """
         print_boxed("PREPROCESSING")
 
+        for callback in self.callbacks:
+            callback.on_preprocess_start(self.config_obj.to_dict())
+
         preprocessing_params = get_preprocessing_params(self.config_obj)
 
-        with provision_preprocessing_workers(self.backend):
-            # TODO (Connor): Refactor to use self.config_obj
-            preprocessed_data = preprocess_for_training(
-                self.config_obj.to_dict(),
-                dataset=dataset,
-                training_set=training_set,
-                validation_set=validation_set,
-                test_set=test_set,
-                training_set_metadata=training_set_metadata,
-                data_format=data_format,
-                skip_save_processed_input=skip_save_processed_input,
-                preprocessing_params=preprocessing_params,
-                backend=self.backend,
-                random_seed=random_seed,
-                callbacks=self.callbacks,
-            )
+        try:
+            with provision_preprocessing_workers(self.backend):
+                # TODO (Connor): Refactor to use self.config_obj
+                preprocessed_data = preprocess_for_training(
+                    self.config_obj.to_dict(),
+                    dataset=dataset,
+                    training_set=training_set,
+                    validation_set=validation_set,
+                    test_set=test_set,
+                    training_set_metadata=training_set_metadata,
+                    data_format=data_format,
+                    skip_save_processed_input=skip_save_processed_input,
+                    preprocessing_params=preprocessing_params,
+                    backend=self.backend,
+                    random_seed=random_seed,
+                    callbacks=self.callbacks,
+                )
 
-        (proc_training_set, proc_validation_set, proc_test_set, training_set_metadata) = preprocessed_data
+            (proc_training_set, proc_validation_set, proc_test_set, training_set_metadata) = preprocessed_data
 
-        return PreprocessedDataset(proc_training_set, proc_validation_set, proc_test_set, training_set_metadata)
+            return PreprocessedDataset(proc_training_set, proc_validation_set, proc_test_set, training_set_metadata)
+        finally:
+            for callback in self.callbacks:
+                callback.on_preprocess_end(proc_training_set, proc_validation_set, proc_test_set, training_set_metadata)
 
     @staticmethod
     def load(


### PR DESCRIPTION
Previously the callback functions `on_preprocess_start` and `on_preprocess_end` were called only from within `model.train()`. This PR moves these callback invocations to within the `model.preprocess()` call itself.