### PR TITLE
Adds safe_move_directory to fs_utils

### DIFF
--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -195,7 +195,7 @@ def safe_move_directory(src, dst):
             tmp_dst = f"{dst}.{copy_id}.tmp"
             shutil.copytree(src, tmp_dst)
 
-            # Atomic replace file onto the new name, and clean up original source file.
+            # Atomic replace directory name onto the new name, and clean up original source directory.
             os.replace(tmp_dst, dst)
             os.unlink(src)
         else:

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -184,6 +184,10 @@ def safe_move_file(src, dst):
 
 @DeveloperAPI
 def safe_move_directory(src, dst):
+    """Recursively moves files from src directory to dst directory and removes src directory.
+
+    If dst directory does not exist, it will be created.
+    """
     try:
         os.replace(src, dst)
     except OSError as err:

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -193,7 +193,7 @@ def safe_move_directory(src, dst):
             # random UUID so if different processes are copying into `<dst>`, they don't overlap in their tmp copies.
             copy_id = uuid.uuid4()
             tmp_dst = f"{dst}.{copy_id}.tmp"
-            shutil.copyfile(src, tmp_dst)
+            shutil.copytree(src, tmp_dst)
 
             # Atomic replace file onto the new name, and clean up original source file.
             os.replace(tmp_dst, dst)

--- a/tests/ludwig/utils/test_fs_utils.py
+++ b/tests/ludwig/utils/test_fs_utils.py
@@ -6,7 +6,7 @@ from urllib.parse import quote
 
 import pytest
 
-from ludwig.utils.fs_utils import get_fs_and_path
+from ludwig.utils.fs_utils import get_fs_and_path, safe_move_directory
 
 logger = logging.getLogger(__name__)
 
@@ -73,3 +73,22 @@ def test_get_fs_and_path_invalid_windows():
         url = f"http://a/{quote(c)}"
         with pytest.raises(e):
             create_file(url)
+
+
+@pytest.mark.filesystem
+def test_safe_move_directory(tmpdir):
+    src_dir = os.path.join(tmpdir, "src")
+    dst_dir = os.path.join(tmpdir, "dst")
+
+    os.mkdir(src_dir)
+    os.mkdir(dst_dir)
+
+    with open(os.path.join(src_dir, "file.txt"), "w") as f:
+        f.write("test")
+
+    safe_move_directory(src_dir, dst_dir)
+
+    assert not os.path.exists(src_dir)
+    assert os.path.exists(os.path.join(dst_dir, "file.txt"))
+    with open(os.path.join(dst_dir, "file.txt")) as f:
+        assert f.read() == "test"


### PR DESCRIPTION
Adds a companion method `safe_move_directory` to fs_utils which is inspired by `safe_move_file`. 