### PR TITLE
Revert "Add sentencepiece as a requirement for MT5 text encoder (#2967)" and disable MT5 Encoder

### DIFF
--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -208,7 +208,8 @@ class ALBERTConfig(BaseEncoderConfig):
 
 
 @DeveloperAPI
-@register_encoder_config("mt5", TEXT)
+# TODO: uncomment when sentencepiece doesn't cause segfaults: https://github.com/ludwig-ai/ludwig/issues/2983
+# @register_encoder_config("mt5", TEXT)
 @dataclass(repr=False)
 class MT5Config(BaseEncoderConfig):
     """This dataclass configures the schema used for an MT5 encoder."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,9 +38,6 @@ retry
 # required for TransfoXLTokenizer when using transformer_xl
 sacremoses
 
-# required for MT5 Encoder
-sentencepiece
-
 # new data format support
 xlwt            # excel
 xlrd            # excel


### PR DESCRIPTION
This reverts commit 12204ba2361d8b6519aac278528a4adcbc24c8c2.
