### PR TITLE
Ray GPU image with Torch 1.13 support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 10 * * *" # everyday at 10am
   push:
-    branches: ["master", "release-*", "torch_113_image_upgrade"]
+    branches: ["master", "release-*"]
     tags: ["v*.*.*"]
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 10 * * *" # everyday at 10am
   push:
-    branches: ["master", "release-*"]
+    branches: ["master", "release-*", "torch_113_image_upgrade"]
     tags: ["v*.*.*"]
 
 jobs:

--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM rayproject/ray:2.0.0-py38-cu113
+FROM rayproject/ray:2.0.0-py38-cu116
 
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
 RUN sudo apt-key del 7fa2af80 && \
@@ -33,7 +33,7 @@ RUN pip install -U pip
 WORKDIR /ludwig
 
 # TODO(travis): remove this once we fix CUDA 11.6 NCCL version in base image
-RUN pip install torch==1.12.1 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+RUN pip install torch==1.13 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116
 
 COPY . .
 RUN HOROVOD_GPU_OPERATIONS=NCCL \
@@ -41,6 +41,6 @@ RUN HOROVOD_GPU_OPERATIONS=NCCL \
     HOROVOD_WITHOUT_MPI=1 \
     HOROVOD_WITHOUT_TENSORFLOW=1 \
     HOROVOD_WITHOUT_MXNET=1 \
-    pip install --no-cache-dir '.[full]' --extra-index-url https://download.pytorch.org/whl/cu113 && \
+    pip install --no-cache-dir '.[full]' --extra-index-url https://download.pytorch.org/whl/cu116 && \
     horovodrun --check-build && \
     python -c "import horovod.torch; horovod.torch.init()"

--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -39,10 +39,10 @@ RUN pip install -U pip
 
 WORKDIR /ludwig
 
-# TODO(travis): remove this once we fix CUDA 11.6 NCCL version in base image
-RUN pip install torch==1.13 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116
+RUN pip install torch==1.13.1 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116
 
 # Downgrade NCCL to 2.11.4 to for compatibility with CUDA 11.6
+# https://github.com/horovod/horovod/issues/3625#issuecomment-1309786643
 RUN sudo apt install --allow-change-held-packages --allow-downgrades -y \
     libnccl2=2.11.4-1+cuda11.6 libnccl-dev=2.11.4-1+cuda11.6
 

--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -18,7 +18,14 @@ RUN sudo apt-key del 7fa2af80 && \
     sudo rm -f /etc/apt/sources.list.d/cuda.list /etc/apt/apt.conf.d/99allow_unauth cuda-keyring_1.0-1_all.deb && \
     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC F60F4B3D7FA2AF80
 
-RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y \
+# Upgrade to GCC-9 from GCC-7.5
+# Required for libgcc-s1 which is a dependency for libnccl2
+RUN sudo apt-get update && sudo apt install -y software-properties-common && \
+    sudo add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    sudo apt update && \
+    sudo apt install -y gcc-9
+
+RUN DEBIAN_FRONTEND="noninteractive" sudo apt-get install -y \
     build-essential \
     wget \
     git \
@@ -34,6 +41,10 @@ WORKDIR /ludwig
 
 # TODO(travis): remove this once we fix CUDA 11.6 NCCL version in base image
 RUN pip install torch==1.13 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116
+
+# Downgrade NCCL to 2.11.4 to for compatibility with CUDA 11.6
+RUN sudo apt install --allow-change-held-packages --allow-downgrades -y \
+    libnccl2=2.11.4-1+cuda11.6 libnccl-dev=2.11.4-1+cuda11.6
 
 COPY . .
 RUN HOROVOD_GPU_OPERATIONS=NCCL \

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -25,8 +25,7 @@ RUN pip install -U pip
 
 WORKDIR /ludwig
 
-# TODO(travis): remove this once we fix CUDA 11.6 NCCL version in base image
-RUN pip install torch==1.12.1 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip install torch==1.13.1 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
 
 COPY . .
 RUN HOROVOD_WITH_PYTORCH=1 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ tensorboard
 torchmetrics<0.9
 torchinfo
 filelock
-psutil
+psutil==5.9.4
 protobuf
 experiment_impact_tracker
 gpustat


### PR DESCRIPTION
This PR bumps the ludwig-ray and ludwig-ray-gpu images to Torch 1.13.1 and Cuda 11.6.
It also pins `psutil` to `5.9.4`