### PR TITLE
fix: Restrict allowed top-level config keys

### DIFF
--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -238,6 +238,7 @@ MODEL_TYPE = "model_type"
 MODEL_ECD = "ecd"
 MODEL_GBM = "gbm"
 DASK_MODULE_NAME = "dask.dataframe"
+LUDWIG_VERSION = "ludwig_version"
 
 PREPROCESSOR = "preprocessor"
 PREDICTOR = "predictor"

--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -30,6 +30,7 @@ from ludwig.constants import (
     DEFAULTS,
     HYPEROPT,
     INPUT_FEATURES,
+    LUDWIG_VERSION,
     MODEL_ECD,
     MODEL_TYPE,
     OUTPUT_FEATURES,
@@ -47,6 +48,14 @@ from ludwig.schema.trainer import get_model_type_jsonschema, get_trainer_jsonsch
 VALIDATION_LOCK = Lock()
 
 
+def get_ludwig_version_jsonschema():
+    return {
+        "type": "string",
+        "title": "ludwig_version",
+        "description": "Current Ludwig model schema version.",
+    }
+
+
 @DeveloperAPI
 @lru_cache(maxsize=2)
 def get_schema(model_type: str = MODEL_ECD):
@@ -60,6 +69,7 @@ def get_schema(model_type: str = MODEL_ECD):
             PREPROCESSING: get_preprocessing_jsonschema(),
             HYPEROPT: get_hyperopt_jsonschema(),
             DEFAULTS: get_defaults_jsonschema(),
+            LUDWIG_VERSION: get_ludwig_version_jsonschema(),
         },
         "definitions": {},
         "required": [INPUT_FEATURES, OUTPUT_FEATURES],

--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -1,27 +1,7 @@
-#
-# Module structure:
-# ludwig.schema               <-- Meant to contain all schemas, utilities, helpers related to describing and validating
-#                                 Ludwig configs.
-# ├── __init__.py             <-- Contains fully assembled Ludwig schema (`get_schema()`), `validate_config()` for YAML
-#                                 validation, and all "top-level" schema functions.
-# ├── utils.py                <-- An extensive set of marshmallow-related fields, methods, and schemas that are used
-#                                 elsewhere in Ludwig.
-# ├── trainer.py              <-- Contains `TrainerConfig()` and `get_trainer_jsonschema`
-# ├── optimizers.py           <-- Contains every optimizer config (e.g. `SGDOptimizerConfig`, `AdamOptimizerConfig`,
-#                                 etc.) and related marshmallow fields/methods.
-# └── combiners/
-#     ├── __init__.py         <-- Imports for each combiner config file (making imports elsewhere more convenient).
-#     ├── utils.py            <-- Location of `combiner_registry`, `get_combiner_jsonschema()`, `get_combiner_conds()`
-#     ├── base.py             <-- Location of `BaseCombinerConfig`
-#     ├── comparator.py       <-- Location of `ComparatorCombinerConfig`
-#     ... <file for each combiner> ...
-#     └──  transformer.py     <-- Location of `TransformerCombinerConfig`
-#
-
 from functools import lru_cache
 from threading import Lock
 
-from jsonschema import Draft7Validator, validate  # , ValidationError
+from jsonschema import Draft7Validator, validate
 from jsonschema.validators import extend
 
 from ludwig.api_annotations import DeveloperAPI
@@ -110,10 +90,4 @@ def validate_config(config):
     splitter.validate(updated_config)
 
     with VALIDATION_LOCK:
-        # There is a race condition during schema validation that can cause the marshmallow schema class to
-        # be missing during validation if more than one thread is trying to validate at once.
-        # try:
-        #     validate(instance=updated_config, schema=get_schema(model_type=model_type), cls=get_validator())
-        # except ValidationError as e:
-        #     print(e.schema_path)
         validate(instance=updated_config, schema=get_schema(model_type=model_type), cls=get_validator())

--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -63,6 +63,7 @@ def get_schema(model_type: str = MODEL_ECD):
         },
         "definitions": {},
         "required": [INPUT_FEATURES, OUTPUT_FEATURES],
+        "additionalProperties": False,
     }
 
     if model_type == MODEL_ECD:

--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -21,7 +21,7 @@
 from functools import lru_cache
 from threading import Lock
 
-from jsonschema import Draft7Validator, validate
+from jsonschema import Draft7Validator, validate  # , ValidationError
 from jsonschema.validators import extend
 
 from ludwig.api_annotations import DeveloperAPI
@@ -112,4 +112,8 @@ def validate_config(config):
     with VALIDATION_LOCK:
         # There is a race condition during schema validation that can cause the marshmallow schema class to
         # be missing during validation if more than one thread is trying to validate at once.
+        # try:
+        #     validate(instance=updated_config, schema=get_schema(model_type=model_type), cls=get_validator())
+        # except ValidationError as e:
+        #     print(e.schema_path)
         validate(instance=updated_config, schema=get_schema(model_type=model_type), cls=get_validator())

--- a/ludwig/schema/model_config.py
+++ b/ludwig/schema/model_config.py
@@ -124,12 +124,9 @@ class ModelConfig(BaseMarshmallowConfig):
     """
 
     def __init__(self, config_dict: ModelConfigDict):
-        print("dog")
-        print(config_dict.keys())
 
         # ===== Backwards Compatibility =====
         upgraded_config_dict = self._upgrade_config(config_dict)
-        print(config_dict.keys())
 
         # ===== Initialize Top Level Config Sections =====
 
@@ -201,7 +198,6 @@ class ModelConfig(BaseMarshmallowConfig):
         self._set_hyperopt_defaults()
 
         # ===== Validate Config =====
-        print(self.to_dict().keys())
         if self.model_type == MODEL_GBM:
             self.combiner = None
 

--- a/ludwig/schema/model_config.py
+++ b/ludwig/schema/model_config.py
@@ -124,9 +124,12 @@ class ModelConfig(BaseMarshmallowConfig):
     """
 
     def __init__(self, config_dict: ModelConfigDict):
+        print("dog")
+        print(config_dict.keys())
 
         # ===== Backwards Compatibility =====
         upgraded_config_dict = self._upgrade_config(config_dict)
+        print(config_dict.keys())
 
         # ===== Initialize Top Level Config Sections =====
 
@@ -198,6 +201,10 @@ class ModelConfig(BaseMarshmallowConfig):
         self._set_hyperopt_defaults()
 
         # ===== Validate Config =====
+        print(self.to_dict().keys())
+        if self.model_type == MODEL_GBM:
+            self.combiner = None
+
         self._validate_config(self.to_dict())
 
     def __repr__(self):
@@ -533,10 +540,12 @@ class ModelConfig(BaseMarshmallowConfig):
             "model_type": self.model_type,
             "input_features": input_features,
             "output_features": output_features,
-            "combiner": self.combiner.to_dict(),
             "trainer": self.trainer.to_dict(),
             "preprocessing": self.preprocessing.to_dict(),
             "hyperopt": self.hyperopt,
             "defaults": self.defaults.to_dict(),
         }
+
+        if self.combiner is not None:
+            config_dict["combiner"] = self.combiner.to_dict()
         return convert_submodules(config_dict)

--- a/tests/ludwig/schema/test_validate_config_misc.py
+++ b/tests/ludwig/schema/test_validate_config_misc.py
@@ -393,3 +393,19 @@ def test_ludwig_schema_serialization(model_type):
         raise TypeError(
             f"Ludwig schema of type `{model_type}` cannot be represented by valid JSON. See further details: {e}"
         )
+
+
+def test_top_level_schema_keys():
+    config = {
+        "model_type": "gbm",  # Typo
+        "input_features": [
+            category_feature(),
+            number_feature(),
+        ],
+        "output_features": [category_feature(output_feature=True)],
+        "trainer": {"learning_rate": "auto", "batch_size": "auto"},
+        "combiner": "test",
+    }
+
+    # Ensure validation succeeds with ECD trainer params and ECD model type
+    validate_config(config)

--- a/tests/ludwig/schema/test_validate_config_misc.py
+++ b/tests/ludwig/schema/test_validate_config_misc.py
@@ -393,19 +393,3 @@ def test_ludwig_schema_serialization(model_type):
         raise TypeError(
             f"Ludwig schema of type `{model_type}` cannot be represented by valid JSON. See further details: {e}"
         )
-
-
-def test_top_level_schema_keys():
-    config = {
-        "model_type": "gbm",  # Typo
-        "input_features": [
-            category_feature(),
-            number_feature(),
-        ],
-        "output_features": [category_feature(output_feature=True)],
-        "trainer": {"learning_rate": "auto", "batch_size": "auto"},
-        "combiner": "test",
-    }
-
-    # Ensure validation succeeds with ECD trainer params and ECD model type
-    validate_config(config)


### PR DESCRIPTION
By setting `additionalProperties` to `False` at the top level of the schema, a user is prevented from entering erroneous values like `type` instead of `model_type` (or from otherwise making typos for top-level keys).