### PR TITLE
Support MLFlowCallback logging to an existing run

### DIFF
--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -38,9 +38,23 @@ _get_or_create_experiment_id = get_or_create_experiment_id
 @PublicAPI
 class MlflowCallback(Callback):
     def __init__(self, tracking_uri=None, log_artifacts: bool = True):
-        self.experiment_id = None
-        self.experiment_name = None
-        self.run = None
+        if tracking_uri:
+            mlflow.set_tracking_uri(tracking_uri)
+
+        active_run = mlflow.active_run()
+        if active_run is not None:
+            # Use experiment already set in the current environment
+            self.run = active_run
+            self.experiment_id = self.run.info.experiment_id
+            self.experiment_name = mlflow.get_experiment(self.experiment_id).name
+            self.external_run = True
+        else:
+            # Will create an experiment at training time
+            self.run = None
+            self.experiment_id = None
+            self.experiment_name = None
+            self.external_run = False
+
         self.run_ended = False
         self.tracking_uri = tracking_uri
         self.training_set_metadata = None
@@ -49,8 +63,6 @@ class MlflowCallback(Callback):
         self.save_fn = None
         self.save_thread = None
         self.log_artifacts = log_artifacts
-        if tracking_uri:
-            mlflow.set_tracking_uri(tracking_uri)
 
     def get_experiment_id(self, experiment_name):
         return get_or_create_experiment_id(experiment_name)
@@ -91,7 +103,7 @@ class MlflowCallback(Callback):
 
         active_run = mlflow.active_run()
         if active_run is not None:
-            # Currently active run started by Ray Tune MLflow mixin.
+            # Currently active run started by Ray Tune MLflow mixin or external run
             self.run = active_run
         else:
             run_id = None
@@ -118,7 +130,8 @@ class MlflowCallback(Callback):
     def on_train_end(self, output_directory):
         if self.log_artifacts:
             _log_artifacts(output_directory)
-        if self.run is not None:
+        if self.run is not None and not self.external_run:
+            # Only end runs managed internally to this callback
             mlflow.end_run()
             self.run_ended = True
 
@@ -180,6 +193,8 @@ class MlflowCallback(Callback):
         if self.tracking_uri:
             mlflow.set_tracking_uri(self.tracking_uri)
         if self.run and not self.run_ended:
+            # Run has already been set, but may not be active due to training workers running in a separate
+            # process, so resume the run
             mlflow.end_run()
             self.run = mlflow.start_run(run_id=self.run.info.run_id, experiment_id=self.run.info.experiment_id)
 

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -1,7 +1,7 @@
 import os
 import shutil
-from unittest import mock
 import uuid
+from unittest import mock
 
 import mlflow
 import pandas as pd

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -16,20 +16,23 @@ from ludwig.export import export_mlflow
 from tests.integration_tests.utils import category_feature, FakeRemoteBackend, generate_data, sequence_feature
 
 
-def run_mlflow_callback_test(mlflow_client, config, training_data, val_data, test_data, tmpdir):
-    exp_name = "mlflow_test"
+def run_mlflow_callback_test(mlflow_client, config, training_data, val_data, test_data, tmpdir, exp_name=None):
+    ludwig_exp_name = "mlflow_test"
     callback = MlflowCallback()
     wrapped_callback = mock.Mock(wraps=callback)
 
     model = LudwigModel(config, callbacks=[wrapped_callback], backend=FakeRemoteBackend())
-    model.train(training_set=training_data, validation_set=val_data, test_set=test_data, experiment_name=exp_name)
+    model.train(
+        training_set=training_data, validation_set=val_data, test_set=test_data, experiment_name=ludwig_exp_name
+    )
     expected_df, _ = model.predict(test_data)
 
     # Check mlflow artifacts
     assert callback.experiment_id is not None
     assert callback.run is not None
 
-    experiment = mlflow.get_experiment_by_name(exp_name)
+    mlflow_exp_name = exp_name or ludwig_exp_name
+    experiment = mlflow.get_experiment_by_name(mlflow_exp_name)
     assert experiment.experiment_id == callback.experiment_id
 
     df = mlflow.search_runs([experiment.experiment_id])
@@ -39,7 +42,8 @@ def run_mlflow_callback_test(mlflow_client, config, training_data, val_data, tes
     assert run_id == callback.run.info.run_id
 
     run = mlflow.get_run(run_id)
-    assert run.info.status == "FINISHED"
+    expected_status = "FINISHED" if exp_name is None else "RUNNING"
+    assert run.info.status == expected_status
     assert wrapped_callback.on_trainer_train_setup.call_count == 1
     assert wrapped_callback.on_trainer_train_teardown.call_count == 1
 
@@ -116,14 +120,15 @@ def test_mlflow(tmpdir, external_run):
     mlflow.set_tracking_uri(mlflow_uri)
     client = MlflowClient(tracking_uri=mlflow_uri)
 
+    exp_name = None
     run = None
     if external_run:
         # Start a run here and make sure it's still active when training completes
-        run = mlflow.start_run(
-            experiment_id=f"ext_experiment_{uuid.uuid4().hex}", run_name=f"ext_run_{uuid.uuid4().hex}"
-        )
+        exp_name = f"ext_experiment_{uuid.uuid4().hex}"
+        exp_id = mlflow.create_experiment(name=exp_name)
+        run = mlflow.start_run(experiment_id=exp_id, run_name=f"ext_run_{uuid.uuid4().hex}")
 
-    callback_run = run_mlflow_callback_test(client, config, data_csv, val_csv, test_csv, tmpdir)
+    callback_run = run_mlflow_callback_test(client, config, data_csv, val_csv, test_csv, tmpdir, exp_name=exp_name)
 
     if not external_run:
         run_mlflow_callback_test_without_artifacts(client, config, data_csv, val_csv, test_csv)


### PR DESCRIPTION
Fixes #2891.

With this change, if `mlflow.active_run()` already exists when the `MLFlowCallback` is created, then we will not attempt to create a new run, but rather log all artifacts to the existing active run.