### PR TITLE
Store mlflow tracking URI to ensure consistency across processes

### DIFF
--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -117,6 +117,7 @@ class MlflowCallback(Callback):
                 run_name = os.path.basename(output_directory)
                 self.run = mlflow.start_run(experiment_id=self.experiment_id, run_name=run_name)
 
+        print("!!! ON TRAIN INIT !!!", mlflow.get_tracking_uri(), mlflow.active_run())
         self.log_config(base_config)
 
     def log_config(self, config):
@@ -192,6 +193,7 @@ class MlflowCallback(Callback):
         self.__dict__ = d
         if self.tracking_uri:
             mlflow.set_tracking_uri(self.tracking_uri)
+        print("!!! SET STATE !!!", mlflow.get_tracking_uri(), mlflow.active_run())
         if self.run and not self.run_ended:
             # Run has already been set, but may not be active due to training workers running in a separate
             # process, so resume the run

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -40,6 +40,7 @@ class MlflowCallback(Callback):
     def __init__(self, tracking_uri=None, log_artifacts: bool = True):
         if tracking_uri:
             mlflow.set_tracking_uri(tracking_uri)
+        self.tracking_uri = mlflow.get_tracking_uri()
 
         active_run = mlflow.active_run()
         if active_run is not None:
@@ -56,7 +57,6 @@ class MlflowCallback(Callback):
             self.external_run = False
 
         self.run_ended = False
-        self.tracking_uri = tracking_uri
         self.training_set_metadata = None
         self.config = None
         self.save_in_background = True
@@ -117,7 +117,6 @@ class MlflowCallback(Callback):
                 run_name = os.path.basename(output_directory)
                 self.run = mlflow.start_run(experiment_id=self.experiment_id, run_name=run_name)
 
-        print("!!! ON TRAIN INIT !!!", mlflow.get_tracking_uri(), mlflow.active_run())
         self.log_config(base_config)
 
     def log_config(self, config):
@@ -193,7 +192,6 @@ class MlflowCallback(Callback):
         self.__dict__ = d
         if self.tracking_uri:
             mlflow.set_tracking_uri(self.tracking_uri)
-        print("!!! SET STATE !!!", mlflow.get_tracking_uri(), mlflow.active_run())
         if self.run and not self.run_ended:
             # Run has already been set, but may not be active due to training workers running in a separate
             # process, so resume the run

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -163,7 +163,7 @@ def test_export_mlflow_local(tmpdir):
 
     exp_name = "mlflow_test"
     output_dir = os.path.join(tmpdir, "output")
-    model = LudwigModel(config, callbacks=[MlflowCallback()], backend="ray")
+    model = LudwigModel(config, backend=FakeRemoteBackend())
     _, _, output_directory = model.train(training_set=data_csv, experiment_name=exp_name, output_directory=output_dir)
 
     model_path = os.path.join(output_directory, "model")


### PR DESCRIPTION
In the previous implementation, we pull the tracking URI from the environment every time we change context, which can result in inconsistent behavior if, for example, the current working directory changes and no external MLFlow service is being used.