### PR TITLE
Set RayBackend Config to use single worker for tests

### DIFF
--- a/tests/integration_tests/test_class_imbalance_feature.py
+++ b/tests/integration_tests/test_class_imbalance_feature.py
@@ -8,7 +8,7 @@ import pytest
 
 from ludwig.api import LudwigModel
 from ludwig.backend import LocalBackend
-from tests.integration_tests.utils import create_data_set_to_use, spawn
+from tests.integration_tests.utils import create_data_set_to_use, RAY_BACKEND_CONFIG, spawn
 
 try:
     import ray
@@ -18,20 +18,6 @@ except ImportError:
     ray = None
 
 rs = np.random.RandomState(42)
-RAY_BACKEND_CONFIG = {
-    "type": "ray",
-    "processor": {
-        "parallelism": 2,
-    },
-    "trainer": {
-        "use_gpu": False,
-        "num_workers": 2,
-        "resources_per_worker": {
-            "CPU": 0.1,
-            "GPU": 0,
-        },
-    },
-}
 
 
 @contextlib.contextmanager

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+import copy
 import os
 import tempfile
 
@@ -846,7 +847,8 @@ def test_ray_distributed_predict(tmpdir, ray_cluster_2cpu):
     }
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        backend_config = {**RAY_BACKEND_CONFIG}
+        # Deep copy RAY_BACKEND_CONFIG to avoid shallow copy modification
+        backend_config = copy.deepcopy({**RAY_BACKEND_CONFIG})
         # Manually override num workers to 2 for distributed training and distributed predict
         backend_config["trainer"]["num_workers"] = 2
         csv_filename = os.path.join(tmpdir, "dataset.csv")

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -847,13 +847,14 @@ def test_ray_distributed_predict(tmpdir, ray_cluster_2cpu):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         backend_config = {**RAY_BACKEND_CONFIG}
+        # Manually override num workers to 2 for distributed training and distributed predict
+        backend_config["trainer"]["num_workers"] = 2
         csv_filename = os.path.join(tmpdir, "dataset.csv")
         dataset_csv = generate_data(input_features, output_features, csv_filename, num_examples=100)
         dataset = create_data_set_to_use("csv", dataset_csv, nan_percent=0.0)
         model = LudwigModel(config, backend=backend_config)
-        output_dir = None
 
-        _, _, output_dir = model.train(
+        _, _, _ = model.train(
             dataset=dataset,
             training_set=dataset,
             skip_save_processed_input=True,

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -848,7 +848,7 @@ def test_ray_distributed_predict(tmpdir, ray_cluster_2cpu):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Deep copy RAY_BACKEND_CONFIG to avoid shallow copy modification
-        backend_config = copy.deepcopy({**RAY_BACKEND_CONFIG})
+        backend_config = copy.deepcopy(RAY_BACKEND_CONFIG)
         # Manually override num workers to 2 for distributed training and distributed predict
         backend_config["trainer"]["num_workers"] = 2
         csv_filename = os.path.join(tmpdir, "dataset.csv")

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -101,7 +101,7 @@ RAY_BACKEND_CONFIG = {
     },
     "trainer": {
         "use_gpu": False,
-        "num_workers": 2,
+        "num_workers": 1,
         "resources_per_worker": {
             "CPU": 0.1,
             "GPU": 0,


### PR DESCRIPTION
This PR sets the number of training workers to 1 (from 2) to speed up our Ray tests.