### PR TITLE
Add a clear error message about invalid column names in GBM datasets

### DIFF
--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -812,7 +812,7 @@ class LightGBMTrainer(BaseTrainer):
                 raise ValueError(
                     "Some column names in the training set contain invalid characters. Please ensure column names only "
                     "contain alphanumeric characters and underscores, then try training again."
-                )
+                ) from e
             else:
                 raise
 
@@ -828,7 +828,7 @@ class LightGBMTrainer(BaseTrainer):
                     raise ValueError(
                         "Some column names in the validation set contain invalid characters. Please ensure column "
                         "names only contain alphanumeric characters and underscores, then try training again."
-                    )
+                    ) from e
                 else:
                     raise
             eval_sets.append(lgb_val)

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import numpy as np
 import pytest
@@ -11,7 +12,7 @@ import torch
 from jsonschema.exceptions import ValidationError
 
 from ludwig.api import LudwigModel
-from ludwig.constants import INPUT_FEATURES, MODEL_TYPE, OUTPUT_FEATURES, TRAINER
+from ludwig.constants import COLUMN, INPUT_FEATURES, MODEL_TYPE, NAME, OUTPUT_FEATURES, TRAINER
 from tests.integration_tests import synthetic_test_data
 from tests.integration_tests.utils import binary_feature, category_feature, generate_data, number_feature, text_feature
 
@@ -311,3 +312,22 @@ def test_save_load(tmpdir, local_backend):
     preds, _ = model.predict(dataset=os.path.join(tmpdir, "training.csv"), split="test")
 
     assert init_preds.equals(preds)
+
+
+def test_lgbm_dataset_setup(tmpdir, local_backend):
+    """Test that LGBM dataset column name errors are handled."""
+    input_features = [number_feature()]
+    output_features = [binary_feature()]
+
+    # Overwrite the automatically generated feature/column name with an invalid string.
+    input_features[0][NAME] = ",Unnamed: 0"
+    input_features[0][COLUMN] = input_features[0][NAME]
+
+    # Test that the custom error is raised (lightgbm.basic.LightGBMError -> ValueError)
+    with pytest.raises(ValueError):
+        try:
+            _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend)
+        except ValueError as e:
+            # Check that the intended ValueError was raised
+            assert re.search("Some column names in the training set contain invalid characters", str(e))
+            raise


### PR DESCRIPTION
When prepping data for GBM training/eval, column names with invalid characters may cause `lightgbm.Dataset` to throw the following error:
```
lightgbm.basic.LightGBMError: Do not support special JSON characters in feature name.
```

This update catches the `LightGBMError` and provides more descriptive feedback.
