### PR TITLE
Adds quick fix for pretrained models not loading by modifying state_dict keys on load.

### DIFF
--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -14,6 +14,7 @@ from ludwig.schema.model_config import ModelConfig
 from ludwig.utils import output_feature_utils
 from ludwig.utils.data_utils import clear_data_cache
 from ludwig.utils.fs_utils import open_file
+from ludwig.utils.state_dict_backward_compatibility import update_state_dict
 from ludwig.utils.torch_utils import get_torch_device
 
 logger = logging.getLogger(__name__)
@@ -150,7 +151,8 @@ class ECD(BaseModel):
         weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
         device = torch.device(get_torch_device())
         with open_file(weights_save_path, "rb") as f:
-            self.load_state_dict(torch.load(f, map_location=device))
+            state_dict = torch.load(f, map_location=device)
+            self.load_state_dict(update_state_dict(state_dict))
 
     def get_args(self):
         """Returns init arguments for constructing this model."""

--- a/ludwig/utils/state_dict_backward_compatibility.py
+++ b/ludwig/utils/state_dict_backward_compatibility.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2023 Predibase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+def _update_transformers_to_freeze_module(state_dict):
+    """Updates pre-trained encoders which were saved prior to the addition of FreezeModule."""
+    return {
+        k.replace("encoder_obj.transformer.", "encoder_obj.transformer.module.")
+        if "encoder_obj.transformer.module" not in k
+        else k: v
+        for k, v in state_dict.items()
+    }
+
+
+def update_state_dict(state_dict):
+    """Checks state_dict on load, updates state dict if needed."""
+    state_dict = _update_transformers_to_freeze_module(state_dict)
+    return state_dict

--- a/tests/ludwig/utils/test_state_dict_backward_compatibility.py
+++ b/tests/ludwig/utils/test_state_dict_backward_compatibility.py
@@ -4,8 +4,8 @@ from ludwig.utils.state_dict_backward_compatibility import update_state_dict
 def test_update_transformer_module_keys():
     state_dict_with_old_keys = {
         "input_features.module_dict.sentence__ludwig.encoder_obj.transformer.embeddings.LayerNorm.bias": 0.0,
-        "module_dict.sentence__ludwig.encoder_obj.transformer.encoder.layer.0.attention.output.LayerNorm.weight": 0.0,
-        "input_features.module_dict.sentence__ludwig.encoder_obj.transformer.embeddings.word_embeddings.weight": 0.0,
+        "sentence__ludwig.encoder_obj.transformer.encoder.layer.0.attention.output.LayerNorm.weight": 0.0,
+        "module_dict.sentence__ludwig.encoder_obj.transformer.embeddings.word_embeddings.weight": 0.0,
     }
 
     expected_state_dict = {

--- a/tests/ludwig/utils/test_state_dict_backward_compatibility.py
+++ b/tests/ludwig/utils/test_state_dict_backward_compatibility.py
@@ -1,0 +1,31 @@
+from ludwig.utils.state_dict_backward_compatibility import update_state_dict
+
+
+def test_update_transformer_module_keys():
+    state_dict_with_old_keys = {
+        "input_features.module_dict.sentence__ludwig.encoder_obj.transformer.embeddings.LayerNorm.bias": 0.0,
+        "module_dict.sentence__ludwig.encoder_obj.transformer.encoder.layer.0.attention.output.LayerNorm.weight": 0.0,
+        "input_features.module_dict.sentence__ludwig.encoder_obj.transformer.embeddings.word_embeddings.weight": 0.0,
+    }
+
+    expected_state_dict = {
+        "input_features.module_dict.sentence__ludwig.encoder_obj.transformer.module.embeddings.LayerNorm.bias": 0.0,
+        "sentence__ludwig.encoder_obj.transformer.module.encoder.layer.0.attention.output.LayerNorm.weight": 0.0,
+        "module_dict.sentence__ludwig.encoder_obj.transformer.module.embeddings.word_embeddings.weight": 0.0,
+    }
+
+    # Ensures that, for models saved before FreezeModule was added, 'module' is added to the key path.
+    updated_state_dict = update_state_dict(state_dict_with_old_keys)
+    assert updated_state_dict == expected_state_dict
+
+
+def test_does_not_update_freeze_module():
+    state_dict = {
+        "module_dict.sentence__ludwig.encoder_obj.transformer.module.embeddings.LayerNorm.bias": 0.0,
+        "sentence__ludwig.encoder_obj.transformer.module.encoder.layer.0.attention.output.LayerNorm.weight": 0.0,
+        "module_dict.sentence__ludwig.encoder_obj.transformer.module.embeddings.word_embeddings.weight": 0.0,
+    }
+
+    # Ensures that models saved with FreezeModule aren't modified.
+    updated_state_dict = update_state_dict(state_dict)
+    assert updated_state_dict == state_dict


### PR DESCRIPTION
Quick fix for loading modules with pre-trained encoders which were saved prior to the addition of FreezeModule (https://github.com/ludwig-ai/ludwig/pull/2855).
