### PR TITLE
Cleaning up seed / random_seed usage discrepancy

### DIFF
--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -6,7 +6,6 @@ import threading
 from ludwig.api_annotations import DeveloperAPI, PublicAPI
 from ludwig.callbacks import Callback
 from ludwig.constants import TRAINER
-from ludwig.data.dataset.base import Dataset
 from ludwig.globals import MODEL_HYPERPARAMETERS_FILE_NAME, TRAIN_SET_METADATA_FILE_NAME
 from ludwig.types import TrainingSetMetadataDict
 from ludwig.utils.data_utils import chunk_dict, flatten_dict, save_json, to_json_dict
@@ -69,9 +68,9 @@ class MlflowCallback(Callback):
 
     def on_preprocess_end(
         self,
-        training_set: Dataset,
-        validation_set: Dataset,
-        test_set: Dataset,
+        training_set: "Dataset",  # noqa
+        validation_set: "Dataset",  # noqa
+        test_set: "Dataset",  # noqa
         training_set_metadata: TrainingSetMetadataDict,
     ):
         self.training_set_metadata = training_set_metadata

--- a/ludwig/data/dataset/base.py
+++ b/ludwig/data/dataset/base.py
@@ -17,6 +17,9 @@
 import contextlib
 from abc import ABC, abstractmethod
 
+from ludwig.distributed import DistributedStrategy
+from ludwig.utils.defaults import default_random_seed
+
 
 class Dataset(ABC):
     @abstractmethod
@@ -25,7 +28,14 @@ class Dataset(ABC):
 
     @contextlib.contextmanager
     @abstractmethod
-    def initialize_batcher(self, batch_size=128, should_shuffle=True, seed=0, ignore_last=False, distributed=None):
+    def initialize_batcher(
+        self,
+        batch_size: int = 128,
+        should_shuffle: bool = True,
+        random_seed: int = default_random_seed,
+        ignore_last: bool = False,
+        distributed: DistributedStrategy = None,
+    ):
         raise NotImplementedError()
 
     def to_df(self):

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -23,9 +23,11 @@ from ludwig.constants import PREPROCESSING, TRAINING
 from ludwig.data.batcher.random_access import RandomAccessBatcher
 from ludwig.data.dataset.base import Dataset, DatasetManager
 from ludwig.data.sampler import DistributedSampler
+from ludwig.distributed import DistributedStrategy
 from ludwig.features.base_feature import BaseFeature
 from ludwig.utils.data_utils import DATA_TRAIN_HDF5_FP, save_hdf5
 from ludwig.utils.dataframe_utils import from_numpy_dataset, to_numpy_dataset
+from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.fs_utils import download_h5
 from ludwig.utils.misc_utils import get_proc_features
 
@@ -80,8 +82,17 @@ class PandasDataset(Dataset):
         return df.memory_usage(deep=True).sum() if df is not None else 0
 
     @contextlib.contextmanager
-    def initialize_batcher(self, batch_size=128, should_shuffle=True, seed=0, ignore_last=False, distributed=None):
-        sampler = DistributedSampler(len(self), shuffle=should_shuffle, seed=seed, distributed=distributed)
+    def initialize_batcher(
+        self,
+        batch_size: int = 128,
+        should_shuffle: bool = True,
+        random_seed: int = default_random_seed,
+        ignore_last: bool = False,
+        distributed: DistributedStrategy = None,
+    ):
+        sampler = DistributedSampler(
+            len(self), shuffle=should_shuffle, random_seed=random_seed, distributed=distributed
+        )
         batcher = RandomAccessBatcher(self, sampler, batch_size=batch_size, ignore_last=ignore_last)
         yield batcher
 

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -34,8 +34,10 @@ from ludwig.backend.base import Backend
 from ludwig.constants import BINARY, CATEGORY, NAME, NUMBER, TYPE
 from ludwig.data.batcher.base import Batcher
 from ludwig.data.dataset.base import Dataset, DatasetManager
+from ludwig.distributed import DistributedStrategy
 from ludwig.types import FeatureConfigDict, ModelConfigDict, TrainingSetMetadataDict
 from ludwig.utils.data_utils import DATA_TRAIN_HDF5_FP, DATA_TRAIN_PARQUET_FP
+from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.error_handling_utils import default_retry
 from ludwig.utils.fs_utils import get_fs_and_path
 from ludwig.utils.misc_utils import get_proc_features
@@ -108,7 +110,7 @@ class RayDataset(Dataset):
         self,
         batch_size=128,
         should_shuffle=True,
-        seed=0,
+        random_seed=0,
         ignore_last=False,
         distributed=None,
     ):
@@ -218,7 +220,14 @@ class RayDatasetShard(Dataset):
             self.epoch_iter = self.dataset_shard.repeat().iter_epochs()
 
     @contextlib.contextmanager
-    def initialize_batcher(self, batch_size=128, should_shuffle=True, seed=0, ignore_last=False, distributed=None):
+    def initialize_batcher(
+        self,
+        batch_size: int = 128,
+        should_shuffle: bool = True,
+        random_seed: int = default_random_seed,
+        ignore_last: bool = False,
+        distributed: DistributedStrategy = None,
+    ):
         yield RayDatasetBatcher(
             self.epoch_iter,
             self.features,

--- a/ludwig/data/sampler.py
+++ b/ludwig/data/sampler.py
@@ -18,11 +18,20 @@ import math
 
 import numpy as np
 
+from ludwig.distributed import DistributedStrategy
+from ludwig.utils.defaults import default_random_seed
+
 
 class DistributedSampler:
     """Adapted from `torch.utils.data.distributed.DistributedSampler`."""
 
-    def __init__(self, dataset_size, shuffle=True, seed=0, distributed=None):
+    def __init__(
+        self,
+        dataset_size: int,
+        shuffle: bool = True,
+        random_seed: int = default_random_seed,
+        distributed: DistributedStrategy = None,
+    ):
         self.dataset_size = dataset_size
         self.num_replicas = distributed.size() if distributed else 1
         self.rank = distributed.rank() if distributed else 0
@@ -30,7 +39,7 @@ class DistributedSampler:
         self.num_samples = int(math.ceil(self.dataset_size * 1.0 / self.num_replicas))
         self.total_size = self.num_samples * self.num_replicas
         self.shuffle = shuffle
-        self.seed = seed
+        self.seed = random_seed
 
     def __iter__(self):
         if self.shuffle:

--- a/ludwig/data/sampler.py
+++ b/ludwig/data/sampler.py
@@ -39,12 +39,12 @@ class DistributedSampler:
         self.num_samples = int(math.ceil(self.dataset_size * 1.0 / self.num_replicas))
         self.total_size = self.num_samples * self.num_replicas
         self.shuffle = shuffle
-        self.seed = random_seed
+        self.random_seed = random_seed
 
     def __iter__(self):
         if self.shuffle:
             # deterministically shuffle based on epoch and seed
-            indices = np.random.RandomState(seed=self.seed + self.epoch).permutation(self.dataset_size).tolist()
+            indices = np.random.RandomState(seed=self.random_seed + self.epoch).permutation(self.dataset_size).tolist()
         else:
             indices = list(range(self.dataset_size))
 

--- a/ludwig/data/split.py
+++ b/ludwig/data/split.py
@@ -33,11 +33,11 @@ from ludwig.schema.split import (
 )
 from ludwig.types import ModelConfigDict, PreprocessingConfigDict
 from ludwig.utils.data_utils import hash_dict, split_dataset_ttv
+from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.registry import Registry
 from ludwig.utils.types import DataFrame
 
 split_registry = Registry()
-default_random_seed = 42
 logger = logging.getLogger(__name__)
 
 TMP_SPLIT_COL = "__SPLIT__"
@@ -47,7 +47,7 @@ DEFAULT_PROBABILITIES = (0.7, 0.1, 0.2)
 class Splitter(ABC):
     @abstractmethod
     def split(
-        self, df: DataFrame, backend: Backend, random_seed: float = default_random_seed
+        self, df: DataFrame, backend: Backend, random_seed: int = default_random_seed
     ) -> Tuple[DataFrame, DataFrame, DataFrame]:
         pass
 

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -14,7 +14,7 @@ import torch
 from ludwig.constants import COMBINED, LAST_HIDDEN, LOGITS
 from ludwig.data.dataset.base import Dataset
 from ludwig.data.utils import convert_to_dict
-from ludwig.distributed.base import LocalStrategy
+from ludwig.distributed.base import DistributedStrategy, LocalStrategy
 from ludwig.globals import is_progressbar_disabled, PREDICTIONS_PARQUET_FILE_NAME, TEST_STATISTICS_FILE_NAME
 from ludwig.models.base import BaseModel
 from ludwig.progress_bar import LudwigProgressBar
@@ -63,7 +63,14 @@ class BasePredictor(ABC):
 class Predictor(BasePredictor):
     """Predictor is a class that uses a model to predict and evaluate."""
 
-    def __init__(self, model: BaseModel, batch_size=128, distributed=None, report_tqdm_to_ray=False, **kwargs):
+    def __init__(
+        self,
+        model: BaseModel,
+        batch_size: int = 128,
+        distributed: DistributedStrategy = None,
+        report_tqdm_to_ray: bool = False,
+        **kwargs,
+    ):
         self._batch_size = batch_size
         self._distributed = distributed if distributed is not None else LocalStrategy()
         self.report_tqdm_to_ray = report_tqdm_to_ray

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -654,7 +654,7 @@ class Trainer(BaseTrainer):
             with training_set.initialize_batcher(
                 batch_size=self.batch_size,
                 should_shuffle=self.should_shuffle,
-                seed=self.random_seed,
+                random_seed=self.random_seed,
                 distributed=self.distributed,
                 ignore_last=True,
             ) as batcher:


### PR DESCRIPTION
When `seed` was used i changed it to `random_seed`.
I also made sure type hints where there in the signature of the affected functions.
Finally i discovered there were two `default_random_seed` parameters in two separate files, I removed one and imported the other.