### PR TITLE
Evaluate training set in the training loop

### DIFF
--- a/ludwig/models/base.py
+++ b/ludwig/models/base.py
@@ -170,6 +170,10 @@ class BaseModel(LudwigModule, metaclass=ABCMeta):
     def predictions(self, inputs):
         """Returns the model's predictions for the given inputs."""
         outputs = self(inputs)
+        return self.outputs_to_predictions(outputs)
+
+    def outputs_to_predictions(self, outputs):
+        """Returns the model's predictions given the raw model outputs."""
         predictions = {}
         for of_name in self.output_features:
             predictions[of_name] = self.output_features[of_name].predictions(outputs, of_name)

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -139,8 +139,15 @@ class ECDTrainerConfig(BaseTrainerConfig):
     )
 
     evaluate_training_set: bool = schema_utils.Boolean(
-        default=True,
-        description="Whether to include the entire training set during evaluation.",
+        default=False,
+        description=(
+            "Whether to evaluate on the entire training set during evaluation. By default, training metrics will be "
+            "computed at the end of each training step, and accumulated up to the evaluation phase. In practice, "
+            "computing training set metrics during training is up to 30% faster than running a separate evaluation "
+            "pass over the training set, but results in more noisy training metrics, particularly during the earlier "
+            "epochs. It's recommended to only set this to True if you need very exact training set metrics, and are "
+            "willing to pay a significant performance penalty for them."
+        ),
         parameter_metadata=TRAINER_METADATA["evaluate_training_set"],
     )
 
@@ -353,8 +360,15 @@ class GBMTrainerConfig(BaseTrainerConfig):
     )
 
     evaluate_training_set: bool = schema_utils.Boolean(
-        default=True,
-        description="Whether to include the entire training set during evaluation.",
+        default=False,
+        description=(
+            "Whether to evaluate on the entire training set during evaluation. By default, training metrics will be "
+            "computed at the end of each training step, and accumulated up to the evaluation phase. In practice, "
+            "computing training set metrics during training is up to 30% faster than running a separate evaluation "
+            "pass over the training set, but results in more noisy training metrics, particularly during the earlier "
+            "epochs. It's recommended to only set this to True if you need very exact training set metrics, and are "
+            "willing to pay a significant performance penalty for them."
+        ),
         parameter_metadata=TRAINER_METADATA["evaluate_training_set"],
     )
 

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -344,6 +344,7 @@ class Trainer(BaseTrainer):
         self.model.train()  # Sets model training mode.
         durations = []
         for _ in range(total_steps):
+            self.model.reset_metrics()
             start_ts = time.time()
             inputs = {
                 input_feature_name: input_feature.create_sample_input(batch_size=batch_size).to(self.device)

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -238,6 +238,12 @@ class Trainer(BaseTrainer):
                 targets, model_outputs, self.regularization_type, self.regularization_lambda
             )
 
+            if not self.evaluate_training_set:
+                # Update evaluation metrics with current model params:
+                # noisy but fast way to get metrics on the training set
+                predictions = self.model.outputs_to_predictions(model_outputs)
+                self.model.update_metrics(targets, predictions)
+
             return loss, all_losses
 
         self.optimizer.zero_grad()

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -269,7 +269,8 @@ class Trainer(BaseTrainer):
 
         # Update evaluation metrics with current model params:
         # noisy but fast way to get metrics on the training set
-        self.model.update_metrics(targets, model_outputs)
+        predictions = self.model.outputs_to_predictions(model_outputs)
+        self.model.update_metrics(targets, predictions)
 
         return loss, all_losses
 

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -596,6 +596,7 @@ class Trainer(BaseTrainer):
             metrics=progress_tracker.train_metrics,
             step=progress_tracker.steps,
         )
+        self.model.reset_metrics()
 
         if validation_set is not None:
             self.callback(lambda c: c.on_validation_start(self, progress_tracker, save_path))

--- a/tests/integration_tests/test_model_save_and_load.py
+++ b/tests/integration_tests/test_model_save_and_load.py
@@ -221,7 +221,11 @@ def test_model_weights_match_training(tmpdir, csv_filename):
     config = {
         "input_features": input_features,
         "output_features": output_features,
-        "trainer": {"epochs": 5, "batch_size": 32},
+        "trainer": {
+            "epochs": 5,
+            "batch_size": 32,
+            "evaluate_training_set": True,  # needed to ensure exact training metrics computed
+        },
     }
 
     model = LudwigModel(

--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -243,7 +243,7 @@ def test_optimizers(optimizer_type, tmp_path):
         "input_features": input_features,
         "output_features": output_features,
         "combiner": {"type": "concat"},
-        TRAINER: {"epochs": 5, "batch_size": 16, "optimizer": {"type": optimizer_type}},
+        TRAINER: {"epochs": 5, "batch_size": 16, "evaluate_training_set": True, "optimizer": {"type": optimizer_type}},
     }
 
     # special handling for adadelta, break out of local minima


### PR DESCRIPTION
This PR dramatically speeds up training for large datasets that take hours to train. In the previous implementation, `evaluate_training_set` defaulted to `True`, which meant that at the start of every evaluation phase (e.g., at the end of each epoch) there would be a pass over the training set again to compute the train metrics. In practice, this ends up being about 30 - 35% of the total training wall clock time. In other words, if your training process took 3 hours to run, you could save an entire hour by disabling this evaluation phase.

Instead of computing training metrics in a separate pass, we can do it during the training loop that updates the model weights, at the end of the forward / backward pass, which is what this PR now does when `evaluate_training_set` is `False` (the new default). The only downside to this approach is that the model weights are changing each step, so the reported training metrics are actually an accumulation over different batch + model weight combinations during the epoch. So if your goal is to know how well the model performed using the weights at the end of the epoch, then this approach is an approximation.

In practice, this noisiness in the training metrics is only an issue in the first few epochs when the model weights are very random. As training progresses, the weights change less dramatically, so the difference in performance between the first step in the epoch and the last is minor, and the train metrics end up looking very close to what they would be if evaluated at the end of the epoch, but without having to pay the cost of computing them (which is dominated by the I/O).

Need to implement similar logic for GBMs. This PR only addresses ECD.