### PR TITLE
Disable bagging when using GOSS GBM boosting type

### DIFF
--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -137,6 +137,12 @@ class LightGBMTrainer(BaseTrainer):
         self.max_bin = config.max_bin
         self.feature_pre_filter = config.feature_pre_filter
 
+        if self.boosting_type == "goss" and self.bagging_freq != 0:
+            logger.info(
+                "Bagging is not compatible with the GOSS boosting type. Disabling bagging for this training session."
+            )
+            self.bagging_freq = 0
+
         self.device = device
         if self.device is None:
             self.device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -351,3 +351,11 @@ def test_boosting_type_rf_invalid(tmpdir, local_backend):
 
     with pytest.raises(ValidationError):
         _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend, boosting_type="rf")
+
+
+def test_goss_deactivate_bagging(tmpdir, local_backend):
+    """Test that bagging is disabled for the GOSS boosting type."""
+    input_features = [number_feature()]
+    output_features = [binary_feature()]
+
+    _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend, boosting_type="goss", bagging_freq=5)


### PR DESCRIPTION
Bagging is not compatible with LightGBM's GOSS boosting type, and a config with `boosting_type: goss` and `bagging_freq > 0` will throw the following liblightgbm error:

`lightgbm.basic.LightGBMError: Cannot use bagging in GOSS`

This update had the trainer automatically set `bagging_freq: 0` when using GOSS.