### PR TITLE
Fix CLIPTokenizer initialization for torchtext 0.12.0

### DIFF
--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -920,7 +920,7 @@ try:
     import torchtext
 
     torchtext_version = torch.torch_version.TorchVersion(torchtext.__version__)
-    torchtext_112 = torchtext_version == (0, 12, 0)
+    torchtext_113 = torchtext_version < (0, 13, 0)
 
     if torchtext_version >= (0, 12, 0):
         """torchtext 0.12.0 tokenizers.
@@ -999,11 +999,13 @@ try:
                 super().__init__(pretrained_model_name_or_path, vocab_file)
 
             def _init_tokenizer(self, pretrained_model_name_or_path: str, vocab_file: str):
-                if torchtext_112:
+                if torchtext_113:
+                    # Uses vbe_path kwarg in torchtext 0.12.0
                     return torchtext.transforms.CLIPTokenizer(
                         encoder_json_path=vocab_file, vocab_bpe_path=pretrained_model_name_or_path
                     )
                 else:
+                    # Uses merges_path in torchtext 0.13.0
                     return torchtext.transforms.CLIPTokenizer(
                         encoder_json_path=vocab_file, merges_path=pretrained_model_name_or_path
                     )

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -997,7 +997,7 @@ try:
 
             def _init_tokenizer(self, pretrained_model_name_or_path: str, vocab_file: str):
                 return torchtext.transforms.CLIPTokenizer(
-                    encoder_json_path=vocab_file, merges_path=pretrained_model_name_or_path
+                    encoder_json_path=vocab_file, vocab_bpe_path=pretrained_model_name_or_path
                 )
 
         class GPT2BPETokenizer(_BPETokenizer):

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -919,7 +919,10 @@ tokenizer_registry = {
 try:
     import torchtext
 
-    if torch.torch_version.TorchVersion(torchtext.__version__) >= (0, 12, 0):
+    torchtext_version = torch.torch_version.TorchVersion(torchtext.__version__)
+    torchtext_112 = torchtext_version == (0, 12, 0)
+
+    if torchtext_version >= (0, 12, 0):
         """torchtext 0.12.0 tokenizers.
 
         Only available with torchtext>=0.12.0.
@@ -996,9 +999,14 @@ try:
                 super().__init__(pretrained_model_name_or_path, vocab_file)
 
             def _init_tokenizer(self, pretrained_model_name_or_path: str, vocab_file: str):
-                return torchtext.transforms.CLIPTokenizer(
-                    encoder_json_path=vocab_file, vocab_bpe_path=pretrained_model_name_or_path
-                )
+                if torchtext_112:
+                    return torchtext.transforms.CLIPTokenizer(
+                        encoder_json_path=vocab_file, vocab_bpe_path=pretrained_model_name_or_path
+                    )
+                else:
+                    return torchtext.transforms.CLIPTokenizer(
+                        encoder_json_path=vocab_file, merges_path=pretrained_model_name_or_path
+                    )
 
         class GPT2BPETokenizer(_BPETokenizer):
             def __init__(


### PR DESCRIPTION
In torchtext 0.12.0, the CLIPTokenizer class takes `vocab_bpe_path` instead of `merges_path` as the input parameter. I found this when running `tests/ludwig/features/test_sequence_features.py::test_sequence_preproc_module_clip_tokenizer` locally.

Torchtext 0.12: https://github.com/pytorch/text/blob/orig/release/0.12/torchtext/transforms.py#L312
Torchtext 0.13: https://github.com/pytorch/text/blob/orig/release/0.13/torchtext/transforms.py#L385