### PR TITLE
Simplify titanic example to read config in-line, and skip saving processed input.

### DIFF
--- a/examples/titanic/simple_model_training.py
+++ b/examples/titanic/simple_model_training.py
@@ -10,6 +10,8 @@ import logging
 import os
 import shutil
 
+import yaml
+
 from ludwig.api import LudwigModel
 from ludwig.datasets import titanic
 
@@ -19,15 +21,46 @@ shutil.rmtree("./results", ignore_errors=True)
 # Download and prepare the dataset
 training_set, test_set, _ = titanic.load(split=True)
 
+config = yaml.safe_load(
+    """
+input_features:
+    - name: Pclass
+      type: category
+    - name: Sex
+      type: category
+    - name: Age
+      type: number
+      preprocessing:
+          missing_value_strategy: fill_with_mean
+    - name: SibSp
+      type: number
+    - name: Parch
+      type: number
+    - name: Fare
+      type: number
+      preprocessing:
+          missing_value_strategy: fill_with_mean
+    - name: Embarked
+      type: category
+
+output_features:
+    - name: Survived
+      type: binary
+
+"""
+)
+
 # Define Ludwig model object that drive model training
-model = LudwigModel(config="./model1_config.yaml", logging_level=logging.INFO)
+model = LudwigModel(config=config, logging_level=logging.INFO)
 
 # initiate model training
 (
     train_stats,  # dictionary containing training statistics
     preprocessed_data,  # tuple Ludwig Dataset objects of pre-processed training data
     output_directory,  # location of training results stored on disk
-) = model.train(dataset=training_set, experiment_name="simple_experiment", model_name="simple_model")
+) = model.train(
+    dataset=training_set, experiment_name="simple_experiment", model_name="simple_model", skip_save_processed_input=True
+)
 
 # list contents of output directory
 print("contents of output directory:", output_directory)


### PR DESCRIPTION
I often use the titanic example to test local changes. Making some modifications here to make it a bit more convenient to use and avoid producing vestigial files.