### PR TITLE
Fix TLE: safe divide by zero + normalize at sequence level

### DIFF
--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -429,7 +429,10 @@ def get_token_attributions(
     )
 
     # Normalize token-level attributions to visualize the relative importance of each token.
-    token_attributions = token_attributions / torch.norm(token_attributions)
+    norm = torch.linalg.norm(token_attributions, dim=1)
+    # Safe divide by zero by setting the norm to 1 if the norm is 0.
+    norm = torch.where(norm == 0, torch.ones_like(norm), norm)
+    token_attributions = token_attributions / norm.unsqueeze(-1)
 
     # map input ids to input tokens via the vocabulary
     feature = model.training_set_metadata[feature_name]

--- a/tests/ludwig/explain/test_captum.py
+++ b/tests/ludwig/explain/test_captum.py
@@ -1,0 +1,60 @@
+import torch
+
+from ludwig.explain.captum import get_token_attributions
+
+
+def test_get_token_attributions():
+    feature_name = "text_8D824"
+    input_ids = torch.tensor([[1, 5, 6, 4, 4, 4, 6, 0, 2], [1, 4, 5, 6, 4, 4, 6, 5, 0]], dtype=torch.int8)
+    model = type("Model", (), {})()
+    model.training_set_metadata = {
+        feature_name: {
+            "idx2str": [
+                "<EOS>",
+                "<SOS>",
+                "<PAD>",
+                "<UNK>",
+                "oypszb",
+                "yscnrkzw",
+                "llcgslcvzr",
+            ]
+        }
+    }
+    token_attributions = torch.tensor(
+        [
+            [-0.1289, -0.3222, -0.4931, -0.2914, -0.2891, -0.2871, -0.4118, -0.4647, 0.0000],
+            # zero norm should not lead to division by zero
+            [0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
+        ],
+        dtype=torch.float64,
+    )
+
+    toks_and_attrs = get_token_attributions(model, feature_name, input_ids, token_attributions)
+
+    # assert equality up to 4 decimal places
+    assert [[(ta[0], round(ta[1], 4)) for ta in tas] for tas in toks_and_attrs] == [
+        [
+            # normalized attributions
+            ("<SOS>", -0.1289),
+            ("yscnrkzw", -0.3222),
+            ("llcgslcvzr", -0.4931),
+            ("oypszb", -0.2914),
+            ("oypszb", -0.2891),
+            ("oypszb", -0.2871),
+            ("llcgslcvzr", -0.4118),
+            ("<EOS>", -0.4647),
+            ("<PAD>", 0.0),
+        ],
+        [
+            # zero norm should retain original zero attributions
+            ("<SOS>", 0.0),
+            ("oypszb", 0.0),
+            ("yscnrkzw", 0.0),
+            ("llcgslcvzr", 0.0),
+            ("oypszb", 0.0),
+            ("oypszb", 0.0),
+            ("llcgslcvzr", 0.0),
+            ("yscnrkzw", 0.0),
+            ("<EOS>", 0.0),
+        ],
+    ]


### PR DESCRIPTION
This PR fixes
1. a bug where token attributions contained NaN values
2. a bug where token attributions were normalized by the norm across the whole batch instead of the per-sequence norm 

and adds a test to avoid these from happening again going forward.

For 1., the cause was a division by zero silently returning NaNs. 
The norm of token attributions is 0 when all attributions are 0. In that case, we now return the original 0 attributions instead of NaNs.

For 2., the cause was a missing `dim` argument in the call to `torch.linalg.norm`.