### PR TITLE
Remove RNN invalid cell types from the schema

### DIFF
--- a/ludwig/encoders/sequence_encoders.py
+++ b/ludwig/encoders/sequence_encoders.py
@@ -1311,12 +1311,9 @@ class StackedRNN(SequenceEncoder):
         :param num_rec_layers: the number of stacked recurrent layers.
         :type num_rec_layers: Integer
         :param cell_type: the type of recurrent cell to use.
-               Available values are: `rnn`, `lstm`, `lstm_block`, `lstm`,
-               `ln`, `lstm_cudnn`, `gru`, `gru_block`, `gru_cudnn`.
+               Available values are: `rnn`, `lstm`, `gru`.
                For reference about the differences between the cells please
-               refer to PyTorch's documentation. We suggest to use the
-               `block` variants on CPU and the `cudnn` variants on GPU
-               because of their increased speed.
+               refer to PyTorch's documentation.
         :type cell_type: str
         :param state_size: the size of the state of the rnn.
         :type state_size: Integer
@@ -1564,12 +1561,9 @@ class StackedCNNRNN(SequenceEncoder):
         :param num_layers: the number of stacked recurrent layers.
         :type num_layers: Integer
         :param cell_type: the type of recurrent cell to use.
-               Available values are: `rnn`, `lstm`, `lstm_block`, `lstm`,
-               `ln`, `lstm_cudnn`, `gru`, `gru_block`, `gru_cudnn`.
+               Available values are: `rnn`, `lstm`, `gru`.
                For reference about the differences between the cells please
-               refer to PyTorch's documentation. We suggest to use the
-               `block` variants on CPU and the `cudnn` variants on GPU
-               because of their increased speed.
+               refer to PyTorch's documentation.
         :type cell_type: str
         :param state_size: the size of the state of the rnn.
         :type state_size: Integer

--- a/ludwig/schema/encoders/sequence_encoders.py
+++ b/ludwig/schema/encoders/sequence_encoders.py
@@ -740,12 +740,10 @@ class StackedRNNConfig(SequenceEncoderConfig):
     )
 
     cell_type: str = schema_utils.StringOptions(
-        ["rnn", "lstm", "lstm_block", "ln", "lstm_cudnn", "gru", "gru_block", "gru_cudnn"],
+        ["rnn", "lstm", "gru"],
         default="rnn",
-        description="The type of recurrent cell to use. Available values are: `rnn`, `lstm`, `lstm_block`, `lstm`, "
-        "`ln`, `lstm_cudnn`, `gru`, `gru_block`, `gru_cudnn`. For reference about the differences between "
-        "the cells please refer to PyTorch's documentation. We suggest to use the `block` variants on "
-        "CPU and the `cudnn` variants on GPU because of their increased speed. ",
+        description="The type of recurrent cell to use. Available values are: `rnn`, `lstm`, `gru`. For reference "
+        "about the differences between the cells please refer to PyTorch's documentation",
         parameter_metadata=ENCODER_METADATA["StackedRNN"]["cell_type"],
     )
 
@@ -968,12 +966,10 @@ class StackedCNNRNNConfig(SequenceEncoderConfig):
     )
 
     cell_type: str = schema_utils.StringOptions(
-        ["rnn", "lstm", "lstm_block", "ln", "lstm_cudnn", "gru", "gru_block", "gru_cudnn"],
+        ["rnn", "lstm", "gru"],
         default="rnn",
-        description="The type of recurrent cell to use. Available values are: `rnn`, `lstm`, `lstm_block`, `lstm`, "
-        "`ln`, `lstm_cudnn`, `gru`, `gru_block`, `gru_cudnn`. For reference about the differences between "
-        "the cells please refer to PyTorch's documentation. We suggest to use the `block` variants on "
-        "CPU and the `cudnn` variants on GPU because of their increased speed. ",
+        description="The type of recurrent cell to use. Available values are: `rnn`, `lstm`, `gru`. For reference "
+        "about the differences between the cells please refer to PyTorch's documentation.",
         parameter_metadata=ENCODER_METADATA["StackedCNNRNN"]["cell_type"],
     )
 


### PR DESCRIPTION
The schema currently supports `StackedRNN` and `StackedCNNRNN` cell types that are not in the registry, including `lstm_block`, `ln`, `lstm_cudnn`, `gru_block`, `gru_cudnn`, and `None`. This update removes the invalid cell types from the schema and updates docstrings.