### PR TITLE
Fix dataset synthesizer

### DIFF
--- a/ludwig/data/dataset_synthesizer.py
+++ b/ludwig/data/dataset_synthesizer.py
@@ -164,6 +164,9 @@ parameters_builders_registry = {
 
 @DeveloperAPI
 def build_synthetic_dataset_df(dataset_size: int, config: ModelConfigDict) -> pd.DataFrame:
+    for feature in config[OUTPUT_FEATURES]:
+        if DECODER not in feature:
+            feature[DECODER] = {}
     features = config[INPUT_FEATURES] + config[OUTPUT_FEATURES]
     df = build_synthetic_dataset(dataset_size, features)
     data = [next(df) for _ in range(dataset_size + 1)]

--- a/tests/ludwig/utils/test_data_utils.py
+++ b/tests/ludwig/utils/test_data_utils.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 # ==============================================================================
 import json
+import logging
 
 import numpy as np
 import pandas as pd
 import pytest
 from fsspec.config import conf
 
+from ludwig.api import LudwigModel
+from ludwig.data.dataset_synthesizer import build_synthetic_dataset_df
 from ludwig.data.cache.types import CacheableDataframe
 from ludwig.utils.data_utils import (
     add_sequence_feature_column,
@@ -155,3 +158,14 @@ def test_numpy_encoder():
         assert json.dumps(x, cls=NumpyEncoder) == "[0.0, 1.0, 2.0, 3.0, 4.0]"
         for i in x:
             assert json.dumps(i, cls=NumpyEncoder) == f"{i}"
+
+
+def test_dataset_synthesizer_output_feature_decoder():
+    config = {
+            "input_features": [{"name": "sentence", "type": "text"}],
+            "output_features": [{"name": "product", "type": "category"}],
+            "trainer": {"epochs": 5},
+            "model_type": "ecd",
+        }
+    build_synthetic_dataset_df(dataset_size=100, config=config)
+    LudwigModel(config=config, logging_level=logging.INFO)

--- a/tests/ludwig/utils/test_data_utils.py
+++ b/tests/ludwig/utils/test_data_utils.py
@@ -21,8 +21,8 @@ import pytest
 from fsspec.config import conf
 
 from ludwig.api import LudwigModel
-from ludwig.data.dataset_synthesizer import build_synthetic_dataset_df
 from ludwig.data.cache.types import CacheableDataframe
+from ludwig.data.dataset_synthesizer import build_synthetic_dataset_df
 from ludwig.utils.data_utils import (
     add_sequence_feature_column,
     figure_data_format_dataset,
@@ -162,10 +162,10 @@ def test_numpy_encoder():
 
 def test_dataset_synthesizer_output_feature_decoder():
     config = {
-            "input_features": [{"name": "sentence", "type": "text"}],
-            "output_features": [{"name": "product", "type": "category"}],
-            "trainer": {"epochs": 5},
-            "model_type": "ecd",
-        }
+        "input_features": [{"name": "sentence", "type": "text"}],
+        "output_features": [{"name": "product", "type": "category"}],
+        "trainer": {"epochs": 5},
+        "model_type": "ecd",
+    }
     build_synthetic_dataset_df(dataset_size=100, config=config)
     LudwigModel(config=config, logging_level=logging.INFO)


### PR DESCRIPTION
Turns out this was just an issue with the dataset synthesizer. The dataset synthesizer groups input and output features together as one group of features and then checks whether there is an encoder or decoder present on each feature. If there is not, then by default it adds an encoder. This causes a problem when there is an output feature without a decoder specified since it creates an encoder entry on the decoder with a structure like this:
`{
     'name': 'product', 
     'type': 'category', 
     'decoder': {'encoder': {'idx2str': ['oXpJUe', 'fmzl', 'xZFbGsbW', 'YlUXGspxB', 'lru', 'wtQppfKBo', 'XgIhvyQg', 'wcvA', 'oVWamB', 'zZJjV'], 'vocab_size': 10}},
      'column': 'product', 
     'proc_column': 'product_mZFLky'
}`

I created a quick check in the dataset synthesizer that adds a decoder to output features without a decoder parameter which fixes the failure.