### PR TITLE
Add support for automatic mixed precision (AMP) training

### DIFF
--- a/ludwig/schema/metadata/trainer_metadata.py
+++ b/ludwig/schema/metadata/trainer_metadata.py
@@ -882,5 +882,23 @@ TRAINER_METADATA = (
                                             commonly_used=False,
                                             expected_impact=ExpectedImpact.HIGH,
                                             literature_references=None,
-                                            internal_only=False)}
+                                            internal_only=False),
+     'use_mixed_precision': ParameterMetadata(ui_display_name='Use Mixed Precision',
+                                    default_value_reasoning='Speed up training by using float16 parameters where it '
+                                                            'makes sense.',
+                                    example_value=None,
+                                    related_parameters=None,
+                                    other_information=None,
+                                    description_implications='Mixed precision training on GPU can dramatically speed'
+                                                             'up training, with some risks to model convergence.',
+                                    suggested_values=False,
+                                    suggested_values_reasoning='Suggested to enable this if training is taking too '
+                                                               'long on GPU.',
+                                    commonly_used=False,
+                                    expected_impact=ExpectedImpact.HIGH,
+                                    literature_references=[
+                                        'https://pytorch.org/blog/what-every-user-should-know-about-mixed-precision-training-in-pytorch/'
+                                    ],
+                                    internal_only=False)
+    }
 )

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -303,6 +303,12 @@ class ECDTrainerConfig(BaseTrainerConfig):
         parameter_metadata=TRAINER_METADATA["bucketing_field"],
     )
 
+    use_mixed_precision: bool = schema_utils.Boolean(
+        default=False,
+        description="Enable automatic mixed-precision (AMP) during training.",
+        parameter_metadata=TRAINER_METADATA["use_mixed_precision"],
+    )
+
 
 @DeveloperAPI
 @register_trainer_schema(MODEL_GBM)

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -287,19 +287,10 @@ class Trainer(BaseTrainer):
             else:
                 self.optimizer.step()
 
-<<<<<<< HEAD
-=======
         if self.use_amp:
             # Update scaler in case of overflow/underflow
             self.scaler.update()
 
-        if not self.evaluate_training_set:
-            # Update evaluation metrics with current model params:
-            # noisy but fast way to get metrics on the training set
-            predictions = self.model.outputs_to_predictions(model_outputs)
-            self.model.update_metrics(targets, predictions)
-
->>>>>>> 48eb6b855 (Add support for automatic mixed precision (AMP) training)
         return loss, all_losses
 
     def clip_grads(self, variables):

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -280,12 +280,12 @@ class Trainer(BaseTrainer):
         self.clip_grads(variables)
 
         # Apply gradient updates
-        if self.horovod:
-            # Because we already synchronized above, we can doing so here
-            with self.optimizer.skip_synchronize():
+        with self.optimizer.skip_synchronize() if self.horovod else contextlib.nullcontext():
+            # Because we already synchronized above, we skip doing so here
+            if self.use_amp:
+                self.scaler.step(self.optimizer)
+            else:
                 self.optimizer.step()
-        else:
-            self.optimizer.step()
 
 <<<<<<< HEAD
 =======

--- a/tests/integration_tests/test_trainer.py
+++ b/tests/integration_tests/test_trainer.py
@@ -6,6 +6,7 @@ from unittest import mock
 import numpy as np
 import pandas as pd
 import pytest
+import torch
 
 from ludwig.api import LudwigModel
 from ludwig.callbacks import Callback
@@ -18,6 +19,7 @@ from tests.integration_tests.utils import (
     number_feature,
     RAY_BACKEND_CONFIG,
     sequence_feature,
+    text_feature,
     vector_feature,
 )
 
@@ -239,3 +241,33 @@ def test_lightgbm_dataset_partition(ray_cluster_2cpu):
     assert train_ds.ds.num_blocks() == 2
     assert val_ds.ds.num_blocks() == 2
     assert test_ds.ds.num_blocks() == 2
+
+
+@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="test requires at least 1 gpu")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires gpu support")
+def test_mixed_precision(tmpdir):
+    input_features = [text_feature()]
+    output_features = [category_feature(decoder={"vocab_size": 2}, reduce_input="sum")]
+
+    csv_filename = os.path.join(tmpdir, "training.csv")
+    data_csv = generate_data(input_features, output_features, csv_filename)
+    val_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "validation.csv"))
+    test_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "test.csv"))
+
+    trainer = {
+        "epochs": 2,
+        "use_mixed_precision": True,
+    }
+
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        "combiner": {"type": "concat", "output_size": 14},
+        TRAINER: trainer,
+    }
+
+    # Just test that training completes without error.
+    # TODO(travis): We may want to expand upon this in the future to include some checks on model
+    # convergence like gradient magnitudes, etc. Should also add distributed tests.
+    model = LudwigModel(config, backend=LocalTestBackend(), logging_level=logging.INFO)
+    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv, output_directory=tmpdir)


### PR DESCRIPTION
Usage:

```
trainer:
    use_mixed_precision: true
```

In our tests fine-tuning BERT with 8 Ampere GPUs, we found a 2.2x speedup using mixed precision training with similar convergence properties.