### PR TITLE
Remove passthrough encoder from sequence and text features encoder registry

### DIFF
--- a/ludwig/schema/encoders/sequence_encoders.py
+++ b/ludwig/schema/encoders/sequence_encoders.py
@@ -19,7 +19,7 @@ class SequenceEncoderConfig(BaseEncoderConfig):
 
 
 @DeveloperAPI
-@register_encoder_config("passthrough", [SEQUENCE, TEXT, TIMESERIES])
+@register_encoder_config("passthrough", [TIMESERIES])
 @ludwig_dataclass
 class SequencePassthroughConfig(SequenceEncoderConfig):
     @staticmethod


### PR DESCRIPTION
Using the passthrough encoder with sequence or text features leads to the following error:

```
File "/home/ray/anaconda3/lib/python3.8/site-packages/ludwig/utils/torch_utils.py", line 211, in _computed_output_shape
    dummy_input = torch.rand(2, *self.input_shape, device=self.device)
TypeError: rand() argument after * must be an iterable, not NoneType
```
This update removes the passthrough encoder from the sequence and text features' encoder registries.