### PR TITLE
Fix key error in AutoML model select

### DIFF
--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -362,14 +362,16 @@ def _model_select(
                 base_config = merge_dict(base_config, default_configs["combiner"][model_type])
     else:
         # text heuristics
-        for input_feature in default_configs["base_config"]["input_features"]:
+        input_features = default_configs["base_config"]["input_features"]
+        for i, input_feature in enumerate(input_features):
+            base_config_input_feature = base_config["input_features"][i]
             # default text encoder is bert
             if input_feature[TYPE] == TEXT:
                 model_category = TEXT
                 if ENCODER in input_feature:
-                    input_feature[ENCODER][TYPE] = AUTOML_DEFAULT_TEXT_ENCODER
+                    base_config_input_feature[ENCODER][TYPE] = AUTOML_DEFAULT_TEXT_ENCODER
                 else:
-                    input_feature[ENCODER] = {TYPE: AUTOML_DEFAULT_TEXT_ENCODER}
+                    base_config_input_feature[ENCODER] = {TYPE: AUTOML_DEFAULT_TEXT_ENCODER}
                 # TODO(shreya): Should this hyperopt config param be set here?
                 base_config[HYPEROPT]["executor"]["num_samples"] = 5  # set for small hyperparameter search space
                 base_config = merge_dict(base_config, default_configs[TEXT][AUTOML_DEFAULT_TEXT_ENCODER])
@@ -378,9 +380,9 @@ def _model_select(
             if input_feature[TYPE] == IMAGE:
                 model_category = IMAGE
                 if ENCODER in input_feature:
-                    input_feature[ENCODER][TYPE] = AUTOML_DEFAULT_IMAGE_ENCODER
+                    base_config_input_feature[ENCODER][TYPE] = AUTOML_DEFAULT_IMAGE_ENCODER
                 else:
-                    input_feature[ENCODER] = {TYPE: AUTOML_DEFAULT_IMAGE_ENCODER}
+                    base_config_input_feature[ENCODER] = {TYPE: AUTOML_DEFAULT_IMAGE_ENCODER}
 
         # Merge combiner config
         base_config = merge_dict(base_config, default_configs["combiner"]["concat"])

--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -382,7 +382,7 @@ def _model_select(
                     input_feature[ENCODER] = {TYPE: AUTOML_DEFAULT_IMAGE_ENCODER}
 
         # Needs to be outside for loop because merge dict creates deep copy - this prevents image section from setting
-        base_config = merge_dict(base_config, default_configs[TEXT][AUTOML_DEFAULT_TEXT_ENCODER])
+        base_config = merge_dict(base_config, default_configs.get(TEXT, {}).get(AUTOML_DEFAULT_TEXT_ENCODER, {}))
         base_config = merge_dict(base_config, default_configs["combiner"]["concat"])
 
     # override and constrain automl config based on user specified values

--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -256,8 +256,6 @@ def create_auto_config(
     if not isinstance(dataset, DatasetInfo):
         dataset = load_dataset(dataset, df_lib=backend.df_engine.df_lib)
 
-    print("Auto-generating config for dataset: {} ...".format(dataset))
-
     dataset_info = get_dataset_info(dataset) if not isinstance(dataset, DatasetInfo) else dataset
     default_configs = _create_default_config(
         dataset_info, target, time_limit_s, random_seed, imbalance_threshold, backend

--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -174,7 +174,7 @@ def _create_default_config(
       trial
 
     # Inputs
-    :param dataset: (str) filepath to dataset.
+    :param dataset_info: (str) filepath Dataset Info object.
     :param target_name: (str, List[str]) name of target feature
     :param time_limit_s: (int, float) total time allocated to auto_train. acts
                                     as the stopping parameter
@@ -183,6 +183,7 @@ def _create_default_config(
                         hyperparameter search sampling, as well as data splitting,
                         parameter initialization and training set shuffling
     :param imbalance_threshold: (float) maximum imbalance ratio (minority / majority) to perform stratified sampling
+    :param backend: (Backend) backend to use for training.
 
     # Return
     :return: (dict) dictionaries contain auto train config files for all available
@@ -234,7 +235,7 @@ def _create_default_config(
         combiner_config = load_yaml(default_config)
         model_configs[COMBINER][combiner_type] = combiner_config
 
-    return model_configs, features_metadata
+    return model_configs
 
 
 # Read in the score and configuration of a reference model trained by Ludwig for each dataset in a list.

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -57,6 +57,7 @@ def is_image(src_path: str, img_entry: Union[bytes, str], column: str) -> bool:
             return imghdr.what(None, bytes_obj) is not None
         return imghdr.what(bytes_obj) is not None
     except AttributeError:
+        # An AttributeError is raised when an image doesn't exist in the dataset, and we want to silence those errors.
         return False
     except Exception as e:
         logger.warning(f"While assessing potential image in is_image() for column {column}, encountered exception: {e}")

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -56,6 +56,8 @@ def is_image(src_path: str, img_entry: Union[bytes, str], column: str) -> bool:
         if isinstance(bytes_obj, bytes):
             return imghdr.what(None, bytes_obj) is not None
         return imghdr.what(bytes_obj) is not None
+    except AttributeError:
+        return False
     except Exception as e:
         logger.warning(f"While assessing potential image in is_image() for column {column}, encountered exception: {e}")
         return False

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ markers =
     distributed: mark a test as a distributed test.
     filesystem: mark to test operating system systems.
     slow: mark test as slow.
+filterwarnings =
+    ignore::DeprecationWarning

--- a/tests/integration_tests/test_automl.py
+++ b/tests/integration_tests/test_automl.py
@@ -13,6 +13,7 @@ from ludwig.api import LudwigModel
 from ludwig.constants import COLUMN, ENCODER, INPUT_FEATURES, NAME, OUTPUT_FEATURES, PREPROCESSING, SPLIT, TYPE
 from ludwig.types import FeatureConfigDict
 from tests.integration_tests.utils import (
+    binary_feature,
     category_feature,
     generate_data,
     image_feature,
@@ -41,7 +42,7 @@ def to_name_set(features: List[FeatureConfigDict]) -> Set[str]:
 
 
 @pytest.fixture(scope="module")
-def test_data():
+def test_data_tabular_large():
     with tempfile.TemporaryDirectory() as tmpdir:
         input_features = [
             number_feature(),
@@ -56,13 +57,85 @@ def test_data():
         yield input_features, output_features, dataset_csv
 
 
+@pytest.fixture(scope="module")
+def test_data_tabular_small():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_features = [
+            number_feature(),
+            category_feature(encoder={"vocab_size": 3}),
+        ]
+        output_features = [category_feature(decoder={"vocab_size": 3})]
+        dataset_csv = generate_data(
+            input_features, output_features, os.path.join(tmpdir, "dataset.csv"), num_examples=100
+        )
+        yield input_features, output_features, dataset_csv
+
+
+@pytest.fixture(scope="module")
+def test_data_image():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        image_dest_folder = os.path.join(tmpdir, "generated_images")
+        input_features = [
+            image_feature(folder=image_dest_folder),
+        ]
+        output_features = [binary_feature()]
+        dataset_csv = generate_data(
+            input_features, output_features, os.path.join(tmpdir, "dataset.csv"), num_examples=20
+        )
+        yield input_features, output_features, dataset_csv
+
+
+@pytest.fixture(scope="module")
+def test_data_text():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_features = [
+            text_feature(preprocessing={"tokenizer": "space"}),
+        ]
+        output_features = [binary_feature()]
+        dataset_csv = generate_data(
+            input_features, output_features, os.path.join(tmpdir, "dataset.csv"), num_examples=20
+        )
+        yield input_features, output_features, dataset_csv
+
+
+@pytest.fixture(scope="module")
+def test_data_multimodal():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        image_dest_folder = os.path.join(tmpdir, "generated_images")
+        input_features = [
+            image_feature(folder=image_dest_folder),
+            text_feature(preprocessing={"tokenizer": "space"}),
+        ]
+        output_features = [binary_feature()]
+        dataset_csv = generate_data(
+            input_features, output_features, os.path.join(tmpdir, "dataset.csv"), num_examples=10
+        )
+        yield input_features, output_features, dataset_csv
+
+
 @pytest.mark.distributed
-@pytest.mark.parametrize("tune_for_memory", [True, False])
-def test_create_auto_config(tune_for_memory, test_data, ray_cluster_2cpu):
+@pytest.mark.parametrize(
+    "test_data",
+    ["test_data_tabular_large", "test_data_tabular_small", "test_data_image", "test_data_text", "test_data_multimodal"],
+)
+def test_create_auto_config(test_data, ray_cluster_2cpu, request):
+    test_data = request.getfixturevalue(test_data)
     input_features, output_features, dataset_csv = test_data
     targets = [feature[NAME] for feature in output_features]
     df = dd.read_csv(dataset_csv)
-    config = create_auto_config(df, targets, time_limit_s=600, tune_for_memory=tune_for_memory, backend="ray")
+    config = create_auto_config(df, targets, time_limit_s=600, tune_for_memory=False, backend="ray")
+
+    assert to_name_set(config[INPUT_FEATURES]) == to_name_set(input_features)
+    assert to_name_set(config[OUTPUT_FEATURES]) == to_name_set(output_features)
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize("tune_for_memory", [True, False])
+def test_create_auto_config_tune_for_mem(tune_for_memory, test_data_tabular_large, ray_cluster_2cpu):
+    input_features, output_features, dataset_csv = test_data_tabular_large
+    targets = [feature[NAME] for feature in output_features]
+    df = dd.read_csv(dataset_csv)
+    config = create_auto_config(df, targets, time_limit_s=600, tune_for_memory=True, backend="ray")
 
     assert to_name_set(config[INPUT_FEATURES]) == to_name_set(input_features)
     assert to_name_set(config[OUTPUT_FEATURES]) == to_name_set(output_features)

--- a/tests/integration_tests/test_automl.py
+++ b/tests/integration_tests/test_automl.py
@@ -142,8 +142,8 @@ def test_create_auto_config_tune_for_mem(tune_for_memory, test_data_tabular_larg
 
 
 @pytest.mark.distributed
-def test_create_auto_config_with_dataset_profile(test_data, ray_cluster_2cpu):
-    input_features, output_features, dataset_csv = test_data
+def test_create_auto_config_with_dataset_profile(test_data_tabular_large, ray_cluster_2cpu):
+    input_features, output_features, dataset_csv = test_data_tabular_large
     targets = [feature[NAME] for feature in output_features]
     df = dd.read_csv(dataset_csv)
     config = create_auto_config_with_dataset_profile(dataset=df, target=targets[0], backend="ray")
@@ -218,12 +218,12 @@ def test_autoconfig_preprocessing_text_image(tmpdir):
 
 @pytest.mark.distributed
 @pytest.mark.parametrize("time_budget", [200, 1], ids=["high", "low"])
-def test_train_with_config(time_budget, test_data, ray_cluster_2cpu, tmpdir):
-    _run_train_with_config(time_budget, test_data, tmpdir)
+def test_train_with_config(time_budget, test_data_tabular_large, ray_cluster_2cpu, tmpdir):
+    _run_train_with_config(time_budget, test_data_tabular_large, tmpdir)
 
 
 @pytest.mark.parametrize("fs_protocol,bucket", [private_param(("s3", "ludwig-tests"))], ids=["s3"])
-def test_train_with_config_remote(fs_protocol, bucket, test_data, ray_cluster_2cpu):
+def test_train_with_config_remote(fs_protocol, bucket, test_data_tabular_large, ray_cluster_2cpu):
     backend = {
         "type": "local",
         "credentials": {
@@ -233,7 +233,7 @@ def test_train_with_config_remote(fs_protocol, bucket, test_data, ray_cluster_2c
 
     with remote_tmpdir(fs_protocol, bucket) as tmpdir:
         with pytest.raises(ValueError) if not _ray200 else contextlib.nullcontext():
-            _run_train_with_config(200, test_data, tmpdir, backend=backend)
+            _run_train_with_config(200, test_data_tabular_large, tmpdir, backend=backend)
 
 
 def _run_train_with_config(time_budget, test_data, tmpdir, **kwargs):


### PR DESCRIPTION
This PR makes the following changes

- Removes `features_metadata` as a returned value from `_create_default_config` and as an argument of `_model_select`
- Merges text feature default config into base config while iterating over features 
- Update docstring for `_create_default_config `
- Remove warnings from image utils's `is_image` function in case of AttributeErrors
- Filter `DeprecationWarning` in pytest
- Add test coverage for `_create_default_config` for small tabular, large tabular, image, text and multi modal datasets.

Fixes MLI-206 