### PR TITLE
Fixes longformer encoder by passing in pretrained_kwargs correctly

### DIFF
--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -1803,7 +1803,7 @@ class LongformerEncoder(HFTextEncoder):
 
         if use_pretrained and not saved_weights_in_checkpoint:
             pretrained_kwargs = pretrained_kwargs or {}
-            transformer = load_pretrained_hf_model(LongformerModel, pretrained_model_name_or_path, pretrained_kwargs)
+            transformer = load_pretrained_hf_model(LongformerModel, pretrained_model_name_or_path, **pretrained_kwargs)
         else:
             config = LongformerConfig(attention_window, sep_token_id, **kwargs)
             transformer = LongformerModel(config)

--- a/tests/ludwig/encoders/test_text_encoders.py
+++ b/tests/ludwig/encoders/test_text_encoders.py
@@ -181,7 +181,7 @@ def test_xlmroberta_encoder(use_pretrained: bool, reduce_output: str, max_sequen
     assert outputs["encoder_output"].shape[1:] == xlmroberta_encoder.output_shape
 
 
-@pytest.mark.parametrize("use_pretrained", [False])
+@pytest.mark.parametrize("use_pretrained", [False, True])
 @pytest.mark.parametrize("reduce_output", [None, "cls_pooled"])
 @pytest.mark.parametrize("max_sequence_length", [20])
 def test_longformer_encoder(use_pretrained: bool, reduce_output: str, max_sequence_length: int):


### PR DESCRIPTION
The call to `load_pretrained_hf_model` was failing because we didn't use ** so it treated it as a positional argument, which didn't meet the function definition. This change fixes it!

I also double-checked this for all of the other text encoders and it looks like it should work correctly. Just this one has the error.