### PR TITLE
text_encoder: RoBERTa max_sequence_length

### DIFF
--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -1181,6 +1181,12 @@ class RoBERTaConfig(BaseEncoderConfig):
         description="Type of encoder.",
     )
 
+    max_sequence_length: int = schema_utils.PositiveInteger(
+        default=None,
+        description="Maximum length of the input sequence.",
+        parameter_metadata=ENCODER_METADATA["RoBERTaEncoder"]["max_sequence_length"],
+    )
+
     use_pretrained: bool = schema_utils.Boolean(
         default=True,
         description="Whether to use the pretrained weights for the model.",


### PR DESCRIPTION
Adds the `max_sequence_length` type to the encoder dataclass for the text encoder `RoBERTa`

fixes #2851

The current unit test for this encoder already includes `max_sequence_length` as a parameter so a passing test should indicate whether this is working correctly or not: https://github.com/ludwig-ai/ludwig/blob/master/tests/ludwig/encoders/test_text_encoders.py#L73
