### PR TITLE
Catch and surface Runtime exceptions during preprocessing

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1335,48 +1335,50 @@ class LudwigModel:
     ) -> PreprocessedDataset:
         """This function is used to preprocess data.
 
-        # Inputs
+        # Args:
+            :param dataset: (Union[str, dict, pandas.DataFrame], default: `None`)
+                source containing the entire dataset to be used in the experiment.
+                If it has a split column, it will be used for splitting
+                (0 for train, 1 for validation, 2 for test),
+                otherwise the dataset will be randomly split.
+            :param training_set: (Union[str, dict, pandas.DataFrame], default: `None`)
+                source containing training data.
+            :param validation_set: (Union[str, dict, pandas.DataFrame], default: `None`)
+                source containing validation data.
+            :param test_set: (Union[str, dict, pandas.DataFrame], default: `None`)
+                source containing test data.
+            :param training_set_metadata: (Union[str, dict], default: `None`)
+                metadata JSON file or loaded metadata. Intermediate preprocessed
+            structure containing the mappings of the input
+                dataset created the first time an input file is used in the same
+                directory with the same name and a '.meta.json' extension.
+            :param data_format: (str, default: `None`) format to interpret data
+                sources. Will be inferred automatically if not specified.  Valid
+                formats are `'auto'`, `'csv'`, `'df'`, `'dict'`, `'excel'`,
+                `'feather'`, `'fwf'`,
+                `'hdf5'` (cache file produced during previous training),
+                `'html'` (file containing a single HTML `<table>`),
+                `'json'`, `'jsonl'`, `'parquet'`,
+                `'pickle'` (pickled Pandas DataFrame),
+                `'sas'`, `'spss'`, `'stata'`, `'tsv'`.
+            :param skip_save_processed_input: (bool, default: `False`) if input
+                dataset is provided it is preprocessed and cached by saving an HDF5
+                and JSON files to avoid running the preprocessing again. If this
+                parameter is `False`, the HDF5 and JSON file are not saved.
+            :param output_directory: (str, default: `'results'`) the directory that
+                will contain the training statistics, TensorBoard logs, the saved
+                model and the training progress files.
+            :param random_seed: (int, default: `42`) a random seed that will be
+                used anywhere there is a call to a random number generator: data
+                splitting, parameter initialization and training set shuffling
 
-        :param dataset: (Union[str, dict, pandas.DataFrame], default: `None`)
-            source containing the entire dataset to be used in the experiment.
-            If it has a split column, it will be used for splitting
-            (0 for train, 1 for validation, 2 for test),
-            otherwise the dataset will be randomly split.
-        :param training_set: (Union[str, dict, pandas.DataFrame], default: `None`)
-            source containing training data.
-        :param validation_set: (Union[str, dict, pandas.DataFrame], default: `None`)
-            source containing validation data.
-        :param test_set: (Union[str, dict, pandas.DataFrame], default: `None`)
-            source containing test data.
-        :param training_set_metadata: (Union[str, dict], default: `None`)
-            metadata JSON file or loaded metadata. Intermediate preprocessed
-        structure containing the mappings of the input
-            dataset created the first time an input file is used in the same
-            directory with the same name and a '.meta.json' extension.
-        :param data_format: (str, default: `None`) format to interpret data
-            sources. Will be inferred automatically if not specified.  Valid
-            formats are `'auto'`, `'csv'`, `'df'`, `'dict'`, `'excel'`,
-            `'feather'`, `'fwf'`,
-            `'hdf5'` (cache file produced during previous training),
-            `'html'` (file containing a single HTML `<table>`),
-            `'json'`, `'jsonl'`, `'parquet'`,
-            `'pickle'` (pickled Pandas DataFrame),
-            `'sas'`, `'spss'`, `'stata'`, `'tsv'`.
-        :param skip_save_processed_input: (bool, default: `False`) if input
-            dataset is provided it is preprocessed and cached by saving an HDF5
-            and JSON files to avoid running the preprocessing again. If this
-            parameter is `False`, the HDF5 and JSON file are not saved.
-        :param output_directory: (str, default: `'results'`) the directory that
-            will contain the training statistics, TensorBoard logs, the saved
-            model and the training progress files.
-        :param random_seed: (int, default: `42`) a random seed that will be
-               used anywhere there is a call to a random number generator: data
-               splitting, parameter initialization and training set shuffling
+        # Returns:
+            :return: (PreprocessedDataset) data structure containing
+                `(proc_training_set, proc_validation_set, proc_test_set, training_set_metadata)`.
 
-        # Return
-
-        :return: (PreprocessedDataset) data structure containing
-            `(proc_training_set, proc_validation_set, proc_test_set, training_set_metadata)`.
+        # Raises:
+            RuntimeError: An error occured while preprocessing the data. Examples include training dataset
+                being empty after preprocessing, lazy loading not being supported with RayBackend, etc.
         """
         print_boxed("PREPROCESSING")
 

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1385,6 +1385,7 @@ class LudwigModel:
 
         preprocessing_params = get_preprocessing_params(self.config_obj)
 
+        proc_training_set = proc_validation_set = proc_test_set = None
         try:
             with provision_preprocessing_workers(self.backend):
                 # TODO (Connor): Refactor to use self.config_obj
@@ -1406,6 +1407,8 @@ class LudwigModel:
             (proc_training_set, proc_validation_set, proc_test_set, training_set_metadata) = preprocessed_data
 
             return PreprocessedDataset(proc_training_set, proc_validation_set, proc_test_set, training_set_metadata)
+        except Exception as e:
+            raise RuntimeError(f"Caught exception during model preprocessing: {e}")
         finally:
             for callback in self.callbacks:
                 callback.on_preprocess_end(proc_training_set, proc_validation_set, proc_test_set, training_set_metadata)

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -370,7 +370,7 @@ def test_empty_training_set_error(backend, tmpdir, ray_cluster_2cpu):
     df[out_feat[COLUMN]] = None
 
     ludwig_model = LudwigModel(config, backend=backend)
-    with pytest.raises(ValueError, match="Training data is empty following preprocessing"):
+    with pytest.raises(RuntimeError, match="Training data is empty following preprocessing"):
         ludwig_model.preprocess(dataset=df)
 
 

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -307,7 +307,7 @@ def run_test_with_features(
         dataset = augment_dataset_with_none(dataset, first_row_none, last_row_none, nan_cols)
 
         if expect_error:
-            with pytest.raises(ValueError):
+            with pytest.raises(RuntimeError):
                 run_fn(
                     config,
                     dataset=dataset,


### PR DESCRIPTION
In the existing implementation of `model.preprocess`, if there is an error or exception thrown, we never get to see it because  of the way our try-except-finally block is written. 

In particular, when preprocessing fails, the variables returned from `preprocess_for_training` aren't set/don't exist in scope during the finally block, which causes an `UnboundLocalError` for referencing a variable before definition. 

This PR updates the implementation to catch the exception and issue a RuntimeError since model training can never succeed if preprocessing the data itself fails. 