### PR TITLE
Ensure correct output reduction for text encoders like MT5 and add warning messages when not supported

### DIFF
--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -50,6 +50,8 @@ logger = logging.getLogger(__name__)
 
 
 def _cls_pooled_error_message(encoder: str):
+    # TODO(Arnav): Remove this once we have reduce_output options set for
+    # each encoder type in the schema
     logger.error(f"reduce_output cannot be cls_pooled for {encoder}")
     sys.exit(1)
 

--- a/tests/ludwig/encoders/test_text_encoders.py
+++ b/tests/ludwig/encoders/test_text_encoders.py
@@ -5,7 +5,6 @@ from ludwig.encoders import text_encoders
 from tests.integration_tests.utils import slow
 
 
-@slow
 @pytest.mark.parametrize("use_pretrained", [False])
 @pytest.mark.parametrize("reduce_output", [None, "sum"])
 @pytest.mark.parametrize("max_sequence_length", [20])
@@ -16,12 +15,10 @@ def test_albert_encoder(use_pretrained: bool, reduce_output: str, max_sequence_l
         max_sequence_length=max_sequence_length,
     )
     inputs = torch.rand((2, max_sequence_length)).type(albert_encoder.input_dtype)
-    inputs = torch.rand((2, max_sequence_length)).type(albert_encoder.input_dtype)
     outputs = albert_encoder(inputs)
     assert outputs["encoder_output"].shape[1:] == albert_encoder.output_shape
 
 
-@slow
 @pytest.mark.parametrize("use_pretrained", [False])
 @pytest.mark.parametrize("reduce_output", [None, "cls_pooled", "sum"])
 @pytest.mark.parametrize("max_sequence_length", [20])
@@ -66,7 +63,6 @@ def test_gpt_encoder(use_pretrained: bool, reduce_output: str, max_sequence_leng
     assert outputs["encoder_output"].shape[1:] == gpt_encoder.output_shape
 
 
-@slow
 @pytest.mark.parametrize("use_pretrained", [False])
 @pytest.mark.parametrize("reduce_output", ["cls_pooled", "sum"])
 @pytest.mark.parametrize("max_sequence_length", [20])
@@ -155,7 +151,6 @@ def test_camembert_encoder(use_pretrained: bool, reduce_output: str, max_sequenc
     assert outputs["encoder_output"].shape[1:] == encoder.output_shape
 
 
-@slow
 @pytest.mark.parametrize("use_pretrained", [False])
 @pytest.mark.parametrize("reduce_output", [None, "sum"])
 @pytest.mark.parametrize("max_sequence_length", [20])
@@ -247,3 +242,16 @@ def test_t5_encoder(use_pretrained: bool, reduce_output: str, max_sequence_lengt
     inputs = torch.rand((2, max_sequence_length)).type(encoder.input_dtype)
     outputs = encoder(inputs)
     assert outputs["encoder_output"].shape[1:] == encoder.output_shape
+
+
+@slow
+@pytest.mark.parametrize("use_pretrained", [False])
+@pytest.mark.parametrize("reduce_output", [None, "sum"])
+@pytest.mark.parametrize("max_sequence_length", [20])
+def test_xlnet_encoder(use_pretrained: bool, reduce_output: str, max_sequence_length: int):
+    xlnet_encoder = text_encoders.XLNetEncoder(
+        use_pretrained=use_pretrained, reduce_output=reduce_output, max_sequence_length=max_sequence_length
+    )
+    inputs = torch.rand((2, max_sequence_length)).type(xlnet_encoder.input_dtype)
+    outputs = xlnet_encoder(inputs)
+    assert outputs["encoder_output"].shape[1:] == xlnet_encoder.output_shape


### PR DESCRIPTION
This PR fixes an issue where `reduce_output==cls_pooled` was causing index out-of-range errors. This happens because the MT5Encoder doesn't have `pooler_outputs` returned from the Transformer. 

As a part of this PR, I reviewed all of the outputs for each of the text encoders to ensure that we only support `cls_pooled` for compatible text encoders, and log errors in cases where it doesn't work for that particular encoder.

This also adds a test for XLNetEncoder, which was missing. 