### PR TITLE
Add missing standardize_image key to metadata

### DIFF
--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -848,5 +848,7 @@ def _is_image_feature(feature_config: FeatureConfigDict):
 
 
 def _update_old_image_preprocessing(feature_config: FeatureConfigDict):
-    standardize_image = feature_config.get(PREPROCESSING, {}).get("standardize_image", None)
-    feature_config[PREPROCESSING].update({"standardize_image": standardize_image})
+    preprocessing = feature_config.get(PREPROCESSING)
+    if not preprocessing:
+        return
+    preprocessing["standardize_image"] = preprocessing.get("standardize_image")

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -33,6 +33,7 @@ from ludwig.constants import (
     EVAL_BATCH_SIZE,
     EXECUTOR,
     FORCE_SPLIT,
+    HEIGHT,
     IMAGE,
     INPUT_FEATURES,
     LOSS,
@@ -59,6 +60,7 @@ from ludwig.constants import (
     TRAINING,
     TYPE,
     USE_BIAS,
+    WIDTH,
 )
 from ludwig.features.feature_registries import get_base_type_registry
 from ludwig.globals import LUDWIG_VERSION
@@ -815,6 +817,8 @@ def _upgrade_metadata_missing_values(metadata: TrainingSetMetadataDict):
     for k, v in metadata.items():
         if isinstance(v, dict) and _is_old_missing_value_strategy(v):
             _update_old_missing_value_strategy(v)
+        elif isinstance(v, dict) and _is_image_feature(v):
+            _update_old_image_preprocessing(v)
 
 
 def _update_old_missing_value_strategy(feature_config: FeatureConfigDict):
@@ -836,3 +840,13 @@ def _is_old_missing_value_strategy(feature_config: FeatureConfigDict):
     if not missing_value_strategy or missing_value_strategy not in ("backfill", "pad"):
         return False
     return True
+
+
+def _is_image_feature(feature_config: FeatureConfigDict):
+    preproc = feature_config.get(PREPROCESSING, {})
+    return HEIGHT in preproc and WIDTH in preproc
+
+
+def _update_old_image_preprocessing(feature_config: FeatureConfigDict):
+    standardize_image = feature_config.get(PREPROCESSING, {}).get("standardize_image", None)
+    feature_config[PREPROCESSING].update({"standardize_image": standardize_image})


### PR DESCRIPTION
A Ludwig model from before #2408 failed to `preprocess_for_prediction`:

```python-traceback
File /workspaces/ludwig/ludwig/features/image_feature.py:479, in ImageFeatureMixin._finalize_preprocessing_parameters(preprocessing_parameters, encoder_type, column)
    475 assert isinstance(num_channels, int), ValueError("Number of image channels needs to be an integer")
    477 average_file_size = np.mean(sample_num_bytes) if sample_num_bytes else None
--> 479 standardize_image = preprocessing_parameters["standardize_image"]
    480 if standardize_image == "imagenet1k" and num_channels != 3:
    481     warnings.warn(
    482         f"'standardize_image=imagenet1k' is defined only for 'num_channels=3' but "
    483         f"detected 'num_channels={num_channels}'.  For this situation setting 'standardize_image=None'.",
    484         RuntimeWarning,
    485     )

KeyError: 'standardize_image'
```