### PR TITLE
Generate proc_column only after all preprocessing parameters are merged in to prevent incorrect cached dataset reads

### DIFF
--- a/ludwig/data/cache/util.py
+++ b/ludwig/data/cache/util.py
@@ -1,5 +1,5 @@
 import ludwig
-from ludwig.constants import DEFAULTS, INPUT_FEATURES, OUTPUT_FEATURES, PREPROCESSING, PROC_COLUMN, TYPE
+from ludwig.constants import DEFAULTS, INPUT_FEATURES, NAME, OUTPUT_FEATURES, PREPROCESSING, TYPE
 from ludwig.data.cache.types import CacheableDataset
 from ludwig.types import ModelConfigDict
 from ludwig.utils.data_utils import hash_dict
@@ -12,7 +12,7 @@ def calculate_checksum(original_dataset: CacheableDataset, config: ModelConfigDi
         "dataset_checksum": original_dataset.checksum,
         "global_preprocessing": config.get(PREPROCESSING, {}),
         "global_defaults": config.get(DEFAULTS, {}),
-        "feature_proc_columns": [feature[PROC_COLUMN] for feature in features],
+        "feature_names": [feature[NAME] for feature in features],
         "feature_types": [feature[TYPE] for feature in features],
         "feature_preprocessing": [feature.get(PREPROCESSING, {}) for feature in features],
     }

--- a/ludwig/data/cache/util.py
+++ b/ludwig/data/cache/util.py
@@ -12,7 +12,7 @@ def calculate_checksum(original_dataset: CacheableDataset, config: ModelConfigDi
         "dataset_checksum": original_dataset.checksum,
         "global_preprocessing": config.get(PREPROCESSING, {}),
         "global_defaults": config.get(DEFAULTS, {}),
-        "feature_names": [feature[PROC_COLUMN] for feature in features],
+        "feature_proc_columns": [feature[PROC_COLUMN] for feature in features],
         "feature_types": [feature[TYPE] for feature in features],
         "feature_preprocessing": [feature.get(PREPROCESSING, {}) for feature in features],
     }

--- a/ludwig/data/cache/util.py
+++ b/ludwig/data/cache/util.py
@@ -1,5 +1,5 @@
 import ludwig
-from ludwig.constants import DEFAULTS, INPUT_FEATURES, NAME, OUTPUT_FEATURES, PREPROCESSING, TYPE
+from ludwig.constants import DEFAULTS, INPUT_FEATURES, OUTPUT_FEATURES, PREPROCESSING, PROC_COLUMN, TYPE
 from ludwig.data.cache.types import CacheableDataset
 from ludwig.types import ModelConfigDict
 from ludwig.utils.data_utils import hash_dict
@@ -12,7 +12,7 @@ def calculate_checksum(original_dataset: CacheableDataset, config: ModelConfigDi
         "dataset_checksum": original_dataset.checksum,
         "global_preprocessing": config.get(PREPROCESSING, {}),
         "global_defaults": config.get(DEFAULTS, {}),
-        "feature_names": [feature[NAME] for feature in features],
+        "feature_names": [feature[PROC_COLUMN] for feature in features],
         "feature_types": [feature[TYPE] for feature in features],
         "feature_preprocessing": [feature.get(PREPROCESSING, {}) for feature in features],
     }

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -60,7 +60,6 @@ from ludwig.data.dataset.base import Dataset
 from ludwig.data.split import get_splitter, split_dataset
 from ludwig.data.utils import set_fixed_split
 from ludwig.features.feature_registries import get_base_type_registry
-from ludwig.features.feature_utils import compute_feature_hash
 from ludwig.models.embedder import create_embed_batch_size_evaluator, create_embed_transform_fn
 from ludwig.schema.encoders.utils import get_encoder_cls
 from ludwig.types import FeatureConfigDict, PreprocessingConfigDict, TrainingSetMetadataDict

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1133,8 +1133,6 @@ def build_dataset(
     feature_configs = []
     feature_hashes = set()
     for feature in features:
-        if PROC_COLUMN not in feature:
-            feature[PROC_COLUMN] = compute_feature_hash(feature)
         if feature[PROC_COLUMN] not in feature_hashes:
             feature_configs.append(feature)
             feature_hashes.add(feature[PROC_COLUMN])

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -130,8 +130,6 @@ class BaseFeature:
             feature.column = self.feature_name
         self.column = feature.column
 
-        if not feature.proc_column:
-            feature.proc_column = compute_feature_hash(type(feature).Schema().dump(feature))
         self.proc_column = feature.proc_column
 
 

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -22,7 +22,7 @@ from torch import Tensor
 from ludwig.constants import HIDDEN, LENGTHS, LOGITS, LOSS, PREDICTIONS, PROBABILITIES
 from ludwig.decoders.registry import get_decoder_cls
 from ludwig.encoders.registry import get_encoder_cls
-from ludwig.features.feature_utils import compute_feature_hash, get_input_size_with_dependencies
+from ludwig.features.feature_utils import get_input_size_with_dependencies
 from ludwig.modules.fully_connected_modules import FCStack
 from ludwig.modules.loss_modules import get_loss_cls
 from ludwig.modules.metric_modules import MeanMetric

--- a/ludwig/schema/model_types/base.py
+++ b/ludwig/schema/model_types/base.py
@@ -49,7 +49,6 @@ class ModelConfig(schema_utils.BaseMarshmallowConfig, ABC):
         config = copy.deepcopy(config)
         config = upgrade_config_dict_to_latest_version(config)
         config = merge_with_defaults(config)
-        set_derived_feature_columns_(config)
 
         model_type = config.get("model_type", MODEL_ECD)
         if model_type not in model_type_schema_registry:
@@ -84,6 +83,10 @@ class ModelConfig(schema_utils.BaseMarshmallowConfig, ABC):
         # TODO(travis): do this post-processing stuff at the dict level before we load
         set_validation_parameters(config_obj)
         set_hyperopt_defaults_(config_obj)
+
+        # Derive proc_col for each feature from the feature's preprocessing parameters
+        # after all preprocessing parameters have been set
+        set_derived_feature_columns_(config_obj)
 
         return config_obj
 

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -164,15 +164,15 @@ def set_derived_feature_columns_(config_obj: "ModelConfig"):
     Proc_column is set to a hash of the feature's preprocessing configuration.
     """
     for feature in config_obj.input_features:
-        if not feature.column:
+        if feature.column is None:
             feature.column = feature.name
-        if not feature.proc_column:
+        if feature.proc_column is None:
             feature.proc_column = compute_feature_hash(feature.to_dict())
 
     for feature in config_obj.output_features:
-        if not feature.column:
+        if feature.column is None:
             feature.column = feature.name
-        if not feature.proc_column:
+        if feature.proc_column is None:
             feature.proc_column = compute_feature_hash(feature.to_dict())
 
 

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -163,7 +163,9 @@ def set_validation_parameters(config: "ModelConfig"):
 
 def set_derived_feature_columns_(config_obj: "ModelConfig"):
     """Assigns column and proc_column values to features that do not have them set.
-    Proc_column is set to a hash of the feature's preprocessing configuration."""
+
+    Proc_column is set to a hash of the feature's preprocessing configuration.
+    """
     for feature in config_obj.input_features:
         if not feature.column:
             feature.column = feature.name

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -161,12 +161,20 @@ def set_validation_parameters(config: "ModelConfig"):
         config.trainer.validation_metric = output_config_registry[out_type].default_validation_metric
 
 
-def set_derived_feature_columns_(config: ModelConfigDict):
-    for feature in config.get(INPUT_FEATURES, []) + config.get(OUTPUT_FEATURES, []):
-        if COLUMN not in feature:
-            feature[COLUMN] = feature[NAME]
-        if PROC_COLUMN not in feature:
-            feature[PROC_COLUMN] = compute_feature_hash(feature)
+def set_derived_feature_columns_(config_obj: "ModelConfig"):
+    """Assigns column and proc_column values to features that do not have them set.
+    Proc_column is set to a hash of the feature's preprocessing configuration."""
+    for feature in config_obj.input_features:
+        if not feature.column:
+            feature.column = feature.name
+        if not feature.proc_column:
+            feature.proc_column = compute_feature_hash(feature.to_dict())
+
+    for feature in config_obj.output_features:
+        if not feature.column:
+            feature.column = feature.name
+        if not feature.proc_column:
+            feature.proc_column = compute_feature_hash(feature.to_dict())
 
 
 def set_hyperopt_defaults_(config: "ModelConfig"):

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -8,7 +8,6 @@ from marshmallow import ValidationError
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import (
-    COLUMN,
     COMBINED,
     DECODER,
     DEFAULTS,
@@ -16,11 +15,9 @@ from ludwig.constants import (
     GRID_SEARCH,
     INPUT_FEATURES,
     LOSS,
-    NAME,
     OUTPUT_FEATURES,
     PARAMETERS,
     PREPROCESSING,
-    PROC_COLUMN,
     SPACE,
     TYPE,
 )

--- a/tests/integration_tests/test_class_imbalance_feature.py
+++ b/tests/integration_tests/test_class_imbalance_feature.py
@@ -101,8 +101,8 @@ def run_test_imbalance_local(
 
     input_train_set = input_df.sample(frac=0.7, replace=False)
     processed_len = output_dataset[0].size
-    processed_target_pos = sum(output_dataset[0].dataset["Label_mZFLky"])
-    processed_target_neg = len(output_dataset[0].dataset["Label_mZFLky"]) - processed_target_pos
+    processed_target_pos = sum(output_dataset[0].dataset["Label_TFqFe_"])
+    processed_target_neg = len(output_dataset[0].dataset["Label_TFqFe_"]) - processed_target_pos
     assert len(input_train_set) == 140
     assert 0.05 <= len(input_train_set[input_train_set["Label"] == 1]) / len(input_train_set) <= 0.15
     assert round(processed_target_pos / processed_target_neg, 1) == 0.5

--- a/tests/integration_tests/test_trainer.py
+++ b/tests/integration_tests/test_trainer.py
@@ -231,8 +231,8 @@ def test_lightgbm_dataset_partition(ray_cluster_2cpu):
     def create_dataset(model: LudwigModel, size: int) -> RayDataset:
         df = pd.DataFrame(
             {
-                "in_column_mZFLky": np.random.randint(0, 1, size=(size,), dtype=np.uint8),
-                "out_column_mZFLky": np.random.randint(0, 1, size=(size,), dtype=np.uint8),
+                "in_column_MFjIZ4": np.random.randint(0, 1, size=(size,), dtype=np.uint8),
+                "out_column_TFqFe_": np.random.randint(0, 1, size=(size,), dtype=np.uint8),
             }
         )
         df = dask.dataframe.from_pandas(df, npartitions=1)

--- a/tests/ludwig/data/test_cache_util.py
+++ b/tests/ludwig/data/test_cache_util.py
@@ -1,3 +1,4 @@
+import copy
 import uuid
 from typing import List
 from unittest import mock
@@ -64,3 +65,30 @@ def test_calculate_checksum(input_features: List[FeatureConfigDict], diff: List[
         calculate_checksum(mock_dataset, ModelConfig.from_dict(config).to_dict())
         == calculate_checksum(mock_dataset, ModelConfig.from_dict(diff_config).to_dict())
     ) == expected
+
+
+def test_proc_col_checksum_consistency():
+    """Tests that proc_col is equal if checksum are equal."""
+    config_dict1 = {
+        "input_features": [{"name": "txt1", "type": "text", "encoder": {"type": "bert"}}],
+        "output_features": [{"name": "bin1", "type": "binary"}],
+    }
+    config1 = ModelConfig.from_dict(config_dict1)
+
+    config_dict2 = copy.deepcopy(config_dict1)
+    config_dict2["input_features"][0]["preprocessing"] = {
+        "tokenizer": "bert",
+    }
+    config2 = ModelConfig.from_dict(config_dict2)
+
+    mock_dataset = mock.Mock()
+    mock_dataset.checksum = uuid.uuid4().hex
+    assert calculate_checksum(mock_dataset, config1.to_dict()) == calculate_checksum(mock_dataset, config2.to_dict())
+
+    for if1, if2 in zip(config1.input_features, config2.input_features):
+        assert if1.name == if2.name
+        assert if1.proc_column == if2.proc_column
+
+    for of1, of2 in zip(config1.output_features, config2.output_features):
+        assert of1.name == of2.name
+        assert of1.proc_column == of2.proc_column


### PR DESCRIPTION
This PR fixes situations where two configs using the same dataset would result in the same checksum, but the underlying feature proc_cols would be different because of different feature-specific preprocessing params.

Namely, it makes two changes:

1. Moves generation of the proc_col at the end of the instantiation of the ModelConfig object.
2. Modifies checksum calculation to account for the proc column name rather than the raw feature column name.