### PR TITLE
Add new data utility functions for buffers and files, and rename registry

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -303,6 +303,12 @@ def read_hdf5(data_fp, **kwargs):
 @DeveloperAPI
 @spread
 def read_buffer(buf, fname):
+    """
+    Reads data in from a binary buffer by first writing the data to a temporary file,
+    and then processes it based on its format (hdf5, csv, tsv etc).
+
+    Useful if object is a binary buffer coming from streaming data.
+    """
     data_format = figure_data_format_dataset(fname)
     reader_fn = data_reader_registry[data_format]
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -315,6 +321,11 @@ def read_buffer(buf, fname):
 @DeveloperAPI
 @spread
 def read_fname(fname, data_format=None, df_lib=pd, **kwargs):
+    """
+    This function reads data from fname using the df_lib data processing library (defaults to pandas).
+
+    Useful if you don't know the file type extension in advance.
+    """
     data_format = data_format or figure_data_format_dataset(fname)
     reader_fn = data_reader_registry[data_format]
     return reader_fn(fname, df_lib, **kwargs)

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -194,8 +194,8 @@ def read_xsv(data_fp, df_lib=PANDAS_DF, separator=",", header=0, nrows=None, ski
     return df
 
 
-read_csv = functools.partial(read_xsv, dtype=None, separator=",")
-read_tsv = functools.partial(read_xsv, dtype=None, separator="\t")
+read_csv = functools.partial(read_xsv, separator=",")
+read_tsv = functools.partial(read_xsv, separator="\t")
 
 
 @spread

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -37,7 +37,7 @@ from ludwig.contrib import add_contrib_callback_args
 from ludwig.utils import visualization_utils
 from ludwig.utils.data_utils import (
     CACHEABLE_FORMATS,
-    external_data_reader_registry,
+    data_reader_registry,
     figure_data_format_dataset,
     load_array,
     load_from_file,
@@ -228,7 +228,7 @@ def _get_ground_truth_df(ground_truth: str) -> DataFrame:
         raise ValueError(
             "{} is not supported for ground truth file, " "valid types are {}".format(data_format, CACHEABLE_FORMATS)
         )
-    reader = get_from_registry(data_format, external_data_reader_registry)
+    reader = get_from_registry(data_format, data_reader_registry)
 
     # retrieve ground truth from source data set
     if data_format in {"csv", "tsv"}:


### PR DESCRIPTION
This PR adds two new utility functions:
1. `read_buffer`: Reads data in from a buffer `buf` after writing the data from a buffer to a temporary file, and then processes it based on its format (hdf5, csv, tsv etc)
2. `read_fname`: This function reads data from `fname` using the `df_lib` data processing library (defaults to pandas)