### PR TITLE
Improve warnings about backwards compatibility and dataset splitting.

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -54,6 +54,7 @@ from ludwig.data.cache.types import wrap
 from ludwig.data.concatenate_datasets import concatenate_df, concatenate_files, concatenate_splits
 from ludwig.data.dataset.base import Dataset
 from ludwig.data.split import get_splitter, split_dataset
+from ludwig.data.utils import set_fixed_split
 from ludwig.encoders.registry import get_encoder_cls
 from ludwig.features.feature_registries import base_type_registry
 from ludwig.features.feature_utils import compute_feature_hash
@@ -1762,20 +1763,8 @@ def _preprocess_file_for_training(
         concatenated_df = concatenate_files(training_set, validation_set, test_set, read_fn, backend)
         training_set_metadata[SRC] = training_set
 
-        # Data is pre-split, so we override whatever split policy the user specified
-        if preprocessing_params["split"]:
-            warnings.warn(
-                'Preprocessing "split" section provided, but pre-split dataset given as input. '
-                "Ignoring split configuration."
-            )
-
-        preprocessing_params = {
-            **preprocessing_params,
-            "split": {
-                "type": "fixed",
-                "column": SPLIT,
-            },
-        }
+        # Data is pre-split.
+        preprocessing_params = set_fixed_split(preprocessing_params)
 
         data, training_set_metadata = build_dataset(
             concatenated_df,
@@ -1836,20 +1825,8 @@ def _preprocess_df_for_training(
         logger.info("Using training dataframe")
         dataset = concatenate_df(training_set, validation_set, test_set, backend)
 
-        # Data is pre-split, so we override whatever split policy the user specified
-        if preprocessing_params["split"]:
-            warnings.warn(
-                'Preprocessing "split" section provided, but pre-split dataset given as input. '
-                "Ignoring split configuration."
-            )
-
-        preprocessing_params = {
-            **preprocessing_params,
-            "split": {
-                "type": "fixed",
-                "column": SPLIT,
-            },
-        }
+        # Data is pre-split.
+        preprocessing_params = set_fixed_split(preprocessing_params)
 
     logger.info("Building dataset (it may take a while)")
 

--- a/ludwig/data/utils.py
+++ b/ludwig/data/utils.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 
+from ludwig.constants import SPLIT
 from ludwig.utils.dataframe_utils import is_dask_series_or_df
 from ludwig.utils.types import DataFrame
 
@@ -30,3 +31,18 @@ def convert_to_dict(
             feature_dict[subgroup] = values
         output[of_name] = feature_dict
     return output
+
+
+def set_fixed_split(preprocessing_params: Dict[str, Any]) -> Dict[str, Any]:
+    """Sets the split policy explicitly to a fixed split.
+
+    This potentially overrides the split configuration that the user set or what came from schema defaults.
+    """
+
+    return {
+        **preprocessing_params,
+        "split": {
+            "type": "fixed",
+            "column": SPLIT,
+        },
+    }

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -312,31 +312,39 @@ def _upgrade_encoder_decoder_params(feature: Dict[str, Any], input_feature: bool
         input_feature (Bool): Whether this feature is an input feature or not.
     """
     input_feature_keys = [
+        # Encoder-external parameters.
         "name",
         "type",
-        "column",
-        "proc_column",
         "encoder",
         "tied",
+        # Internal-only parameters.
+        "column",
+        "proc_column",
         "preprocessing",
         "vector_size",
+        "active",
     ]
 
     output_feature_keys = [
+        # Decoder-external parameters.
         "name",
         "type",
         "calibration",
-        "column",
-        "proc_column",
         "decoder",
-        "num_classes",
+        # Internal-only parameters.
         "preprocessing",
         "loss",
+        "column",
+        "proc_column",
+        "num_classes",
         "reduce_input",
         "dependencies",
         "reduce_dependencies",
         "top_k",
         "vector_size",
+        "active",
+        "default_validation_metric",
+        "input_size",
     ]
 
     fc_layer_keys = [

--- a/ludwig/utils/version_transformation.py
+++ b/ludwig/utils/version_transformation.py
@@ -47,9 +47,10 @@ class VersionTransformation:
         """Transforms the sepcified config, returns the transformed config."""
         prefixes = self.prefixes if self.prefixes else [""]
         for prefix in prefixes:
-            # Skip undefined or empty config prefixes.
-            if prefix and prefix in config and config[prefix]:
-                config = self.transform_config_with_prefix(config, prefix)
+            if prefix and prefix not in config:
+                # Skip non-empty absent config prefixes.
+                continue
+            config = self.transform_config_with_prefix(config, prefix)
         return config
 
     def transform_config_with_prefix(self, config: Dict, prefix: Optional[str] = None) -> Dict:

--- a/ludwig/utils/version_transformation.py
+++ b/ludwig/utils/version_transformation.py
@@ -47,8 +47,9 @@ class VersionTransformation:
         """Transforms the sepcified config, returns the transformed config."""
         prefixes = self.prefixes if self.prefixes else [""]
         for prefix in prefixes:
-            if prefix and prefix not in config:
-                # Skip non-empty absent config prefixes.
+            if prefix and (prefix not in config or not config[prefix]):
+                # If the prefix is non-empty (transformation applies to a specific section), but the section is either
+                # absent or empty, then skip.
                 continue
             config = self.transform_config_with_prefix(config, prefix)
         return config

--- a/ludwig/utils/version_transformation.py
+++ b/ludwig/utils/version_transformation.py
@@ -47,7 +47,9 @@ class VersionTransformation:
         """Transforms the sepcified config, returns the transformed config."""
         prefixes = self.prefixes if self.prefixes else [""]
         for prefix in prefixes:
-            config = self.transform_config_with_prefix(config, prefix)
+            # Skip undefined or empty config prefixes.
+            if prefix and prefix in config and config[prefix]:
+                config = self.transform_config_with_prefix(config, prefix)
         return config
 
     def transform_config_with_prefix(self, config: Dict, prefix: Optional[str] = None) -> Dict:


### PR DESCRIPTION
## Removing the fixed split override warning.

Ludwig users can pass pre-split data to `LudwigModel.train()` using via `model.train(training_set=..., valdiation_set=..., test_set=...)`. In preprocessing, we understand this to be the user using a fixed split.

At the moment, all users using `LudwigModel.train()` in this way get a warning about their preprocessing split configuration getting ignored. However, the `split` configuration may be entirely unspecified, set by the schema by default `(0.7, 0.2, 0.1)`.

I've removed this warning entirely, as it seems rare that a user using a fixed split would explicitly specify a different data split policy in their config, or be surprised/confused when that policy is simply ignored (they are using a fixed split).

## Fixing overtriggering of backwards compatibility warnings for encoder/decoder nesting.

There are additional internal-only parameters that live at the config feature-level that should not be flagged for not being nested within the `encoder`/`decoder` section. These additional internal-only parameters are used by `tests.integration_tests.utils`, affecting many tests, and so our test suite produces many extra (and irrelevant) backwards-compatibility warnings from our own system.

## Sample verification

`pytest tests/integration_tests/test_visualization.py` gives us these warnings from Ludwig:

```
tests/integration_tests/test_visualization.py: 28 warnings
  /workspaces/ludwig/ludwig/utils/backward_compatibility.py:433: DeprecationWarning: Missing "executor" section, adding "ray" executor will be flagged as error in v0.6
    warnings.warn(

tests/integration_tests/test_visualization.py: 28 warnings
  /workspaces/ludwig/ludwig/utils/backward_compatibility.py:470: DeprecationWarning: Missing "search_alg" at hyperopt top-level, adding in default value, will be flagged as error in v0.6
    warnings.warn(

tests/integration_tests/test_visualization.py: 45 warnings
  /workspaces/ludwig/ludwig/utils/backward_compatibility.py:389: DeprecationWarning: encoder specific parameters should now be nested within a dictionary under the 'encoder' parameter. Support for un-nested encoder specific parameters will be removed in v0.7
    warnings.warn(

tests/integration_tests/test_visualization.py: 30 warnings
  /workspaces/ludwig/ludwig/utils/backward_compatibility.py:389: DeprecationWarning: decoder specific parameters should now be nested within a dictionary under the 'decoder' parameter. Support for un-nested decoder specific parameters will be removed in v0.7
    warnings.warn(
```

After this PR:
- All removed.