### PR TITLE
Retry HuggingFace pretrained model download on failure

### DIFF
--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -43,6 +43,7 @@ from ludwig.schema.encoders.text_encoders import (
     XLMRoBERTaConfig,
     XLNetConfig,
 )
+from ludwig.utils.hf_utils import load_pretrained_hf_model
 from ludwig.utils.torch_utils import FreezeModule
 
 logger = logging.getLogger(__name__)
@@ -119,7 +120,7 @@ class ALBERTEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = AlbertModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(AlbertModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = AlbertConfig(
                 vocab_size=vocab_size,
@@ -236,7 +237,7 @@ class MT5Encoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = MT5EncoderModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(MT5EncoderModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = MT5Config(
                 vocab_size=vocab_size,
@@ -334,7 +335,7 @@ class XLMRoBERTaEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = XLMRobertaModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(XLMRobertaModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = XLMRobertaConfig(
                 pad_token_id=pad_token_id,
@@ -432,7 +433,7 @@ class BERTEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = BertModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(BertModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = BertConfig(
                 vocab_size=vocab_size,
@@ -557,7 +558,7 @@ class XLMEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = XLMModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(XLMModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = XLMConfig(
                 vocab_size=vocab_size,
@@ -673,7 +674,7 @@ class GPTEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = OpenAIGPTModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(OpenAIGPTModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = OpenAIGPTConfig(
                 vocab_size=vocab_size,
@@ -767,7 +768,7 @@ class GPT2Encoder(HFTextEncoder):
 
         if use_pretrained:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = GPT2Model.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(GPT2Model, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = GPT2Config(
                 vocab_size=vocab_size,
@@ -854,7 +855,7 @@ class RoBERTaEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = RobertaModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(RobertaModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = RobertaConfig(
                 pad_token_id=pad_token_id,
@@ -953,7 +954,7 @@ class TransformerXLEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = TransfoXLModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(TransfoXLModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = TransfoXLConfig(
                 vocab_size=vocab_size,
@@ -1068,7 +1069,7 @@ class XLNetEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = XLNetModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(XLNetModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = XLNetConfig(
                 vocab_size=vocab_size,
@@ -1177,7 +1178,7 @@ class DistilBERTEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = DistilBertModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(DistilBertModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = DistilBertConfig(
                 vocab_size=vocab_size,
@@ -1276,7 +1277,7 @@ class CTRLEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = CTRLModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(CTRLModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = CTRLConfig(
                 vocab_size=vocab_size,
@@ -1374,7 +1375,7 @@ class CamemBERTEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = CamembertModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(CamembertModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = CamembertConfig(
                 vocab_size=vocab_size,
@@ -1480,7 +1481,7 @@ class T5Encoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = T5Model.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(T5Model, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = T5Config(
                 vocab_size=vocab_size,
@@ -1593,7 +1594,7 @@ class FlauBERTEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = FlaubertModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(FlaubertModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = FlaubertConfig(
                 vocab_size=vocab_size,
@@ -1709,7 +1710,7 @@ class ELECTRAEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = ElectraModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+            transformer = load_pretrained_hf_model(ElectraModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = ElectraConfig(
                 vocab_size=vocab_size,
@@ -1802,7 +1803,7 @@ class LongformerEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = LongformerModel.from_pretrained(pretrained_model_name_or_path, pretrained_kwargs)
+            transformer = load_pretrained_hf_model(LongformerModel, pretrained_model_name_or_path, pretrained_kwargs)
         else:
             config = LongformerConfig(attention_window, sep_token_id, **kwargs)
             transformer = LongformerModel(config)
@@ -1875,7 +1876,7 @@ class AutoTransformerEncoder(HFTextEncoder):
         from transformers import AutoModel
 
         pretrained_kwargs = pretrained_kwargs or {}
-        transformer = AutoModel.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
+        transformer = load_pretrained_hf_model(AutoModel, pretrained_model_name_or_path, **pretrained_kwargs)
         self.reduce_output = reduce_output
         if self.reduce_output != "cls_pooled":
             self.reduce_sequence = SequenceReducer(reduce_mode=reduce_output)

--- a/ludwig/utils/hf_utils.py
+++ b/ludwig/utils/hf_utils.py
@@ -1,0 +1,20 @@
+from os import PathLike
+from typing import Optional, Type, Union
+
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+from ludwig.utils.error_handling_utils import default_retry
+
+
+@default_retry()
+def load_pretrained_hf_model(
+    modelClass: Type, pretrained_model_name_or_path: Optional[Union[str, PathLike]], **pretrained_kwargs
+) -> PreTrainedTokenizerBase:
+    """Download a HuggingFace model.
+    Downloads a model from the HuggingFace zoo with retry on failure.
+    Args:
+        model: Class of the model to download.
+    Returns:
+        The pretrained model object.
+    """
+    return modelClass.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -22,6 +22,7 @@ import torch
 
 from ludwig.constants import PADDING_SYMBOL, UNKNOWN_SYMBOL
 from ludwig.utils.data_utils import load_json
+from ludwig.utils.hf_utils import load_pretrained_hf_model
 from ludwig.utils.nlp_utils import load_nlp_pipeline, process_text
 
 logger = logging.getLogger(__name__)
@@ -790,7 +791,8 @@ class HFTokenizer(BaseTokenizer):
         super().__init__()
         from transformers import AutoTokenizer
 
-        self.tokenizer = AutoTokenizer.from_pretrained(
+        self.tokenizer = load_pretrained_hf_model(
+            AutoTokenizer,
             pretrained_model_name_or_path,
         )
 
@@ -1180,7 +1182,7 @@ def get_hf_tokenizer(pretrained_model_name_or_path, **kwargs):
     hf_name = pretrained_model_name_or_path
     # use_fast=False to leverage python class inheritance
     # cannot tokenize HF tokenizers directly because HF lacks strict typing and List[str] cannot be traced
-    hf_tokenizer = AutoTokenizer.from_pretrained(hf_name, use_fast=False)
+    hf_tokenizer = load_pretrained_hf_model(AutoTokenizer, hf_name, use_fast=False)
 
     torchtext_tokenizer = None
     if "bert" in TORCHSCRIPT_COMPATIBLE_TOKENIZERS and isinstance(hf_tokenizer, BertTokenizer):

--- a/tests/ludwig/utils/test_hf_utils.py
+++ b/tests/ludwig/utils/test_hf_utils.py
@@ -2,68 +2,17 @@ import os
 from typing import Type
 
 import pytest
-from transformers import (  # CamembertModel,
-    AlbertModel,
-    BertModel,
-    BertTokenizer,
-    CTRLModel,
-    DistilBertModel,
-    ElectraModel,
-    FlaubertModel,
-    GPT2Model,
-    LongformerModel,
-    MT5EncoderModel,
-    OpenAIGPTModel,
-    RobertaModel,
-    T5Model,
-    TransfoXLModel,
-    XLMModel,
-    XLMRobertaModel,
-    XLNetModel,
-)
+from transformers import BertModel, BertTokenizer
 
-from ludwig.encoders.text_encoders import (  # CamemBERTEncoder,
-    ALBERTEncoder,
-    BERTEncoder,
-    CTRLEncoder,
-    DistilBERTEncoder,
-    ELECTRAEncoder,
-    FlauBERTEncoder,
-    GPT2Encoder,
-    GPTEncoder,
-    LongformerEncoder,
-    MT5Encoder,
-    RoBERTaEncoder,
-    T5Encoder,
-    TransformerXLEncoder,
-    XLMEncoder,
-    XLMRoBERTaEncoder,
-    XLNetEncoder,
-)
+from ludwig.encoders.text_encoders import BERTEncoder
 from ludwig.utils.hf_utils import load_pretrained_hf_model
 
 
 @pytest.mark.parametrize(
     ("model", "name"),
     [
-        (AlbertModel, ALBERTEncoder.DEFAULT_MODEL_NAME),
         (BertModel, BERTEncoder.DEFAULT_MODEL_NAME),
         (BertTokenizer, "bert-base-uncased"),
-        # (CamembertModel, CamemBERTEncoder.DEFAULT_MODEL_NAME),
-        (CTRLModel, CTRLEncoder.DEFAULT_MODEL_NAME),
-        (DistilBertModel, DistilBERTEncoder.DEFAULT_MODEL_NAME),
-        (ElectraModel, ELECTRAEncoder.DEFAULT_MODEL_NAME),
-        (FlaubertModel, FlauBERTEncoder.DEFAULT_MODEL_NAME),
-        (GPT2Model, GPT2Encoder.DEFAULT_MODEL_NAME),
-        (LongformerModel, LongformerEncoder.DEFAULT_MODEL_NAME),
-        (MT5EncoderModel, MT5Encoder.DEFAULT_MODEL_NAME),
-        (OpenAIGPTModel, GPTEncoder.DEFAULT_MODEL_NAME),
-        (RobertaModel, RoBERTaEncoder.DEFAULT_MODEL_NAME),
-        (T5Model, T5Encoder.DEFAULT_MODEL_NAME),
-        (TransfoXLModel, TransformerXLEncoder.DEFAULT_MODEL_NAME),
-        (XLMModel, XLMEncoder.DEFAULT_MODEL_NAME),
-        (XLMRobertaModel, XLMRoBERTaEncoder.DEFAULT_MODEL_NAME),
-        (XLNetModel, XLNetEncoder.DEFAULT_MODEL_NAME),
     ],
 )
 def test_load_hf_model(model: Type, name: str, tmpdir: os.PathLike):

--- a/tests/ludwig/utils/test_hf_utils.py
+++ b/tests/ludwig/utils/test_hf_utils.py
@@ -1,0 +1,75 @@
+import os
+from typing import Type
+
+import pytest
+from transformers import (  # CamembertModel,
+    AlbertModel,
+    BertModel,
+    BertTokenizer,
+    CTRLModel,
+    DistilBertModel,
+    ElectraModel,
+    FlaubertModel,
+    GPT2Model,
+    LongformerModel,
+    MT5EncoderModel,
+    OpenAIGPTModel,
+    RobertaModel,
+    T5Model,
+    TransfoXLModel,
+    XLMModel,
+    XLMRobertaModel,
+    XLNetModel,
+)
+
+from ludwig.encoders.text_encoders import (  # CamemBERTEncoder,
+    ALBERTEncoder,
+    BERTEncoder,
+    CTRLEncoder,
+    DistilBERTEncoder,
+    ELECTRAEncoder,
+    FlauBERTEncoder,
+    GPT2Encoder,
+    GPTEncoder,
+    LongformerEncoder,
+    MT5Encoder,
+    RoBERTaEncoder,
+    T5Encoder,
+    TransformerXLEncoder,
+    XLMEncoder,
+    XLMRoBERTaEncoder,
+    XLNetEncoder,
+)
+from ludwig.utils.hf_utils import load_pretrained_hf_model
+
+
+@pytest.mark.parametrize(
+    ("model", "name"),
+    [
+        (AlbertModel, ALBERTEncoder.DEFAULT_MODEL_NAME),
+        (BertModel, BERTEncoder.DEFAULT_MODEL_NAME),
+        (BertTokenizer, "bert-base-uncased"),
+        # (CamembertModel, CamemBERTEncoder.DEFAULT_MODEL_NAME),
+        (CTRLModel, CTRLEncoder.DEFAULT_MODEL_NAME),
+        (DistilBertModel, DistilBERTEncoder.DEFAULT_MODEL_NAME),
+        (ElectraModel, ELECTRAEncoder.DEFAULT_MODEL_NAME),
+        (FlaubertModel, FlauBERTEncoder.DEFAULT_MODEL_NAME),
+        (GPT2Model, GPT2Encoder.DEFAULT_MODEL_NAME),
+        (LongformerModel, LongformerEncoder.DEFAULT_MODEL_NAME),
+        (MT5EncoderModel, MT5Encoder.DEFAULT_MODEL_NAME),
+        (OpenAIGPTModel, GPTEncoder.DEFAULT_MODEL_NAME),
+        (RobertaModel, RoBERTaEncoder.DEFAULT_MODEL_NAME),
+        (T5Model, T5Encoder.DEFAULT_MODEL_NAME),
+        (TransfoXLModel, TransformerXLEncoder.DEFAULT_MODEL_NAME),
+        (XLMModel, XLMEncoder.DEFAULT_MODEL_NAME),
+        (XLMRobertaModel, XLMRoBERTaEncoder.DEFAULT_MODEL_NAME),
+        (XLNetModel, XLNetEncoder.DEFAULT_MODEL_NAME),
+    ],
+)
+def test_load_hf_model(model: Type, name: str, tmpdir: os.PathLike):
+    """Ensure that the HF models used in ludwig download correctly."""
+    cache_dir = os.path.join(tmpdir, name.replace(os.path.sep, "_") if name else str(model.__name__))
+    os.makedirs(cache_dir, exist_ok=True)
+    loaded_model = load_pretrained_hf_model(model, name, cache_dir=cache_dir, force_download=True)
+    assert isinstance(loaded_model, model)
+    assert os.listdir(cache_dir)


### PR DESCRIPTION
This adds a utility function to download pretrained HuggingFace models with retry on download failure. Calls to from_pretrained in text encoder and tokenizer classes have been replaced with calls to the utility.