### PR TITLE
Dynamically resize confusion matrix and f1 plots

### DIFF
--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -1113,7 +1113,7 @@ def double_axis_line_plot(
 
     # Dynamically adjust figure size based on number of labels
     _, height = plt.rcParams.get("figure.figsize")
-    fig, ax1 = plt.subplots(layout="constrained", figsize=(len(labels) / 2, height))
+    fig, ax1 = plt.subplots(layout="constrained", figsize=(len(labels) / 3, height))
 
     if title is not None:
         ax1.set_title(title)

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -1068,7 +1068,9 @@ def confusion_matrix_plot(
     callbacks=None,
 ):
     mpl.rcParams.update({"figure.autolayout": True})
-    fig, ax = plt.subplots()
+
+    # Dynamically set the size of the plot based on the number of labels
+    fig, ax = plt.subplots(figsize=(len(labels) / 2, len(labels) / 2))
 
     ax.invert_yaxis()
     ax.xaxis.tick_top()
@@ -1082,14 +1084,15 @@ def confusion_matrix_plot(
     ax.set_yticklabels([""] + labels)
     ax.grid(False)
     ax.tick_params(axis="both", which="both", length=0)
-    fig.colorbar(cax, ax=ax, extend="max")
+    # https://stackoverflow.com/a/26720422/10102370 works nicely for square plots
+    fig.colorbar(cax, ax=ax, extend="max", fraction=0.046, pad=0.04)
     ax.set_xlabel(f"Predicted {output_feature_name}")
     ax.set_ylabel(f"Actual {output_feature_name}")
 
     plt.tight_layout()
     visualize_callbacks(callbacks, plt.gcf())
     if filename:
-        plt.savefig(filename)
+        plt.savefig(filename, bbox_inches="tight")
     else:
         plt.show()
 
@@ -1108,7 +1111,9 @@ def double_axis_line_plot(
 
     colors = plt.get_cmap("tab10").colors
 
-    fig, ax1 = plt.subplots()
+    # Dynamically adjust figure size based on number of labels
+    _, height = plt.rcParams.get("figure.figsize")
+    fig, ax1 = plt.subplots(layout="constrained", figsize=(len(labels) / 2, height))
 
     if title is not None:
         ax1.set_title(title)


### PR DESCRIPTION
This PR uses a heuristic to resize confusion matrix and f1 plots to prevent labels getting smushed. 

Before:

<img width="446" alt="Screen Shot 2023-01-05 at 5 30 01 PM" src="https://user-images.githubusercontent.com/106701836/210911269-526ae641-f41e-452c-887b-de9c2dea2367.png">

<img width="644" alt="Screen Shot 2023-01-05 at 5 30 22 PM" src="https://user-images.githubusercontent.com/106701836/210911294-7cfeba9a-2059-45f2-b55e-527e91bfdc8e.png">

Now:

![image](https://user-images.githubusercontent.com/106701836/210911332-1b771873-12d3-443c-ba97-5af0dae0587c.png)

<img width="674" alt="Screen Shot 2023-01-05 at 5 27 59 PM" src="https://user-images.githubusercontent.com/106701836/210911367-bf33ecb1-ff49-4585-9b4c-9e65421bcac9.png">
