### PR TITLE
fix: Remove extra properties from `input_features`, `output_features`, `defaults` schemas for GBM models

### DIFF
--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -48,7 +48,7 @@ def get_schema(model_type: str = MODEL_ECD):
             TRAINER: get_trainer_jsonschema(model_type),
             PREPROCESSING: get_preprocessing_jsonschema(),
             HYPEROPT: get_hyperopt_jsonschema(),
-            DEFAULTS: get_defaults_jsonschema(),
+            DEFAULTS: get_defaults_jsonschema(model_type),
             LUDWIG_VERSION: get_ludwig_version_jsonschema(),
         },
         "definitions": {},

--- a/ludwig/schema/defaults/defaults.py
+++ b/ludwig/schema/defaults/defaults.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from marshmallow_dataclass import dataclass
 
 from ludwig.api_annotations import DeveloperAPI
@@ -9,6 +11,8 @@ from ludwig.constants import (
     DATE,
     H3,
     IMAGE,
+    MODEL_ECD,
+    MODEL_GBM,
     NUMBER,
     SEQUENCE,
     SET,
@@ -51,15 +55,36 @@ class DefaultsConfig(schema_utils.BaseMarshmallowConfig):
     vector: BaseFeatureConfig = DefaultsDataclassField(feature_type=VECTOR)
 
 
+def prune_gbm_props(schema: Dict):
+    """Removes unsupported props from the given JSON schema.
+
+    Designed for use with `get_defaults_jsonschema`.
+    """
+    gbm_feature_types = ["binary", "category", "number"]
+    pruned_props = {}
+    for default_feature_type in schema["properties"]:
+        if default_feature_type in gbm_feature_types:
+            ft_schema = schema["properties"][default_feature_type]
+            pruned_ft_schema_properties = {
+                k: v for k, v in ft_schema["properties"].items() if k not in ["encoder", "decoder", "tied"]
+            }
+            pruned_props[default_feature_type] = {**ft_schema, "properties": pruned_ft_schema_properties}
+    return {**schema, "properties": pruned_props}
+
+
 @DeveloperAPI
-def get_defaults_jsonschema():
+def get_defaults_jsonschema(model_type: str = MODEL_ECD):
     """Returns a JSON schema structured to only require a `type` key and then conditionally apply a corresponding
     combiner's field constraints."""
     preproc_schema = schema_utils.unload_jsonschema_from_marshmallow_class(DefaultsConfig)
-    props = preproc_schema["properties"]
+
+    # Prune extra props if is GBM model:
+    if model_type == MODEL_GBM:
+        preproc_schema = prune_gbm_props(preproc_schema)
+
     return {
         "type": "object",
-        "properties": props,
+        "properties": preproc_schema["properties"],
         "additionalProperties": False,
         "title": "global_defaults_options",
         "description": "Set global defaults for input and output features",

--- a/ludwig/schema/features/utils.py
+++ b/ludwig/schema/features/utils.py
@@ -28,10 +28,19 @@ def prune_gbm_features(schema: Dict):
     """
     gbm_feature_types = ["binary", "category", "number"]
     pruned_all_of = []
+
     for cond in schema["items"]["allOf"]:
         if_type = cond["if"]["properties"]["type"]["const"]
         if if_type in gbm_feature_types:
+            pruned_then_properties = {
+                k: v
+                for k, v in cond["then"]["properties"].items()
+                if k not in ["encoder", "decoder", "tied", "input_size", "num_classes", "top_k"]
+            }
+            cond["then"]["properties"] = pruned_then_properties
+
             pruned_all_of += [cond]
+
     schema["items"]["allOf"] = pruned_all_of
 
 


### PR DESCRIPTION
Removes extra properties from the features and defaults schemas that are otherwise unsupported by GBM.

In particular
* `encoder` and `decoder` sub schemas are removed
* Only GBM-supported feature types are left behind after pruning the defaults schema
* Extra fields with references to encoders/decoders are removed: `input_size`, 'top_k`, `num_classes` - can I get a double check on this?