### PR TITLE
LIghtGBMRayTrainer repartition datasets with fewer blocks than Ray actors

### DIFF
--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -173,6 +173,17 @@ class RayDataset(Dataset):
     def to_df(self):
         return self.df_engine.from_ray_dataset(self.ds)
 
+    def repartition(self, num_blocks: int):
+        """Repartition the dataset into the specified number of blocks.
+
+        This operation occurs in place and overwrites `self.ds` with a
+        new repartitioned dataset.
+
+        Args:
+            num_blocks: Number of blocks in the repartitioned data.
+        """
+        self.ds = self.ds.repartition(num_blocks=num_blocks)
+
 
 class RayDatasetManager(DatasetManager):
     def __init__(self, backend):

--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -957,7 +957,7 @@ class LightGBMRayTrainer(LightGBMTrainer):
         # TODO(shreya): Refactor preprocessing so that this can be moved upstream.
         if training_set.ds.num_blocks() < self.ray_params.num_actors:
             # Repartition to ensure that there is at least one block per actor
-            training_set = training_set.repartition(self.ray_params.num_actors)
+            training_set.repartition(self.ray_params.num_actors)
 
         lgb_train = RayDMatrix(
             # NOTE: batch_size=None to make sure map_batches doesn't change num_blocks.
@@ -972,7 +972,7 @@ class LightGBMRayTrainer(LightGBMTrainer):
         if validation_set is not None:
             if validation_set.ds.num_blocks() < self.ray_params.num_actors:
                 # Repartition to ensure that there is at least one block per actor
-                validation_set = validation_set.repartition(self.ray_params.num_actors)
+                validation_set.repartition(self.ray_params.num_actors)
 
             lgb_val = RayDMatrix(
                 validation_set.ds.map_batches(lambda df: df[feat_cols], batch_size=None),
@@ -985,7 +985,7 @@ class LightGBMRayTrainer(LightGBMTrainer):
         if test_set is not None:
             if test_set.ds.num_blocks() < self.ray_params.num_actors:
                 # Repartition to ensure that there is at least one block per actor
-                test_set = test_set.repartition(self.ray_params.num_actors)
+                test_set.repartition(self.ray_params.num_actors)
 
             lgb_test = RayDMatrix(
                 test_set.ds.map_batches(lambda df: df[feat_cols], batch_size=None),

--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -957,7 +957,7 @@ class LightGBMRayTrainer(LightGBMTrainer):
         # TODO(shreya): Refactor preprocessing so that this can be moved upstream.
         if training_set.ds.num_blocks() < self.ray_params.num_actors:
             # Repartition to ensure that there is at least one block per actor
-            training_set = training_set.ds.repartition(num_blocks=self.ray_params.num_actors)
+            training_set = training_set.repartition(self.ray_params.num_actors)
 
         lgb_train = RayDMatrix(
             # NOTE: batch_size=None to make sure map_batches doesn't change num_blocks.
@@ -972,7 +972,7 @@ class LightGBMRayTrainer(LightGBMTrainer):
         if validation_set is not None:
             if validation_set.ds.num_blocks() < self.ray_params.num_actors:
                 # Repartition to ensure that there is at least one block per actor
-                validation_set = validation_set.ds.repartition(num_blocks=self.ray_params.num_actors)
+                validation_set = validation_set.repartition(self.ray_params.num_actors)
 
             lgb_val = RayDMatrix(
                 validation_set.ds.map_batches(lambda df: df[feat_cols], batch_size=None),
@@ -985,7 +985,7 @@ class LightGBMRayTrainer(LightGBMTrainer):
         if test_set is not None:
             if test_set.ds.num_blocks() < self.ray_params.num_actors:
                 # Repartition to ensure that there is at least one block per actor
-                test_set.ds = test_set.ds.repartition(num_blocks=self.ray_params.num_actors)
+                test_set = test_set.repartition(self.ray_params.num_actors)
 
             lgb_test = RayDMatrix(
                 test_set.ds.map_batches(lambda df: df[feat_cols], batch_size=None),

--- a/tests/integration_tests/test_trainer.py
+++ b/tests/integration_tests/test_trainer.py
@@ -8,7 +8,7 @@ import pytest
 
 from ludwig.api import LudwigModel
 from ludwig.callbacks import Callback
-from ludwig.constants import DEFAULT_BATCH_SIZE, LIGHTGBM_TRAINER, TRAINER
+from ludwig.constants import DEFAULT_BATCH_SIZE, TRAINER
 from tests.integration_tests.utils import (
     binary_feature,
     category_feature,
@@ -192,7 +192,6 @@ def test_lightgbm_dataset_partition(ray_cluster_2cpu):
         "input_features": [{"name": "in_column", "type": "binary"}],
         "output_features": [{"name": "out_column", "type": "binary"}],
         "model_type": "gbm",
-        LIGHTGBM_TRAINER: {"epochs": 1, "batch_size": 128},
     }
     backend_config = {**RAY_BACKEND_CONFIG}
     backend_config["preprocessor_kwargs"] = {"num_cpu": 1}


### PR DESCRIPTION
This PR adds a `repartition` method to `RayDataset` and updates `LightGBMRayTrainer` to use `RayDataset.repartition` rather than accessing the underling dataset object. Additionally, it adds tests to ensure `LightGBMRayTrainer` repartitions data only if the number of blocks in the RayDataset is less than the number of actors. This addresses an error that can occur during distributed training (`AttributeError: 'Dataset' object has no attribute 'ds' (type: RayTaskError(AttributeError), retryable: true`).

