### PR TITLE
Save GBM after training if not previously saved

### DIFF
--- a/ludwig/models/gbm.py
+++ b/ludwig/models/gbm.py
@@ -15,6 +15,7 @@ from ludwig.globals import MODEL_WEIGHTS_FILE_NAME
 from ludwig.models.base import BaseModel
 from ludwig.schema.model_config import ModelConfig, OutputFeaturesContainer
 from ludwig.utils import output_feature_utils
+from ludwig.utils.fs_utils import path_exists
 from ludwig.utils.torch_utils import get_torch_device
 from ludwig.utils.types import TorchDevice
 
@@ -225,7 +226,7 @@ class GBM(BaseModel):
         return trace
 
     def has_saved(self, save_path):
-        return os.path.exists(os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME))
+        return path_exists(os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME))
 
     def get_args(self):
         """Returns init arguments for constructing this model."""

--- a/ludwig/models/gbm.py
+++ b/ludwig/models/gbm.py
@@ -224,6 +224,9 @@ class GBM(BaseModel):
             trace = super().to_torchscript(device)
         return trace
 
+    def has_saved(self, save_path):
+        return os.path.exists(os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME))
+
     def get_args(self):
         """Returns init arguments for constructing this model."""
         return self.config_obj.input_features.to_list(), self.config_obj.output_features.to_list(), self._random_seed

--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -670,6 +670,9 @@ class LightGBMTrainer(BaseTrainer):
                     break
         finally:
             # ================ Finished Training ================
+            if not self.model.has_saved(save_path) and self.is_coordinator() and not self.skip_save_model:
+                self.model.save(save_path)
+
             self.callback(
                 lambda c: c.on_trainer_train_teardown(self, progress_tracker, save_path, self.is_coordinator()),
                 coordinator_only=False,

--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -671,7 +671,10 @@ class LightGBMTrainer(BaseTrainer):
         finally:
             # ================ Finished Training ================
             if not self.model.has_saved(save_path) and self.is_coordinator() and not self.skip_save_model:
-                self.model.save(save_path)
+                try:
+                    self.model.save(save_path)
+                except ValueError:
+                    logger.info("No LightGBM model initialized, skipping save")
 
             self.callback(
                 lambda c: c.on_trainer_train_teardown(self, progress_tracker, save_path, self.is_coordinator()),


### PR DESCRIPTION
GBM models save during training if one of two conditions is met:

1. [No validation set was provided](https://github.com/ludwig-ai/ludwig/blob/gbm-not-saved/ludwig/trainers/trainer_lightgbm.py#L317-L329)
2. [The model improved since the last evaluation](https://github.com/ludwig-ai/ludwig/blob/gbm-not-saved/ludwig/trainers/trainer_lightgbm.py#L421-L429)

If neither condition is met--no validation set and the model never improved--the GBM will never be saved, and a `FileNotFoundError` is thrown [when loading the best model after training](https://github.com/ludwig-ai/ludwig/blob/gbm-not-saved/ludwig/trainers/trainer_lightgbm.py#L688-L690).

This update adds a method to check whether or not the GBM has been saved, and a post-training check that saves the model if it was never saved.