### PR TITLE
Update transformer `hidden_size / num_heads` error message

### DIFF
--- a/ludwig/modules/attention_modules.py
+++ b/ludwig/modules/attention_modules.py
@@ -46,7 +46,10 @@ class MultiHeadSelfAttention(LudwigModule):
         self.embedding_size = hidden_size
         self.num_heads = num_heads
         if hidden_size % num_heads != 0:
-            raise ValueError(f"hidden size = {hidden_size}, " f"should be divisible by number of heads = {num_heads}")
+            raise ValueError(
+                f"When using multi-head attention, `hidden_size` ({hidden_size}), should be divisible by "
+                f"`num_heads` ({num_heads}). Please update the `transformer` section of the model config."
+            )
         self.projection_dim = hidden_size // num_heads
         self.query_dense = nn.Linear(input_size, hidden_size)
         self.key_dense = nn.Linear(input_size, hidden_size)


### PR DESCRIPTION
A constraint of the `MultiHeadSelfAttention` module is that `hidden_size` must be divisible by `num_heads`. The error message was somewhat unclear on how to address a mismatch, so this updates the message with more concrete instructions.