### PR TITLE
GBM DART boosting type incopatible with early stopping

### DIFF
--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -369,7 +369,6 @@ class LightGBMTrainer(BaseTrainer):
 
         progress_bar.update(self.boosting_rounds_per_checkpoint)
         progress_tracker.steps += self.boosting_rounds_per_checkpoint
-        progress_tracker.best_eval_metric_steps = self.model.lgbm_model.best_iteration_
 
         output_features = self.model.output_features
         metrics_names = get_metric_names(output_features)
@@ -428,7 +427,13 @@ class LightGBMTrainer(BaseTrainer):
 
             # Save the value, steps, epoch, and checkpoint number.
             progress_tracker.best_eval_metric_value = eval_metric_value
-            progress_tracker.best_eval_metric_steps = progress_tracker.steps
+
+            # Use LGBM fine-grained internal tracking if available, otherwise fall back to coarse-grained tracking
+            # every `boosting_rounds_per_checkpoint`.
+            if self.model.lgbm_model.best_iteration_ is not None:
+                progress_tracker.best_eval_metric_steps = self.model.lgbm_model.best_iteration_
+            else:
+                progress_tracker.best_eval_metric_steps = progress_tracker.steps
             progress_tracker.best_eval_metric_epoch = progress_tracker.epoch
             progress_tracker.best_eval_metric_checkpoint_number = progress_tracker.checkpoint_number
 
@@ -521,6 +526,12 @@ class LightGBMTrainer(BaseTrainer):
             else (lgb_train.label.size,)
         )
 
+        callbacks = [store_predictions(train_logits)]
+
+        # DART is not compatible with early stopping.
+        if self.boosting_type != "dart":
+            callbacks.append(lgb.early_stopping(boost_rounds_per_train_step))
+
         gbm = gbm_sklearn_cls(n_estimators=boost_rounds_per_train_step, **params).fit(
             X=lgb_train.get_data(),
             y=lgb_train.get_label(),
@@ -528,7 +539,7 @@ class LightGBMTrainer(BaseTrainer):
             eval_set=[(ds.get_data(), ds.get_label()) for ds in eval_sets],
             eval_names=eval_names,
             # add early stopping callback to populate best_iteration
-            callbacks=[lgb.early_stopping(boost_rounds_per_train_step), store_predictions(train_logits)],
+            callbacks=callbacks,
         )
         evals_result.update(gbm.evals_result_)
 

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -359,3 +359,11 @@ def test_goss_deactivate_bagging(tmpdir, local_backend):
     output_features = [binary_feature()]
 
     _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend, boosting_type="goss", bagging_freq=5)
+
+
+def test_dart_boosting_type(tmpdir, local_backend):
+    """Test that DART does not error during eval due to progress tracking."""
+    input_features = [number_feature()]
+    output_features = [binary_feature()]
+
+    _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend, boosting_type="dart")


### PR DESCRIPTION
Setting `boosting_type: dart` leads to the following error iff an epoch ends with no model improvement:

``` 
File "/home/ray/anaconda3/lib/python3.8/site-packages/ludwig/trainers/trainer_lightgbm.py", line 456, in check_progress_on_validation
    last_improvement_in_steps = progress_tracker.steps - progress_tracker.best_eval_metric_steps
TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'
```

This error is caused by an inconsistency in updating `progress_tracker.best_eval_metric_steps` coupled with DART's incompatibility with the LGBM early stopping callback. LGBM models keep track of the best observed step in `model.best_iteration_`, however this only happens when the early stopping callback is used; otherwise, `best_iteration_` is always `None`. Since DART does not use early stopping, the latter condition seems to be true. The `progress_tracker` update can then set the step tracker to `None` and subsequently not update it with Ludwig-level tracking if the model did not improve

This update
- removes the LGBM early stopping callback from training when using `boosting_type: dart`
- reorganizes `progress_tracker` updates to use LGBM internal tracking if available with a fallback to Trainer-level tracking
- adds an integration test for DART

