### PR TITLE
Hyperopt invalid GBM config

### DIFF
--- a/ludwig/schema/model_config.py
+++ b/ludwig/schema/model_config.py
@@ -527,19 +527,21 @@ class ModelConfig(BaseMarshmallowConfig):
 
         max_t = scheduler.get("max_t")
         time_attr = scheduler.get("time_attr")
-        epochs = self.trainer.to_dict().get("epochs", None)
+        epochs_key = "epochs" if self.model_type == MODEL_ECD else "num_boost_round"
+        epochs = self.trainer.to_dict().get(epochs_key, None)
         if max_t is not None:
             if time_attr == "time_total_s":
                 if epochs is None:
-                    setattr(self.trainer, "epochs", sys.maxsize)  # continue training until time limit hit
+                    setattr(self.trainer, epochs_key, sys.maxsize)  # continue training until time limit hit
                 # else continue training until either time or trainer epochs limit hit
             elif epochs is not None and epochs != max_t:
                 raise ValueError(
-                    "Cannot set trainer `epochs` when using hyperopt scheduler w/different training_iteration `max_t`. "
+                    f"Cannot set trainer `{epochs_key}` when using hyperopt scheduler w/ "
+                    "different training_iteration `max_t`. "
                     "Unset one of these parameters in your config or make sure their values match."
                 )
             else:
-                setattr(self.trainer, "epochs", max_t)  # run trainer until scheduler epochs limit hit
+                setattr(self.trainer, epochs_key, max_t)  # run trainer until scheduler epochs limit hit
         elif epochs is not None:
             scheduler["max_t"] = epochs  # run scheduler until trainer epochs limit hit
 

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -527,6 +527,11 @@ class GBMTrainerConfig(BaseTrainerConfig):
         default=255, description="Maximum number of bins to use for discretizing features with GBM trainer."
     )
 
+    feature_pre_filter: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether to ignore features that are unsplittable based on min_data_in_leaf in the GBM trainer.",
+    )
+
 
 @DeveloperAPI
 def get_model_type_jsonschema(model_type: str = MODEL_ECD):

--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -137,6 +137,7 @@ class LightGBMTrainer(BaseTrainer):
         self.path_smooth = config.path_smooth
         self.verbose = config.verbose
         self.max_bin = config.max_bin
+        self.feature_pre_filter = config.feature_pre_filter
 
         self.device = device
         if self.device is None:
@@ -813,6 +814,7 @@ class LightGBMTrainer(BaseTrainer):
             "tree_learner": self.tree_learner,
             "min_data_in_leaf": self.min_data_in_leaf,
             "min_sum_hessian_in_leaf": self.min_sum_hessian_in_leaf,
+            "feature_pre_filter": self.feature_pre_filter,
             "seed": self.random_seed,
             **output_params,
         }

--- a/tests/ludwig/hyperopt/test_hyperopt.py
+++ b/tests/ludwig/hyperopt/test_hyperopt.py
@@ -90,6 +90,9 @@ def test_grid_search_more_than_one_sample():
 
 
 def test_hyperopt_config_gbm():
+    """This test was added due to a schema validation error when hyperopting GBMs:
+    ```jsonschema.exceptions.ValidationError: Additional properties are not allowed ('epochs' was unexpected)```
+    """
     config = {
         "input_features": [{"name": "Date received", "type": "category"}],
         "output_features": [{"name": "Product", "type": "category"}],

--- a/tests/ludwig/hyperopt/test_hyperopt.py
+++ b/tests/ludwig/hyperopt/test_hyperopt.py
@@ -91,6 +91,7 @@ def test_grid_search_more_than_one_sample():
 
 def test_hyperopt_config_gbm():
     """This test was added due to a schema validation error when hyperopting GBMs:
+
     ```jsonschema.exceptions.ValidationError: Additional properties are not allowed ('epochs' was unexpected)```
     """
     config = {

--- a/tests/ludwig/hyperopt/test_hyperopt.py
+++ b/tests/ludwig/hyperopt/test_hyperopt.py
@@ -2,6 +2,7 @@ import pytest
 
 from ludwig.constants import INPUT_FEATURES, NAME, OUTPUT_FEATURES, TYPE
 from ludwig.hyperopt.utils import log_warning_if_all_grid_type_parameters, substitute_parameters
+from ludwig.schema.model_config import ModelConfig
 
 BASE_CONFIG = {
     INPUT_FEATURES: [{NAME: "title", TYPE: "text"}],
@@ -86,3 +87,34 @@ def test_grid_search_more_than_one_sample():
             },
             num_samples=2,
         )
+
+
+def test_hyperopt_config_gbm():
+    config = {
+        "input_features": [{"name": "Date received", "type": "category"}],
+        "output_features": [{"name": "Product", "type": "category"}],
+        "hyperopt": {
+            "goal": "minimize",
+            "metric": "loss",
+            "executor": {
+                "type": "ray",
+                "scheduler": {
+                    "type": "async_hyperband",
+                    "max_t": 3600,
+                    "time_attr": "time_total_s",
+                    "grace_period": 72,
+                    "reduction_factor": 5,
+                },
+                "num_samples": 10,
+                "time_budget_s": 3600,
+                "cpu_resources_per_trial": 1,
+            },
+            "parameters": {"trainer.learning_rate": {"space": "choice", "categories": [0.005, 0.01, 0.02, 0.025]}},
+            "search_alg": {"type": "hyperopt", "random_state_seed": 42},
+            "output_feature": "Product",
+        },
+        "model_type": "gbm",
+    }
+
+    # Config should not raise an exception
+    ModelConfig.from_dict(config)


### PR DESCRIPTION
- `_set_hyperopt_defaults` was assuming ECD models (due to setting `epochs`, vs `num_boost_round` for GBM)
- added basic GBM tests to our hyperopt integration test suite