### PR TITLE
FIX: Error computing AUROC metric for categorical output feature during training

### DIFF
--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -317,7 +317,7 @@ class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):
         return torch.Size([1])
 
     def metric_kwargs(self):
-        return dict(top_k=self.top_k)
+        return dict(top_k=self.top_k, num_classes=self.decoder_obj.num_classes)
 
     @staticmethod
     def update_config_with_metadata(feature_config, feature_metadata, *args, **kwargs):

--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -169,7 +169,11 @@ class AUROCMetric(AUROC, LudwigMetric):
     """Area under the receiver operating curve."""
 
     def __init__(self, **kwargs):
-        super().__init__(dist_sync_fn=_gather_all_tensors_fn())
+        # if `num_classes` is not specified, assume it is a binary output feature and
+        # return None, torchmetrics function will handle this case
+        num_classes = kwargs.pop("num_classes", None)
+
+        super().__init__(num_classes=num_classes, dist_sync_fn=_gather_all_tensors_fn())
 
     @classmethod
     def get_objective(cls):


### PR DESCRIPTION
# Code Pull Requests

Fix Issue #2938 

Sample training log metrics with missing `auc_roc` metric for categorical output feature
```
╒══════════════════╤════════════╤═════════════╤════════╤═══════════╕
│ category_FB597   │   accuracy │   hits_at_k │   loss │   roc_auc │
╞══════════════════╪════════════╪═════════════╪════════╪═══════════╡
│ train            │     0.0914 │      0.3300 │ 2.3248 │    0.5046 │
├──────────────────┼────────────┼─────────────┼────────┼───────────┤
│ validation       │     0.0900 │      0.3500 │ 2.3146 │    0.5049 │
├──────────────────┼────────────┼─────────────┼────────���───────────┤
│ test             │     0.0900 │      0.2750 │ 2.3285 │    0.5188 │
╘══════════════════╧════════════╧═════════════╧════════╧═══════════╛
╒════════════╤════════╕
│ combined   │   loss │
╞════════════╪════════╡
│ train      │ 2.3248 │
├────────────┼────────┤
│ validation │ 2.3146 │
├────────────┼────────┤
│ test       │ 2.3285 │
╘════════════╧════════╛
Last improvement of category_FB597 validation accuracy happened 11 step(s) ago.
```

Sample training log metrics with missing `auc_roc` metric for binary output feature.  This confirms fix did not affect reporting for the binary output feature
```
╒════════════════╤════════════╤════════╤═════════════╤══════════╤═══════════╕
│ binary_F0C78   │   accuracy │   loss │   precision │   recall │   roc_auc │
╞════════════════╪════════════╪════════╪═════════════╪══════════╪═══════════╡
│ train          │     0.5357 │ 0.7841 │      0.5357 │   1.0000 │    0.5331 │
├────────────────┼────────────┼────────┼─────────────┼──────────┼───────────┤
│ validation     │     0.5900 │ 0.7442 │      0.5900 │   1.0000 │    0.4444 │
├────────────────���────────────┼────────┼─────────────┼──────────┼───────────┤
│ test           │     0.5300 │ 0.7962 │      0.5300 │   1.0000 │    0.4731 │
╘════════════════╧════════════╧════════╧═════════════╧══════════╧═══════════╛
╒════════════╤════════╕
│ combined   │   loss │
╞════════════╪════════╡
│ train      │ 0.7841 │
├────────────┼────────┤
│ validation │ 0.7442 │
├────────────┼────────┤
│ test       │ 0.7962 │
╘════════════╧════════╛
Last improvement of binary_F0C78 validation roc_auc happened 11 step(s) ago.
```