### PR TITLE
feat: Hyperopt schema v0, part 3: Enable optional min/max support for `FloatTupleMarshmallowField` fields

### DIFF
--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -793,12 +793,12 @@ def InitializerOrDict(
 
 
 def FloatRangeTupleDataclassField(
-    n=2,
+    n: int = 2,
     default: Union[Tuple, None] = (0.9, 0.999),
     allow_none: bool = True,
-    min=0,
-    max=1,
-    description="",
+    min: Union[int, None] = 0,
+    max: Union[int, None] = 1,
+    description: str = "",
     parameter_metadata: ParameterMetadata = None,
 ):
     """Returns a dataclass field with marshmallow metadata enforcing a `N`-dim.


### PR DESCRIPTION
Lets `min` and `max` be optional kwargs on `FloatTupleMarshmallowField` (currently, you are forced to provide them or otherwise except [0,1] as your range).