### PR TITLE
Pin torchvision to 0.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ tqdm
 torch>=1.13.1
 torchaudio
 torchtext
-torchvision>=0.14.0
+torchvision
 transformers>=4.10.1,<4.22
 spacy>=2.3
 PyYAML>=3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scipy>=0.18
 tabulate>=0.7
 scikit-learn<1.2.0
 tqdm
-torch>=1.10.0
+torch>=1.13.1
 torchaudio
 torchtext
 torchvision>=0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scipy>=0.18
 tabulate>=0.7
 scikit-learn<1.2.0
 tqdm
-torch>=1.13.1
+torch>=1.13.0
 torchaudio
 torchtext
 torchvision

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ tqdm
 torch>=1.10.0
 torchaudio
 torchtext
-torchvision>=0.10.1
+torchvision>=0.14.0
 transformers>=4.10.1,<4.22
 spacy>=2.3
 PyYAML>=3.12


### PR DESCRIPTION
With https://github.com/ludwig-ai/ludwig/pull/2408 merged in, we now need torchvision at `>=0.14.0` due to some vision models not being available in previous versions. Specifically, there's a model called `maxvit_t` that's being imported on line 349 of `image_torchvision_encoders.py` which isn't available until `0.14.0`. For compatibility sake we may need to pin the other torch dependencies to `>=0.13.0`.

Looks like torch `0.13.0` has a [vulnerability](https://devhub.checkmarx.com/cve-details/CVE-2022-45907/?utm_source=jetbrains&utm_medium=referral&utm_campaign=pycharm&utm_term=python) so I pinned to `0.13.1`.