### PR TITLE
Set reduce_output to sum for XLM encoder

### DIFF
--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -707,7 +707,7 @@ class XLMConfig(BaseEncoderConfig):
     )
 
     reduce_output: str = schema_utils.String(
-        default="cls_pooled",
+        default="sum",
         description="The method used to reduce a sequence of tensors down to a single tensor.",
         parameter_metadata=ENCODER_METADATA["XLM"]["reduce_output"],
     )


### PR DESCRIPTION
XLM doesn't support `cls_pooled` as a `reduce_output` strategy