### PR TITLE
Proceed with model training even if saving preprocessed data fails.

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1791,9 +1791,6 @@ def _preprocess_file_for_training(
     else:
         raise ValueError("either data or data_train have to be not None")
 
-    # print("backend", backend)
-    # print("data", backend.df_engine.compute(data))
-
     logger.debug("split train-val-test")
     training_data, validation_data, test_data = split_dataset(data, preprocessing_params, backend, random_seed)
 
@@ -1801,7 +1798,13 @@ def _preprocess_file_for_training(
         logger.debug("writing split file")
         splits_df = concatenate_splits(training_data, validation_data, test_data, backend)
         split_fp = get_split_path(dataset or training_set)
-        backend.df_engine.to_parquet(splits_df, split_fp, index=True)
+        try:
+            backend.df_engine.to_parquet(splits_df, split_fp, index=True)
+        except Exception as e:
+            logger.warning(
+                f"Encountered error: '{e}' while writing data to parquet during saving processed input. "
+                "Skipping saving processed input."
+            )
 
     logger.info("Building dataset: DONE")
     if preprocessing_params["oversample_minority"] or preprocessing_params["undersample_majority"]:

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1802,8 +1802,8 @@ def _preprocess_file_for_training(
             backend.df_engine.to_parquet(splits_df, split_fp, index=True)
         except Exception as e:
             logger.warning(
-                f"Encountered error: '{e}' while writing data to parquet during saving processed input. "
-                "Skipping saving processed input."
+                f"Encountered error: '{e}' while writing data to parquet during saving preprocessed data. "
+                "Skipping saving processed data."
             )
 
     logger.info("Building dataset: DONE")


### PR DESCRIPTION
Running experiments in parallel, sometimes I run into an error where saving the data as a 
parquet file fails (perhaps there's a duplicate or pre-existing file).

Perhaps it's reasonable to catch the exception and log a warning, simply skipping saving preprocessed data, and continuing to proceed to training, rather than crashing.