### PR TITLE
Integrated Gradients: reset sample_ratio to 1.0 if set

### DIFF
--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -80,6 +80,7 @@ def get_input_tensors(model: LudwigModel, input_set: pd.DataFrame) -> List[torch
     :return: A list of variables, one for each input feature. Shape of each variable is [batch size, embedding size].
     """
     # Ignore sample_ratio from the model config, since we want to explain all the data.
+    sample_ratio_bak = model.config_obj.preprocessing.sample_ratio
     model.config_obj.preprocessing.sample_ratio = 1.0
 
     # Convert raw input data into preprocessed tensor data
@@ -93,6 +94,9 @@ def get_input_tensors(model: LudwigModel, input_set: pd.DataFrame) -> List[torch
         backend=model.backend,
         callbacks=model.callbacks,
     )
+
+    # Restore sample_ratio
+    model.config_obj.preprocessing.sample_ratio = sample_ratio_bak
 
     # Make sure the number of rows in the preprocessed dataset matches the number of rows in the input data
     assert (

--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -79,6 +79,9 @@ def get_input_tensors(model: LudwigModel, input_set: pd.DataFrame) -> List[torch
 
     :return: A list of variables, one for each input feature. Shape of each variable is [batch size, embedding size].
     """
+    # Ignore sample_ratio from the model config, since we want to explain all the data.
+    model.config_obj.preprocessing.sample_ratio = 1.0
+
     # Convert raw input data into preprocessed tensor data
     dataset, _ = preprocess_for_prediction(
         model.config_obj.to_dict(),
@@ -90,6 +93,11 @@ def get_input_tensors(model: LudwigModel, input_set: pd.DataFrame) -> List[torch
         backend=model.backend,
         callbacks=model.callbacks,
     )
+
+    # Make sure the number of rows in the preprocessed dataset matches the number of rows in the input data
+    assert (
+        dataset.to_df().shape[0] == input_set.shape[0]
+    ), f"Expected {input_set.shape[0]} rows in preprocessed dataset, but got {dataset.to_df().shape[0]}"
 
     # Convert dataset into a dict of tensors, and split each tensor into batches to control GPU memory usage
     inputs = {


### PR DESCRIPTION
If `model.config_obj.preprocessing.sample_ratio` was set for a model, it was also applied to the explanation input. For small input sizes, this could result in empty explanation inputs.

Resolution: reset sample_ratio to 1.0 before preprocessing explanation inputs.