### PR TITLE
Use native LightGBM for intermittent eval during training

### DIFF
--- a/ludwig/models/gbm.py
+++ b/ludwig/models/gbm.py
@@ -98,24 +98,24 @@ class GBM(BaseModel):
             raise ValueError("Model has not been trained yet.")
 
         if isinstance(inputs, tuple):
-            inputs, targets = inputs
+            inputs, _ = inputs
             # Convert targets to tensors.
-            for target_feature_name, target_value in targets.items():
-                if not isinstance(target_value, torch.Tensor):
-                    targets[target_feature_name] = torch.from_numpy(target_value)
-                else:
-                    targets[target_feature_name] = target_value
-        else:
-            targets = None
+            # for target_feature_name, target_value in targets.items():
+            #     if not isinstance(target_value, torch.Tensor):
+            #         targets[target_feature_name] = torch.from_numpy(target_value)
+            #     else:
+            #         targets[target_feature_name] = target_value
+        # else:
+        #     targets = None
 
         assert list(inputs.keys()) == self.input_features.keys()
 
         # Convert inputs to tensors of type float as expected by hummingbird GEMMTreeImpl.
-        for input_feature_name, input_values in inputs.items():
-            if not isinstance(input_values, torch.Tensor):
-                inputs[input_feature_name] = torch.from_numpy(input_values).float()
-            else:
-                inputs[input_feature_name] = input_values.view(-1, 1).float()
+        # for input_feature_name, input_values in inputs.items():
+        #     if not isinstance(input_values, torch.Tensor):
+        #         inputs[input_feature_name] = torch.from_numpy(input_values).float()
+        #     else:
+        #         inputs[input_feature_name] = input_values.view(-1, 1).float()
 
         # TODO(travis): include encoder and decoder steps during inference
         # encoder_outputs = {}
@@ -125,44 +125,55 @@ class GBM(BaseModel):
         #     encoder_outputs[input_feature_name] = encoder_output
 
         # concatenate inputs
-        inputs = torch.cat(list(inputs.values()), dim=1)
+        # inputs = torch.cat(list(inputs.values()), dim=1)
 
         # Invoke output features.
         output_logits = {}
         output_feature_name = self.output_features.keys()[0]
         output_feature = self.output_features[output_feature_name]
 
-        assert (
-            type(inputs) is torch.Tensor
-            and inputs.dtype == torch.float32
-            and inputs.ndim == 2
-            and inputs.shape[1] == len(self.input_features)
-        ), (
-            f"Expected inputs to be a 2D tensor of shape (batch_size, {len(self.input_features)}) of type float32, "
-            f"but got {inputs.shape} of type {inputs.dtype}"
-        )
+        # assert (
+        #     type(inputs) is torch.Tensor
+        #     and inputs.dtype == torch.float32
+        #     and inputs.ndim == 2
+        #     and inputs.shape[1] == len(self.input_features)
+        # ), (
+        #     f"Expected inputs to be a 2D tensor of shape (batch_size, {len(self.input_features)}) of type float32, "
+        #     f"but got {inputs.shape} of type {inputs.dtype}"
+        # )
         # Predict using PyTorch module, so it is included when converting to TorchScript.
-        preds = self.compiled_model.model(inputs)
+        # preds = self.compiled_model.model(inputs)
+
+        in_array = np.stack(list(inputs.values()), axis=0).T
 
         if output_feature.type() == NUMBER:
-            # regression
+            preds = torch.from_numpy(self.lgbm_model.predict(in_array))
             logits = preds.view(-1)
         else:
-            # classification
-            _, probs = preds
-
+            probs = torch.from_numpy(self.lgbm_model.predict_proba(in_array))
             if output_feature.type() == BINARY:
-                # keep positive class only for binary feature
-                probs = probs[:, 1]  # shape (batch_size,)
-            elif output_feature.num_classes > 2:
-                probs = probs.view(-1, 2, output_feature.num_classes)  # shape (batch_size, 2, num_classes)
-                probs = probs.transpose(2, 1)  # shape (batch_size, num_classes, 2)
+                probs = torch.logit(probs[:, 1])
+            logits = probs
 
-                # probabilities for belonging to each class
-                probs = probs[:, :, 1]  # shape (batch_size, num_classes)
+        # if output_feature.type() == NUMBER:
+        #     # regression
+        #     logits = preds.view(-1)
+        # else:
+        #     # classification
+        #     _, probs = preds
 
-            # invert sigmoid to get back logits and use Ludwig's output feature prediction functionality
-            logits = torch.logit(probs)
+        #     if output_feature.type() == BINARY:
+        #         # keep positive class only for binary feature
+        #         probs = probs[:, 1]  # shape (batch_size,)
+        #     elif output_feature.num_classes > 2:
+        #         probs = probs.view(-1, 2, output_feature.num_classes)  # shape (batch_size, 2, num_classes)
+        #         probs = probs.transpose(2, 1)  # shape (batch_size, num_classes, 2)
+
+        #         # probabilities for belonging to each class
+        #         probs = probs[:, :, 1]  # shape (batch_size, num_classes)
+
+        #     # invert sigmoid to get back logits and use Ludwig's output feature prediction functionality
+        #     logits = torch.logit(probs)
 
         output_feature_utils.set_output_feature_tensor(output_logits, output_feature_name, LOGITS, logits)
 

--- a/ludwig/models/gbm.py
+++ b/ludwig/models/gbm.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import contextmanager
 from typing import Dict, Optional, Tuple, Union
 
 import lightgbm as lgb
@@ -74,6 +75,7 @@ class GBM(BaseModel):
 
         return output_features
 
+    @contextmanager
     def compile(self):
         """Convert the LightGBM model to a PyTorch model and store internally."""
         if self.lgbm_model is None:
@@ -86,6 +88,8 @@ class GBM(BaseModel):
             else {}
         )
         self.compiled_model = convert(self.lgbm_model, "torch", extra_config=extra_config)
+        yield
+        self.compiled_model = None
 
     def forward(
         self,
@@ -99,30 +103,97 @@ class GBM(BaseModel):
         output_feature_name = self.output_features.keys()[0]
         output_feature = self.output_features[output_feature_name]
 
-        # If `inputs` is a tuple, it should contain (inputs, targets). When using the LGBM sklearn interface, targets
-        # is not needed, so we extract the inputs here.
-        if isinstance(inputs, tuple):
-            inputs, _ = inputs
+        # If the model has not been compiled, predict using the LightGBM sklearn iterface. Otherwise, use torch with
+        # the Hummingbird compiled model. Notably, when compiling the model to torchscript, compiling with Hummingbird
+        # first should preserve the torch predictions code path.
+        if self.compiled_model is None:
+            # If `inputs` is a tuple, it should contain `(inputs, targets)``. When using the LGBM sklearn interface,
+            # `targets` is not needed, so it is discarded here.
+            if isinstance(inputs, tuple):
+                inputs, _ = inputs
 
-        assert list(inputs.keys()) == self.input_features.keys()
+            assert list(inputs.keys()) == self.input_features.keys()
 
-        # The LGBM sklearn interface works with array-likes, so we place the inputs into a 2D numpy array.
-        in_array = np.stack(list(inputs.values()), axis=0).T
+            # The LGBM sklearn interface works with array-likes, so we place the inputs into a 2D numpy array.
+            in_array = np.stack(list(inputs.values()), axis=0).T
 
-        # Predict on the input batch. The predictions are then converted to torch tensors so that we can pass them to
-        # the existing metrics modules.
-        if output_feature.type() == NUMBER:
-            # Input: 2D eval_batch_size x n_features array
-            # Output: 1D eval_batch_size array
-            preds = torch.from_numpy(self.lgbm_model.predict(in_array))
-            logits = preds.view(-1)
+            # Predict on the input batch and convert the predictions to torch tensors so that they are compatible with
+            # the existing metrics modules.
+            if output_feature.type() == NUMBER:
+                # Input: 2D eval_batch_size x n_features array
+                # Output: 1D eval_batch_size array
+                preds = torch.from_numpy(self.lgbm_model.predict(in_array))
+                logits = preds.view(-1)
+            else:
+                # Input: 2D eval_batch_size x n_features array
+                # Output: 2D eval_batch_size x n_classes array
+                probs = torch.from_numpy(self.lgbm_model.predict_proba(in_array))
+                if output_feature.type() == BINARY:
+                    probs = torch.logit(probs[:, 1])
+                logits = probs
+
         else:
-            # Input: 2D eval_batch_size x n_features array
-            # Output: 2D eval_batch_size x n_classes array
-            probs = torch.from_numpy(self.lgbm_model.predict_proba(in_array))
-            if output_feature.type() == BINARY:
-                probs = torch.logit(probs[:, 1])
-            logits = probs
+            if isinstance(inputs, tuple):
+                inputs, targets = inputs
+                # Convert targets to tensors.
+                for target_feature_name, target_value in targets.items():
+                    if not isinstance(target_value, torch.Tensor):
+                        targets[target_feature_name] = torch.from_numpy(target_value)
+                    else:
+                        targets[target_feature_name] = target_value
+            else:
+                targets = None
+
+            assert list(inputs.keys()) == self.input_features.keys()
+
+            # Convert inputs to tensors of type float as expected by hummingbird GEMMTreeImpl.
+            for input_feature_name, input_values in inputs.items():
+                if not isinstance(input_values, torch.Tensor):
+                    inputs[input_feature_name] = torch.from_numpy(input_values).float()
+                else:
+                    inputs[input_feature_name] = input_values.view(-1, 1).float()
+
+            # TODO(travis): include encoder and decoder steps during inference
+            # encoder_outputs = {}
+            # for input_feature_name, input_values in inputs.items():
+            #     encoder = self.input_features[input_feature_name]
+            #     encoder_output = encoder(input_values)
+            #     encoder_outputs[input_feature_name] = encoder_output
+
+            # concatenate inputs
+            inputs = torch.cat(list(inputs.values()), dim=1)
+
+            assert (
+                type(inputs) is torch.Tensor
+                and inputs.dtype == torch.float32
+                and inputs.ndim == 2
+                and inputs.shape[1] == len(self.input_features)
+            ), (
+                f"Expected inputs to be a 2D tensor of shape (batch_size, {len(self.input_features)}) of type float32, "
+                f"but got {inputs.shape} of type {inputs.dtype}"
+            )
+            # Predict using PyTorch module, so it is included when converting to TorchScript.
+            preds = self.compiled_model.model(inputs)
+
+            if output_feature.type() == NUMBER:
+                # regression
+                logits = preds.view(-1)
+            else:
+                # classification
+                _, probs = preds
+
+                if output_feature.type() == BINARY:
+                    # keep positive class only for binary feature
+                    probs = probs[:, 1]  # shape (batch_size,)
+                elif output_feature.num_classes > 2:
+                    probs = probs.view(-1, 2, output_feature.num_classes)  # shape (batch_size, 2, num_classes)
+                    probs = probs.transpose(2, 1)  # shape (batch_size, num_classes, 2)
+
+                    # probabilities for belonging to each class
+                    probs = probs[:, :, 1]  # shape (batch_size, num_classes)
+
+                # invert sigmoid to get back logits and use Ludwig's output feature prediction functionality
+                logits = torch.logit(probs)
 
         output_feature_utils.set_output_feature_tensor(output_logits, output_feature_name, LOGITS, logits)
 
@@ -145,18 +216,15 @@ class GBM(BaseModel):
         weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
         self.lgbm_model = joblib.load(weights_save_path)
 
-        self.compile()
-
-        device = torch.device(get_torch_device())
-        self.compiled_model.to(device)
-
     def to_torchscript(self, device: Optional[TorchDevice] = None):
         """Converts the ECD model as a TorchScript model."""
-
-        # Disable gradient calculation for hummingbird Parameter nodes.
-        self.compiled_model.model.requires_grad_(False)
-
-        return super().to_torchscript(device)
+        with self.compile():
+            # Disable gradient calculation for hummingbird Parameter nodes.
+            device = torch.device(get_torch_device())
+            self.compiled_model.to(device)
+            self.compiled_model.model.requires_grad_(False)
+            trace = super().to_torchscript(device)
+        return trace
 
     def get_args(self):
         """Returns init arguments for constructing this model."""

--- a/ludwig/models/gbm.py
+++ b/ludwig/models/gbm.py
@@ -94,86 +94,98 @@ class GBM(BaseModel):
         ],
         mask=None,
     ) -> Dict[str, torch.Tensor]:
-        if self.compiled_model is None:
-            raise ValueError("Model has not been trained yet.")
-
-        if isinstance(inputs, tuple):
-            inputs, _ = inputs
-            # Convert targets to tensors.
-            # for target_feature_name, target_value in targets.items():
-            #     if not isinstance(target_value, torch.Tensor):
-            #         targets[target_feature_name] = torch.from_numpy(target_value)
-            #     else:
-            #         targets[target_feature_name] = target_value
-        # else:
-        #     targets = None
-
-        assert list(inputs.keys()) == self.input_features.keys()
-
-        # Convert inputs to tensors of type float as expected by hummingbird GEMMTreeImpl.
-        # for input_feature_name, input_values in inputs.items():
-        #     if not isinstance(input_values, torch.Tensor):
-        #         inputs[input_feature_name] = torch.from_numpy(input_values).float()
-        #     else:
-        #         inputs[input_feature_name] = input_values.view(-1, 1).float()
-
-        # TODO(travis): include encoder and decoder steps during inference
-        # encoder_outputs = {}
-        # for input_feature_name, input_values in inputs.items():
-        #     encoder = self.input_features[input_feature_name]
-        #     encoder_output = encoder(input_values)
-        #     encoder_outputs[input_feature_name] = encoder_output
-
-        # concatenate inputs
-        # inputs = torch.cat(list(inputs.values()), dim=1)
-
         # Invoke output features.
         output_logits = {}
         output_feature_name = self.output_features.keys()[0]
         output_feature = self.output_features[output_feature_name]
 
-        # assert (
-        #     type(inputs) is torch.Tensor
-        #     and inputs.dtype == torch.float32
-        #     and inputs.ndim == 2
-        #     and inputs.shape[1] == len(self.input_features)
-        # ), (
-        #     f"Expected inputs to be a 2D tensor of shape (batch_size, {len(self.input_features)}) of type float32, "
-        #     f"but got {inputs.shape} of type {inputs.dtype}"
-        # )
-        # Predict using PyTorch module, so it is included when converting to TorchScript.
-        # preds = self.compiled_model.model(inputs)
+        if get_torch_device() == "gpu":
+            if self.compiled_model is None:
+                raise ValueError("Model has not been trained yet.")
 
-        in_array = np.stack(list(inputs.values()), axis=0).T
+            self.compiled_model.model.cuda()
 
-        if output_feature.type() == NUMBER:
-            preds = torch.from_numpy(self.lgbm_model.predict(in_array))
-            logits = preds.view(-1)
+            if isinstance(inputs, tuple):
+                inputs, targets = inputs
+                # Convert targets to tensors.
+                for target_feature_name, target_value in targets.items():
+                    if not isinstance(target_value, torch.Tensor):
+                        targets[target_feature_name] = torch.from_numpy(target_value)
+                    else:
+                        targets[target_feature_name] = target_value
+            else:
+                targets = None
+
+            assert list(inputs.keys()) == self.input_features.keys()
+
+            # Convert inputs to tensors of type float as expected by hummingbird GEMMTreeImpl.
+            for input_feature_name, input_values in inputs.items():
+                if not isinstance(input_values, torch.Tensor):
+                    inputs[input_feature_name] = torch.from_numpy(input_values).float()
+                else:
+                    inputs[input_feature_name] = input_values.view(-1, 1).float()
+
+            # TODO(travis): include encoder and decoder steps during inference
+            # encoder_outputs = {}
+            # for input_feature_name, input_values in inputs.items():
+            #     encoder = self.input_features[input_feature_name]
+            #     encoder_output = encoder(input_values)
+            #     encoder_outputs[input_feature_name] = encoder_output
+
+            # concatenate inputs
+            inputs = torch.cat(list(inputs.values()), dim=1).cuda()
+
+            assert (
+                type(inputs) is torch.Tensor
+                and inputs.dtype == torch.float32
+                and inputs.ndim == 2
+                and inputs.shape[1] == len(self.input_features)
+            ), (
+                f"Expected inputs to be a 2D tensor of shape (batch_size, {len(self.input_features)}) of type float32, "
+                f"but got {inputs.shape} of type {inputs.dtype}"
+            )
+
+            # Predict using PyTorch module, so it is included when converting to TorchScript.
+            preds = self.compiled_model.model(inputs).cpu()
+            self.compiled_model.model.cpu()
+            inputs = inputs.cpu()
+
+            if output_feature.type() == NUMBER:
+                # regression
+                logits = preds.view(-1)
+            else:
+                # classification
+                _, probs = preds
+
+                if output_feature.type() == BINARY:
+                    # keep positive class only for binary feature
+                    probs = probs[:, 1]  # shape (batch_size,)
+                elif output_feature.num_classes > 2:
+                    probs = probs.view(-1, 2, output_feature.num_classes)  # shape (batch_size, 2, num_classes)
+                    probs = probs.transpose(2, 1)  # shape (batch_size, num_classes, 2)
+
+                    # probabilities for belonging to each class
+                    probs = probs[:, :, 1]  # shape (batch_size, num_classes)
+
+                # invert sigmoid to get back logits and use Ludwig's output feature prediction functionality
+                logits = torch.logit(probs)
+
         else:
-            probs = torch.from_numpy(self.lgbm_model.predict_proba(in_array))
-            if output_feature.type() == BINARY:
-                probs = torch.logit(probs[:, 1])
-            logits = probs
+            if isinstance(inputs, tuple):
+                inputs, _ = inputs
 
-        # if output_feature.type() == NUMBER:
-        #     # regression
-        #     logits = preds.view(-1)
-        # else:
-        #     # classification
-        #     _, probs = preds
+            assert list(inputs.keys()) == self.input_features.keys()
 
-        #     if output_feature.type() == BINARY:
-        #         # keep positive class only for binary feature
-        #         probs = probs[:, 1]  # shape (batch_size,)
-        #     elif output_feature.num_classes > 2:
-        #         probs = probs.view(-1, 2, output_feature.num_classes)  # shape (batch_size, 2, num_classes)
-        #         probs = probs.transpose(2, 1)  # shape (batch_size, num_classes, 2)
+            in_array = np.stack(list(inputs.values()), axis=0).T
 
-        #         # probabilities for belonging to each class
-        #         probs = probs[:, :, 1]  # shape (batch_size, num_classes)
-
-        #     # invert sigmoid to get back logits and use Ludwig's output feature prediction functionality
-        #     logits = torch.logit(probs)
+            if output_feature.type() == NUMBER:
+                preds = torch.from_numpy(self.lgbm_model.predict(in_array))
+                logits = preds.view(-1)
+            else:
+                probs = torch.from_numpy(self.lgbm_model.predict_proba(in_array))
+                if output_feature.type() == BINARY:
+                    probs = torch.logit(probs[:, 1])
+                logits = probs
 
         output_feature_utils.set_output_feature_tensor(output_logits, output_feature_name, LOGITS, logits)
 

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -347,13 +347,13 @@ class GBMTrainerConfig(BaseTrainerConfig):
     # NOTE: Overwritten here to provide a default value. In many places, we fall back to eval_batch_size if batch_size
     # is not specified. GBM does not have a value for batch_size, so we need to specify eval_batch_size here.
     eval_batch_size: Union[None, int, str] = schema_utils.PositiveInteger(
-        default=1024,
+        default=1048576,
         description="Size of batch to pass to the model for evaluation.",
         parameter_metadata=TRAINER_METADATA["eval_batch_size"],
     )
 
     evaluate_training_set: bool = schema_utils.Boolean(
-        default=True,
+        default=False,
         description="Whether to include the entire training set during evaluation.",
         parameter_metadata=TRAINER_METADATA["evaluate_training_set"],
     )

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -353,7 +353,7 @@ class GBMTrainerConfig(BaseTrainerConfig):
     )
 
     evaluate_training_set: bool = schema_utils.Boolean(
-        default=False,
+        default=True,
         description="Whether to include the entire training set during evaluation.",
         parameter_metadata=TRAINER_METADATA["evaluate_training_set"],
     )

--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -367,10 +367,6 @@ class LightGBMTrainer(BaseTrainer):
         progress_tracker.steps += self.boosting_rounds_per_checkpoint
         progress_tracker.last_improvement_steps = self.model.lgbm_model.best_iteration_
 
-        # convert to pytorch for inference
-        self.model.compile()
-        self.model = self.model.to(self.device)
-
         output_features = self.model.output_features
         metrics_names = get_metric_names(output_features)
         output_feature_name = next(iter(output_features))

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -209,16 +209,19 @@ def test_ray_gbm_number(tmpdir, ray_backend, ray_cluster_4cpu):
 
 
 def test_hummingbird_conversion_binary(tmpdir, local_backend):
+    """Verify that Hummingbird conversion predictions match LightGBM predictions for binary outputs."""
     input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
     output_features = [binary_feature()]
     output_feature = f'{output_features[0]["name"]}_probabilities'
 
+    # Train a model and predict using the LightGBM interface
     preds_lgbm, model = _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend)
     probs_lgbm = preds_lgbm[output_feature]
 
     _, _, test, _ = model.preprocess(os.path.join(tmpdir, "training.csv"))
     test_inputs = test.to_df(model.model.input_features.values())
 
+    # Predict using the Hummingbird compiled model
     with model.model.compile():
         preds_hb, _ = model.predict(dataset=test_inputs)
         probs_hb = preds_hb[output_feature]
@@ -228,24 +231,30 @@ def test_hummingbird_conversion_binary(tmpdir, local_backend):
 
 
 def test_hummingbird_conversion_regression(tmpdir, local_backend):
+    """Verify that Hummingbird conversion predictions match LightGBM predictions for numeric outputs."""
     input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
     output_features = [number_feature()]
 
+    # Train a model and predict using the LightGBM interface
     preds_lgbm, model = _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend)
     _, _, test, _ = model.preprocess(os.path.join(tmpdir, "training.csv"))
     test_inputs = test.to_df(model.model.input_features.values())
 
+    # Predict using the Hummingbird compiled model
     with model.model.compile():
         preds_hb, _ = model.predict(dataset=test_inputs)
 
+    # sanity check Hummingbird prediction equal to LightGBM prediction
     assert np.allclose(preds_hb.values, preds_lgbm)
 
 
 @pytest.mark.parametrize("vocab_size", [2, 3])
 def test_hummingbird_conversion_category(vocab_size, tmpdir, local_backend):
+    """Verify that Hummingbird conversion predictions match LightGBM predictions for categorical outputs."""
     input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
     output_features = [category_feature(decoder={"vocab_size": vocab_size})]
 
+    # Train a model and predict using the LightGBM interface
     preds_lgbm, model = _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend)
     output_feature = next(iter(model.model.output_features.values()))
     output_feature_name = f"{output_feature.column}_probabilities"
@@ -254,6 +263,7 @@ def test_hummingbird_conversion_category(vocab_size, tmpdir, local_backend):
     _, _, test, _ = model.preprocess(os.path.join(tmpdir, "training.csv"))
     test_inputs = test.to_df(model.model.input_features.values())
 
+    # Predict using the Hummingbird compiled model
     with model.model.compile():
         preds_hb, _ = model.predict(dataset=test_inputs)
         probs_hb = np.stack(preds_hb[output_feature_name].to_numpy())

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -7,7 +7,6 @@ try:
     import ray as _ray
 except ImportError:
     _ray = None
-import torch
 from jsonschema.exceptions import ValidationError
 
 from ludwig.api import LudwigModel
@@ -212,31 +211,32 @@ def test_ray_gbm_number(tmpdir, ray_backend, ray_cluster_4cpu):
 def test_hummingbird_conversion_binary(tmpdir, local_backend):
     input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
     output_features = [binary_feature()]
+    output_feature = f'{output_features[0]["name"]}_probabilities'
 
-    preds_hb, model = _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend)
+    preds_lgbm, model = _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend)
+    probs_lgbm = preds_lgbm[output_feature]
 
     _, _, test, _ = model.preprocess(os.path.join(tmpdir, "training.csv"))
     test_inputs = test.to_df(model.model.input_features.values())
 
-    output_feature = output_features[0]
-
-    probs_hb = preds_hb[f'{output_feature["name"]}_probabilities']
-    probs_lgbm = model.model.lgbm_model.predict_proba(test_inputs)
+    with model.model.compile():
+        preds_hb, _ = model.predict(dataset=test_inputs)
+        probs_hb = preds_hb[output_feature]
 
     # sanity check Hummingbird probabilities equal to LightGBM probabilities
-    assert np.allclose(np.stack(probs_hb.values), probs_lgbm, atol=1e-8)
+    assert np.allclose(np.stack(probs_hb.values), np.stack(probs_lgbm.values), atol=1e-8)
 
 
 def test_hummingbird_conversion_regression(tmpdir, local_backend):
     input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
     output_features = [number_feature()]
 
-    preds_hb, model = _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend)
-
+    preds_lgbm, model = _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend)
     _, _, test, _ = model.preprocess(os.path.join(tmpdir, "training.csv"))
     test_inputs = test.to_df(model.model.input_features.values())
 
-    preds_lgbm = model.model.lgbm_model.predict(test_inputs)
+    with model.model.compile():
+        preds_hb, _ = model.predict(dataset=test_inputs)
 
     assert np.allclose(preds_hb.values, preds_lgbm)
 
@@ -246,26 +246,20 @@ def test_hummingbird_conversion_category(vocab_size, tmpdir, local_backend):
     input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
     output_features = [category_feature(decoder={"vocab_size": vocab_size})]
 
-    preds_hb, model = _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend)
+    preds_lgbm, model = _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend)
+    output_feature = next(iter(model.model.output_features.values()))
+    output_feature_name = f"{output_feature.column}_probabilities"
+    probs_lgbm = np.stack(preds_lgbm[output_feature_name].to_numpy())
 
     _, _, test, _ = model.preprocess(os.path.join(tmpdir, "training.csv"))
     test_inputs = test.to_df(model.model.input_features.values())
 
-    output_feature = next(iter(model.model.output_features.values()))
-
-    probs_hb = preds_hb[f"{output_feature.column}_probabilities"]
-
-    if output_feature.num_classes == 2:
-        # LightGBM binary classifier transforms logits using sigmoid, so we need to invert the
-        # transformation to get the logits back, and then use softmax to get the probabilities to match
-        # Ludwig's category feature prediction behavior.
-        probs_lgbm = torch.softmax(torch.logit(torch.from_numpy(model.model.lgbm_model.predict_proba(test_inputs))), -1)
-    else:
-        # Otherwise, just compare to the raw probabilities from LightGBM
-        probs_lgbm = model.model.lgbm_model.predict_proba(test_inputs)
+    with model.model.compile():
+        preds_hb, _ = model.predict(dataset=test_inputs)
+        probs_hb = np.stack(preds_hb[output_feature_name].to_numpy())
 
     # sanity check Hummingbird probabilities equal to LightGBM probabilities
-    assert np.allclose(np.stack(probs_hb.values), probs_lgbm, atol=1e-4)
+    assert np.allclose(probs_hb, probs_lgbm, atol=1e-4)
 
 
 def test_loss_decreases(tmpdir, local_backend):

--- a/tests/integration_tests/test_model_save_and_load.py
+++ b/tests/integration_tests/test_model_save_and_load.py
@@ -187,9 +187,16 @@ def test_gbm_model_save_reload_api(tmpdir, csv_filename, tmp_path):
             for if1_w, if2_w in zip(if1.encoder_obj.parameters(), if2.encoder_obj.parameters()):
                 assert torch.allclose(if1_w, if2_w)
 
-        tree1 = ludwig_model1.model.compiled_model.model
-        tree2 = ludwig_model2.model.compiled_model.model
-        for t1_w, t2_w in zip(tree1.parameters(), tree2.parameters()):
+        tree1 = ludwig_model1.model
+        tree2 = ludwig_model2.model
+
+        with tree1.compile():
+            tree1_params = tree1.compiled_model.model.parameters()
+
+        with tree2.compile():
+            tree2_params = tree2.compiled_model.model.parameters()
+
+        for t1_w, t2_w in zip(tree1_params, tree2_params):
             assert torch.allclose(t1_w, t2_w)
 
         for of_name in ludwig_model1.model.output_features:


### PR DESCRIPTION
During GBM training, we intermittently run an eval step for metrics reporting and early stopping detection. Based on a benchmarking sweep over eval batch sizes using two 1GB datasets (Criteo 1GB and HIggs) it was determined that native LightGBM eval outperformed Hummingbird-compiled pytorch models. This update refactors the in-training eval step to use LightGBM's sklearn interface and updates the default eval batch size to 1,048,576 (which should in many cases encompass the validation and test sets). Additionally, eval on the training set is now disabled by default.