### PR TITLE
Populate hyperopt defaults using schema

### DIFF
--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -41,7 +41,6 @@ from ludwig.hyperopt.utils import (
     should_tune_preprocessing,
     update_hyperopt_params_with_defaults,
 )
-from ludwig.schema.hyperopt import HyperoptConfig
 from ludwig.schema.model_config import ModelConfig
 from ludwig.utils.backward_compatibility import upgrade_config_dict_to_latest_version
 from ludwig.utils.dataset_utils import generate_dataset_statistics
@@ -223,11 +222,6 @@ def hyperopt(
     full_config = config_obj.to_dict()  # TODO (Connor): Refactor to use config object
 
     hyperopt_config = full_config[HYPEROPT]
-
-    # Convert hyperopt config to hyperopt schema to populate with schema defaults
-    # This fills in missing splits, executor config, search_alg, etc.
-    hyperopt_config_from_schema = HyperoptConfig.Schema().load(hyperopt_config)
-    hyperopt_config = hyperopt_config_from_schema.to_dict()
 
     # Explicitly default to a local backend to avoid picking up Ray or Horovod
     # backend from the environment.

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -41,6 +41,7 @@ from ludwig.hyperopt.utils import (
     should_tune_preprocessing,
     update_hyperopt_params_with_defaults,
 )
+from ludwig.schema.hyperopt import HyperoptConfig
 from ludwig.schema.model_config import ModelConfig
 from ludwig.utils.backward_compatibility import upgrade_config_dict_to_latest_version
 from ludwig.utils.dataset_utils import generate_dataset_statistics
@@ -222,6 +223,11 @@ def hyperopt(
     full_config = config_obj.to_dict()  # TODO (Connor): Refactor to use config object
 
     hyperopt_config = full_config[HYPEROPT]
+
+    # Convert hyperopt config to hyperopt schema to populate with schema defaults
+    # This fills in missing splits, executor config, search_alg, etc.
+    hyperopt_config_from_schema = HyperoptConfig.Schema().load(hyperopt_config)
+    hyperopt_config = hyperopt_config_from_schema.to_dict()
 
     # Explicitly default to a local backend to avoid picking up Ray or Horovod
     # backend from the environment.

--- a/ludwig/schema/hyperopt/scheduler.py
+++ b/ludwig/schema/hyperopt/scheduler.py
@@ -384,9 +384,9 @@ class PopulationBasedBanditsSchedulerConfig(BaseSchedulerConfig, CommonScheduler
 @register_scheduler_config("hb_bohb")
 @dataclass
 class BOHBSchedulerConfig(BaseSchedulerConfig, CommonSchedulerOptions):
-    """Hyperband for BOHB scheduler settings."""
+    """Hyperband for BOHB (hb_bohb) scheduler settings."""
 
-    type: str = schema_utils.ProtectedString("bohb")
+    type: str = schema_utils.ProtectedString("hb_bohb")
 
     max_t: int = max_t_alias(default=81)
 

--- a/ludwig/schema/model_config.py
+++ b/ludwig/schema/model_config.py
@@ -205,10 +205,6 @@ class ModelConfig(BaseMarshmallowConfig):
         # ===== Hyperopt =====
         self.hyperopt = upgraded_config_dict.get(HYPEROPT, {})
 
-        # Convert hyperopt config to hyperopt schema to populate with schema defaults
-        # This fills in missing splits, executor config, search_alg, etc.
-        self.hyperopt = HyperoptConfig.Schema().load(self.hyperopt).to_dict()
-
         self._set_hyperopt_defaults()
 
         # Set up default validation metric, which is used for plateau metrics and early stopping.
@@ -516,6 +512,10 @@ class ModelConfig(BaseMarshmallowConfig):
         """
         if not self.hyperopt:
             return
+
+        # Convert hyperopt config to hyperopt schema to populate with schema defaults
+        # This fills in missing splits, executor config, search_alg, etc.
+        self.hyperopt = HyperoptConfig.Schema().load(self.hyperopt).to_dict()
 
         scheduler = self.hyperopt.get("executor", {}).get("scheduler", {})
         if not scheduler:

--- a/ludwig/schema/model_config.py
+++ b/ludwig/schema/model_config.py
@@ -511,7 +511,7 @@ class ModelConfig(BaseMarshmallowConfig):
         if not self.hyperopt:
             return
 
-        scheduler = self.hyperopt.get("executor", {}).get("scheduler")
+        scheduler = self.hyperopt.get("executor", {}).get("scheduler", {})
         if not scheduler:
             return
 

--- a/ludwig/schema/model_config.py
+++ b/ludwig/schema/model_config.py
@@ -55,6 +55,7 @@ from ludwig.schema.features.utils import (
     input_config_registry,
     output_config_registry,
 )
+from ludwig.schema.hyperopt import HyperoptConfig
 from ludwig.schema.optimizers import get_optimizer_cls
 from ludwig.schema.preprocessing import PreprocessingConfig
 from ludwig.schema.split import get_split_cls
@@ -203,6 +204,11 @@ class ModelConfig(BaseMarshmallowConfig):
 
         # ===== Hyperopt =====
         self.hyperopt = upgraded_config_dict.get(HYPEROPT, {})
+
+        # Convert hyperopt config to hyperopt schema to populate with schema defaults
+        # This fills in missing splits, executor config, search_alg, etc.
+        self.hyperopt = HyperoptConfig.Schema().load(self.hyperopt).to_dict()
+
         self._set_hyperopt_defaults()
 
         # Set up default validation metric, which is used for plateau metrics and early stopping.

--- a/ludwig/schema/model_config.py
+++ b/ludwig/schema/model_config.py
@@ -515,9 +515,9 @@ class ModelConfig(BaseMarshmallowConfig):
 
         # Convert hyperopt config to hyperopt schema to populate with schema defaults
         # This fills in missing splits, executor config, search_alg, etc.
-        self.hyperopt = HyperoptConfig.Schema().load(self.hyperopt).to_dict()
+        self.hyperopt = HyperoptConfig.from_dict(self.hyperopt).to_dict()
 
-        scheduler = self.hyperopt.get("executor", {}).get("scheduler", {})
+        scheduler = self.hyperopt.get("executor", {}).get("scheduler")
         if not scheduler:
             return
 

--- a/ludwig/schema/model_config.py
+++ b/ludwig/schema/model_config.py
@@ -527,9 +527,9 @@ class ModelConfig(BaseMarshmallowConfig):
         # Disable early stopping when using a scheduler. We achieve this by setting the parameter
         # to -1, which ensures the condition to apply early stopping is never met.
         early_stop = self.trainer.early_stop
-        if early_stop is not None and early_stop != -1:
+        if early_stop is not None and early_stop != -1 and scheduler.get("type", {}) != "fifo":
             warnings.warn("Can't utilize `early_stop` while using a hyperopt scheduler. Setting early stop to -1.")
-        self.trainer.early_stop = -1
+            self.trainer.early_stop = -1
 
         max_t = scheduler.get("max_t")
         time_attr = scheduler.get("time_attr")

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -984,7 +984,6 @@ def OneOfOptionsField(
                 try:
                     if value is None and mfield_meta.allow_none:
                         return None
-                    print(option, value)
                     mfield_meta.validate(value)
                     return mfield_meta._serialize(value, attr, obj, **kwargs)
                 except Exception:

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -16,6 +16,7 @@ from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import ACTIVE, COLUMN, NAME, PROC_COLUMN, TYPE
 from ludwig.modules.reduction_modules import reduce_mode_registry
 from ludwig.schema.metadata.parameter_metadata import convert_metadata_to_json, ParameterMetadata
+from ludwig.utils.misc_utils import memoized_method
 from ludwig.utils.torch_utils import activations, initializer_registry
 
 RECURSION_STOP_ENUM = {"weights_initializer", "bias_initializer", "norm_params"}
@@ -149,9 +150,20 @@ class BaseMarshmallowConfig(ABC):
         return convert_submodules(self.__dict__)
 
     @classmethod
+    def from_dict(cls, d: TDict[str, Any]):
+        schema = cls.get_class_schema()()
+        return schema.load(d)
+
+    @classmethod
+    @memoized_method(maxsize=1)
     def get_valid_field_names(cls) -> Set[str]:
-        schema = marshmallow_dataclass.class_schema(cls)()
+        schema = cls.get_class_schema()()
         return set(schema.fields.keys())
+
+    @classmethod
+    @memoized_method(maxsize=1)
+    def get_class_schema(cls):
+        return marshmallow_dataclass.class_schema(cls)
 
     def __repr__(self):
         return yaml.dump(self.to_dict(), sort_keys=False)
@@ -972,6 +984,7 @@ def OneOfOptionsField(
                 try:
                     if value is None and mfield_meta.allow_none:
                         return None
+                    print(option, value)
                     mfield_meta.validate(value)
                     return mfield_meta._serialize(value, attr, obj, **kwargs)
                 except Exception:

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -581,7 +581,7 @@ def test_hyperopt_without_config_defaults(csv_filename, tmpdir, ray_cluster_7cpu
             },
             "goal": "minimize",
             "output_feature": output_features[0]["name"],
-            "validation_metrics": "loss",
+            "metric": "loss",
         },
     }
 

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -557,3 +557,34 @@ def test_hyperopt_nested_parameters(csv_filename, tmpdir, ray_cluster_7cpu):
             assert trial_config[TRAINER]["learning_rate_scaling"] == "linear"
 
         assert trial_config[TRAINER]["learning_rate"] in {0.7, 0.42}
+
+
+def test_hyperopt_without_config_defaults(csv_filename, tmpdir, ray_cluster_7cpu):
+    input_features = [category_feature(encoder={"vocab_size": 3})]
+    output_features = [category_feature(decoder={"vocab_size": 3})]
+
+    rel_path = generate_data(input_features, output_features, csv_filename)
+
+    config = {
+        INPUT_FEATURES: input_features,
+        OUTPUT_FEATURES: output_features,
+        COMBINER: {TYPE: "concat"},
+        TRAINER: {"train_steps": 5, "learning_rate": 0.001, BATCH_SIZE: 128},
+        # Missing search_alg and executor, but should still work
+        HYPEROPT: {
+            "parameters": {
+                "trainer.learning_rate": {
+                    "lower": 0.0001,
+                    "upper": 0.01,
+                    "space": "loguniform",
+                }
+            },
+            "goal": "minimize",
+            "output_feature": output_features[0]["name"],
+            "validation_metrics": "loss",
+        },
+    }
+
+    experiment_name = f"test_hyperopt_{uuid.uuid4().hex}"
+    hyperopt_results = hyperopt(config, dataset=rel_path, output_directory=tmpdir, experiment_name=experiment_name)
+    assert hyperopt_results.experiment_analysis.results_df.shape[0] == 10

--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -15,7 +15,7 @@
 import json
 import logging
 import os.path
-from typing import List
+from typing import Dict, List
 
 import mlflow
 import pandas as pd
@@ -90,7 +90,7 @@ SCENARIOS = [
 ]
 
 
-def _get_config(search_alg, executor):
+def _get_config(search_alg: Dict, executor: Dict, epochs: int):
     input_features = [
         text_feature(name="utterance", encoder={"cell_type": "lstm", "reduce_output": "sum"}),
         category_feature(encoder={"vocab_size": 2}, reduce_input="sum"),
@@ -102,7 +102,7 @@ def _get_config(search_alg, executor):
         "input_features": input_features,
         "output_features": output_features,
         "combiner": {"type": "concat"},
-        TRAINER: {"epochs": 2, "learning_rate": 0.001, BATCH_SIZE: 128},
+        TRAINER: {"epochs": epochs, "learning_rate": 0.001, BATCH_SIZE: 128},
         "hyperopt": {
             **HYPEROPT_CONFIG,
             "executor": executor,
@@ -154,13 +154,14 @@ class HyperoptTestCallback(TuneCallback):
 def run_hyperopt_executor(
     search_alg,
     executor,
+    epochs,
     csv_filename,
     tmpdir,
     validate_output_feature=False,
     validation_metric=None,
     use_split=True,
 ):
-    config = _get_config(search_alg, executor)
+    config = _get_config(search_alg, executor, epochs)
     rel_path = generate_data(config["input_features"], config["output_features"], csv_filename)
 
     if not use_split:
@@ -207,7 +208,9 @@ def run_hyperopt_executor(
 def test_hyperopt_executor(scenario, csv_filename, tmpdir, ray_cluster_4cpu):
     search_alg = scenario["search_alg"]
     executor = scenario["executor"]
-    run_hyperopt_executor(search_alg, executor, csv_filename, tmpdir)
+    # When using the hb_bohb scheduler, num_epochs must equal max_t (which is 81 by default)
+    epochs = 2 if scenario["executor"].get("scheduler", {}).get("type", {}) != "hb_bohb" else 81
+    run_hyperopt_executor(search_alg, executor, epochs, csv_filename, tmpdir)
 
 
 @pytest.mark.distributed
@@ -216,6 +219,7 @@ def test_hyperopt_executor_with_metric(use_split, csv_filename, tmpdir, ray_clus
     run_hyperopt_executor(
         {"type": "variant_generator"},  # search_alg
         {"type": "ray", "num_samples": 2},  # executor
+        2,
         csv_filename,
         tmpdir,
         validate_output_feature=True,
@@ -304,7 +308,9 @@ def test_hyperopt_ray_mlflow(csv_filename, tmpdir, ray_cluster_4cpu):
 
     num_samples = 2
     config = _get_config(
-        {"type": "variant_generator"}, {"type": "ray", "num_samples": num_samples}  # search_alg  # executor
+        {"type": "variant_generator"},  # search_alg
+        {"type": "ray", "num_samples": num_samples},  # executor
+        2,  # epochs
     )
 
     rel_path = generate_data(config["input_features"], config["output_features"], csv_filename)

--- a/tests/integration_tests/test_hyperopt_ray_horovod.py
+++ b/tests/integration_tests/test_hyperopt_ray_horovod.py
@@ -132,8 +132,8 @@ def _get_config(search_alg, executor):
     input_features = [number_feature()]
     output_features = [binary_feature()]
 
-    # Bohb causes training failures when num epochs is 1
-    num_epochs = 1 if search_alg["type"] == "variant_generator" else 2
+    # When using the hb_bohb scheduler, num_epochs must equal max_t (which is 81 by default)
+    num_epochs = 1 if search_alg["type"] == "variant_generator" else 81
 
     return {
         "input_features": input_features,

--- a/tests/ludwig/utils/test_defaults.py
+++ b/tests/ludwig/utils/test_defaults.py
@@ -244,6 +244,5 @@ def test_merge_with_defaults():
     assert LOSS in merged_config[DEFAULTS][CATEGORY]
     assert COMBINER in merged_config
     assert merged_config[TRAINER][EARLY_STOP] == 5
-    assert SCHEDULER not in merged_config[HYPEROPT][EXECUTOR]
     assert TYPE in merged_config[INPUT_FEATURES][1][ENCODER]
     assert TYPE in merged_config[OUTPUT_FEATURES][0][DECODER]


### PR DESCRIPTION
This PR adds a new step to ensure that all of the defaults for search algorithm, split, executor etc. are correctly populated using the schema object before accessing them to prevent key errors. All of these parameters are required by hyperopt and expected to be present downstream for config validation, executor creation, and trial execution.

The reason we've not noticed this before in our tests is because all of our tests specify `search_alg` in the hyperopt config. 

Co-authored-by: Kabir Brar <kabir@predibase.com>
Co-authored-by: Travis Addair <tgaddair@gmail.com>