### PR TITLE
Use iloc to fetch first audio value.

### DIFF
--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -95,7 +95,7 @@ class AudioFeatureMixin(BaseFeatureMixin):
     def get_feature_meta(
         column, preprocessing_parameters: PreprocessingConfigDict, backend, is_input_feature: bool
     ) -> FeatureMetadataDict:
-        first_audio_file_path = column.head(1)[0]
+        first_audio_file_path = column.head(1).iloc[0]
         _, sampling_rate_in_hz = torchaudio.load(first_audio_file_path)
 
         feature_dim = AudioFeatureMixin._get_feature_dim(preprocessing_parameters, sampling_rate_in_hz)

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -37,7 +37,7 @@ def test_sample_ratio(backend, tmpdir, ray_cluster_2cpu):
     num_examples = 100
     sample_ratio = 0.25
 
-    input_features = [sequence_feature(encoder={"reduce_output": "sum"})]
+    input_features = [sequence_feature(encoder={"reduce_output": "sum"}), audio_feature(folder=tmpdir)]
     output_features = [category_feature(decoder={"vocab_size": 5}, reduce_input="sum")]
     data_csv = generate_data(
         input_features, output_features, os.path.join(tmpdir, "dataset.csv"), num_examples=num_examples


### PR DESCRIPTION
If `preprocessing.sample_ratio` is set, it's not guaranteed that the index-0 element will be included in the training data sub-sample.

Use `iloc` instead.

Tested (reproduced and fixed):

```python
import logging
import os
import tempfile

from ludwig.api import LudwigModel
from tests.integration_tests.utils import generate_data, category_feature, audio_feature

with tempfile.TemporaryDirectory() as tmp_dir:
    input_features = [audio_feature(folder=tmp_dir)]
    output_features = [category_feature(output_feature=True)]
    rel_path = generate_data(input_features, output_features, os.path.join(tmp_dir, "data.csv"), 1000)

    config = {
        "preprocessing": {"sample_ratio": 0.1},
        "input_features": input_features,
        "output_features": output_features,
        "trainer": {"epochs": 2, "batch_size": 64},
    }
    model = LudwigModel(config, logging_level=logging.INFO)
    model.experiment(dataset=rel_path)

```

Fixes #2995