### PR TITLE
Dynamic resizing for Confusion Matrix, Brier, F1 Plot, etc.

### DIFF
--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -61,11 +61,6 @@ RAY_TUNE_CATEGORY_SPACES = {"choice", "grid_search"}
 _matplotlib_34 = version.parse(mpl.__version__) >= version.parse("3.4")
 
 
-# plt.rc('xtick', labelsize='x-large')
-# plt.rc('ytick', labelsize='x-large')
-# plt.rc('axes', labelsize='x-large')
-
-
 def visualize_callbacks(callbacks, fig):
     if callbacks is None:
         return
@@ -1070,13 +1065,18 @@ def confusion_matrix_plot(
     mpl.rcParams.update({"figure.autolayout": True})
 
     # Dynamically set the size of the plot based on the number of labels
-    fig, ax = plt.subplots(figsize=(len(labels) / 2, len(labels) / 2))
+    # Use minimum size to prevent plot from being too small
+    default_width, default_height = plt.rcParams.get("figure.figsize")
+    width = max(default_width, len(labels) / 2)
+    height = max(default_height, len(labels) / 2)
+    fig, ax = plt.subplots(figsize=(width, height))
 
     ax.invert_yaxis()
     ax.xaxis.tick_top()
     ax.xaxis.set_label_position("top")
 
-    cax = ax.matshow(confusion_matrix, cmap="Pastel1")
+    # Set alpha value to prevent blue hues from being too dark
+    cax = ax.matshow(confusion_matrix, cmap="Blues", alpha=0.6)
     # Annotate confusion matrix plot
     for (i, j), z in np.ndenumerate(confusion_matrix):
         ax.text(
@@ -1266,7 +1266,11 @@ def bar_plot(
 
     sns.set_style("whitegrid")
 
-    fig, ax = plt.subplots()
+    # Dynamically set the size of the plot based on the number of labels
+    # Use minimum size to prevent plot from being too small
+    default_width, default_height = plt.rcParams.get("figure.figsize")
+    width = max(default_width, len(labels) / 2)
+    _, ax = plt.subplots(figsize=(width, default_height))
 
     ax.grid(which="both")
     ax.grid(which="minor", alpha=0.5)

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -971,9 +971,14 @@ def brier_plot(
     filename=None,
     callbacks=None,
 ):
-
-    fig, ax = plt.subplots()
     sns.set_style("whitegrid")
+
+    # Dynamically set the size of the plot based on the number of labels
+    # Use minimum size to prevent plot from being too small
+    default_width, default_height = plt.rcParams.get("figure.figsize")
+    width = max(default_width, len(class_names) / 2)
+    height = max(default_height, len(class_names) / 2)
+    fig, ax = plt.subplots(figsize=(width, height))
 
     if title is not None:
         plt.title(title)

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -1124,15 +1124,13 @@ def double_axis_line_plot(
     colors = plt.get_cmap("tab10").colors
 
     # Dynamically adjust figure size based on number of labels
-    _, height = plt.rcParams.get("figure.figsize")
-    fig, ax1 = plt.subplots(layout="constrained", figsize=(len(labels) / 3, height))
+    default_width, default_height = plt.rcParams.get("figure.figsize")
+    width = max(default_width, len(labels) / 3)
+    height = max(default_height, len(labels) / 3)
+    fig, ax1 = plt.subplots(layout="constrained", figsize=(width, height))
 
     if title is not None:
         ax1.set_title(title)
-
-    # ax1.grid(which='both')
-    # ax1.grid(which='minor', alpha=0.5)
-    # ax1.grid(which='major', alpha=0.75)
 
     ax1.set_xlabel(f"class (sorted by {y1_name})")
     ax1.set_xlim(0, len(y1_sorted) - 1)


### PR DESCRIPTION
**Confusion Matrix:**

1. Set minimum height and width to prevent plot from shrinking beyond a certain size
2. Changed colors to blues with slight alpha gradient so that there's a gradient coloration on the plot

Before:
![image](https://user-images.githubusercontent.com/106701836/212450546-db1cd1a1-6838-4132-830f-c6947f8b31f6.png)

Now:
<img width="459" alt="Screen Shot 2023-01-13 at 7 54 49 PM" src="https://user-images.githubusercontent.com/106701836/212450565-71eb7f3d-b5be-4c14-8e88-29b7b4c6d244.png">

Before:
<img width="555" alt="Screen Shot 2023-01-13 at 8 27 49 PM" src="https://user-images.githubusercontent.com/106701836/212450577-c07c9b91-1ef0-4002-91c2-f5b222c6a0d0.png">

Now:
<img width="559" alt="Screen Shot 2023-01-13 at 7 54 38 PM" src="https://user-images.githubusercontent.com/106701836/212450583-c92276fa-0aed-4d29-888e-8df35815a4e2.png">


**Brier Plot**

1. Set minimum height and width to prevent plot from shrinking beyond a certain size
2. Dynamic resize width and height

Before:
<img width="454" alt="Screen Shot 2023-01-13 at 8 29 13 PM" src="https://user-images.githubusercontent.com/106701836/212450615-c57c9b0e-1f15-4170-8116-ff404bffe094.png">

Now (it will adjust dynamically, this plot just shows 2 models overlaid on the same chart):
<img width="609" alt="Screen Shot 2023-01-13 at 8 29 43 PM" src="https://user-images.githubusercontent.com/106701836/212450635-39321561-760a-4d72-95c7-9eb6b386263e.png">

**F1 Score Plot**

1. Set minimum height and width to prevent plot from shrinking beyond a certain size
2. Dynamic resize width and height

Before:
<img width="339" alt="Screen Shot 2023-01-13 at 8 30 33 PM" src="https://user-images.githubusercontent.com/106701836/212450665-0af3487d-76a2-45a5-a638-f0db04cb1190.png">

Now (height is also dynamically adjusted):
<img width="852" alt="Screen Shot 2023-01-13 at 8 02 48 PM" src="https://user-images.githubusercontent.com/106701836/212450670-aaf25939-8aa4-4d1f-8e5a-06baf3c57323.png">