### PR TITLE
Deactivate GBM random forest boosting type 

### DIFF
--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -348,7 +348,7 @@ class GBMTrainerConfig(BaseTrainerConfig):
 
     # LightGBM core parameters (https://lightgbm.readthedocs.io/en/latest/Parameters.html)
     boosting_type: str = schema_utils.StringOptions(
-        ["gbdt", "rf", "dart", "goss"],
+        ["gbdt", "dart", "goss"],
         default="gbdt",
         description="Type of boosting algorithm to use with GBM trainer.",
     )


### PR DESCRIPTION
Training a GBM with `boosting_type=rf` leads to the following error:

`lightgbm.basic.LightGBMError: RF mode do not support custom objective function, please use built-in objectives.`

We currently pass a custom objective function into LGBM training, and this can be deactivated in the code. However, doing so leads to the following error:

`lightgbm.basic.LightGBMError: Check failed: (train_data->metadata().init_score()) == (nullptr) at /private/var/folders/8r/s_bsn5kj3fv6dr7l58slg48r0000gn/T/pip-install-_ygu6ap_/lightgbm_9c96da0ed3b24382834b859f69313149/compile/src/boosting/rf.hpp, line 44 .`

This error occurs because RF GBMs  do not support model reloading, and we rely on model checkpointing for in the loop performance reporting. It can be overcome by setting `num_boost_rounds < boosting_rounds_per_checkpoint`.

Ideally, we would like to handle this with something like disabling checkpointing when `boosting_type: rf` is in the config. In the short term, this update deactivates random forests until a more full-fledged solution can be implemented.

