### PR TITLE
Annotate Confusion Matrix with updated cmap

### DIFF
--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -1074,12 +1074,24 @@ def confusion_matrix_plot(
     ax.xaxis.tick_top()
     ax.xaxis.set_label_position("top")
 
-    cax = ax.matshow(confusion_matrix, cmap="viridis")
+    cax = ax.matshow(confusion_matrix, cmap="Pastel1")
+    # Annotate confusion matrix plot
+    for (i, j), z in np.ndenumerate(confusion_matrix):
+        ax.text(
+            j,
+            i,
+            f"{z:.0f}",
+            ha="center",
+            va="center",
+            color="black",
+            fontweight="bold",
+            wrap=True,
+        )
 
     ax.xaxis.set_major_locator(ticker.MultipleLocator(1))
     ax.yaxis.set_major_locator(ticker.MultipleLocator(1))
     ax.set_xticklabels([""] + labels, rotation=45, ha="left")
-    ax.set_yticklabels([""] + labels)
+    ax.set_yticklabels([""] + labels, rotation=45, ha="right")
     ax.grid(False)
     ax.tick_params(axis="both", which="both", length=0)
     fig.colorbar(cax, ax=ax, extend="max")

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -1084,7 +1084,7 @@ def confusion_matrix_plot(
             ha="center",
             va="center",
             color="black",
-            fontweight="bold",
+            fontweight="medium",
             wrap=True,
         )
 


### PR DESCRIPTION
Before:

<img width="598" alt="Screen Shot 2023-01-05 at 4 13 34 PM" src="https://user-images.githubusercontent.com/106701836/210904238-744a249a-8977-4ea5-bcf8-0f31a08f3cd1.png">

Now:

<img width="633" alt="Screen Shot 2023-01-05 at 4 28 58 PM" src="https://user-images.githubusercontent.com/106701836/210905435-4947fd66-3112-4163-bf4d-60c62ffddda9.png">


Changes:

- Changed cmap from viridis to pastel1 to ensure that annotated text (cm numbers) can always be seen. Pastel has lighter colors only so ensures that this happens.
- Rotate y-axis labels to be consistent with the x-axis
- Adds confusion matrix number annotations inside the confusion matrix plot with a medium font-weight (can change this to normal if it's too much)