### PR TITLE
Start fresh training run if files for resuming training are missing

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -444,7 +444,9 @@ class LudwigModel:
                 output_directory = model_resume_path
             else:
                 if self.backend.is_coordinator():
-                    logger.info("Model resume path does not exists, " "starting training from scratch")
+                    logger.info(
+                        f"Model resume path '{model_resume_path}' does not exist, starting training from scratch"
+                    )
                 model_resume_path = None
 
         if model_resume_path is None:

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -51,6 +51,7 @@ from ludwig.trainers.registry import register_trainer
 from ludwig.utils import time_utils
 from ludwig.utils.checkpoint_utils import Checkpoint, CheckpointManager
 from ludwig.utils.defaults import default_random_seed
+from ludwig.utils.fs_utils import path_exists
 from ludwig.utils.horovod_utils import return_first
 from ludwig.utils.math_utils import exponential_decay, learning_rate_warmup, learning_rate_warmup_distributed
 from ludwig.utils.metric_utils import get_metric_names, TrainerMetric
@@ -749,6 +750,7 @@ class Trainer(BaseTrainer):
             checkpoint = Checkpoint(model=self.model, optimizer=self.optimizer)
             checkpoint_manager = CheckpointManager(checkpoint, training_checkpoints_path, device=self.device)
 
+        # ====== Setup Tensorboard writers =======
         train_summary_writer = None
         validation_summary_writer = None
         test_summary_writer = None
@@ -760,11 +762,13 @@ class Trainer(BaseTrainer):
                 test_summary_writer = SummaryWriter(os.path.join(tensorboard_log_dir, TEST))
 
         # ================ Resume logic ================
-        if self.resume:
+        if self.resume and self.resume_files_exist(training_progress_tracker_path, training_checkpoints_path):
+            logger.info("Resuming training from previous run.")
             progress_tracker = self.resume_training_progress_tracker(training_progress_tracker_path)
             if self.is_coordinator():
                 self.resume_weights_and_optimizer(training_checkpoints_path, checkpoint)
         else:
+            logger.info("Creating fresh model training run.")
             progress_tracker = get_new_progress_tracker(
                 batch_size=self.batch_size,
                 learning_rate=self.base_learning_rate,
@@ -1235,6 +1239,26 @@ class Trainer(BaseTrainer):
             if self.original_sigint_handler:
                 signal.signal(signal.SIGINT, self.original_sigint_handler)
             sys.exit(1)
+
+    def resume_files_exist(
+        self,
+        training_progress_tracker_path: str,
+        training_checkpoint_path: str,
+    ) -> bool:
+        """ """
+        missing_files = []
+        # training_progress.json
+        if not path_exists(training_progress_tracker_path):
+            missing_files.append(training_progress_tracker_path)
+        # latest.ckpt in training_checkpoints/
+        if self.is_coordinator():
+            latest_ckpt = os.path.join(training_checkpoint_path, "latest.ckpt")
+            if not path_exists(latest_ckpt):
+                missing_files.append(latest_ckpt)
+        if missing_files:
+            logger.warning(f"Could not find {missing_files} while trying to resume model training.")
+            return False
+        return True
 
     def resume_training_progress_tracker(self, training_progress_tracker_path):
         if self.is_coordinator():

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -1245,7 +1245,6 @@ class Trainer(BaseTrainer):
         training_progress_tracker_path: str,
         training_checkpoint_path: str,
     ) -> bool:
-        """"""
         missing_files = []
         # training_progress.json
         if not path_exists(training_progress_tracker_path):

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -1245,7 +1245,7 @@ class Trainer(BaseTrainer):
         training_progress_tracker_path: str,
         training_checkpoint_path: str,
     ) -> bool:
-        """ """
+        """"""
         missing_files = []
         # training_progress.json
         if not path_exists(training_progress_tracker_path):

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -658,6 +658,44 @@ def test_experiment_model_resume(tmpdir):
     shutil.rmtree(output_dir, ignore_errors=True)
 
 
+@pytest.mark.parametrize(
+    "missing_file",
+    ["training_progress.json", "training_checkpoints"],
+    ids=["training_progress", "training_checkpoints"],
+)
+def test_experiment_model_resume_missing_file(tmpdir, missing_file):
+    # Single sequence input, single category output
+    # Tests saving a model file, loading it to rerun training and predict
+    input_features = [sequence_feature(encoder={"type": "rnn", "reduce_output": "sum"})]
+    output_features = [category_feature(decoder={"reduce_input": "sum", "vocab_size": 2})]
+    # Generate test data
+    rel_path = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"))
+
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        "combiner": {"type": "concat", "output_size": 14},
+        TRAINER: {"epochs": 2},
+    }
+
+    _, _, _, _, output_dir = experiment_cli(config, dataset=rel_path, output_directory=tmpdir)
+
+    try:
+        # Remove file to simulate failure during first epoch of training which prevents
+        # training_checkpoints to be empty and training_progress.json to not be created
+        missing_file_path = os.path.join(output_dir, "model", missing_file)
+        if missing_file == "training_progress.json":
+            os.remove(missing_file_path)
+        else:
+            shutil.rmtree(missing_file_path)
+    finally:
+        # Training should start a fresh model training run without any errors
+        experiment_cli(config, dataset=rel_path, model_resume_path=output_dir)
+
+    predict_cli(os.path.join(output_dir, "model"), dataset=rel_path)
+    shutil.rmtree(output_dir, ignore_errors=True)
+
+
 def test_experiment_various_feature_types(csv_filename):
     input_features = [binary_feature(), bag_feature()]
     output_features = [set_feature(decoder={"max_len": 3, "vocab_size": 5})]


### PR DESCRIPTION
If training fails during the first epoch, then `training_progress.json` will be missing and `training_checkpoints` will not have the `latest.ckpt` file. In this case, Ludwig throws errors. However, it might be better to indicate that model resumption failed, and that a fresh model training run is being created. 