### PR TITLE
Address some warnings when running hyperopt tests

### DIFF
--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -37,7 +37,7 @@ from tests.integration_tests.utils import category_feature, generate_data, text_
 try:
     import ray
     from ray.tune import Callback as TuneCallback
-    from ray.tune.trial import Trial
+    from ray.tune.experiment.trial import Trial
 
     from ludwig.hyperopt.execution import get_build_hyperopt_executor
 except ImportError:

--- a/tests/integration_tests/test_hyperopt_ray_horovod.py
+++ b/tests/integration_tests/test_hyperopt_ray_horovod.py
@@ -154,7 +154,7 @@ class MockRayTuneExecutor(RayTuneExecutor):
         return mock_storage_client(remote_checkpoint_dir), remote_checkpoint_dir
 
 
-class TestCallback(Callback):
+class CustomTestCallback(Callback):
     def __init__(self):
         self.preprocessed = False
 
@@ -309,7 +309,7 @@ def run_hyperopt(
     out_dir,
     experiment_name="ray_hyperopt",
 ):
-    callback = TestCallback()
+    callback = CustomTestCallback()
     hyperopt_results = hyperopt(
         config,
         dataset=rel_path,


### PR DESCRIPTION
1. Path has moved from `ray.tune.trial` to `ray.tune.experiment.trial` 
2. `pytest` tries to treat the `TestCallback` class as a test that it is unable to load, so I renamed it to `CustomTestCallback` so it doesn't try to treat it as a test.