### PR TITLE
fix: Fix GBM type enum and GBM defaults schema

### DIFF
--- a/ludwig/config_validation/validation.py
+++ b/ludwig/config_validation/validation.py
@@ -59,7 +59,7 @@ def get_schema(model_type: str = MODEL_ECD):
             TRAINER: get_trainer_jsonschema(model_type),
             PREPROCESSING: get_preprocessing_jsonschema(),
             HYPEROPT: get_hyperopt_jsonschema(),
-            DEFAULTS: get_defaults_jsonschema(),
+            DEFAULTS: get_defaults_jsonschema(model_type),
             LUDWIG_VERSION: get_ludwig_version_jsonschema(),
             BACKEND: get_backend_jsonschema(),
         },

--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -59,7 +59,7 @@ def get_schema(model_type: str = MODEL_ECD):
             TRAINER: get_trainer_jsonschema(model_type),
             PREPROCESSING: get_preprocessing_jsonschema(),
             HYPEROPT: get_hyperopt_jsonschema(),
-            DEFAULTS: get_defaults_jsonschema(),
+            DEFAULTS: get_defaults_jsonschema(model_type),
             LUDWIG_VERSION: get_ludwig_version_jsonschema(),
             BACKEND: get_backend_jsonschema(),
         },

--- a/ludwig/schema/defaults/defaults.py
+++ b/ludwig/schema/defaults/defaults.py
@@ -9,6 +9,7 @@ from ludwig.constants import (
     DATE,
     H3,
     IMAGE,
+    MODEL_ECD,
     NUMBER,
     SEQUENCE,
     SET,
@@ -51,11 +52,21 @@ class DefaultsConfig(schema_utils.BaseMarshmallowConfig):
     vector: BaseFeatureConfig = DefaultsDataclassField(feature_type=VECTOR)
 
 
+@dataclass
+class GBMDefaultsConfig(schema_utils.BaseMarshmallowConfig):
+    binary: BaseFeatureConfig = DefaultsDataclassField(feature_type=BINARY)
+
+    category: BaseFeatureConfig = DefaultsDataclassField(feature_type=CATEGORY)
+
+    number: BaseFeatureConfig = DefaultsDataclassField(feature_type=NUMBER)
+
+
 @DeveloperAPI
-def get_defaults_jsonschema():
+def get_defaults_jsonschema(model_type: str = MODEL_ECD):
     """Returns a JSON schema structured to only require a `type` key and then conditionally apply a corresponding
     combiner's field constraints."""
-    preproc_schema = schema_utils.unload_jsonschema_from_marshmallow_class(DefaultsConfig)
+    cls = DefaultsConfig if model_type == MODEL_ECD else GBMDefaultsConfig
+    preproc_schema = schema_utils.unload_jsonschema_from_marshmallow_class(cls)
     props = preproc_schema["properties"]
     return {
         "type": "object",

--- a/ludwig/schema/features/utils.py
+++ b/ludwig/schema/features/utils.py
@@ -70,8 +70,6 @@ def get_input_feature_jsonschema(model_type: str):
     if model_type == MODEL_GBM:
         prune_gbm_features(schema)
 
-    print(schema["items"]["properties"]["type"])
-
     return schema
 
 

--- a/ludwig/schema/features/utils.py
+++ b/ludwig/schema/features/utils.py
@@ -33,6 +33,7 @@ def prune_gbm_features(schema: Dict):
         if if_type in gbm_feature_types:
             pruned_all_of += [cond]
     schema["items"]["allOf"] = pruned_all_of
+    schema["items"]["properties"]["type"]["enum"] = gbm_feature_types
 
 
 @DeveloperAPI
@@ -68,6 +69,8 @@ def get_input_feature_jsonschema(model_type: str):
 
     if model_type == MODEL_GBM:
         prune_gbm_features(schema)
+
+    print(schema["items"]["properties"]["type"])
 
     return schema
 

--- a/ludwig/schema/model_config.py
+++ b/ludwig/schema/model_config.py
@@ -45,7 +45,7 @@ from ludwig.schema.combiners.base import BaseCombinerConfig
 from ludwig.schema.combiners.concat import ConcatCombinerConfig
 from ludwig.schema.combiners.utils import combiner_registry
 from ludwig.schema.decoders.utils import get_decoder_cls
-from ludwig.schema.defaults.defaults import DefaultsConfig
+from ludwig.schema.defaults.defaults import DefaultsConfig, GBMDefaultsConfig
 from ludwig.schema.encoders.base import PassthroughEncoderConfig
 from ludwig.schema.encoders.utils import get_encoder_cls
 from ludwig.schema.features.utils import (
@@ -146,7 +146,8 @@ class ModelConfig(BaseMarshmallowConfig):
         self.combiner: BaseCombinerConfig = ConcatCombinerConfig()
         self.trainer: BaseTrainerConfig = ECDTrainerConfig()
         self.preprocessing: PreprocessingConfig = PreprocessingConfig()
-        self.defaults: DefaultsConfig = copy.deepcopy(DefaultsConfig())
+        defaults_cls = GBMDefaultsConfig() if upgraded_config_dict.get(DEFAULTS, None) == MODEL_GBM else DefaultsConfig
+        self.defaults: DefaultsConfig = copy.deepcopy(defaults_cls())
 
         # ===== Set User Defined Global Defaults =====
         if DEFAULTS in upgraded_config_dict:

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -77,9 +77,7 @@ def run_test_gbm_output_not_supported(tmpdir, backend_config):
     input_features = [number_feature(), category_feature(encoder={"reduce_output": "sum"})]
     output_features = [text_feature(output_feature=True)]
 
-    with pytest.raises(
-        ValueError, match="Model type GBM only supports numerical, categorical, or binary output " "features.*"
-    ):
+    with pytest.raises(ValidationError, match="Failed validating 'enum'.*"):
         _train_and_predict_gbm(input_features, output_features, tmpdir, backend_config)
 
 


### PR DESCRIPTION
Removes extra feature types from GBM input/output type enums and adds a separate, streamlined GBM defaults schema (leanest thing I could think of). Again, target will be to refactor/clean up these custom tweaks after #2906 