### PR TITLE
fix: Fix validation and serialization for `Boolean` and `OneOfOptionsField` fields

### DIFF
--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -390,6 +390,7 @@ def Boolean(default: bool, description: str, parameter_metadata: ParameterMetada
             "marshmallow_field": fields.Boolean(
                 truthy={True},
                 falsy={False},
+                # Necessary because marshmallow will otherwise cast any non-boolean value to a boolean:
                 validate=validate.OneOf([True, False]),
                 allow_none=False,
                 load_default=default,
@@ -985,6 +986,7 @@ def OneOfOptionsField(
                 try:
                     if value is None and mfield_meta.allow_none:
                         return None
+                    # Not every field (e.g. our custom dataclass fields) has a `validate` method:
                     if mfield_meta.validate:
                         mfield_meta.validate(value)
                     return mfield_meta._serialize(value, attr, obj, **kwargs)
@@ -998,6 +1000,7 @@ def OneOfOptionsField(
             for option in field_options:
                 mfield_meta = option.metadata["marshmallow_field"]
                 try:
+                    # Not every field (e.g. our custom dataclass fields) has a `validate` method:
                     if mfield_meta.validate:
                         mfield_meta.validate(value)
                     return mfield_meta._deserialize(value, attr, obj, **kwargs)

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -390,6 +390,7 @@ def Boolean(default: bool, description: str, parameter_metadata: ParameterMetada
             "marshmallow_field": fields.Boolean(
                 truthy={True},
                 falsy={False},
+                validate=validate.OneOf([True, False]),
                 allow_none=False,
                 load_default=default,
                 dump_default=default,
@@ -984,7 +985,8 @@ def OneOfOptionsField(
                 try:
                     if value is None and mfield_meta.allow_none:
                         return None
-                    mfield_meta.validate(value)
+                    if mfield_meta.validate:
+                        mfield_meta.validate(value)
                     return mfield_meta._serialize(value, attr, obj, **kwargs)
                 except Exception:
                     continue


### PR DESCRIPTION
This is an interesting little bug related to our marshmallow validation pattern (and marshmallow's looseness). Apologies for the length of this PR description, but I think the full context is helpful.

## Why the change? / What happened:

In @jimthompson5802 's latest attempt to add an `augmentation` parameter to image features that supports both `bool` and `list` values, he defined the parameter roughly as so:
```
    augmentation: Union[bool, List[BaseAugmentationConfig]] = schema_utils.OneOfOptionsField(
        default=False,
        description="Augmentation configuration.",
        field_options=[
            schema_utils.Boolean(
                default=False,
                description="Whether to use augmentation or not.",
            ),
            AugmentationContainerDataclassField(
                feature_type=IMAGE,
                default=[
                    {"type": "random_horizontal_flip"},
                    {"type": "random_rotate", "degree": 15},
                ]
            )
        ]
    )
```

Then, while running a test he consistently received an error at import time that looked like this:
```
ImportError while loading conftest '/home/ksbrar/work/ludwig/tests/conftest.py'.
tests/conftest.py:35: in <module>
    from ludwig.hyperopt.run import hyperopt
ludwig/hyperopt/run.py:11: in <module>
    from ludwig.api import LudwigModel
ludwig/api.py:40: in <module>
    from ludwig.backend import Backend, initialize_backend, provision_preprocessing_workers
ludwig/backend/__init__.py:22: in <module>
    from ludwig.backend.base import Backend, LocalBackend
ludwig/backend/base.py:29: in <module>
    from ludwig.data.cache.manager import CacheManager
ludwig/data/cache/manager.py:7: in <module>
    from ludwig.data.cache.util import calculate_checksum
ludwig/data/cache/util.py:4: in <module>
    from ludwig.utils.config_utils import merge_fixed_preprocessing_params
ludwig/utils/config_utils.py:5: in <module>
    from ludwig.encoders.registry import get_encoder_cls
ludwig/encoders/__init__.py:2: in <module>
    import ludwig.encoders.bag_encoders
ludwig/encoders/bag_encoders.py:27: in <module>
    from ludwig.schema.encoders.bag_encoders import BagEmbedWeightedConfig
ludwig/schema/__init__.py:23: in <module>
    from ludwig.schema.defaults.defaults import get_defaults_jsonschema
ludwig/schema/defaults/defaults.py:26: in <module>
    class DefaultsConfig(schema_utils.BaseMarshmallowConfig):
ludwig/schema/defaults/defaults.py:39: in DefaultsConfig
    image: BaseFeatureConfig = DefaultsDataclassField(feature_type=IMAGE)
ludwig/schema/defaults/utils.py:83: in DefaultsDataclassField
    raise ValidationError(f"Unsupported feature type: {feature_type}. See input_type_registry. " f"Details: {e}")
E   marshmallow.exceptions.ValidationError: Unsupported feature type: image. See input_type_registry. Details: Value to serialize does not match any valid option schemas: False
```

Clearly from the way Jim defined the parameter, this seems spurious. How does a default of `False` fail the serialization check in the `OneOfOptionsField` _even  when the first option is the boolean_?

## What went wrong?

Three things:

1) If you look at line 987 in this PR we see a reference to `mfield_meta.validate(value)`. This is the line that is supposed to check to see if the value in question matches the current option's schema during the schema-check loop. _But not every field has this function defined_. Look through our custom fields in `schema.utils` and you'll see what I mean. This results in a very confusing error message (`Value to serialize does not match any valid option schemas`) - the original error (which is a `NoneType` error because Python is trying to apply a `None`-function to `value`) is erased by our current error handling. In the `_deserialize` method a few lines below (line 1001) we correctly first check to see if the function exists, so I've added that check here.

2) But! _Even then serialization would fail_. It would fail by succeeding! To my surprise, `marshmallow` decides to simply cast any value passed for boolean serialization _regardless of how you set the `truthy`/`falsy` enums_. See this line: https://github.com/marshmallow-code/marshmallow/blob/ab4dd8a058d291d34a74b3cdf7cec94db2c15aec/src/marshmallow/fields.py#L1197. So I've added a hard `validate` function to our `Boolean` field to compensate.

3) We now validate using two separate functions - `validate` and `_serialize`/`_deserialize`, and this makes reasoning about the intended behaviors of our fields a bit troublesome. This was the natural outgrowth of how we've tweaked our fields over time, but it bears the question - should validation happen twice? If once, where should it happen? Should every field have a `validate` function? In the example of `OneOfOptionsField` does it make sense to you that sometimes _both_ `validate` and `_serialize`/`_deserialize` do validation and some other times only one will?

## Points of discussion:
* We should improve our error messages (see point 1 above)
* We should probably refactor our validation patterns.
