### PR TITLE
[automl] Exclude text fields with low avg words

### DIFF
--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -408,6 +408,7 @@ def get_field_metadata(fields: List[FieldInfo], row_count: int, targets: Set[str
     """
 
     metadata = []
+    column_count = len(fields)
     for idx, field in enumerate(fields):
         missing_value_percent = 1 - float(field.nonnull_values) / row_count
         dtype = infer_type(field, missing_value_percent, row_count)
@@ -419,7 +420,7 @@ def get_field_metadata(fields: List[FieldInfo], row_count: int, targets: Set[str
                     column=field.name,
                     type=dtype,
                 ),
-                excluded=should_exclude(idx, field, dtype, row_count, targets),
+                excluded=should_exclude(idx, field, dtype, column_count, row_count, targets),
                 mode=infer_mode(field, targets),
                 missing_values=missing_value_percent,
                 imbalance_ratio=field.distinct_values_balance,

--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -6,6 +6,7 @@ from jsonschema.validators import extend
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import (
+    BACKEND,
     COMBINER,
     DEFAULTS,
     HYPEROPT,
@@ -36,6 +37,16 @@ def get_ludwig_version_jsonschema():
     }
 
 
+def get_backend_jsonschema():
+    # TODO(travis): implement full backend schema
+    return {
+        "type": "object",
+        "title": "backend",
+        "description": "Backend configuration.",
+        "additionalProperties": True,
+    }
+
+
 @DeveloperAPI
 @lru_cache(maxsize=2)
 def get_schema(model_type: str = MODEL_ECD):
@@ -50,6 +61,7 @@ def get_schema(model_type: str = MODEL_ECD):
             HYPEROPT: get_hyperopt_jsonschema(),
             DEFAULTS: get_defaults_jsonschema(),
             LUDWIG_VERSION: get_ludwig_version_jsonschema(),
+            BACKEND: get_backend_jsonschema(),
         },
         "definitions": {},
         "required": [INPUT_FEATURES, OUTPUT_FEATURES],

--- a/ludwig/utils/automl/type_inference.py
+++ b/ludwig/utils/automl/type_inference.py
@@ -62,7 +62,9 @@ def infer_type(field: FieldInfo, missing_value_percent: float, row_count: int) -
 
 
 @DeveloperAPI
-def should_exclude(idx: int, field: FieldInfo, dtype: str, row_count: int, targets: Set[str]) -> bool:
+def should_exclude(
+    idx: int, field: FieldInfo, dtype: str, column_count: int, row_count: int, targets: Set[str]
+) -> bool:
     if field.key == "PRI":
         return True
 
@@ -81,5 +83,10 @@ def should_exclude(idx: int, field: FieldInfo, dtype: str, row_count: int, targe
             or upper_name.startswith("ID")
         ):
             return True
+
+    # For TEXT fields, we only want to use them if they appear "interesting", otherwise we would rather exclude
+    # them and treat the problem as a tabular problem
+    if column_count > 3 and dtype == TEXT and field.avg_words < 5:
+        return False
 
     return False

--- a/ludwig/utils/automl/type_inference.py
+++ b/ludwig/utils/automl/type_inference.py
@@ -10,6 +10,10 @@ from ludwig.utils.automl.field_info import FieldInfo
 # assign the CATEGORY type.
 CATEGORY_TYPE_DISTINCT_VALUE_PERCENTAGE_CUTOFF = 0.5
 
+# Consider the field a valid text field if it has at least 5 average words. Fewer than this and it may be a cateogry
+# or an ID field (like a name or place) of some kind.
+TEXT_AVG_WORDS_CUTOFF = 5
+
 
 @DeveloperAPI
 def infer_type(field: FieldInfo, missing_value_percent: float, row_count: int) -> str:
@@ -42,6 +46,9 @@ def infer_type(field: FieldInfo, missing_value_percent: float, row_count: int) -
 
     if field.audio_values >= 3:
         return AUDIO
+
+    if field.avg_words and field.avg_words >= TEXT_AVG_WORDS_CUTOFF:
+        return TEXT
 
     # Use CATEGORY if:
     # - The number of distinct values is significantly less than the total number of examples.
@@ -90,7 +97,7 @@ def should_exclude(
 
     # For TEXT fields, we only want to use them if they appear "interesting", otherwise we would rather exclude
     # them and treat the problem as a tabular problem
-    if column_count > 3 and dtype == TEXT and (field.avg_words or 0) < 5:
+    if column_count > 3 and dtype == TEXT and (field.avg_words or 0) < TEXT_AVG_WORDS_CUTOFF:
         logging.info(f"Exclude {field.name} ({dtype}): too few average words")
         return True
 

--- a/ludwig/utils/automl/type_inference.py
+++ b/ludwig/utils/automl/type_inference.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Set
 
 from ludwig.api_annotations import DeveloperAPI
@@ -66,12 +67,14 @@ def should_exclude(
     idx: int, field: FieldInfo, dtype: str, column_count: int, row_count: int, targets: Set[str]
 ) -> bool:
     if field.key == "PRI":
+        logging.info(f"Exclude {field.name} ({dtype}): primary key")
         return True
 
     if field.name in targets:
         return False
 
     if field.num_distinct_values <= 1:
+        logging.info(f"Exclude {field.name} ({dtype}): less than 2 distinct values")
         return True
 
     distinct_value_percent = float(field.num_distinct_values) / row_count
@@ -82,11 +85,13 @@ def should_exclude(
             or upper_name.endswith("ID")
             or upper_name.startswith("ID")
         ):
+            logging.info(f"Exclude {field.name} ({dtype}): unique ID column")
             return True
 
     # For TEXT fields, we only want to use them if they appear "interesting", otherwise we would rather exclude
     # them and treat the problem as a tabular problem
     if column_count > 3 and dtype == TEXT and (field.avg_words or 0) < 5:
+        logging.info(f"Exclude {field.name} ({dtype}): too few average words")
         return True
 
     return False

--- a/ludwig/utils/automl/type_inference.py
+++ b/ludwig/utils/automl/type_inference.py
@@ -47,15 +47,13 @@ def infer_type(field: FieldInfo, missing_value_percent: float, row_count: int) -
     if field.audio_values >= 3:
         return AUDIO
 
-    if field.avg_words and field.avg_words >= TEXT_AVG_WORDS_CUTOFF:
-        return TEXT
-
     # Use CATEGORY if:
     # - The number of distinct values is significantly less than the total number of examples.
     # - The distinct values are not all numbers.
     # - The distinct values are all numbers but comprise of a perfectly sequential list of integers that suggests the
     #   values represent categories.
-    if num_distinct_values < row_count * CATEGORY_TYPE_DISTINCT_VALUE_PERCENTAGE_CUTOFF and (
+    valid_row_count = row_count * (1.0 - missing_value_percent)
+    if num_distinct_values < valid_row_count * CATEGORY_TYPE_DISTINCT_VALUE_PERCENTAGE_CUTOFF and (
         (not strings_utils.are_all_numbers(distinct_values)) or strings_utils.are_sequential_integers(distinct_values)
     ):
         return CATEGORY

--- a/ludwig/utils/automl/type_inference.py
+++ b/ludwig/utils/automl/type_inference.py
@@ -86,7 +86,7 @@ def should_exclude(
 
     # For TEXT fields, we only want to use them if they appear "interesting", otherwise we would rather exclude
     # them and treat the problem as a tabular problem
-    if column_count > 3 and dtype == TEXT and field.avg_words < 5:
-        return False
+    if column_count > 3 and dtype == TEXT and (field.avg_words or 0) < 5:
+        return True
 
     return False

--- a/tests/ludwig/schema/test_validate_config_misc.py
+++ b/tests/ludwig/schema/test_validate_config_misc.py
@@ -3,6 +3,7 @@ from jsonschema.exceptions import ValidationError
 
 from ludwig.constants import (
     ACTIVE,
+    BACKEND,
     CATEGORY,
     COLUMN,
     DECODER,
@@ -121,7 +122,7 @@ def test_config_encoders():
         validate_config(config)
 
 
-def test_config_tabnet():
+def test_config_with_backend():
     config = {
         "input_features": [
             category_feature(encoder={"type": "dense", "vocab_size": 2}, reduce_input="sum"),
@@ -154,6 +155,7 @@ def test_config_tabnet():
             "regularization_type": "l2",
             "validation_field": "label",
         },
+        BACKEND: {"type": "ray", "trainer": {"num_workers": 2}},
     }
     validate_config(config)
 

--- a/tests/ludwig/utils/automl/test_type_inference.py
+++ b/tests/ludwig/utils/automl/test_type_inference.py
@@ -42,9 +42,9 @@ TARGET_NAME = "target"
         (ROW_COUNT, [], ROW_COUNT, 0, None, 0.0, IMAGE),
         # Audio.
         (ROW_COUNT, [], 0, ROW_COUNT, None, 0.0, AUDIO),
-        # String with low distinct value percent / high missing value percent: text or category based on average words
+        # Text with low distinct value percent / high missing value percent
         (ROW_COUNT // 4, [generate_string(5) for _ in range(ROW_COUNT)], 0, 0, 5, 0.75, TEXT),
-        (ROW_COUNT // 4, [generate_string(3) for _ in range(ROW_COUNT)], 0, 0, 3, 0.75, CATEGORY),
+        (ROW_COUNT // 4, [generate_string(5) for _ in range(ROW_COUNT)], 0, 0, 5, 0.25, CATEGORY),
     ],
 )
 def test_infer_type(num_distinct_values, distinct_values, img_values, audio_values, avg_words, missing_vals, expected):

--- a/tests/ludwig/utils/automl/test_type_inference.py
+++ b/tests/ludwig/utils/automl/test_type_inference.py
@@ -82,7 +82,7 @@ def test_infer_type_explicit_date():
 )
 def test_should_exclude(idx, num_distinct_values, dtype, name, expected):
     column_count = 10
-    field = FieldInfo(name=name, dtype=dtype, num_distinct_values=num_distinct_values)
+    field = FieldInfo(name=name, dtype=dtype, num_distinct_values=num_distinct_values, avg_words=10)
     assert should_exclude(idx, field, dtype, column_count, ROW_COUNT, {TARGET_NAME}) == expected
 
 
@@ -94,3 +94,17 @@ def test_auto_type_inference_single_value_binary_feature():
     assert should_exclude(
         idx=3, field=field, dtype="object", column_count=10, row_count=ROW_COUNT, targets={TARGET_NAME}
     )
+
+
+@pytest.mark.parametrize(
+    "column_count,avg_words,expected",
+    [
+        (1, 10, False),
+        (1, 2, False),
+        (5, 2, True),
+        (5, 10, False),
+    ],
+)
+def test_should_exclude_text(column_count, avg_words, expected):
+    field = FieldInfo(name="sentence", dtype=TEXT, avg_words=avg_words, num_distinct_values=ROW_COUNT)
+    assert should_exclude(0, field, TEXT, column_count, ROW_COUNT, {TARGET_NAME}) == expected

--- a/tests/ludwig/utils/automl/test_type_inference.py
+++ b/tests/ludwig/utils/automl/test_type_inference.py
@@ -81,8 +81,9 @@ def test_infer_type_explicit_date():
     ],
 )
 def test_should_exclude(idx, num_distinct_values, dtype, name, expected):
+    column_count = 10
     field = FieldInfo(name=name, dtype=dtype, num_distinct_values=num_distinct_values)
-    assert should_exclude(idx, field, dtype, ROW_COUNT, {TARGET_NAME}) == expected
+    assert should_exclude(idx, field, dtype, column_count, ROW_COUNT, {TARGET_NAME}) == expected
 
 
 def test_auto_type_inference_single_value_binary_feature():
@@ -90,4 +91,6 @@ def test_auto_type_inference_single_value_binary_feature():
         name="foo", dtype="object", num_distinct_values=1, distinct_values=["1" for i in range(ROW_COUNT)]
     )
     assert infer_type(field=field, missing_value_percent=0, row_count=ROW_COUNT) == CATEGORY
-    assert should_exclude(idx=3, field=field, dtype="object", row_count=ROW_COUNT, targets={TARGET_NAME})
+    assert should_exclude(
+        idx=3, field=field, dtype="object", column_count=10, row_count=ROW_COUNT, targets={TARGET_NAME}
+    )


### PR DESCRIPTION
Many tabular datasets have text features that aren't particularly informative like "name", which are really just unique identifiers, but tricky to identify as such (as they can contain more than one word).

This PR adds heuristics to filter out such fields under the assumption that they occur primarily when there are many other fields and when the number of average words per field is low.