### PR TITLE
Revert "Bump Ludwig images to Ray 2.2.0 (#3023)"

### DIFF
--- a/.github/workflows/pytest_benchmarks.yml
+++ b/.github/workflows/pytest_benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
           - python-version: 3.8
             pytorch-version: 1.13.1
             torchscript-version: 1.10.2
-            ray-version: 2.2.0
+            ray-version: 2.0.0
     env:
       PYTORCH: ${{ matrix.pytorch-version }}
       MARKERS: ${{ matrix.test-markers }}

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,9 +20,9 @@ from the project's `master` branch.
 - `ludwigai/ludwig` Ludwig packaged with PyTorch
 - `ludwigai/ludwig-gpu` Ludwig packaged with gpu-enabled version of PyTorch
 - `ludwigai/ludwig-ray` Ludwig packaged with PyTorch
-  and Ray 2.2.0 (https://github.com/ray-project/ray)
+  and Ray 2.0.0 (https://github.com/ray-project/ray)
 - `ludwigai/ludwig-ray-gpu` Ludwig packaged with gpu-enabled versions of PyTorch
-  and Ray 2.2.0 (https://github.com/ray-project/ray)
+  and Ray 2.0.0 (https://github.com/ray-project/ray)
 
 ## Image Tags
 

--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM rayproject/ray:2.2.0-py38-cu116
+FROM rayproject/ray:2.0.0-py38-cu116
 
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
 RUN sudo apt-key del 7fa2af80 && \

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM rayproject/ray:2.2.0-py38
+FROM rayproject/ray:2.0.0-py38
 
 # https://github.com/kubernetes/release/issues/1982
 RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list && \

--- a/examples/ray/kubernetes/clusters/ludwig-ray-cpu-cluster.yaml
+++ b/examples/ray/kubernetes/clusters/ludwig-ray-cpu-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: ludwig-ray-cpu-cluster
 spec:
-  rayVersion: "2.2.0"
+  rayVersion: "2.0.0"
   headGroupSpec:
     serviceType: ClusterIP
     replicas: 1

--- a/examples/ray/kubernetes/clusters/ludwig-ray-gpu-cluster.yaml
+++ b/examples/ray/kubernetes/clusters/ludwig-ray-gpu-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: ludwig-ray-gpu-cluster
 spec:
-  rayVersion: "2.2.0"
+  rayVersion: "2.0.0"
   headGroupSpec:
     serviceType: ClusterIP
     replicas: 1


### PR DESCRIPTION
This reverts commit 5bef6601217dbe0fda106b04e61bbea2ee19bfc2.

Reverting to unblock future Ludwig commits in the interim.