### PR TITLE
Set `max_failures` for Tuner to 0

### DIFF
--- a/ludwig/hyperopt/execution.py
+++ b/ludwig/hyperopt/execution.py
@@ -856,7 +856,7 @@ class RayTuneExecutor:
                         stop=CallbackStopper(callbacks),
                         callbacks=tune_callbacks,
                         failure_config=FailureConfig(
-                            max_failures=1,
+                            max_failures=0,
                         ),
                         sync_config=self.sync_config,
                         checkpoint_config=CheckpointConfig(


### PR DESCRIPTION
Until we get a better handle of Ray Actors terminating ungracefully and leaving orphaned placement groups, we want this param set to 0 to prevent deadlocks, particularly on GPU.