### PR TITLE
fix: Add back missing split fields

### DIFF
--- a/ludwig/schema/split.py
+++ b/ludwig/schema/split.py
@@ -149,6 +149,7 @@ def get_split_conds():
     for splitter in split_config_registry.data:
         splitter_cls = split_config_registry.data[splitter]
         other_props = schema_utils.unload_jsonschema_from_marshmallow_class(splitter_cls)["properties"]
+        schema_utils.remove_duplicate_fields(other_props, TYPE)
         splitter_cond = schema_utils.create_cond(
             {"type": splitter},
             other_props,

--- a/ludwig/schema/split.py
+++ b/ludwig/schema/split.py
@@ -149,7 +149,6 @@ def get_split_conds():
     for splitter in split_config_registry.data:
         splitter_cls = split_config_registry.data[splitter]
         other_props = schema_utils.unload_jsonschema_from_marshmallow_class(splitter_cls)["properties"]
-        schema_utils.remove_duplicate_fields(other_props)
         splitter_cond = schema_utils.create_cond(
             {"type": splitter},
             other_props,

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -4,7 +4,7 @@ from dataclasses import field
 from typing import Any
 from typing import Dict as TDict
 from typing import List as TList
-from typing import Tuple, Type, Union
+from typing import Optional, Tuple, Type, Union
 
 import yaml
 from marshmallow import EXCLUDE, fields, schema, validate, ValidationError
@@ -103,7 +103,7 @@ def create_cond(if_pred: TDict, then_pred: TDict):
 
 
 @DeveloperAPI
-def remove_duplicate_fields(properties: dict) -> None:
+def remove_duplicate_fields(properties: dict, fields: Optional[TList[str]] = None) -> None:
     """Util function for removing duplicated schema elements. For example, input feature json schema mapping has a
     type param defined directly on the json schema, but also has a parameter defined on the schema class. We need
     both -
@@ -114,7 +114,8 @@ def remove_duplicate_fields(properties: dict) -> None:
     Args:
         properties: Dictionary of properties generated from a Ludwig schema class
     """
-    for key in [NAME, TYPE, COLUMN, PROC_COLUMN, ACTIVE]:  # TODO: Remove col/proc_col once train metadata decoupled
+    duplicate_fields = [NAME, TYPE, COLUMN, PROC_COLUMN, ACTIVE] if fields is None else fields
+    for key in duplicate_fields:  # TODO: Remove col/proc_col once train metadata decoupled
         if key in properties:
             del properties[key]
 

--- a/tests/ludwig/schema/test_validate_config_misc.py
+++ b/tests/ludwig/schema/test_validate_config_misc.py
@@ -365,9 +365,6 @@ def test_schema_no_duplicates():
         assert field not in schema["properties"]["combiner"]["allOf"][0]["then"]["properties"]
         assert field not in schema["properties"]["trainer"]["properties"]["optimizer"]["allOf"][0]["then"]["properties"]
         assert (
-            field not in schema["properties"]["preprocessing"]["properties"]["split"]["allOf"][0]["then"]["properties"]
-        )
-        assert (
             field
             not in schema["properties"]["input_features"]["items"]["allOf"][0]["then"]["properties"]["encoder"][
                 "allOf"


### PR DESCRIPTION
As far as I can tell this line was too extensive for split configs, and it was responsible for the `column` fields being removed. I changed the function so that it only redacts `type`.

This is what the keys looked like before and after the original call to `remove_duplicate_fields`:
```
odict_keys(['type', 'column', 'probabilities'])
odict_keys(['probabilities'])
```