### PR TITLE
[Hyperopt] Set default num_samples based on parameter space

### DIFF
--- a/ludwig/hyperopt/utils.py
+++ b/ludwig/hyperopt/utils.py
@@ -175,16 +175,28 @@ def substitute_parameters(
 
 
 @DeveloperAPI
+def contains_grid_search_parameters(config: ModelConfigDict) -> bool:
+    """Returns True if any hyperopt parameter in the config is using the grid_search space."""
+    for _, param_info in config[PARAMETERS].items():
+        if param_info.get(SPACE, None) == GRID_SEARCH:
+            return True
+    return False
+
+
+@DeveloperAPI
 def get_num_duplicate_trials(hyperopt_config: HyperoptConfigDict) -> int:
+    """Returns the number of duplicate trials that will be created.
+
+    Duplicate trials are only created when there are grid type parameters and num_samples > 1.
+    """
     num_samples = hyperopt_config[EXECUTOR].get(NUM_SAMPLES, 1)
     if num_samples == 1:
         return 0
 
     total_grid_search_trials = 1
     for _, param_info in hyperopt_config[PARAMETERS].items():
-        if param_info.get(SPACE, None) != GRID_SEARCH:
-            return 0
-        total_grid_search_trials *= len(param_info.get("values", []))
+        if param_info.get(SPACE, None) == GRID_SEARCH:
+            total_grid_search_trials *= len(param_info.get("values", []))
 
     num_duplicate_trials = (total_grid_search_trials * num_samples) - total_grid_search_trials
     return num_duplicate_trials

--- a/ludwig/hyperopt/utils.py
+++ b/ludwig/hyperopt/utils.py
@@ -175,9 +175,9 @@ def substitute_parameters(
 
 
 @DeveloperAPI
-def contains_grid_search_parameters(config: ModelConfigDict) -> bool:
+def contains_grid_search_parameters(hyperopt_config: HyperoptConfigDict) -> bool:
     """Returns True if any hyperopt parameter in the config is using the grid_search space."""
-    for _, param_info in config[PARAMETERS].items():
+    for _, param_info in hyperopt_config[PARAMETERS].items():
         if param_info.get(SPACE, None) == GRID_SEARCH:
             return True
     return False

--- a/ludwig/schema/hyperopt/executor.py
+++ b/ludwig/schema/hyperopt/executor.py
@@ -18,10 +18,11 @@ class ExecutorConfig(schema_utils.BaseMarshmallowConfig):
     type: str = schema_utils.ProtectedString(RAY)
 
     num_samples: int = schema_utils.PositiveInteger(
-        default=10,
+        default=None,
+        allow_none=True,
         description=(
             "This parameter, along with the space specifications in the parameters section, controls how many "
-            "trials are generated "
+            "trials are generated."
         ),
     )
 

--- a/ludwig/schema/model_config.py
+++ b/ludwig/schema/model_config.py
@@ -519,7 +519,7 @@ class ModelConfig(BaseMarshmallowConfig):
         self.hyperopt = HyperoptConfig.from_dict(self.hyperopt).to_dict()
 
         # Set default num_samples based on search space if not set by user
-        if self.hyperopt.get(EXECUTOR).get(NUM_SAMPLES) is None:
+        if self.hyperopt[EXECUTOR].get(NUM_SAMPLES) is None:
             _contains_grid_search_params = contains_grid_search_parameters(self.hyperopt)
             if _contains_grid_search_params:
                 logger.info(

--- a/tests/ludwig/hyperopt/test_hyperopt.py
+++ b/tests/ludwig/hyperopt/test_hyperopt.py
@@ -167,7 +167,11 @@ def test_hyperopt_config_gbm():
     ids=["all_grid_search", "mixed", "no_grid_search"],
 )
 def test_default_num_samples(parameters, expected_num_samples):
+    """This test ensures that the default number of samples is set correctly when the user does not specify the
+    number of samples in the hyperopt config."""
     config = _get_config()
+
+    # Override to set num_samples to None so we can test inference logic
     config["hyperopt"]["executor"]["num_samples"] = None
     config["hyperopt"]["parameters"] = parameters
 


### PR DESCRIPTION
This PR sets the default `num_samples` to None, and then infers a value for it (either 1 or 10) based on the parameters search space passed into hyperopt. 

In particular, when there are parameters with grid search, we want to prevent duplication of trials because grid search creates all possible combinations of trials using the discrete values in the space, so we set the num_samples to 1 to prevent this duplication. 

If the parameter space doesn't contain any grid search parameters, there is no chance of duplication and we can safely set the default value to 10 (like we were before). 

This will continue to respect user's choices if they are set in the config.

Note: We don't currently have a `hyperopt.yaml` in `ludwig/schema/metadata` so there's nothing else to update. I will follow this PR up with an update to the docs.