### PR TITLE
GBM: disable goss boosting type

### DIFF
--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -348,6 +348,7 @@ class GBMTrainerConfig(BaseTrainerConfig):
 
     # LightGBM core parameters (https://lightgbm.readthedocs.io/en/latest/Parameters.html)
     boosting_type: str = schema_utils.StringOptions(
+        # TODO: Re-enable "goss" when supported: https://github.com/ludwig-ai/ludwig/issues/2988
         ["gbdt", "dart"],
         default="gbdt",
         description="Type of boosting algorithm to use with GBM trainer.",

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -348,7 +348,7 @@ class GBMTrainerConfig(BaseTrainerConfig):
 
     # LightGBM core parameters (https://lightgbm.readthedocs.io/en/latest/Parameters.html)
     boosting_type: str = schema_utils.StringOptions(
-        ["gbdt", "dart", "goss"],
+        ["gbdt", "dart"],
         default="gbdt",
         description="Type of boosting algorithm to use with GBM trainer.",
     )

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -356,7 +356,7 @@ def test_boosting_type_rf_invalid(tmpdir, local_backend):
 @pytest.mark.skip(reason="LightGBMError: Number of class for initial score error")
 def test_goss_deactivate_bagging(tmpdir, local_backend):
     """Test that bagging is disabled for the GOSS boosting type.
-    
+
     TODO: Re-enable when GOSS is supported: https://github.com/ludwig-ai/ludwig/issues/2988
     """
     input_features = [number_feature()]

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -353,8 +353,12 @@ def test_boosting_type_rf_invalid(tmpdir, local_backend):
         _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend, boosting_type="rf")
 
 
+@pytest.mark.skip(reason="LightGBMError: Number of class for initial score error")
 def test_goss_deactivate_bagging(tmpdir, local_backend):
-    """Test that bagging is disabled for the GOSS boosting type."""
+    """Test that bagging is disabled for the GOSS boosting type.
+    
+    TODO: Re-enable when GOSS is supported: https://github.com/ludwig-ai/ludwig/issues/2988
+    """
     input_features = [number_feature()]
     output_features = [binary_feature()]
 


### PR DESCRIPTION
Leads to `lightgbm.basic.LightGBMError: Number of class for initial score error`. Disabling until we have capacity to support non-default boosting types