### PR TITLE
Add InterQuartileTransformer normalization strategy for Number Features

### DIFF
--- a/ludwig/features/number_feature.py
+++ b/ludwig/features/number_feature.py
@@ -133,7 +133,7 @@ class InterQuartileTransformer(nn.Module):
         compute = backend.df_engine.compute
         return {
             "q1": compute(np.percentile(column.astype(np.float32), 25)),
-            "q2": compute(np.percentile(column.astype(np.float32), 50)),
+            "q2": compute(column.astype(np.float32).median()),
             "q3": compute(np.percentile(column.astype(np.float32), 75)),
         }
 

--- a/ludwig/features/number_feature.py
+++ b/ludwig/features/number_feature.py
@@ -108,7 +108,10 @@ class InterQuartileTransformer(nn.Module):
         self.q1 = float(q1) if q1 is not None else q1
         self.q2 = float(q2) if q2 is not None else q2
         self.q3 = float(q3) if q3 is not None else q3
-        self.interquartile_range = self.q3 - self.q1
+        if self.q1 is None or self.q3 is None:
+            self.interquartile_range = None
+        else:
+            self.interquartile_range = self.q3 - self.q1
         self.feature_name = kwargs.get(NAME, "")
         if self.interquartile_range == 0:
             raise RuntimeError(
@@ -133,7 +136,7 @@ class InterQuartileTransformer(nn.Module):
         compute = backend.df_engine.compute
         return {
             "q1": compute(np.percentile(column.astype(np.float32), 25)),
-            "q2": compute(column.astype(np.float32).median()),
+            "q2": compute(np.percentile(column.astype(np.float32), 50)),
             "q3": compute(np.percentile(column.astype(np.float32), 75)),
         }
 

--- a/ludwig/features/number_feature.py
+++ b/ludwig/features/number_feature.py
@@ -102,6 +102,40 @@ class MinMaxTransformer(nn.Module):
         }
 
 
+class InterQuartileTransformer(nn.Module):
+    def __init__(self, q1: float = None, q3: float = None, **kwargs: dict):
+        super().__init__()
+        self.q1 = float(q1) if q1 is not None else q1
+        self.q3 = float(q3) if q3 is not None else q3
+        self.interquartile_range = self.q3 - self.q1
+        self.feature_name = kwargs.get(NAME, "")
+        if self.interquartile_range == 0:
+            raise RuntimeError(
+                f"Cannot apply InterQuartile (RobustScaler) normalization to `{self.feature_name}` since"
+                "interquartile range is 0, which will result in a ZeroDivisionError."
+            )
+
+    def transform(self, x: np.ndarray) -> np.ndarray:
+        return (x - self.q1) / self.interquartile_range
+
+    def inverse_transform(self, x: np.ndarray) -> np.ndarray:
+        return x * self.interquartile_range + self.q1
+
+    def transform_inference(self, x: torch.Tensor) -> torch.Tensor:
+        return (x - self.q1) / self.interquartile_range
+
+    def inverse_transform_inference(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.interquartile_range + self.q1
+
+    @staticmethod
+    def fit_transform_params(column: np.ndarray, backend: "Backend") -> dict:  # noqa
+        compute = backend.df_engine.compute
+        return {
+            "q1": compute(np.percentile(column.astype(np.float32), 25)),
+            "q3": compute(np.percentile(column.astype(np.float32), 75)),
+        }
+
+
 class Log1pTransformer(nn.Module):
     def __init__(self, **kwargs: dict):
         super().__init__()
@@ -152,6 +186,7 @@ numeric_transformation_registry = {
     "minmax": MinMaxTransformer,
     "zscore": ZScoreTransformer,
     "log1p": Log1pTransformer,
+    "iq": InterQuartileTransformer,
     None: IdentityTransformer,
 }
 

--- a/ludwig/schema/features/preprocessing/number.py
+++ b/ludwig/schema/features/preprocessing/number.py
@@ -38,7 +38,7 @@ class NumberPreprocessingConfig(BasePreprocessingConfig):
     )
 
     normalization: str = schema_utils.StringOptions(
-        ["zscore", "minmax", "log1p"],
+        ["zscore", "minmax", "log1p", "iq"],
         default=None,
         allow_none=True,
         description="Normalization strategy to use for this number feature.",

--- a/tests/ludwig/utils/test_normalization.py
+++ b/tests/ludwig/utils/test_normalization.py
@@ -35,10 +35,13 @@ proc_df = pd.DataFrame(columns=["x"])
 def test_norm():
     feature_1_meta = NumberFeatureMixin.get_feature_meta(data_df["x"], {"normalization": "zscore"}, LOCAL_BACKEND)
     feature_2_meta = NumberFeatureMixin.get_feature_meta(data_df["x"], {"normalization": "minmax"}, LOCAL_BACKEND)
+    feature_3_meta = NumberFeatureMixin.get_feature_meta(data_df["x"], {"normalization": "iq"}, LOCAL_BACKEND)
 
     assert feature_1_meta["mean"] == 6
     assert feature_2_meta["min"] == 2
     assert feature_2_meta["max"] == 10
+    assert feature_3_meta["q1"] == 4
+    assert feature_3_meta["q3"] == 8
 
     # value checks after normalization
     num_feature = number_feature()
@@ -66,3 +69,14 @@ def test_norm():
         skip_save_processed_input=False,
     )
     assert np.allclose(np.array(proc_df[num_feature[PROC_COLUMN]]), np.array([0, 0.25, 0.5, 0.75, 1]))
+
+    NumberFeatureMixin.add_feature_data(
+        feature_config=num_feature,
+        input_df=data_df,
+        proc_df=proc_df,
+        metadata={num_feature[NAME]: feature_3_meta},
+        preprocessing_parameters={"normalization": "iq"},
+        backend=LOCAL_BACKEND,
+        skip_save_processed_input=False,
+    )
+    assert np.allclose(np.array(proc_df[num_feature[PROC_COLUMN]]), np.array([-0.5, 0, 0.5, 1, 1.5]))

--- a/tests/ludwig/utils/test_normalization.py
+++ b/tests/ludwig/utils/test_normalization.py
@@ -41,6 +41,7 @@ def test_norm():
     assert feature_2_meta["min"] == 2
     assert feature_2_meta["max"] == 10
     assert feature_3_meta["q1"] == 4
+    assert feature_3_meta["q2"] == 6
     assert feature_3_meta["q3"] == 8
 
     # value checks after normalization
@@ -79,4 +80,4 @@ def test_norm():
         backend=LOCAL_BACKEND,
         skip_save_processed_input=False,
     )
-    assert np.allclose(np.array(proc_df[num_feature[PROC_COLUMN]]), np.array([-0.5, 0, 0.5, 1, 1.5]))
+    assert np.allclose(np.array(proc_df[num_feature[PROC_COLUMN]]), np.array([-1, -0.5, 0, 0.5, 1]))


### PR DESCRIPTION
This PR adds a new normalization method for numeric features called `InterQuartileTransformer`, which removes the median and scales the data according to the interquartile range. The resulting data has a zero mean and median and a standard deviation of 1, and it is not skewed by outliers (the outliers are still present with the same relative relationships to other values).

This effectively implements https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.RobustScaler.html, which is useful in cases where numeric features have large outliers that skew the distribution that emerges post min-max normalization.

This can be set in Ludwig by specifying `iq` as the normalization method in number feature preprocessing