### PR TITLE
[Annotations] Move feature registries into accessor functions

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -57,7 +57,7 @@ from ludwig.data.dataset.base import Dataset
 from ludwig.data.split import get_splitter, split_dataset
 from ludwig.data.utils import set_fixed_split
 from ludwig.encoders.registry import get_encoder_cls
-from ludwig.features.feature_registries import base_type_registry
+from ludwig.features.feature_registries import get_base_type_registry
 from ludwig.features.feature_utils import compute_feature_hash
 from ludwig.utils import data_utils, strings_utils
 from ludwig.utils.backward_compatibility import upgrade_metadata
@@ -1247,7 +1247,7 @@ def cast_columns(dataset_cols, features, backend) -> None:
         # todo figure out if additional parameters are needed
         #  for the cast_column function
         try:
-            dataset_cols[feature[COLUMN]] = get_from_registry(feature[TYPE], base_type_registry).cast_column(
+            dataset_cols[feature[COLUMN]] = get_from_registry(feature[TYPE], get_base_type_registry()).cast_column(
                 dataset_cols[feature[COLUMN]], backend
             )
         except KeyError as e:
@@ -1323,7 +1323,7 @@ def build_metadata(
         preprocessing_parameters = feature_name_to_preprocessing_parameters[feature_name]
 
         column = dataset_cols[feature_config[COLUMN]]
-        metadata[feature_name] = get_from_registry(feature_config[TYPE], base_type_registry).get_feature_meta(
+        metadata[feature_name] = get_from_registry(feature_config[TYPE], get_base_type_registry()).get_feature_meta(
             column, preprocessing_parameters, backend
         )
 
@@ -1359,7 +1359,7 @@ def build_data(
         # Need to run this again here as cast_columns may have introduced new missing values
         handle_missing_values(input_cols, feature_config, preprocessing_parameters, backend)
 
-        get_from_registry(feature_config[TYPE], base_type_registry).add_feature_data(
+        get_from_registry(feature_config[TYPE], get_base_type_registry()).add_feature_data(
             feature_config,
             input_cols,
             proc_cols,

--- a/ludwig/features/feature_registries.py
+++ b/ludwig/features/feature_registries.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import Dict
+
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import (
     AUDIO,
     BAG,
@@ -45,52 +48,63 @@ from ludwig.features.timeseries_feature import TimeseriesFeatureMixin, Timeserie
 from ludwig.features.vector_feature import VectorFeatureMixin, VectorInputFeature, VectorOutputFeature
 from ludwig.utils.misc_utils import get_from_registry
 
-base_type_registry = {
-    TEXT: TextFeatureMixin,
-    CATEGORY: CategoryFeatureMixin,
-    SET: SetFeatureMixin,
-    BAG: BagFeatureMixin,
-    BINARY: BinaryFeatureMixin,
-    NUMBER: NumberFeatureMixin,
-    SEQUENCE: SequenceFeatureMixin,
-    TIMESERIES: TimeseriesFeatureMixin,
-    IMAGE: ImageFeatureMixin,
-    AUDIO: AudioFeatureMixin,
-    H3: H3FeatureMixin,
-    DATE: DateFeatureMixin,
-    VECTOR: VectorFeatureMixin,
-}
-input_type_registry = {
-    TEXT: TextInputFeature,
-    NUMBER: NumberInputFeature,
-    BINARY: BinaryInputFeature,
-    CATEGORY: CategoryInputFeature,
-    SET: SetInputFeature,
-    SEQUENCE: SequenceInputFeature,
-    IMAGE: ImageInputFeature,
-    AUDIO: AudioInputFeature,
-    TIMESERIES: TimeseriesInputFeature,
-    BAG: BagInputFeature,
-    H3: H3InputFeature,
-    DATE: DateInputFeature,
-    VECTOR: VectorInputFeature,
-}
-output_type_registry = {
-    CATEGORY: CategoryOutputFeature,
-    BINARY: BinaryOutputFeature,
-    NUMBER: NumberOutputFeature,
-    SEQUENCE: SequenceOutputFeature,
-    SET: SetOutputFeature,
-    TEXT: TextOutputFeature,
-    VECTOR: VectorOutputFeature,
-}
+
+@DeveloperAPI
+def get_base_type_registry() -> Dict:
+    return {
+        TEXT: TextFeatureMixin,
+        CATEGORY: CategoryFeatureMixin,
+        SET: SetFeatureMixin,
+        BAG: BagFeatureMixin,
+        BINARY: BinaryFeatureMixin,
+        NUMBER: NumberFeatureMixin,
+        SEQUENCE: SequenceFeatureMixin,
+        TIMESERIES: TimeseriesFeatureMixin,
+        IMAGE: ImageFeatureMixin,
+        AUDIO: AudioFeatureMixin,
+        H3: H3FeatureMixin,
+        DATE: DateFeatureMixin,
+        VECTOR: VectorFeatureMixin,
+    }
+
+
+@DeveloperAPI
+def get_input_type_registry() -> Dict:
+    return {
+        TEXT: TextInputFeature,
+        NUMBER: NumberInputFeature,
+        BINARY: BinaryInputFeature,
+        CATEGORY: CategoryInputFeature,
+        SET: SetInputFeature,
+        SEQUENCE: SequenceInputFeature,
+        IMAGE: ImageInputFeature,
+        AUDIO: AudioInputFeature,
+        TIMESERIES: TimeseriesInputFeature,
+        BAG: BagInputFeature,
+        H3: H3InputFeature,
+        DATE: DateInputFeature,
+        VECTOR: VectorInputFeature,
+    }
+
+
+@DeveloperAPI
+def get_output_type_registry() -> Dict:
+    return {
+        CATEGORY: CategoryOutputFeature,
+        BINARY: BinaryOutputFeature,
+        NUMBER: NumberOutputFeature,
+        SEQUENCE: SequenceOutputFeature,
+        SET: SetOutputFeature,
+        TEXT: TextOutputFeature,
+        VECTOR: VectorOutputFeature,
+    }
 
 
 def update_config_with_metadata(config_obj, training_set_metadata):
     # populate input features fields depending on data
     # config = merge_with_defaults(config)
     for input_feature in config_obj.input_features.to_list():
-        feature = get_from_registry(input_feature[TYPE], input_type_registry)
+        feature = get_from_registry(input_feature[TYPE], get_input_type_registry())
         feature.update_config_with_metadata(
             getattr(config_obj.input_features, input_feature[NAME]),
             training_set_metadata[input_feature[NAME]],
@@ -101,7 +115,7 @@ def update_config_with_metadata(config_obj, training_set_metadata):
 
     # populate output features fields depending on data
     for output_feature in config_obj.output_features.to_list():
-        feature = get_from_registry(output_feature[TYPE], output_type_registry)
+        feature = get_from_registry(output_feature[TYPE], get_output_type_registry())
         feature.update_config_with_metadata(
             getattr(config_obj.output_features, output_feature[NAME]),
             training_set_metadata[output_feature[NAME]],

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -33,7 +33,7 @@ from ludwig.constants import (
     VALIDATION,
 )
 from ludwig.data.split import get_splitter
-from ludwig.features.feature_registries import output_type_registry
+from ludwig.features.feature_registries import get_output_type_registry
 from ludwig.hyperopt.results import HyperoptResults
 from ludwig.hyperopt.utils import (
     log_warning_if_all_grid_type_parameters,
@@ -301,7 +301,7 @@ def hyperopt(
         for of in full_config[OUTPUT_FEATURES]:
             if of[NAME] == output_feature:
                 output_feature_type = of[TYPE]
-        feature_class = get_from_registry(output_feature_type, output_type_registry)
+        feature_class = get_from_registry(output_feature_type, get_output_type_registry())
         if metric not in feature_class.metric_functions:
             # todo v0.4: allow users to specify also metrics from the overall
             #  and per class metrics from the training stats and in general

--- a/ludwig/models/base.py
+++ b/ludwig/models/base.py
@@ -9,7 +9,7 @@ import torch
 from ludwig.combiners.combiners import Combiner
 from ludwig.constants import COMBINED, LOSS, NAME
 from ludwig.features.base_feature import InputFeature, OutputFeature
-from ludwig.features.feature_registries import input_type_registry, output_type_registry
+from ludwig.features.feature_registries import get_input_type_registry, get_output_type_registry
 from ludwig.features.feature_utils import LudwigFeatureDict
 from ludwig.schema.features.base import BaseInputFeatureConfig, BaseOutputFeatureConfig
 from ludwig.schema.model_config import InputFeaturesContainer, OutputFeaturesContainer
@@ -72,7 +72,7 @@ class BaseModel(LudwigModule, metaclass=ABCMeta):
             if tied_input_feature_name in other_input_features:
                 encoder_obj = other_input_features[tied_input_feature_name].encoder_obj
 
-        input_feature_class = get_from_registry(feature_config.type, input_type_registry)
+        input_feature_class = get_from_registry(feature_config.type, get_input_type_registry())
         input_feature_obj = input_feature_class(feature_config, encoder_obj=encoder_obj)
         return input_feature_obj
 
@@ -99,7 +99,7 @@ class BaseModel(LudwigModule, metaclass=ABCMeta):
     ) -> OutputFeature:
         """Builds a single output feature from the output feature definition."""
         logger.debug(f"Output {feature_config.type} feature {feature_config.name}")
-        output_feature_class = get_from_registry(feature_config.type, output_type_registry)
+        output_feature_class = get_from_registry(feature_config.type, get_output_type_registry())
         output_feature_obj = output_feature_class(feature_config, output_features=output_features)
         return output_feature_obj
 

--- a/ludwig/models/inference.py
+++ b/ludwig/models/inference.py
@@ -9,7 +9,7 @@ from torch import nn
 from ludwig.constants import NAME, POSTPROCESSOR, PREDICTOR, PREPROCESSOR, TYPE
 from ludwig.data.postprocessing import convert_dict_to_df
 from ludwig.data.preprocessing import load_metadata
-from ludwig.features.feature_registries import input_type_registry
+from ludwig.features.feature_registries import get_input_type_registry
 from ludwig.features.feature_utils import get_module_dict_key_from_name, get_name_from_module_dict_key
 from ludwig.globals import MODEL_HYPERPARAMETERS_FILE_NAME, TRAIN_SET_METADATA_FILE_NAME
 from ludwig.utils import output_feature_utils
@@ -155,7 +155,7 @@ class _InferencePreprocessor(nn.Module):
         self.preproc_modules = nn.ModuleDict()
         for feature_config in config["input_features"]:
             feature_name = feature_config[NAME]
-            feature = get_from_registry(feature_config[TYPE], input_type_registry)
+            feature = get_from_registry(feature_config[TYPE], get_input_type_registry())
             # prevents collisions with reserved keywords
             module_dict_key = get_module_dict_key_from_name(feature_name)
             self.preproc_modules[module_dict_key] = feature.create_preproc_module(training_set_metadata[feature_name])

--- a/ludwig/utils/automl/utils.py
+++ b/ludwig/utils/automl/utils.py
@@ -20,7 +20,7 @@ from ludwig.constants import (
     TRAINER,
     TYPE,
 )
-from ludwig.features.feature_registries import output_type_registry
+from ludwig.features.feature_registries import get_output_type_registry
 from ludwig.modules.metric_registry import metric_registry
 from ludwig.schema.combiners.utils import get_combiner_jsonschema
 
@@ -118,7 +118,7 @@ def set_output_feature_metric(base_config):
         return base_config
     output_name = base_config["output_features"][0][NAME]
     output_type = base_config["output_features"][0][TYPE]
-    output_metric = output_type_registry[output_type].get_schema_cls().default_validation_metric
+    output_metric = get_output_type_registry()[output_type].get_schema_cls().default_validation_metric
     output_goal = metric_registry[output_metric].get_objective()
     if "validation_field" not in base_config[TRAINER] and "validation_metric" not in base_config[TRAINER]:
         base_config[TRAINER]["validation_field"] = output_name

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -59,7 +59,7 @@ from ludwig.constants import (
     TYPE,
     USE_BIAS,
 )
-from ludwig.features.feature_registries import base_type_registry
+from ludwig.features.feature_registries import get_base_type_registry
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.utils.metric_utils import TrainerMetric
 from ludwig.utils.misc_utils import merge_dict
@@ -505,7 +505,7 @@ def _upgrade_preprocessing_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
     # If preprocessing section specified and it contains feature specific preprocessing parameters,
     # make a copy and delete it from the preprocessing section
     for parameter in list(config.get(PREPROCESSING, {})):
-        if parameter in base_type_registry:
+        if parameter in get_base_type_registry():
             warnings.warn(
                 f"Moving preprocessing configuration for `{parameter}` feature type from `preprocessing` section"
                 " to `defaults` section in Ludwig config. This will be unsupported in v0.8.",

--- a/ludwig/utils/config_utils.py
+++ b/ludwig/utils/config_utils.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Set, Union
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import DECODER, ENCODER, INPUT_FEATURES, PREPROCESSING, TYPE
-from ludwig.features.feature_registries import input_type_registry, output_type_registry
+from ludwig.features.feature_registries import get_input_type_registry, get_output_type_registry
 from ludwig.schema.model_config import ModelConfig
 from ludwig.utils.misc_utils import get_from_registry
 
@@ -49,7 +49,7 @@ def get_preprocessing_params(config_obj: ModelConfig) -> Dict[str, Any]:
     parameters from config defaults."""
     preprocessing_params = {}
     preprocessing_params.update(config_obj.preprocessing.to_dict())
-    for feat_type in input_type_registry.keys():
+    for feat_type in get_input_type_registry().keys():
         preprocessing_params[feat_type] = getattr(config_obj.defaults, feat_type).preprocessing.to_dict()
     return preprocessing_params
 
@@ -71,7 +71,7 @@ def merge_config_preprocessing_with_feature_specific_defaults(
 def get_default_encoder_or_decoder(feature: Dict[str, Any], config_feature_group: str) -> str:
     """Returns the default encoder or decoder for a feature."""
     if config_feature_group == INPUT_FEATURES:
-        feature_schema = get_from_registry(feature.get(TYPE), input_type_registry).get_schema_cls()
+        feature_schema = get_from_registry(feature.get(TYPE), get_input_type_registry()).get_schema_cls()
         return feature_schema().encoder.type
-    feature_schema = get_from_registry(feature.get(TYPE), output_type_registry).get_schema_cls()
+    feature_schema = get_from_registry(feature.get(TYPE), get_output_type_registry()).get_schema_cls()
     return feature_schema().decoder.type

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -21,7 +21,7 @@ import yaml
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.contrib import add_contrib_callback_args
-from ludwig.features.feature_registries import input_type_registry
+from ludwig.features.feature_registries import get_input_type_registry
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.schema import validate_config
 from ludwig.schema.model_config import ModelConfig
@@ -37,7 +37,8 @@ default_random_seed = 42
 
 # Still needed for preprocessing  TODO(Connor): Refactor ludwig/data/preprocessing to use schema
 default_feature_specific_preprocessing_parameters = {
-    name: preproc_sect.get_schema_cls()().preprocessing.to_dict() for name, preproc_sect in input_type_registry.items()
+    name: preproc_sect.get_schema_cls()().preprocessing.to_dict()
+    for name, preproc_sect in get_input_type_registry().items()
 }
 
 default_preprocessing_parameters = copy.deepcopy(default_feature_specific_preprocessing_parameters)

--- a/tests/ludwig/schema/test_validate_config_misc.py
+++ b/tests/ludwig/schema/test_validate_config_misc.py
@@ -18,7 +18,7 @@ from ludwig.constants import (
     TRAINER,
     TYPE,
 )
-from ludwig.features.feature_registries import output_type_registry
+from ludwig.features.feature_registries import get_output_type_registry
 from ludwig.schema import get_schema, validate_config
 from ludwig.schema.defaults.defaults import DefaultsConfig
 from ludwig.schema.features.preprocessing.audio import AudioPreprocessingConfig
@@ -93,7 +93,7 @@ def test_config_features():
 
     # test various invalid output features
     input_only_features = [
-        feature for feature in all_input_features if feature["type"] not in output_type_registry.keys()
+        feature for feature in all_input_features if feature["type"] not in get_output_type_registry().keys()
     ]
     for input_feature in input_only_features:
         config = {


### PR DESCRIPTION
This PR moves `base_type_registry`, `input_type_registry` and `output_type_registry` into accessor methods so that they can't be accessed directly. 