### PR TITLE
Require env var LUDWIG_USE_MPS to enable MPS

### DIFF
--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -19,8 +19,19 @@ _TORCH_INIT_PARAMS: Optional[Tuple] = None
 def get_torch_device():
     if torch.cuda.is_available():
         return "cuda"
-    if torch.backends.mps.is_available() and torch.backends.mps.is_built():
-        return "mps"
+
+    if bool(os.environ.get("LUDWIG_USE_MPS")):
+        if torch.backends.mps.is_available() and torch.backends.mps.is_built():
+            if not bool(os.environ.get("PYTORCH_ENABLE_MPS_FALLBACK")):
+                warnings.warn(
+                    "LUDWIG_USE_MPS is set and MPS is available, but PYTORCH_ENABLE_MPS_FALLBACK has not been set. "
+                    "Depending on your model config, some operations may not be compatible. If errors occur, try "
+                    "setting `PYTORCH_ENABLE_MPS_FALLBACK=1` and retrying."
+                )
+            return "mps"
+        else:
+            warnings.warn("LUDWIG_USE_MPS is set but MPS is not available, falling back to CPU.")
+
     return "cpu"
 
 

--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -20,17 +20,17 @@ def get_torch_device():
     if torch.cuda.is_available():
         return "cuda"
 
-    if bool(os.environ.get("LUDWIG_USE_MPS")):
+    if bool(os.environ.get("LUDWIG_ENABLE_MPS")):
         if torch.backends.mps.is_available() and torch.backends.mps.is_built():
             if not bool(os.environ.get("PYTORCH_ENABLE_MPS_FALLBACK")):
                 warnings.warn(
-                    "LUDWIG_USE_MPS is set and MPS is available, but PYTORCH_ENABLE_MPS_FALLBACK has not been set. "
+                    "LUDWIG_ENABLE_MPS is set and MPS is available, but PYTORCH_ENABLE_MPS_FALLBACK has not been set. "
                     "Depending on your model config, some operations may not be compatible. If errors occur, try "
-                    "setting `PYTORCH_ENABLE_MPS_FALLBACK=1` and retrying."
+                    "setting `PYTORCH_ENABLE_MPS_FALLBACK=1` and resubmitting."
                 )
             return "mps"
         else:
-            warnings.warn("LUDWIG_USE_MPS is set but MPS is not available, falling back to CPU.")
+            warnings.warn("LUDWIG_ENABLE_MPS is set but MPS is not available, falling back to CPU.")
 
     return "cpu"
 


### PR DESCRIPTION
Follow-up to #3072. 

It's been observed in testing that MPS can sometimes hurt performance for small tabular models, and can lead to runtime errors when `PYTORCH_ENABLE_MPS_FALLBACK` is not set.