### PR TITLE
Fixes for the roberta encoder: explicitly set max sequence length, and fix output shape computation

### DIFF
--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -899,6 +899,7 @@ class RoBERTaEncoder(Encoder):
             )
             transformer = RobertaModel(config)
         self.transformer = FreezeModule(transformer, frozen=not trainable)
+        self.max_sequence_length = max_sequence_length
         self.reduce_output = reduce_output
         if not self.reduce_output == "cls_pooled":
             self.reduce_sequence = SequenceReducer(reduce_mode=reduce_output)
@@ -930,7 +931,7 @@ class RoBERTaEncoder(Encoder):
     @property
     def output_shape(self) -> torch.Size:
         if self.reduce_output is None:
-            return torch.Size([self.max_sequence_length, self.transformer.module.config.hidden_size])
+            return torch.Size([self.max_sequence_length - 2, self.transformer.module.config.hidden_size])
         return torch.Size([self.transformer.module.config.hidden_size])
 
     @property

--- a/tests/ludwig/encoders/test_text_encoders.py
+++ b/tests/ludwig/encoders/test_text_encoders.py
@@ -65,7 +65,7 @@ def test_gpt_encoder(use_pretrained: bool, reduce_output: str, max_sequence_leng
 
 
 @pytest.mark.parametrize("use_pretrained", [False])
-@pytest.mark.parametrize("reduce_output", ["cls_pooled", "sum"])
+@pytest.mark.parametrize("reduce_output", ["cls_pooled", "sum", None])
 @pytest.mark.parametrize("max_sequence_length", [20])
 def test_roberta_encoder(use_pretrained: bool, reduce_output: str, max_sequence_length: int):
     roberta_encoder = text_encoders.RoBERTaEncoder(


### PR DESCRIPTION
Closes https://github.com/ludwig-ai/ludwig/issues/2851