### PR TITLE
Reorder Advanced Parameters

### DIFF
--- a/ludwig/schema/decoders/base.py
+++ b/ludwig/schema/decoders/base.py
@@ -11,7 +11,7 @@ from ludwig.schema.metadata import DECODER_METADATA
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class BaseDecoderConfig(schema_utils.BaseMarshmallowConfig, ABC):
     """Base class for decoders."""
 
@@ -105,7 +105,7 @@ class BaseDecoderConfig(schema_utils.BaseMarshmallowConfig, ABC):
 
 @DeveloperAPI
 @register_decoder_config("passthrough", [BINARY, CATEGORY, NUMBER, SET, VECTOR, SEQUENCE, TEXT])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class PassthroughDecoderConfig(BaseDecoderConfig):
     """PassthroughDecoderConfig is a dataclass that configures the parameters used for a passthrough decoder."""
 
@@ -129,7 +129,7 @@ class PassthroughDecoderConfig(BaseDecoderConfig):
 
 @DeveloperAPI
 @register_decoder_config("regressor", [BINARY, NUMBER])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class RegressorConfig(BaseDecoderConfig):
     """RegressorConfig is a dataclass that configures the parameters used for a regressor decoder."""
 
@@ -168,7 +168,7 @@ class RegressorConfig(BaseDecoderConfig):
 
 @DeveloperAPI
 @register_decoder_config("projector", [VECTOR])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class ProjectorConfig(BaseDecoderConfig):
     """ProjectorConfig is a dataclass that configures the parameters used for a projector decoder."""
 
@@ -229,7 +229,7 @@ class ProjectorConfig(BaseDecoderConfig):
 
 @DeveloperAPI
 @register_decoder_config("classifier", [CATEGORY, SET])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class ClassifierConfig(BaseDecoderConfig):
     @classmethod
     def module_name(cls):

--- a/ludwig/schema/decoders/sequence_decoders.py
+++ b/ludwig/schema/decoders/sequence_decoders.py
@@ -10,7 +10,7 @@ from ludwig.schema.metadata import DECODER_METADATA
 
 @DeveloperAPI
 @register_decoder_config("generator", [SEQUENCE, TEXT])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SequenceGeneratorDecoderConfig(BaseDecoderConfig):
     @staticmethod
     def module_name():
@@ -63,7 +63,7 @@ class SequenceGeneratorDecoderConfig(BaseDecoderConfig):
 
 @DeveloperAPI
 @register_decoder_config("tagger", [SEQUENCE, TEXT])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SequenceTaggerDecoderConfig(BaseDecoderConfig):
     @classmethod
     def module_name(cls):

--- a/ludwig/schema/encoders/date_encoders.py
+++ b/ludwig/schema/encoders/date_encoders.py
@@ -12,7 +12,7 @@ from ludwig.schema.metadata import ENCODER_METADATA
 
 @DeveloperAPI
 @register_encoder_config("embed", DATE)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class DateEmbedConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():
@@ -102,7 +102,7 @@ class DateEmbedConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("wave", DATE)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class DateWaveConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():

--- a/ludwig/schema/encoders/h3_encoders.py
+++ b/ludwig/schema/encoders/h3_encoders.py
@@ -12,7 +12,7 @@ from ludwig.schema.metadata import ENCODER_METADATA
 
 @DeveloperAPI
 @register_encoder_config("embed", H3)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class H3EmbedConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():
@@ -108,7 +108,7 @@ class H3EmbedConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("weighted_sum", H3)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class H3WeightedSumConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():
@@ -204,7 +204,7 @@ class H3WeightedSumConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("rnn", H3)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class H3RNNConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():

--- a/ludwig/schema/encoders/sequence_encoders.py
+++ b/ludwig/schema/encoders/sequence_encoders.py
@@ -12,7 +12,7 @@ from ludwig.schema.metadata import ENCODER_METADATA
 
 @DeveloperAPI
 @register_encoder_config("passthrough", [SEQUENCE, TEXT, TIMESERIES])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SequencePassthroughConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():
@@ -45,7 +45,7 @@ class SequencePassthroughConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("embed", [SEQUENCE, TEXT])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SequenceEmbedConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():
@@ -124,7 +124,7 @@ class SequenceEmbedConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("parallel_cnn", [AUDIO, SEQUENCE, TEXT, TIMESERIES])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class ParallelCNNConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():
@@ -292,7 +292,7 @@ class ParallelCNNConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("stacked_cnn", [AUDIO, SEQUENCE, TEXT, TIMESERIES])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class StackedCNNConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():
@@ -492,7 +492,7 @@ class StackedCNNConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("stacked_parallel_cnn", [AUDIO, SEQUENCE, TEXT, TIMESERIES])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class StackedParallelCNNConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():
@@ -678,7 +678,7 @@ class StackedParallelCNNConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("rnn", [AUDIO, SEQUENCE, TEXT, TIMESERIES])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class StackedRNNConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():
@@ -893,7 +893,7 @@ class StackedRNNConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("cnnrnn", [AUDIO, SEQUENCE, TEXT, TIMESERIES])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class StackedCNNRNNConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():
@@ -1189,7 +1189,7 @@ class StackedCNNRNNConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("transformer", [SEQUENCE, TEXT, TIMESERIES])
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class StackedTransformerConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():

--- a/ludwig/schema/encoders/set_encoders.py
+++ b/ludwig/schema/encoders/set_encoders.py
@@ -12,7 +12,7 @@ from ludwig.schema.metadata import ENCODER_METADATA
 
 @DeveloperAPI
 @register_encoder_config("embed", SET)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SetSparseEncoderConfig(BaseEncoderConfig):
     @staticmethod
     def module_name():

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -1907,14 +1907,9 @@ class DistilBERTConfig(BaseEncoderConfig):
 
 
 @DeveloperAPI
-<<<<<<< HEAD
-@register_encoder_config("ctrl", TEXT)
-@dataclass(repr=False, order=True)
-=======
 # TODO: uncomment when CTRL bug (https://github.com/ludwig-ai/ludwig/issues/2977) has been fixed to add back in
 # @register_encoder_config("ctrl", TEXT)
-@dataclass(repr=False)
->>>>>>> 8f6a28135cae03e13884d08dd93c0c4fb10d1de4
+@dataclass(repr=False, order=True)
 class CTRLConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an CTRL encoder."""
 

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -13,7 +13,7 @@ from ludwig.schema.metadata.parameter_metadata import ParameterMetadata
 
 @DeveloperAPI
 @register_encoder_config("albert", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class ALBERTConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an ALBERT encoder."""
 
@@ -209,7 +209,7 @@ class ALBERTConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("mt5", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class MT5Config(BaseEncoderConfig):
     """This dataclass configures the schema used for an MT5 encoder."""
 
@@ -396,7 +396,7 @@ class MT5Config(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("xlmroberta", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class XLMRoBERTaConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an XLMRoBERTa encoder."""
 
@@ -491,7 +491,7 @@ class XLMRoBERTaConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("bert", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class BERTConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an BERT encoder."""
 
@@ -662,7 +662,7 @@ class BERTConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("xlm", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class XLMConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an XLM encoder."""
 
@@ -909,7 +909,7 @@ class XLMConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("gpt", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class GPTConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an GPT encoder."""
 
@@ -1049,7 +1049,7 @@ class GPTConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("gpt2", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class GPT2Config(BaseEncoderConfig):
     """This dataclass configures the schema used for an GPT2 encoder."""
 
@@ -1200,7 +1200,7 @@ class GPT2Config(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("roberta", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class RoBERTaConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an RoBERTa encoder."""
 
@@ -1289,7 +1289,7 @@ class RoBERTaConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("transformer_xl", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class TransformerXLConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an TransformerXL encoder."""
 
@@ -1516,7 +1516,7 @@ class TransformerXLConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("xlnet", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class XLNetConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an XLNet encoder."""
 
@@ -1753,7 +1753,7 @@ class XLNetConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("distilbert", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class DistilBERTConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an DistilBERT encoder."""
 
@@ -1907,7 +1907,7 @@ class DistilBERTConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("ctrl", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class CTRLConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an CTRL encoder."""
 
@@ -2048,7 +2048,7 @@ class CTRLConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("camembert", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class CamemBERTConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an CamemBERT encoder."""
 
@@ -2218,7 +2218,7 @@ class CamemBERTConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("t5", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class T5Config(BaseEncoderConfig):
     """This dataclass configures the schema used for an T5 encoder."""
 
@@ -2363,7 +2363,7 @@ class T5Config(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("flaubert", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class FlauBERTConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an FlauBERT encoder."""
 
@@ -2602,7 +2602,7 @@ class FlauBERTConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("electra", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class ELECTRAConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an ELECTRA encoder."""
 
@@ -2767,7 +2767,7 @@ class ELECTRAConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("longformer", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class LongformerConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for a Longformer encoder."""
 
@@ -2862,7 +2862,7 @@ class LongformerConfig(BaseEncoderConfig):
 
 @DeveloperAPI
 @register_encoder_config("auto_transformer", TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class AutoTransformerConfig(BaseEncoderConfig):
     """This dataclass configures the schema used for an AutoTransformer encoder."""
 

--- a/ludwig/schema/features/audio_feature.py
+++ b/ludwig/schema/features/audio_feature.py
@@ -28,7 +28,7 @@ class AudioInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(AUDIO)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class AudioInputFeatureConfig(BaseInputFeatureConfig, AudioInputFeatureConfigMixin):
     """AudioInputFeatureConfig is a dataclass that configures the parameters used for an audio input feature."""
 

--- a/ludwig/schema/features/bag_feature.py
+++ b/ludwig/schema/features/bag_feature.py
@@ -28,7 +28,7 @@ class BagInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(BAG)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class BagInputFeatureConfig(BaseInputFeatureConfig, BagInputFeatureConfigMixin):
     """BagInputFeatureConfig is a dataclass that configures the parameters used for a bag input feature."""
 

--- a/ludwig/schema/features/binary_feature.py
+++ b/ludwig/schema/features/binary_feature.py
@@ -40,7 +40,7 @@ class BinaryInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(BINARY)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class BinaryInputFeatureConfig(BaseInputFeatureConfig, BinaryInputFeatureConfigMixin):
     """BinaryInputFeatureConfig is a dataclass that configures the parameters used for a binary input feature."""
 
@@ -67,7 +67,7 @@ class BinaryOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @output_config_registry.register(BINARY)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class BinaryOutputFeatureConfig(BaseOutputFeatureConfig, BinaryOutputFeatureConfigMixin):
     """BinaryOutputFeatureConfig is a dataclass that configures the parameters used for a binary output feature."""
 

--- a/ludwig/schema/features/category_feature.py
+++ b/ludwig/schema/features/category_feature.py
@@ -40,7 +40,7 @@ class CategoryInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(CATEGORY)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class CategoryInputFeatureConfig(BaseInputFeatureConfig, CategoryInputFeatureConfigMixin):
     """CategoryInputFeatureConfig is a dataclass that configures the parameters used for a category input
     feature."""
@@ -68,7 +68,7 @@ class CategoryOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @output_config_registry.register(CATEGORY)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class CategoryOutputFeatureConfig(BaseOutputFeatureConfig, CategoryOutputFeatureConfigMixin):
     """CategoryOutputFeatureConfig is a dataclass that configures the parameters used for a category output
     feature."""

--- a/ludwig/schema/features/date_feature.py
+++ b/ludwig/schema/features/date_feature.py
@@ -28,7 +28,7 @@ class DateInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(DATE)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class DateInputFeatureConfig(BaseInputFeatureConfig, DateInputFeatureConfigMixin):
     """DateInputFeature is a dataclass that configures the parameters used for a date input feature."""
 

--- a/ludwig/schema/features/h3_feature.py
+++ b/ludwig/schema/features/h3_feature.py
@@ -28,7 +28,7 @@ class H3InputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(H3)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class H3InputFeatureConfig(BaseInputFeatureConfig, H3InputFeatureConfigMixin):
     """H3InputFeatureConfig is a dataclass that configures the parameters used for an h3 input feature."""
 

--- a/ludwig/schema/features/image_feature.py
+++ b/ludwig/schema/features/image_feature.py
@@ -28,7 +28,7 @@ class ImageInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(IMAGE)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class ImageInputFeatureConfig(BaseInputFeatureConfig, ImageInputFeatureConfigMixin):
     """ImageInputFeatureConfig is a dataclass that configures the parameters used for an image input feature."""
 

--- a/ludwig/schema/features/loss/loss.py
+++ b/ludwig/schema/features/loss/loss.py
@@ -18,7 +18,7 @@ from ludwig.schema.metadata import LOSS_METADATA
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class BaseLossConfig(schema_utils.BaseMarshmallowConfig):
     """Base class for feature configs."""
 
@@ -28,7 +28,7 @@ class BaseLossConfig(schema_utils.BaseMarshmallowConfig):
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class MSELossConfig(BaseLossConfig):
     type: str = schema_utils.ProtectedString(
         MEAN_SQUARED_ERROR,
@@ -43,7 +43,7 @@ class MSELossConfig(BaseLossConfig):
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class MAELossConfig(BaseLossConfig):
     type: str = schema_utils.ProtectedString(
         MEAN_ABSOLUTE_ERROR,
@@ -58,7 +58,7 @@ class MAELossConfig(BaseLossConfig):
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class RMSELossConfig(BaseLossConfig):
     type: str = schema_utils.ProtectedString(
         ROOT_MEAN_SQUARED_ERROR,
@@ -73,7 +73,7 @@ class RMSELossConfig(BaseLossConfig):
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class RMSPELossConfig(BaseLossConfig):
     type: str = schema_utils.ProtectedString(
         ROOT_MEAN_SQUARED_PERCENTAGE_ERROR,
@@ -88,7 +88,7 @@ class RMSPELossConfig(BaseLossConfig):
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class BWCEWLossConfig(BaseLossConfig):
     type: str = schema_utils.ProtectedString(
         BINARY_WEIGHTED_CROSS_ENTROPY,
@@ -121,7 +121,7 @@ class BWCEWLossConfig(BaseLossConfig):
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SoftmaxCrossEntropyLossConfig(BaseLossConfig):
     type: str = schema_utils.ProtectedString(
         SOFTMAX_CROSS_ENTROPY,
@@ -169,7 +169,7 @@ class SoftmaxCrossEntropyLossConfig(BaseLossConfig):
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SequenceSoftmaxCrossEntropyLossConfig(BaseLossConfig):
     type: str = schema_utils.ProtectedString(
         SEQUENCE_SOFTMAX_CROSS_ENTROPY,
@@ -223,7 +223,7 @@ class SequenceSoftmaxCrossEntropyLossConfig(BaseLossConfig):
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SigmoidCrossEntropyLossConfig(BaseLossConfig):
     type: str = schema_utils.ProtectedString(
         SIGMOID_CROSS_ENTROPY,

--- a/ludwig/schema/features/number_feature.py
+++ b/ludwig/schema/features/number_feature.py
@@ -42,7 +42,7 @@ class NumberInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(NUMBER)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class NumberInputFeatureConfig(BaseInputFeatureConfig, NumberInputFeatureConfigMixin):
     """NumberInputFeatureConfig is a dataclass that configures the parameters used for a number input feature."""
 
@@ -69,7 +69,7 @@ class NumberOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @output_config_registry.register(NUMBER)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class NumberOutputFeatureConfig(BaseOutputFeatureConfig, NumberOutputFeatureConfigMixin):
     """NumberOutputFeatureConfig is a dataclass that configures the parameters used for a category output
     feature."""

--- a/ludwig/schema/features/preprocessing/audio.py
+++ b/ludwig/schema/features/preprocessing/audio.py
@@ -10,7 +10,7 @@ from ludwig.schema.metadata import FEATURE_METADATA
 
 @DeveloperAPI
 @register_preprocessor(AUDIO)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class AudioPreprocessingConfig(BasePreprocessingConfig):
     audio_file_length_limit_in_s: int = schema_utils.NonNegativeFloat(
         default=7.5,

--- a/ludwig/schema/features/preprocessing/bag.py
+++ b/ludwig/schema/features/preprocessing/bag.py
@@ -12,7 +12,7 @@ from ludwig.utils.tokenizers import tokenizer_registry
 
 @DeveloperAPI
 @register_preprocessor(BAG)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class BagPreprocessingConfig(BasePreprocessingConfig):
     tokenizer: str = schema_utils.StringOptions(
         tokenizer_registry.keys(),

--- a/ludwig/schema/features/preprocessing/binary.py
+++ b/ludwig/schema/features/preprocessing/binary.py
@@ -63,10 +63,19 @@ class BinaryPreprocessingConfig(BasePreprocessingConfig):
 @register_preprocessor("binary_output")
 @dataclass(repr=False, order=True)
 class BinaryOutputPreprocessingConfig(BinaryPreprocessingConfig):
+
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS + ["fill_with_false"],
         default=DROP_ROW,
         allow_none=False,
         description="What strategy to follow when there's a missing value in a binary output feature",
         parameter_metadata=FEATURE_METADATA[BINARY][PREPROCESSING]["missing_value_strategy"],
+    )
+
+    fallback_true_label: str = schema_utils.String(
+        default=None,
+        allow_none=True,
+        description="The label to interpret as 1 (True) when the binary feature doesn't have a "
+        "conventional boolean value",
+        parameter_metadata=FEATURE_METADATA[BINARY][PREPROCESSING]["fallback_true_label"],
     )

--- a/ludwig/schema/features/preprocessing/binary.py
+++ b/ludwig/schema/features/preprocessing/binary.py
@@ -24,6 +24,14 @@ class BinaryPreprocessingConfig(BasePreprocessingConfig):
         description="What strategy to follow when there's a missing value in a binary column",
         parameter_metadata=FEATURE_METADATA[BINARY][PREPROCESSING]["missing_value_strategy"],
     )
+    
+    fallback_true_label: str = schema_utils.String(
+        default=None,
+        allow_none=True,
+        description="The label to interpret as 1 (True) when the binary feature doesn't have a "
+        "conventional boolean value",
+        parameter_metadata=FEATURE_METADATA[BINARY][PREPROCESSING]["fallback_true_label"],
+    )
 
     fill_value: Union[int, float, str] = schema_utils.OneOfOptionsField(
         default=None,
@@ -48,14 +56,6 @@ class BinaryPreprocessingConfig(BasePreprocessingConfig):
         description="The internally computed fill value to replace missing values with in case the "
         "missing_value_strategy is fill_with_mode or fill_with_mean",
         parameter_metadata=FEATURE_METADATA[BINARY][PREPROCESSING]["computed_fill_value"],
-    )
-
-    fallback_true_label: str = schema_utils.String(
-        default=None,
-        allow_none=True,
-        description="The label to interpret as 1 (True) when the binary feature doesn't have a "
-        "conventional boolean value",
-        parameter_metadata=FEATURE_METADATA[BINARY][PREPROCESSING]["fallback_true_label"],
     )
 
 

--- a/ludwig/schema/features/preprocessing/binary.py
+++ b/ludwig/schema/features/preprocessing/binary.py
@@ -63,7 +63,6 @@ class BinaryPreprocessingConfig(BasePreprocessingConfig):
 @register_preprocessor("binary_output")
 @dataclass(repr=False, order=True)
 class BinaryOutputPreprocessingConfig(BinaryPreprocessingConfig):
-
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS + ["fill_with_false"],
         default=DROP_ROW,

--- a/ludwig/schema/features/preprocessing/binary.py
+++ b/ludwig/schema/features/preprocessing/binary.py
@@ -13,7 +13,7 @@ from ludwig.utils import strings_utils
 
 @DeveloperAPI
 @register_preprocessor(BINARY)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class BinaryPreprocessingConfig(BasePreprocessingConfig):
     """BinaryPreprocessingConfig is a dataclass that configures the parameters used for a binary input feature."""
 
@@ -61,7 +61,7 @@ class BinaryPreprocessingConfig(BasePreprocessingConfig):
 
 @DeveloperAPI
 @register_preprocessor("binary_output")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class BinaryOutputPreprocessingConfig(BinaryPreprocessingConfig):
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS + ["fill_with_false"],

--- a/ludwig/schema/features/preprocessing/category.py
+++ b/ludwig/schema/features/preprocessing/category.py
@@ -58,10 +58,25 @@ class CategoryPreprocessingConfig(BasePreprocessingConfig):
 @register_preprocessor("category_output")
 @dataclass(repr=False, order=True)
 class CategoryOutputPreprocessingConfig(CategoryPreprocessingConfig):
+
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,
         default=DROP_ROW,
         allow_none=False,
         description="What strategy to follow when there's a missing value in a category output feature",
         parameter_metadata=FEATURE_METADATA[CATEGORY][PREPROCESSING]["missing_value_strategy"],
+    )
+
+    lowercase: bool = schema_utils.Boolean(
+        default=False,
+        description="Whether the string has to be lowercased before being handled by the tokenizer.",
+        parameter_metadata=FEATURE_METADATA[CATEGORY][PREPROCESSING]["lowercase"],
+    )
+
+    most_common: int = schema_utils.PositiveInteger(
+        default=10000,
+        allow_none=True,
+        description="The maximum number of most common tokens to be considered. if the data contains more than this "
+        "amount, the most infrequent tokens will be treated as unknown.",
+        parameter_metadata=FEATURE_METADATA[CATEGORY][PREPROCESSING]["most_common"],
     )

--- a/ludwig/schema/features/preprocessing/category.py
+++ b/ludwig/schema/features/preprocessing/category.py
@@ -58,7 +58,6 @@ class CategoryPreprocessingConfig(BasePreprocessingConfig):
 @register_preprocessor("category_output")
 @dataclass(repr=False, order=True)
 class CategoryOutputPreprocessingConfig(CategoryPreprocessingConfig):
-
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,
         default=DROP_ROW,

--- a/ludwig/schema/features/preprocessing/category.py
+++ b/ludwig/schema/features/preprocessing/category.py
@@ -11,7 +11,7 @@ from ludwig.utils import strings_utils
 
 @DeveloperAPI
 @register_preprocessor(CATEGORY)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class CategoryPreprocessingConfig(BasePreprocessingConfig):
     """CategoryPreprocessingConfig is a dataclass that configures the parameters used for a category input
     feature."""
@@ -56,7 +56,7 @@ class CategoryPreprocessingConfig(BasePreprocessingConfig):
 
 @DeveloperAPI
 @register_preprocessor("category_output")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class CategoryOutputPreprocessingConfig(CategoryPreprocessingConfig):
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,

--- a/ludwig/schema/features/preprocessing/date.py
+++ b/ludwig/schema/features/preprocessing/date.py
@@ -10,7 +10,7 @@ from ludwig.schema.metadata import FEATURE_METADATA
 
 @DeveloperAPI
 @register_preprocessor(DATE)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class DatePreprocessingConfig(BasePreprocessingConfig):
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,

--- a/ludwig/schema/features/preprocessing/h3.py
+++ b/ludwig/schema/features/preprocessing/h3.py
@@ -10,7 +10,7 @@ from ludwig.schema.metadata import FEATURE_METADATA
 
 @DeveloperAPI
 @register_preprocessor(H3)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class H3PreprocessingConfig(BasePreprocessingConfig):
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,

--- a/ludwig/schema/features/preprocessing/image.py
+++ b/ludwig/schema/features/preprocessing/image.py
@@ -12,7 +12,7 @@ from ludwig.schema.metadata import FEATURE_METADATA
 
 @DeveloperAPI
 @register_preprocessor(IMAGE)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class ImagePreprocessingConfig(BasePreprocessingConfig):
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,

--- a/ludwig/schema/features/preprocessing/number.py
+++ b/ludwig/schema/features/preprocessing/number.py
@@ -57,3 +57,11 @@ class NumberOutputPreprocessingConfig(NumberPreprocessingConfig):
         description="What strategy to follow when there's a missing value in a number output feature",
         parameter_metadata=FEATURE_METADATA[NUMBER][PREPROCESSING]["missing_value_strategy"],
     )
+
+    normalization: str = schema_utils.StringOptions(
+        ["zscore", "minmax", "log1p", "iq"],
+        default=None,
+        allow_none=True,
+        description="Normalization strategy to use for this number feature.",
+        parameter_metadata=FEATURE_METADATA[NUMBER][PREPROCESSING]["normalization"],
+    )

--- a/ludwig/schema/features/preprocessing/number.py
+++ b/ludwig/schema/features/preprocessing/number.py
@@ -10,7 +10,7 @@ from ludwig.schema.metadata import FEATURE_METADATA
 
 @DeveloperAPI
 @register_preprocessor(NUMBER)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class NumberPreprocessingConfig(BasePreprocessingConfig):
     """NumberPreprocessingConfig is a dataclass that configures the parameters used for a number input feature."""
 
@@ -48,7 +48,7 @@ class NumberPreprocessingConfig(BasePreprocessingConfig):
 
 @DeveloperAPI
 @register_preprocessor("number_output")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class NumberOutputPreprocessingConfig(NumberPreprocessingConfig):
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,

--- a/ludwig/schema/features/preprocessing/sequence.py
+++ b/ludwig/schema/features/preprocessing/sequence.py
@@ -109,10 +109,47 @@ class SequencePreprocessingConfig(BasePreprocessingConfig):
 @register_preprocessor("sequence_output")
 @dataclass(repr=False, order=True)
 class SequenceOutputPreprocessingConfig(SequencePreprocessingConfig):
+
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,
         default=DROP_ROW,
         allow_none=False,
         description="What strategy to follow when there's a missing value in a sequence output feature",
         parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["missing_value_strategy"],
+    )
+
+    max_sequence_length: int = schema_utils.PositiveInteger(
+        default=256,
+        allow_none=False,
+        description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
+        "truncated, while texts that are shorter will be padded.",
+        parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["max_sequence_length"],
+    )
+
+    tokenizer: str = schema_utils.String(
+        default="space",
+        allow_none=False,
+        description="Defines how to map from the raw string content of the dataset column to a sequence of elements.",
+        parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["tokenizer"],
+    )
+
+    lowercase: bool = schema_utils.Boolean(
+        default=False,
+        description="If true, converts the string to lowercase before tokenizing.",
+        parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["lowercase"],
+    )
+
+    most_common: int = schema_utils.PositiveInteger(
+        default=20000,
+        allow_none=False,
+        description="The maximum number of most common tokens in the vocabulary. If the data contains more than this "
+        "amount, the most infrequent symbols will be treated as unknown.",
+        parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["most_common"],
+    )
+
+    ngram_size: int = schema_utils.PositiveInteger(
+        default=2,
+        allow_none=False,
+        description="The size of the ngram when using the `ngram` tokenizer (e.g, 2 = bigram, 3 = trigram, etc.).",
+        parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["ngram_size"],
     )

--- a/ludwig/schema/features/preprocessing/sequence.py
+++ b/ludwig/schema/features/preprocessing/sequence.py
@@ -11,7 +11,7 @@ from ludwig.utils import strings_utils
 
 @DeveloperAPI
 @register_preprocessor(SEQUENCE)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SequencePreprocessingConfig(BasePreprocessingConfig):
     tokenizer: str = schema_utils.String(
         default="space",
@@ -107,7 +107,7 @@ class SequencePreprocessingConfig(BasePreprocessingConfig):
 
 @DeveloperAPI
 @register_preprocessor("sequence_output")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SequenceOutputPreprocessingConfig(SequencePreprocessingConfig):
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,

--- a/ludwig/schema/features/preprocessing/sequence.py
+++ b/ludwig/schema/features/preprocessing/sequence.py
@@ -109,7 +109,6 @@ class SequencePreprocessingConfig(BasePreprocessingConfig):
 @register_preprocessor("sequence_output")
 @dataclass(repr=False, order=True)
 class SequenceOutputPreprocessingConfig(SequencePreprocessingConfig):
-
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,
         default=DROP_ROW,

--- a/ludwig/schema/features/preprocessing/set.py
+++ b/ludwig/schema/features/preprocessing/set.py
@@ -13,7 +13,6 @@ from ludwig.utils import strings_utils
 @register_preprocessor(SET)
 @dataclass(repr=False, order=True)
 class SetPreprocessingConfig(BasePreprocessingConfig):
-
     tokenizer: str = schema_utils.String(
         default="space",
         allow_none=False,
@@ -66,7 +65,6 @@ class SetPreprocessingConfig(BasePreprocessingConfig):
 @register_preprocessor("set_output")
 @dataclass(repr=False, order=True)
 class SetOutputPreprocessingConfig(SetPreprocessingConfig):
-
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,
         default=DROP_ROW,

--- a/ludwig/schema/features/preprocessing/set.py
+++ b/ludwig/schema/features/preprocessing/set.py
@@ -13,6 +13,7 @@ from ludwig.utils import strings_utils
 @register_preprocessor(SET)
 @dataclass(repr=False, order=True)
 class SetPreprocessingConfig(BasePreprocessingConfig):
+
     tokenizer: str = schema_utils.String(
         default="space",
         allow_none=False,
@@ -65,10 +66,35 @@ class SetPreprocessingConfig(BasePreprocessingConfig):
 @register_preprocessor("set_output")
 @dataclass(repr=False, order=True)
 class SetOutputPreprocessingConfig(SetPreprocessingConfig):
+
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,
         default=DROP_ROW,
         allow_none=False,
         description="What strategy to follow when there's a missing value in a set output feature",
         parameter_metadata=FEATURE_METADATA[SET][PREPROCESSING]["missing_value_strategy"],
+    )
+
+    tokenizer: str = schema_utils.String(
+        default="space",
+        allow_none=False,
+        description="Defines how to transform the raw text content of the dataset column to a set of elements. The "
+        "default value space splits the string on spaces. Common options include: underscore (splits on "
+        "underscore), comma (splits on comma), json (decodes the string into a set or a list through a "
+        "JSON parser).",
+        parameter_metadata=FEATURE_METADATA[SET][PREPROCESSING]["tokenizer"],
+    )
+
+    lowercase: bool = schema_utils.Boolean(
+        default=False,
+        description="If true, converts the string to lowercase before tokenizing.",
+        parameter_metadata=FEATURE_METADATA[SET][PREPROCESSING]["lowercase"],
+    )
+
+    most_common: int = schema_utils.PositiveInteger(
+        default=10000,
+        allow_none=True,
+        description="The maximum number of most common tokens to be considered. If the data contains more than this "
+        "amount, the most infrequent tokens will be treated as unknown.",
+        parameter_metadata=FEATURE_METADATA[SET][PREPROCESSING]["most_common"],
     )

--- a/ludwig/schema/features/preprocessing/set.py
+++ b/ludwig/schema/features/preprocessing/set.py
@@ -11,7 +11,7 @@ from ludwig.utils import strings_utils
 
 @DeveloperAPI
 @register_preprocessor(SET)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SetPreprocessingConfig(BasePreprocessingConfig):
     tokenizer: str = schema_utils.String(
         default="space",
@@ -63,7 +63,7 @@ class SetPreprocessingConfig(BasePreprocessingConfig):
 
 @DeveloperAPI
 @register_preprocessor("set_output")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SetOutputPreprocessingConfig(SetPreprocessingConfig):
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,

--- a/ludwig/schema/features/preprocessing/text.py
+++ b/ludwig/schema/features/preprocessing/text.py
@@ -120,7 +120,6 @@ class TextPreprocessingConfig(BasePreprocessingConfig):
 @register_preprocessor("text_output")
 @dataclass(repr=False, order=True)
 class TextOutputPreprocessingConfig(TextPreprocessingConfig):
-
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,
         default=DROP_ROW,

--- a/ludwig/schema/features/preprocessing/text.py
+++ b/ludwig/schema/features/preprocessing/text.py
@@ -120,10 +120,48 @@ class TextPreprocessingConfig(BasePreprocessingConfig):
 @register_preprocessor("text_output")
 @dataclass(repr=False, order=True)
 class TextOutputPreprocessingConfig(TextPreprocessingConfig):
+
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,
         default=DROP_ROW,
         allow_none=False,
         description="What strategy to follow when there's a missing value in a text output feature",
         parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["missing_value_strategy"],
+    )
+
+    max_sequence_length: int = schema_utils.PositiveInteger(
+        default=256,
+        allow_none=False,
+        description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
+        "truncated, while texts that are shorter will be padded.",
+        parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["max_sequence_length"],
+    )
+
+    tokenizer: str = schema_utils.StringOptions(
+        tokenizer_registry.keys(),
+        default="space_punct",
+        allow_none=False,
+        description="Defines how to map from the raw string content of the dataset column to a sequence of elements.",
+        parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["tokenizer"],
+    )
+
+    lowercase: bool = schema_utils.Boolean(
+        default=True,
+        description="If true, converts the string to lowercase before tokenizing.",
+        parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["lowercase"],
+    )
+
+    most_common: int = schema_utils.PositiveInteger(
+        default=20000,
+        allow_none=False,
+        description="The maximum number of most common tokens in the vocabulary. If the data contains more than this "
+        "amount, the most infrequent symbols will be treated as unknown.",
+        parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["most_common"],
+    )
+
+    ngram_size: int = schema_utils.PositiveInteger(
+        default=2,
+        allow_none=False,
+        description="The size of the ngram when using the `ngram` tokenizer (e.g, 2 = bigram, 3 = trigram, etc.).",
+        parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["ngram_size"],
     )

--- a/ludwig/schema/features/preprocessing/text.py
+++ b/ludwig/schema/features/preprocessing/text.py
@@ -12,7 +12,7 @@ from ludwig.utils.tokenizers import tokenizer_registry
 
 @DeveloperAPI
 @register_preprocessor(TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class TextPreprocessingConfig(BasePreprocessingConfig):
     """TextPreprocessingConfig is a dataclass that configures the parameters used for a text input feature."""
 
@@ -118,7 +118,7 @@ class TextPreprocessingConfig(BasePreprocessingConfig):
 
 @DeveloperAPI
 @register_preprocessor("text_output")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class TextOutputPreprocessingConfig(TextPreprocessingConfig):
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,

--- a/ludwig/schema/features/preprocessing/timeseries.py
+++ b/ludwig/schema/features/preprocessing/timeseries.py
@@ -11,7 +11,7 @@ from ludwig.utils.tokenizers import tokenizer_registry
 
 @DeveloperAPI
 @register_preprocessor(TIMESERIES)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class TimeseriesPreprocessingConfig(BasePreprocessingConfig):
     tokenizer: str = schema_utils.StringOptions(
         tokenizer_registry.keys(),

--- a/ludwig/schema/features/preprocessing/vector.py
+++ b/ludwig/schema/features/preprocessing/vector.py
@@ -10,7 +10,7 @@ from ludwig.schema.metadata import FEATURE_METADATA
 
 @DeveloperAPI
 @register_preprocessor(VECTOR)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class VectorPreprocessingConfig(BasePreprocessingConfig):
     vector_size: int = schema_utils.PositiveInteger(
         default=None,
@@ -47,7 +47,7 @@ class VectorPreprocessingConfig(BasePreprocessingConfig):
 
 @DeveloperAPI
 @register_preprocessor("vector_output")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class VectorOutputPreprocessingConfig(VectorPreprocessingConfig):
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,

--- a/ludwig/schema/features/preprocessing/vector.py
+++ b/ludwig/schema/features/preprocessing/vector.py
@@ -12,6 +12,7 @@ from ludwig.schema.metadata import FEATURE_METADATA
 @register_preprocessor(VECTOR)
 @dataclass(repr=False, order=True)
 class VectorPreprocessingConfig(BasePreprocessingConfig):
+
     vector_size: int = schema_utils.PositiveInteger(
         default=None,
         allow_none=True,
@@ -49,10 +50,18 @@ class VectorPreprocessingConfig(BasePreprocessingConfig):
 @register_preprocessor("vector_output")
 @dataclass(repr=False, order=True)
 class VectorOutputPreprocessingConfig(VectorPreprocessingConfig):
+
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,
         default=DROP_ROW,
         allow_none=False,
         description="What strategy to follow when there's a missing value in a vector output feature",
         parameter_metadata=FEATURE_METADATA[VECTOR][PREPROCESSING]["missing_value_strategy"],
+    )
+
+    vector_size: int = schema_utils.PositiveInteger(
+        default=None,
+        allow_none=True,
+        description="The size of the vector. If None, the vector size will be inferred from the data.",
+        parameter_metadata=FEATURE_METADATA[VECTOR][PREPROCESSING]["vector_size"],
     )

--- a/ludwig/schema/features/preprocessing/vector.py
+++ b/ludwig/schema/features/preprocessing/vector.py
@@ -12,7 +12,6 @@ from ludwig.schema.metadata import FEATURE_METADATA
 @register_preprocessor(VECTOR)
 @dataclass(repr=False, order=True)
 class VectorPreprocessingConfig(BasePreprocessingConfig):
-
     vector_size: int = schema_utils.PositiveInteger(
         default=None,
         allow_none=True,
@@ -50,7 +49,6 @@ class VectorPreprocessingConfig(BasePreprocessingConfig):
 @register_preprocessor("vector_output")
 @dataclass(repr=False, order=True)
 class VectorOutputPreprocessingConfig(VectorPreprocessingConfig):
-
     missing_value_strategy: str = schema_utils.StringOptions(
         MISSING_VALUE_STRATEGY_OPTIONS,
         default=DROP_ROW,

--- a/ludwig/schema/features/sequence_feature.py
+++ b/ludwig/schema/features/sequence_feature.py
@@ -40,7 +40,7 @@ class SequenceInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(SEQUENCE)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SequenceInputFeatureConfig(BaseInputFeatureConfig, SequenceInputFeatureConfigMixin):
     """SequenceInputFeatureConfig is a dataclass that configures the parameters used for a sequence input
     feature."""
@@ -68,7 +68,7 @@ class SequenceOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @output_config_registry.register(SEQUENCE)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SequenceOutputFeatureConfig(BaseOutputFeatureConfig, SequenceOutputFeatureConfigMixin):
     """SequenceOutputFeatureConfig is a dataclass that configures the parameters used for a sequence output
     feature."""

--- a/ludwig/schema/features/set_feature.py
+++ b/ludwig/schema/features/set_feature.py
@@ -40,7 +40,7 @@ class SetInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(SET)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SetInputFeatureConfig(BaseInputFeatureConfig, SetInputFeatureConfigMixin):
     """SetInputFeatureConfig is a dataclass that configures the parameters used for a set input feature."""
 
@@ -67,7 +67,7 @@ class SetOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @output_config_registry.register(SET)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SetOutputFeatureConfig(BaseOutputFeatureConfig, SetOutputFeatureConfigMixin):
     """SetOutputFeatureConfig is a dataclass that configures the parameters used for a set output feature."""
 

--- a/ludwig/schema/features/text_feature.py
+++ b/ludwig/schema/features/text_feature.py
@@ -40,7 +40,7 @@ class TextInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class TextInputFeatureConfig(BaseInputFeatureConfig, TextInputFeatureConfigMixin):
     """TextInputFeatureConfig is a dataclass that configures the parameters used for a text input feature."""
 
@@ -67,7 +67,7 @@ class TextOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @output_config_registry.register(TEXT)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class TextOutputFeatureConfig(BaseOutputFeatureConfig, TextOutputFeatureConfigMixin):
     """TextOutputFeatureConfig is a dataclass that configures the parameters used for a text output feature."""
 

--- a/ludwig/schema/features/timeseries_feature.py
+++ b/ludwig/schema/features/timeseries_feature.py
@@ -28,7 +28,7 @@ class TimeseriesInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(TIMESERIES)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class TimeseriesInputFeatureConfig(BaseInputFeatureConfig, TimeseriesInputFeatureConfigMixin):
     """TimeseriesInputFeatureConfig is a dataclass that configures the parameters used for a timeseries input
     feature."""

--- a/ludwig/schema/features/vector_feature.py
+++ b/ludwig/schema/features/vector_feature.py
@@ -40,7 +40,7 @@ class VectorInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @input_config_registry.register(VECTOR)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class VectorInputFeatureConfig(BaseInputFeatureConfig, VectorInputFeatureConfigMixin):
     """VectorInputFeatureConfig is a dataclass that configures the parameters used for a vector input feature."""
 
@@ -67,7 +67,7 @@ class VectorOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @output_config_registry.register(VECTOR)
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class VectorOutputFeatureConfig(BaseOutputFeatureConfig, VectorOutputFeatureConfigMixin):
     """VectorOutputFeatureConfig is a dataclass that configures the parameters used for a vector output feature."""
 

--- a/ludwig/schema/lr_scheduler.py
+++ b/ludwig/schema/lr_scheduler.py
@@ -12,9 +12,35 @@ from ludwig.schema.metadata import TRAINER_METADATA
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class LRSchedulerConfig(schema_utils.BaseMarshmallowConfig, ABC):
     """Configuration for learning rate scheduler parameters."""
+
+    decay: Optional[str] = schema_utils.StringOptions(
+        ["linear", "exponential"],
+        description="Turn on decay of the learning rate.",
+        parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["decay"],
+    )
+
+    decay_rate: float = schema_utils.FloatRange(
+        default=0.96,
+        min=0,
+        max=1,
+        description="Decay per epoch (%): Factor to decrease the Learning rate.",
+        parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["decay_steps"],
+    )
+
+    decay_steps: int = schema_utils.PositiveInteger(
+        default=10000,
+        description="The number of steps to take in the exponential learning rate decay.",
+        parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["decay_steps"],
+    )
+
+    staircase: bool = schema_utils.Boolean(
+        default=False,
+        description="Decays the learning rate at discrete intervals.",
+        parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["staircase"],
+    )
 
     warmup_evaluations: int = schema_utils.NonNegativeFloat(
         default=0,
@@ -26,32 +52,6 @@ class LRSchedulerConfig(schema_utils.BaseMarshmallowConfig, ABC):
         default=0.0,
         description="Fraction of total training steps to warmup the learning rate for.",
         parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["warmup_fraction"],
-    )
-
-    decay: Optional[str] = schema_utils.StringOptions(
-        ["linear", "exponential"],
-        description="Turn on decay of the learning rate.",
-        parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["decay"],
-    )
-
-    decay_steps: int = schema_utils.PositiveInteger(
-        default=10000,
-        description="The number of steps to take in the exponential learning rate decay.",
-        parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["decay_steps"],
-    )
-
-    decay_rate: float = schema_utils.FloatRange(
-        default=0.96,
-        min=0,
-        max=1,
-        description="Decay per epoch (%): Factor to decrease the Learning rate.",
-        parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["decay_steps"],
-    )
-
-    staircase: bool = schema_utils.Boolean(
-        default=False,
-        description="Decays the learning rate at discrete intervals.",
-        parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["staircase"],
     )
 
     reduce_on_plateau: int = schema_utils.NonNegativeInteger(

--- a/ludwig/schema/lr_scheduler.py
+++ b/ludwig/schema/lr_scheduler.py
@@ -42,18 +42,6 @@ class LRSchedulerConfig(schema_utils.BaseMarshmallowConfig, ABC):
         parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["staircase"],
     )
 
-    warmup_evaluations: int = schema_utils.NonNegativeFloat(
-        default=0,
-        description="Number of evaluation steps to warmup the learning rate for.",
-        parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["warmup_evaluations"],
-    )
-
-    warmup_fraction: float = schema_utils.NonNegativeFloat(
-        default=0.0,
-        description="Fraction of total training steps to warmup the learning rate for.",
-        parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["warmup_fraction"],
-    )
-
     reduce_on_plateau: int = schema_utils.NonNegativeInteger(
         default=0,
         description=(
@@ -77,6 +65,18 @@ class LRSchedulerConfig(schema_utils.BaseMarshmallowConfig, ABC):
         max=1,
         description="Rate at which we reduce the learning rate when `reduce_on_plateau > 0`.",
         parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["reduce_on_plateau_rate"],
+    )
+
+    warmup_evaluations: int = schema_utils.NonNegativeFloat(
+        default=0,
+        description="Number of evaluation steps to warmup the learning rate for.",
+        parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["warmup_evaluations"],
+    )
+
+    warmup_fraction: float = schema_utils.NonNegativeFloat(
+        default=0.0,
+        description="Fraction of total training steps to warmup the learning rate for.",
+        parameter_metadata=TRAINER_METADATA["learning_rate_scheduler"]["warmup_fraction"],
     )
 
     reduce_eval_metric: str = schema_utils.String(

--- a/ludwig/schema/metadata/configs/encoders.yaml
+++ b/ludwig/schema/metadata/configs/encoders.yaml
@@ -286,7 +286,6 @@ ALBERT:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -329,7 +328,6 @@ AutoTransformer:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -547,7 +545,6 @@ BERT:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -905,7 +902,6 @@ BagEmbedWeighted:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     weights_initializer:
@@ -1028,7 +1024,6 @@ CTRL:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -1234,7 +1229,6 @@ CamemBERT:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -1464,7 +1458,6 @@ CategoricalSparse:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
 DateEmbed:
@@ -2477,7 +2470,6 @@ DistilBERT:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -2716,7 +2708,6 @@ ELECTRA:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -2911,7 +2902,6 @@ FlauBERT:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -2994,7 +2984,6 @@ GPT2:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -4035,7 +4024,6 @@ Longformer:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -4290,7 +4278,6 @@ MT5:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -4652,7 +4639,6 @@ ParallelCNN:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     weights_initializer:
@@ -5061,7 +5047,6 @@ RoBERTa:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -5175,7 +5160,6 @@ SequenceEmbed:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     weights_initializer:
@@ -5543,7 +5527,6 @@ SetSparseEncoder:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     weights_initializer:
@@ -6333,7 +6316,6 @@ StackedCNN:
             - a
             - b
             - c
-        expected_impact: 1
         internal_only: true
         ui_display_name: Not Displayed
     weights_initializer:
@@ -6924,7 +6906,6 @@ StackedCNNRNN:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     weights_initializer:
@@ -7298,7 +7279,6 @@ StackedParallelCNN:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     weights_initializer:
@@ -7757,7 +7737,6 @@ StackedRNN:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     weights_initializer:
@@ -8196,7 +8175,6 @@ StackedTransformer:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     weights_initializer:
@@ -8347,7 +8325,6 @@ T5:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -8486,7 +8463,6 @@ TransformerXL:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -9054,7 +9030,6 @@ XLM:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -9124,7 +9099,6 @@ XLMRoBERTa:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:
@@ -9297,7 +9271,6 @@ XLNet:
             - a
             - b
             - c
-        expected_impact: 2
         internal_only: true
         ui_display_name: Not Displayed
     vocab_size:

--- a/ludwig/schema/metadata/configs/features.yaml
+++ b/ludwig/schema/metadata/configs/features.yaml
@@ -589,6 +589,7 @@ set:
                 Note that choosing to drop rows with missing values could result in
                 losing information, especially if there is a high proportion of missing
                 values in the dataset.
+            expected_impact: 3
             related_parameters:
                 - fill_value
             ui_display_name: Missing Value Strategy

--- a/ludwig/schema/metadata/configs/trainer.yaml
+++ b/ludwig/schema/metadata/configs/trainer.yaml
@@ -483,7 +483,7 @@ learning_rate_scheduler:
                 \ As a rule of thumb, compared to training without a schedule, you can use\
                 \ a slightly higher maximum learning rate. Since the learning rate changes\
                 \ over time, the whole training is not so sensitive to the value picked."
-        expected_impact: 2
+        expected_impact: 3
         literature_references:
                 - "https://peltarion.com/knowledge-center/documentation/modeling-view/run-a-model/optimization-principles-(in-deep-learning)/learning-rate-schedule "
         related_parameters:

--- a/ludwig/schema/metadata/configs/trainer.yaml
+++ b/ludwig/schema/metadata/configs/trainer.yaml
@@ -483,7 +483,7 @@ learning_rate_scheduler:
                 \ As a rule of thumb, compared to training without a schedule, you can use\
                 \ a slightly higher maximum learning rate. Since the learning rate changes\
                 \ over time, the whole training is not so sensitive to the value picked."
-        expected_impact: 3
+        expected_impact: 2
         literature_references:
                 - "https://peltarion.com/knowledge-center/documentation/modeling-view/run-a-model/optimization-principles-(in-deep-learning)/learning-rate-schedule "
         related_parameters:

--- a/ludwig/schema/metadata/configs/trainer.yaml
+++ b/ludwig/schema/metadata/configs/trainer.yaml
@@ -311,7 +311,7 @@ regularization_type:
          selection, since weights are only reduced to values near 0 instead of 0.
          L1 regularization implicitly performs feature selection. L1 regularization is more
          robust to outliers."
-    expected_impact: 2
+    expected_impact: 3
     literature_references:
         - "https://neptune.ai/blog/fighting-overfitting-with-l1-or-l2-regularization#:~:text=The%20differences%20between%20L1%20and,regularization%20solution%20is%20non%2Dsparse. "
     related_parameters:
@@ -483,7 +483,7 @@ learning_rate_scheduler:
                 \ As a rule of thumb, compared to training without a schedule, you can use\
                 \ a slightly higher maximum learning rate. Since the learning rate changes\
                 \ over time, the whole training is not so sensitive to the value picked."
-        expected_impact: 3
+        expected_impact: 2
         literature_references:
                 - "https://peltarion.com/knowledge-center/documentation/modeling-view/run-a-model/optimization-principles-(in-deep-learning)/learning-rate-schedule "
         related_parameters:

--- a/ludwig/schema/optimizers.py
+++ b/ludwig/schema/optimizers.py
@@ -31,7 +31,7 @@ def get_optimizer_cls(name: str):
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class BaseOptimizerConfig(schema_utils.BaseMarshmallowConfig, ABC):
     """Base class for optimizers. Not meant to be used directly.
 
@@ -53,7 +53,7 @@ class BaseOptimizerConfig(schema_utils.BaseMarshmallowConfig, ABC):
 
 @DeveloperAPI
 @register_optimizer(name="sgd")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class SGDOptimizerConfig(BaseOptimizerConfig):
     """Parameters for stochastic gradient descent."""
 
@@ -81,7 +81,7 @@ class SGDOptimizerConfig(BaseOptimizerConfig):
 
 @DeveloperAPI
 @register_optimizer(name="lbfgs")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class LBFGSOptimizerConfig(BaseOptimizerConfig):
     """Parameters for stochastic gradient descent."""
 
@@ -132,7 +132,7 @@ class LBFGSOptimizerConfig(BaseOptimizerConfig):
 
 @DeveloperAPI
 @register_optimizer(name="adam")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class AdamOptimizerConfig(BaseOptimizerConfig):
     """Parameters for adam optimization."""
 
@@ -170,7 +170,7 @@ class AdamOptimizerConfig(BaseOptimizerConfig):
 
 @DeveloperAPI
 @register_optimizer(name="adamw")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class AdamWOptimizerConfig(BaseOptimizerConfig):
     """Parameters for adamw optimization."""
 
@@ -208,7 +208,7 @@ class AdamWOptimizerConfig(BaseOptimizerConfig):
 
 @DeveloperAPI
 @register_optimizer(name="adadelta")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class AdadeltaOptimizerConfig(BaseOptimizerConfig):
     """Parameters for adadelta optimization."""
 
@@ -241,7 +241,7 @@ class AdadeltaOptimizerConfig(BaseOptimizerConfig):
 
 @DeveloperAPI
 @register_optimizer(name="adagrad")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class AdagradOptimizerConfig(BaseOptimizerConfig):
     """Parameters for adagrad optimization."""
 
@@ -275,7 +275,7 @@ class AdagradOptimizerConfig(BaseOptimizerConfig):
 
 @DeveloperAPI
 @register_optimizer(name="adamax")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class AdamaxOptimizerConfig(BaseOptimizerConfig):
     """Parameters for adamax optimization."""
 
@@ -307,7 +307,7 @@ class AdamaxOptimizerConfig(BaseOptimizerConfig):
 # NOTE: keep ftrl and nadam optimizers out of registry:
 # @register_optimizer(name="ftrl")
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class FtrlOptimizerConfig(BaseOptimizerConfig):
     # optimizer_class: ClassVar[torch.optim.Optimizer] = torch.optim.Ftrl
     type: str = schema_utils.ProtectedString("ftrl")
@@ -331,7 +331,7 @@ class FtrlOptimizerConfig(BaseOptimizerConfig):
 
 @DeveloperAPI
 @register_optimizer(name="nadam")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class NadamOptimizerConfig(BaseOptimizerConfig):
     optimizer_class: ClassVar[torch.optim.Optimizer] = torch.optim.NAdam
     """Points to `torch.optim.NAdam`."""
@@ -363,7 +363,7 @@ class NadamOptimizerConfig(BaseOptimizerConfig):
 
 @DeveloperAPI
 @register_optimizer(name="rmsprop")
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class RMSPropOptimizerConfig(BaseOptimizerConfig):
     """Parameters for rmsprop optimization."""
 
@@ -497,7 +497,7 @@ def OptimizerDataclassField(default={"type": "adam"}, description="TODO"):
 
 
 @DeveloperAPI
-@dataclass(repr=False)
+@dataclass(repr=False, order=True)
 class GradientClippingConfig(schema_utils.BaseMarshmallowConfig):
     """Dataclass that holds gradient clipping parameters."""
 

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -58,24 +58,15 @@ class ECDTrainerConfig(BaseTrainerConfig):
         ],
     )
 
+    learning_rate_scheduler: LRSchedulerConfig = LRSchedulerDataclassField(
+        description="Parameter values for learning rate scheduler.",
+        default=None,
+    )
+
     epochs: int = schema_utils.PositiveInteger(
         default=100,
         description="Number of epochs the algorithm is intended to be run over. Overridden if `train_steps` is set",
         parameter_metadata=TRAINER_METADATA["epochs"],
-    )
-
-    batch_size: Union[int, str] = schema_utils.OneOfOptionsField(
-        default=DEFAULT_BATCH_SIZE,
-        allow_none=False,
-        description=(
-            "The number of training examples utilized in one training step of the model. If ’auto’, the "
-            "biggest batch size (power of 2) that can fit in memory will be used."
-        ),
-        parameter_metadata=TRAINER_METADATA["batch_size"],
-        field_options=[
-            schema_utils.PositiveInteger(default=128, description="", allow_none=False),
-            schema_utils.StringOptions(options=["auto"], default="auto", allow_none=False),
-        ],
     )
 
     checkpoints_per_epoch: int = schema_utils.NonNegativeInteger(
@@ -105,14 +96,18 @@ class ECDTrainerConfig(BaseTrainerConfig):
         parameter_metadata=TRAINER_METADATA["steps_per_checkpoint"],
     )
 
-    early_stop: int = schema_utils.IntegerRange(
-        default=5,
-        min=-1,
+    batch_size: Union[int, str] = schema_utils.OneOfOptionsField(
+        default=DEFAULT_BATCH_SIZE,
+        allow_none=False,
         description=(
-            "Number of consecutive rounds of evaluation without any improvement on the `validation_metric` that "
-            "triggers training to stop. Can be set to -1, which disables early stopping entirely."
+            "The number of training examples utilized in one training step of the model. If ’auto’, the "
+            "biggest batch size (power of 2) that can fit in memory will be used."
         ),
-        parameter_metadata=TRAINER_METADATA["early_stop"],
+        parameter_metadata=TRAINER_METADATA["batch_size"],
+        field_options=[
+            schema_utils.PositiveInteger(default=128, description="", allow_none=False),
+            schema_utils.StringOptions(options=["auto"], default="auto", allow_none=False),
+        ],
     )
 
     max_batch_size: int = schema_utils.PositiveInteger(
@@ -123,6 +118,16 @@ class ECDTrainerConfig(BaseTrainerConfig):
             "value is 2^40."
         ),
         parameter_metadata=TRAINER_METADATA["max_batch_size"],
+    )
+
+    early_stop: int = schema_utils.IntegerRange(
+        default=5,
+        min=-1,
+        description=(
+            "Number of consecutive rounds of evaluation without any improvement on the `validation_metric` that "
+            "triggers training to stop. Can be set to -1, which disables early stopping entirely."
+        ),
+        parameter_metadata=TRAINER_METADATA["early_stop"],
     )
 
     eval_batch_size: Union[None, int, str] = schema_utils.OneOfOptionsField(
@@ -174,11 +179,6 @@ class ECDTrainerConfig(BaseTrainerConfig):
 
     optimizer: BaseOptimizerConfig = OptimizerDataclassField(
         default={"type": "adam"}, description="Parameter values for selected torch optimizer."
-    )
-
-    learning_rate_scheduler: LRSchedulerConfig = LRSchedulerDataclassField(
-        description="Parameter values for learning rate scheduler.",
-        default=None,
     )
 
     regularization_type: Optional[str] = schema_utils.RegularizerOptions(

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -1225,10 +1225,23 @@ def get_hf_tokenizer(pretrained_model_name_or_path, **kwargs):
 
 
 def _get_bert_config(hf_name):
-    from transformers.utils.hub import cached_path
+    """Gets configs from BERT tokenizers in HuggingFace.
+
+    `vocab_file` is required for BERT tokenizers. `tokenizer_config.json` are optional keyword arguments used to
+    initialize the tokenizer object. If no `tokenizer_config.json` is found, then we instantiate the tokenizer with
+    default arguments.
+    """
+    from transformers.utils.hub import cached_path, EntryNotFoundError
 
     vocab_file = cached_path(f"https://huggingface.co/{hf_name}/resolve/main/vocab.txt")
-    tokenizer_config = load_json(cached_path(f"https://huggingface.co/{hf_name}/resolve/main/tokenizer_config.json"))
+
+    try:
+        tokenizer_config = load_json(
+            cached_path(f"https://huggingface.co/{hf_name}/resolve/main/tokenizer_config.json")
+        )
+    except EntryNotFoundError:
+        tokenizer_config = {}
+
     return {"vocab_file": vocab_file, **tokenizer_config}
 
 

--- a/tests/ludwig/utils/test_tokenizers.py
+++ b/tests/ludwig/utils/test_tokenizers.py
@@ -12,6 +12,8 @@ TORCHTEXT_0_14_0_HF_NAMES = [
     "google/electra-small-discriminator",
     "dbmdz/bert-base-italian-cased",  # Community model
     "nreimers/MiniLM-L6-H384-uncased",  # Community model
+    "emilyalsentzer/Bio_ClinicalBERT",  # Community model
+    "bionlp/bluebert_pubmed_mimic_uncased_L-12_H-768_A-12",  # Community model
 ]
 
 


### PR DESCRIPTION
This PR reorders the schema params to be in a more intuitive for users given the expected impact value of each parameter. Parameters with an expected impact of 2 are considered advanced and will be hidden under an advanced parameter accordion.