### PR TITLE
[Annotations] Encoder and Decoder Registries

### DIFF
--- a/ludwig/combiners/combiners.py
+++ b/ludwig/combiners/combiners.py
@@ -23,7 +23,7 @@ from torch.nn import Linear, ModuleList
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import BINARY, NUMBER
-from ludwig.encoders.registry import sequence_encoder_registry
+from ludwig.encoders.registry import get_sequence_encoder_registry
 from ludwig.features.base_feature import InputFeature
 from ludwig.modules.attention_modules import TransformerStack
 from ludwig.modules.embedding_modules import Embed
@@ -331,7 +331,7 @@ class SequenceCombiner(Combiner):
             f"combiner input shape {self.combiner.concatenated_shape}, " f"output shape {self.combiner.output_shape}"
         )
 
-        self.encoder_obj = get_from_registry(config.encoder.type, sequence_encoder_registry)(
+        self.encoder_obj = get_from_registry(config.encoder.type, get_sequence_encoder_registry())(
             should_embed=False,
             reduce_output=config.reduce_output,
             embedding_size=self.combiner.output_shape[1],

--- a/ludwig/decoders/registry.py
+++ b/ludwig/decoders/registry.py
@@ -1,28 +1,37 @@
 from typing import Dict, List, Type, Union
 
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.decoders.base import Decoder
 from ludwig.utils.registry import Registry
 
 decoder_registry = Registry()
 
 
+@DeveloperAPI
+def get_decoder_registry() -> Registry:
+    return decoder_registry
+
+
+@DeveloperAPI
 def register_decoder(name: str, features: Union[str, List[str]]):
     if isinstance(features, str):
         features = [features]
 
     def wrap(cls):
         for feature in features:
-            feature_registry = decoder_registry.get(feature, {})
+            feature_registry = get_decoder_registry().get(feature, {})
             feature_registry[name] = cls
-            decoder_registry[feature] = feature_registry
+            get_decoder_registry()[feature] = feature_registry
         return cls
 
     return wrap
 
 
+@DeveloperAPI
 def get_decoder_cls(feature: str, name: str) -> Type[Decoder]:
-    return decoder_registry[feature][name]
+    return get_decoder_registry()[feature][name]
 
 
+@DeveloperAPI
 def get_decoder_classes(feature: str) -> Dict[str, Type[Decoder]]:
-    return decoder_registry[feature]
+    return get_decoder_registry()[feature]

--- a/ludwig/decoders/registry.py
+++ b/ludwig/decoders/registry.py
@@ -4,12 +4,12 @@ from ludwig.api_annotations import DeveloperAPI
 from ludwig.decoders.base import Decoder
 from ludwig.utils.registry import Registry
 
-decoder_registry = Registry()
+_decoder_registry = Registry()
 
 
 @DeveloperAPI
 def get_decoder_registry() -> Registry:
-    return decoder_registry
+    return _decoder_registry
 
 
 @DeveloperAPI

--- a/ludwig/encoders/registry.py
+++ b/ludwig/encoders/registry.py
@@ -4,19 +4,19 @@ from ludwig.api_annotations import DeveloperAPI
 from ludwig.encoders.base import Encoder
 from ludwig.utils.registry import Registry
 
-encoder_registry = Registry()
+_encoder_registry = Registry()
 
-sequence_encoder_registry = Registry()
+_sequence_encoder_registry = Registry()
 
 
 @DeveloperAPI
 def get_encoder_registry() -> Registry:
-    return encoder_registry
+    return _encoder_registry
 
 
 @DeveloperAPI
 def get_sequence_encoder_registry() -> Registry:
-    return sequence_encoder_registry
+    return _sequence_encoder_registry
 
 
 def register_sequence_encoder(name: str):

--- a/ludwig/encoders/registry.py
+++ b/ludwig/encoders/registry.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Type, Union
 
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.encoders.base import Encoder
 from ludwig.utils.registry import Registry
 
@@ -8,9 +9,19 @@ encoder_registry = Registry()
 sequence_encoder_registry = Registry()
 
 
+@DeveloperAPI
+def get_encoder_registry() -> Registry:
+    return encoder_registry
+
+
+@DeveloperAPI
+def get_sequence_encoder_registry() -> Registry:
+    return sequence_encoder_registry
+
+
 def register_sequence_encoder(name: str):
     def wrap(cls):
-        sequence_encoder_registry[name] = cls
+        get_sequence_encoder_registry()[name] = cls
         return cls
 
     return wrap
@@ -22,17 +33,17 @@ def register_encoder(name: str, features: Union[str, List[str]]):
 
     def wrap(cls):
         for feature in features:
-            feature_registry = encoder_registry.get(feature, {})
+            feature_registry = get_encoder_registry().get(feature, {})
             feature_registry[name] = cls
-            encoder_registry[feature] = feature_registry
+            get_encoder_registry()[feature] = feature_registry
         return cls
 
     return wrap
 
 
 def get_encoder_cls(feature: str, name: str) -> Type[Encoder]:
-    return encoder_registry[feature][name]
+    return get_encoder_registry()[feature][name]
 
 
 def get_encoder_classes(feature: str) -> Dict[str, Type[Encoder]]:
-    return encoder_registry[feature]
+    return get_encoder_registry()[feature]

--- a/tests/ludwig/combiners/test_combiners.py
+++ b/tests/ludwig/combiners/test_combiners.py
@@ -16,7 +16,7 @@ from ludwig.combiners.combiners import (
     TransformerCombiner,
 )
 from ludwig.constants import CATEGORY, TYPE
-from ludwig.encoders.registry import sequence_encoder_registry
+from ludwig.encoders.registry import get_sequence_encoder_registry
 from ludwig.schema.combiners.comparator import ComparatorCombinerConfig
 from ludwig.schema.combiners.concat import ConcatCombinerConfig
 from ludwig.schema.combiners.sequence import SequenceCombinerConfig
@@ -277,7 +277,7 @@ def test_sequence_concat_combiner(
 
 # test for sequence combiner
 @pytest.mark.parametrize("reduce_output", [None, "sum"])
-@pytest.mark.parametrize("encoder", sequence_encoder_registry)
+@pytest.mark.parametrize("encoder", get_sequence_encoder_registry())
 @pytest.mark.parametrize("main_sequence_feature", [None, "feature_3"])
 def test_sequence_combiner(
     encoder_outputs: Tuple, main_sequence_feature: Optional[str], encoder: str, reduce_output: Optional[str]


### PR DESCRIPTION
This PR creates accessor methods for encoder and decoder registries and uses the DeveloperAPI annotation. This will be the best way to retrieve these registries in the future. 

I've made the original variable paths private because there's no good way to remove them without breaking the logic where we instantiate a registry and incrementally register things. 