### PR TITLE
Enable custom HF BERT models with default tokenizer config

### DIFF
--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -1225,6 +1225,12 @@ def get_hf_tokenizer(pretrained_model_name_or_path, **kwargs):
 
 
 def _get_bert_config(hf_name):
+    """Gets configs from BERT tokenizers in HuggingFace.
+
+    `vocab_file` is required for BERT tokenizers. `tokenizer_config.json` are optional keyword arguments used to
+    initialize the tokenizer object. If no `tokenizer_config.json` is found, then we instantiate the tokenizer with
+    default arguments.
+    """
     from transformers.utils.hub import cached_path, EntryNotFoundError
 
     vocab_file = cached_path(f"https://huggingface.co/{hf_name}/resolve/main/vocab.txt")

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -1225,10 +1225,17 @@ def get_hf_tokenizer(pretrained_model_name_or_path, **kwargs):
 
 
 def _get_bert_config(hf_name):
-    from transformers.utils.hub import cached_path
+    from transformers.utils.hub import cached_path, EntryNotFoundError
 
     vocab_file = cached_path(f"https://huggingface.co/{hf_name}/resolve/main/vocab.txt")
-    tokenizer_config = load_json(cached_path(f"https://huggingface.co/{hf_name}/resolve/main/tokenizer_config.json"))
+
+    try:
+        tokenizer_config = load_json(
+            cached_path(f"https://huggingface.co/{hf_name}/resolve/main/tokenizer_config.json")
+        )
+    except EntryNotFoundError:
+        tokenizer_config = {}
+
     return {"vocab_file": vocab_file, **tokenizer_config}
 
 

--- a/tests/ludwig/utils/test_tokenizers.py
+++ b/tests/ludwig/utils/test_tokenizers.py
@@ -12,6 +12,8 @@ TORCHTEXT_0_14_0_HF_NAMES = [
     "google/electra-small-discriminator",
     "dbmdz/bert-base-italian-cased",  # Community model
     "nreimers/MiniLM-L6-H384-uncased",  # Community model
+    "emilyalsentzer/Bio_ClinicalBERT",  # Community model
+    "bionlp/bluebert_pubmed_mimic_uncased_L-12_H-768_A-12",  # Community model
 ]
 
 


### PR DESCRIPTION
Prior to this PR, Ludwig assumed that all custom HuggingFace BERT models have `tokenizer_config.json` in their repository. This is not the case, particularly for these two models:

- https://huggingface.co/bionlp/bluebert_pubmed_mimic_uncased_L-12_H-768_A-12
- https://huggingface.co/emilyalsentzer/Bio_ClinicalBERT

We wrap the attempt to get `tokenizer_config.json` in a try-except block and default to an empty configuration if it does not exist.