### PR TITLE
Move `on_batch_end` callback to omit eval from batch duration during benchmarking

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -948,6 +948,8 @@ class Trainer(BaseTrainer):
                     f"{psutil.Process(os.getpid()).memory_info()[0] / 1e6:0.2f}MB"
                 )
 
+            self.callback(lambda c: c.on_batch_end(self, progress_tracker, save_path))
+
             if progress_tracker.steps % final_steps_per_checkpoint == 0:
                 # Checkpoint the model.
                 if self.is_coordinator() and not self.skip_save_progress:
@@ -972,8 +974,6 @@ class Trainer(BaseTrainer):
                 )
                 if should_break:
                     return should_break
-
-            self.callback(lambda c: c.on_batch_end(self, progress_tracker, save_path))
 
         return False
 


### PR DESCRIPTION
This PR moves the `on_batch_end` callback to before `run_evaluation` is called. This is useful in getting us more accurate batch throughput measurements during benchmarking. Prior to this change, any measurements of average batch duration would incorporate the evaluation step, particularly if the average batch duration was computed across multiple epochs, leading to a (potentially significant) underestimation of average batch duration.