### PR TITLE
[Hyperopt] Modify _get_best_model_path to grab it from the Checkpoint object with ExperimentAnalysis

### DIFF
--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -358,7 +358,7 @@ class RayTuneExecutor:
                 os.remove(marker_path)
 
     @contextlib.contextmanager
-    def _get_best_model_path(self, trial_path: str, analysis: ExperimentAnalysis) -> str:
+    def _get_best_model_path(self, trial_path: str, analysis: ExperimentAnalysis, creds: Dict[str, Any]) -> str:
         print("!!! Trial: ", trial_path)
 
         checkpoint = analysis.get_best_checkpoint(trial=trial_path)
@@ -371,7 +371,7 @@ class RayTuneExecutor:
         if ckpt_type == "uri":
             # Read remote URIs using Ludwig's internal remote file loading APIs, as
             # Ray's do not handle custom credentials at the moment.
-            with use_credentials(self._creds):
+            with use_credentials(creds):
                 print("!!! Remote Checkpoint path: ", ckpt_path)
                 yield ckpt_path
         else:
@@ -902,7 +902,9 @@ class RayTuneExecutor:
                     # Evaluate the best model on the eval_split, which is validation_set
                     if validation_set is not None and validation_set.size > 0:
                         trial_path = trial["trial_dir"]
-                        with self._get_best_model_path(trial_path, analysis) as best_model_path:
+                        with self._get_best_model_path(
+                            trial_path, analysis, backend.storage.artifacts.credentials
+                        ) as best_model_path:
                             if best_model_path is not None:
                                 self._evaluate_best_model(
                                     trial,

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -361,7 +361,7 @@ class RayTuneExecutor:
     def _get_best_model_path(self, trial_path: str, analysis: ExperimentAnalysis, creds: Dict[str, Any]) -> str:
         # `trial_dir` returned by RayTune may have a leading slash, but get_best_checkpoint
         # requires a path without a leading slash since it does a direct key lookup with analysis.trial_dataframes.
-        if trial_path[-1] == "/":
+        if isinstance(trial_path, str) and trial_path[-1] == "/":
             trial_path = trial_path[:-1]
 
         checkpoint = analysis.get_best_checkpoint(trial=trial_path)

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -390,8 +390,6 @@ class RayTuneExecutor:
         backend,
         debug,
     ):
-        print("!!! Evaluating best model")
-        print("!!! Best model path: ", best_model_path)
         best_model = LudwigModel.load(
             os.path.join(best_model_path, "model"),
             backend=backend,

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -359,24 +359,19 @@ class RayTuneExecutor:
 
     @contextlib.contextmanager
     def _get_best_model_path(self, trial_path: str, analysis: ExperimentAnalysis, creds: Dict[str, Any]) -> str:
-        print("!!! Trial: ", trial_path)
-
         checkpoint = analysis.get_best_checkpoint(trial=trial_path)
         if checkpoint is None:
             logger.warning("No best model found")
             return None
 
         ckpt_type, ckpt_path = checkpoint.get_internal_representation()
-        print("!!! Checkpoint type: ", ckpt_type)
         if ckpt_type == "uri":
             # Read remote URIs using Ludwig's internal remote file loading APIs, as
             # Ray's do not handle custom credentials at the moment.
             with use_credentials(creds):
-                print("!!! Remote Checkpoint path: ", ckpt_path)
                 yield ckpt_path
         else:
             with checkpoint.as_directory() as ckpt_path:
-                print("!!! Local Checkpoint path: ", ckpt_path)
                 yield ckpt_path
 
     @staticmethod

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -357,8 +357,9 @@ class RayTuneExecutor:
                 # Remove checkpoint marker on incomplete directory
                 os.remove(marker_path)
 
+    @staticmethod
     @contextlib.contextmanager
-    def _get_best_model_path(self, trial_path: str, analysis: ExperimentAnalysis, creds: Dict[str, Any]) -> str:
+    def _get_best_model_path(trial_path: str, analysis: ExperimentAnalysis, creds: Dict[str, Any]) -> str:
         # `trial_dir` returned by RayTune may have a leading slash, but get_best_checkpoint
         # requires a path without a leading slash since it does a direct key lookup with analysis.trial_dataframes.
         if isinstance(trial_path, str) and trial_path[-1] == "/":

--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -372,8 +372,7 @@ class RayTuneExecutor:
     def _get_best_model_path(trial_path: str, analysis: ExperimentAnalysis, creds: Dict[str, Any]) -> str:
         # `trial_dir` returned by RayTune may have a leading slash, but get_best_checkpoint
         # requires a path without a leading slash since it does a direct key lookup with analysis.trial_dataframes.
-        if isinstance(trial_path, str) and trial_path[-1] == "/":
-            trial_path = trial_path[:-1]
+        trial_path = trial_path.rstrip("/") if isinstance(trial_path, str) else trial_path
 
         checkpoint = analysis.get_best_checkpoint(trial=trial_path)
         if checkpoint is None:

--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -21,7 +21,6 @@ from ludwig.constants import (
     MAX_CONCURRENT_TRIALS,
     METRIC,
     NAME,
-    NUM_SAMPLES,
     OUTPUT_FEATURES,
     PARAMETERS,
     PREPROCESSING,
@@ -231,7 +230,7 @@ def hyperopt(
     update_hyperopt_params_with_defaults(hyperopt_config)
 
     # Check if all features are grid type parameters and log UserWarning if needed
-    log_warning_if_all_grid_type_parameters(hyperopt_config[PARAMETERS], hyperopt_config[EXECUTOR].get(NUM_SAMPLES))
+    log_warning_if_all_grid_type_parameters(hyperopt_config)
 
     # Infer max concurrent trials
     if hyperopt_config[EXECUTOR].get(MAX_CONCURRENT_TRIALS) == AUTO:

--- a/ludwig/hyperopt/utils.py
+++ b/ludwig/hyperopt/utils.py
@@ -5,8 +5,8 @@ import logging
 import os
 import warnings
 from typing import Any, Dict
-from ludwig.api_annotations import DeveloperAPI
 
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import (
     AUTO,
     COMBINED,

--- a/ludwig/hyperopt/utils.py
+++ b/ludwig/hyperopt/utils.py
@@ -5,6 +5,7 @@ import logging
 import os
 import warnings
 from typing import Any, Dict
+from ludwig.api_annotations import DeveloperAPI
 
 from ludwig.constants import (
     AUTO,
@@ -173,22 +174,30 @@ def substitute_parameters(
     return config
 
 
-def log_warning_if_all_grid_type_parameters(
-    hyperopt_parameter_config: HyperoptConfigDict, num_samples: int = 1
-) -> None:
-    """Logs warning if all parameters have a grid type search space and num_samples > 1 since this will result in
-    duplicate trials being created."""
+@DeveloperAPI
+def get_num_duplicate_trials(hyperopt_config: HyperoptConfigDict) -> int:
+    num_samples = hyperopt_config[EXECUTOR].get(NUM_SAMPLES, 1)
     if num_samples == 1:
-        return
+        return 0
 
     total_grid_search_trials = 1
-
-    for _, param_info in hyperopt_parameter_config.items():
+    for _, param_info in hyperopt_config[PARAMETERS].items():
         if param_info.get(SPACE, None) != GRID_SEARCH:
-            return
+            return 0
         total_grid_search_trials *= len(param_info.get("values", []))
 
     num_duplicate_trials = (total_grid_search_trials * num_samples) - total_grid_search_trials
+    return num_duplicate_trials
+
+
+def log_warning_if_all_grid_type_parameters(hyperopt_config: HyperoptConfigDict) -> None:
+    """Logs warning if all parameters have a grid type search space and num_samples > 1 since this will result in
+    duplicate trials being created."""
+    num_duplicate_trials = get_num_duplicate_trials(hyperopt_config)
+    if num_duplicate_trials == 0:
+        return
+
+    num_samples = hyperopt_config[EXECUTOR].get(NUM_SAMPLES, 1)
     warnings.warn(
         "All hyperopt parameters in Ludwig config are using grid_search space, but number of samples "
         f"({num_samples}) is greater than 1. This will result in {num_duplicate_trials} duplicate trials being "

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -187,7 +187,7 @@ def test_hyperopt_search_alg(
     assert isinstance(results, HyperoptResults)
 
     with hyperopt_executor._get_best_model_path(
-        results.experiment_analysis.best_trial, results.experiment_analysis
+        results.experiment_analysis.best_trial, results.experiment_analysis, {}
     ) as path:
         assert path is not None
         assert isinstance(path, str)

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -187,7 +187,7 @@ def test_hyperopt_search_alg(
     assert isinstance(results, HyperoptResults)
 
     with hyperopt_executor._get_best_model_path(
-        results.experiment_analysis.best_trial.logdir, results.experiment_analysis
+        results.experiment_analysis.best_trial, results.experiment_analysis
     ) as path:
         assert path is not None
         assert isinstance(path, str)

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 import json
+import os
 import os.path
 import uuid
 from typing import Dict, Tuple
@@ -349,6 +350,7 @@ def _run_hyperopt_run_hyperopt(csv_filename, search_space, tmpdir, backend, ray_
     ) as path:
         assert path is not None
         assert isinstance(path, str)
+        assert "model" in os.listdir(path)
 
 
 @pytest.mark.parametrize("search_space", ["random", "grid"])

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -58,7 +58,7 @@ from tests.integration_tests.utils import (
 
 ray = pytest.importorskip("ray")
 
-from ludwig.hyperopt.execution import get_build_hyperopt_executor  # noqa
+from ludwig.hyperopt.execution import RayTuneExecutor, get_build_hyperopt_executor  # noqa
 
 pytestmark = pytest.mark.distributed
 
@@ -343,6 +343,12 @@ def _run_hyperopt_run_hyperopt(csv_filename, search_space, tmpdir, backend, ray_
             assert fs_utils.path_exists(
                 os.path.join(tmpdir, experiment_name, f"trial_{trial.trial_id}"),
             )
+
+    with RayTuneExecutor._get_best_model_path(
+        hyperopt_results.experiment_analysis.best_trial, hyperopt_results.experiment_analysis, minio_test_creds()
+    ) as path:
+        assert path is not None
+        assert isinstance(path, str)
 
 
 @pytest.mark.parametrize("search_space", ["random", "grid"])

--- a/tests/ludwig/hyperopt/test_hyperopt.py
+++ b/tests/ludwig/hyperopt/test_hyperopt.py
@@ -82,10 +82,12 @@ def test_grid_search_more_than_one_sample():
     with pytest.warns(RuntimeWarning):
         log_warning_if_all_grid_type_parameters(
             {
-                "trainer.learning_rate": {"space": "grid_search", "values": [0.001, 0.005, 0.1]},
-                "defaults.text.encoder.type": {"space": "grid_search", "values": ["parallel_cnn", "stacked_cnn"]},
-            },
-            num_samples=2,
+                "parameters": {
+                    "trainer.learning_rate": {"space": "grid_search", "values": [0.001, 0.005, 0.1]},
+                    "defaults.text.encoder.type": {"space": "grid_search", "values": ["parallel_cnn", "stacked_cnn"]},
+                },
+                "executor": {"num_samples": 2},
+            }
         )
 
 

--- a/tests/ludwig/hyperopt/test_hyperopt.py
+++ b/tests/ludwig/hyperopt/test_hyperopt.py
@@ -79,6 +79,8 @@ def test_substitute_parameters(parameters, expected):
 
 
 def test_grid_search_more_than_one_sample():
+    """Test logs a user warning indicating that duplicate trials will be created because all of the parameters in
+    the search space are of type grid_search and the number of samples is greater than 1."""
     with pytest.warns(RuntimeWarning):
         log_warning_if_all_grid_type_parameters(
             {


### PR DESCRIPTION
This allows us to pipe credentials to _get_best_checkpoint_dir and ensure that we can load/download artifacts from remote URIs where credentials are needed (and don't exist in the environment variables / explicitly passed in through the Ludwig config)