### PR TITLE
fix: load spacy model for lemmatization in `EnglishLemmatizeFilterTokenizer` to work

### DIFF
--- a/ludwig/utils/nlp_utils.py
+++ b/ludwig/utils/nlp_utils.py
@@ -186,7 +186,7 @@ def process_text(
     filter_short_tokens=False,
     filter_stopwords=False,
 ):
-    doc = nlp_pipeline.tokenizer(text)
+    doc = nlp_pipeline(text)
     return [
         token.lemma_ if return_lemma else token.text
         for token in doc

--- a/tests/ludwig/utils/test_tokenizers.py
+++ b/tests/ludwig/utils/test_tokenizers.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torchtext
 
-from ludwig.utils.tokenizers import NgramTokenizer
+from ludwig.utils.tokenizers import EnglishLemmatizeFilterTokenizer, NgramTokenizer
 
 TORCHTEXT_0_14_0_HF_NAMES = [
     "bert-base-uncased",
@@ -69,3 +69,10 @@ def test_ngram_tokenizer():
     ]
     tokens = tokenizer(inputs)
     assert tokens == tokens_expected
+
+
+def test_english_lemmatize_filter_tokenizer():
+    inputs = "Hello, I'm a single sentence!"
+    tokenizer = EnglishLemmatizeFilterTokenizer()
+    tokens = tokenizer(inputs)
+    assert len(tokens) > 0


### PR DESCRIPTION
`nlp_pipeline.tokenizer(text)` only loads the spacy tokenizer, not the full model. This causes `EnglishLemmatizeFilterTokenizer` to return a list of empty strings since inferring the lemmas requires the model not just the tokenizer.