### PR TITLE
Drop incomplete batches for Ray and Pandas to prevent Batchnorm computation errors

### DIFF
--- a/ludwig/data/batcher/random_access.py
+++ b/ludwig/data/batcher/random_access.py
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import logging
 import math
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.data.batcher.base import Batcher
+
+logger = logging.getLogger(__name__)
 
 
 @DeveloperAPI
@@ -64,6 +67,7 @@ class RandomAccessBatcher(Batcher):
             # index += batch_size after each epoch. So, if our current index in total dataset is 1 less than the total
             # dataset size, then the last batch will only have 1 row. Drop it if this happens.
             if self.index - self.total_size == -1:
+                logger.info("Last batch in epoch only has 1 sample and will be dropped.")
                 return True
         return False
 

--- a/ludwig/data/batcher/random_access.py
+++ b/ludwig/data/batcher/random_access.py
@@ -60,9 +60,9 @@ class RandomAccessBatcher(Batcher):
         # For e.g., batch size = 128 but the dataset only has 100 rows. In this case, only
         # mark last_batch after this batch is done using the first condition above.
         elif self.ignore_last and self.step:
-            # If current index in total dataset + batch size exceeds the total size of the dataset,
-            # this last batch is incomplete so we drop it
-            if self.index + self.batch_size >= self.total_size:
+            # If our current index in total dataset + batch size exceeds the total size of the dataset,
+            # this last batch is incomplete. Drop it iff it has 1 row
+            if self.index - self.total_size == -1:
                 return True
         return False
 

--- a/ludwig/data/batcher/random_access.py
+++ b/ludwig/data/batcher/random_access.py
@@ -57,11 +57,10 @@ class RandomAccessBatcher(Batcher):
         if self.index >= self.total_size:
             return True
         # This avoids the case where batch size > total size and no steps have been done.
-        # For e.g., batch size = 128 but the dataset only has 100 rows. In this case, only
-        # mark last_batch after this batch is done using the first condition above.
+        # For e.g., batch size = 128 but the dataset only has 100 rows.
         elif self.ignore_last and self.step:
-            # If our current index in total dataset + batch size exceeds the total size of the dataset,
-            # this last batch is incomplete. Drop it iff it has 1 row
+            # index += batch_size after each epoch. So, if our current index in total dataset is 1 less than the total
+            # dataset size, then the last batch will only have 1 row. Drop it if this happens.
             if self.index - self.total_size == -1:
                 return True
         return False

--- a/ludwig/data/batcher/random_access.py
+++ b/ludwig/data/batcher/random_access.py
@@ -15,9 +15,11 @@
 # ==============================================================================
 import math
 
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.data.batcher.base import Batcher
 
 
+@DeveloperAPI
 class RandomAccessBatcher(Batcher):
     def __init__(self, dataset, sampler, batch_size=128, ignore_last=False):
         # store our dataset as well

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -287,12 +287,12 @@ class RayDatasetBatcher(Batcher):
         self._fetch_next_epoch()
 
     def _set_ignore_last(self, ignore_last: bool = False) -> bool:
-        if ignore_last and self.batch_size > self.samples_per_epoch:
-            # If the number of samples < batch size, then manually override
-            # ignore_last since Ray will drop all the rows during the iter_batches() call
-            logger.debug("Setting ignore_last to False to prevent infinite stall during training.")
-            return False
-        return True
+        """Set ignore_last based on batch_size and samples_per_epoch."""
+        # Only drop the last batch if it has 1 row, otherwise keep the incomplete last batch
+        if ignore_last and self.samples_per_epoch % self.batch_size == 1:
+            logger.info("Last batch in epoch only has 1 sample and will be dropped.")
+            return True
+        return False
 
     def next_batch(self):
         if self.last_batch():

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -280,6 +280,7 @@ class RayDatasetBatcher(Batcher):
 
         self.features = features
         self.columns = list(features.keys())
+        self._sample_feature_name = self.columns[0]
         self.reshape_map = {
             proc_column: training_set_metadata[feature[NAME]].get("reshape")
             for proc_column, feature in features.items()
@@ -342,8 +343,9 @@ class RayDatasetBatcher(Batcher):
         self._last_batch = False
         try:
             self._next_batch = next(self.dataset_batch_iter)
-            print(self._next_batch)
-            if self.ignore_last and len(self._next_batch) == 1:
+            # If the batch has only one row and self.ignore_last, skip the batch
+            # to prevent batchnorm / dropout related Torch errors
+            if self.ignore_last and len(self._next_batch[self._sample_feature_name]) == 1:
                 raise StopIteration
         except StopIteration:
             self._last_batch = True

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -30,6 +30,7 @@ from ray.data import read_parquet
 from ray.data.dataset_pipeline import DatasetPipeline
 from ray.data.extensions import TensorDtype
 
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.backend.base import Backend
 from ludwig.constants import BINARY, CATEGORY, NAME, NUMBER, TYPE
 from ludwig.data.batcher.base import Batcher
@@ -62,12 +63,14 @@ else:
         return series.astype(TensorDtype())
 
 
+@DeveloperAPI
 @default_retry()
 def read_remote_parquet(path: str):
     fs, path = get_fs_and_path(path)
     return read_parquet(path, filesystem=PyFileSystem(FSSpecHandler(fs)))
 
 
+@DeveloperAPI
 class RayDataset(Dataset):
     """Wrapper around ray.data.Dataset.
 
@@ -184,6 +187,7 @@ class RayDataset(Dataset):
         return self.df_engine.from_ray_dataset(self.ds)
 
 
+@DeveloperAPI
 class RayDatasetManager(DatasetManager):
     def __init__(self, backend):
         self.backend = backend
@@ -223,6 +227,7 @@ class RayDatasetManager(DatasetManager):
         return "parquet"
 
 
+@DeveloperAPI
 class RayDatasetShard(Dataset):
     def __init__(
         self,
@@ -256,6 +261,7 @@ class RayDatasetShard(Dataset):
         return len(self)
 
 
+@DeveloperAPI
 class RayDatasetBatcher(Batcher):
     def __init__(
         self,

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -234,7 +234,7 @@ class Predictor(BasePredictor):
         self.model.eval()  # set model to eval mode
 
         with torch.no_grad():
-            with dataset.initialize_batcher(self._batch_size, should_shuffle=False) as batcher:
+            with dataset.initialize_batcher(self._batch_size, should_shuffle=False, horovod=self._horovod) as batcher:
                 progress_bar_config = {
                     "desc": "Collecting Tensors",
                     "total": batcher.steps_per_epoch,

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -76,7 +76,7 @@ class Predictor(BasePredictor):
         self.model.eval()  # set model to eval mode
 
         with torch.no_grad():
-            with dataset.initialize_batcher(self._batch_size, should_shuffle=False, horovod=self._horovod) as batcher:
+            with dataset.initialize_batcher(self._batch_size, should_shuffle=False) as batcher:
 
                 progress_bar_config = {
                     "desc": "Prediction" if dataset_name is None else f"Prediction {dataset_name: <5.5}",

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -386,7 +386,10 @@ class Trainer(BaseTrainer):
 
         self.model.train()  # Sets model training mode.
         with training_set.initialize_batcher(
-            batch_size=self.batch_size, should_shuffle=self.should_shuffle, horovod=self.horovod
+            batch_size=self.batch_size,
+            should_shuffle=self.should_shuffle,
+            horovod=self.horovod,
+            ignore_last=True,
         ) as batcher:
             step_count = 0
             while epoch < self.epochs and step_count < total_training_steps and not diverging:
@@ -791,6 +794,7 @@ class Trainer(BaseTrainer):
                 should_shuffle=self.should_shuffle,
                 seed=self.random_seed,
                 horovod=self.horovod,
+                ignore_last=True,
             ) as batcher:
                 # ================ Training Loop ================
                 self.total_steps = get_total_steps(self.epochs, batcher.steps_per_epoch, self.train_steps)
@@ -1035,7 +1039,7 @@ class Trainer(BaseTrainer):
     def train_online(self, dataset):
         self.model.train()  # Sets model training mode.
         with dataset.initialize_batcher(
-            batch_size=self.batch_size, should_shuffle=self.should_shuffle, horovod=self.horovod
+            batch_size=self.batch_size, should_shuffle=self.should_shuffle, horovod=self.horovod, ignore_last=True
         ) as batcher:
 
             # training step loop


### PR DESCRIPTION
This PR implements logic to drop the last batch for Pandas and Ray dataset batchers to prevent issues when there is only 1 row in a batch. 

A single row in a batch causes issues when computing Batchnorm (such as in FC layers, Tabnet, etc.) because it can't compute the mean/stddev for a single sample. Additionally, Ludwig has some logic for Tabnet that has a conditional check for sample_size == 1 that we can now safely remove.

Skipping adding tests since our current test suite already has tests that use the batcher classes for model training, so if the tests pass, then this logic should work as well. I modified individual tests locally to be sure.

Note: This only drops incomplete training batches if the batch size < total number of rows in the dataset. Additionally, it will always keep incomplete training batches for validation/test sets.

To follow:

- [ ]  Remove check for batch_size == 1 in Tabnet