### PR TITLE
Use `window_size_bytes: auto` to specify automatic windowing

### DIFF
--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -400,19 +400,13 @@ class RayTrainerV2(BaseTrainer):
         }
 
         dataset = {"train": training_set.ds}
-        stream_window_size = {
-            "train": training_set.get_window_size_bytes(self.data_loader_kwargs.get("window_size_bytes", None))
-        }
+        stream_window_size = {"train": training_set.window_size_bytes}
         if validation_set is not None:
             dataset["val"] = validation_set.ds
-            stream_window_size["val"] = validation_set.get_window_size_bytes(
-                self.data_loader_kwargs.get("window_size_bytes", None)
-            )
+            stream_window_size["val"] = validation_set.window_size_bytes
         if test_set is not None:
             dataset["test"] = test_set.ds
-            stream_window_size["test"] = test_set.get_window_size_bytes(
-                self.data_loader_kwargs.get("window_size_bytes", None)
-            )
+            stream_window_size["test"] = test_set.window_size_bytes
 
         with create_runner(**self.trainer_kwargs) as runner:
             trainer_results = runner.run(
@@ -623,9 +617,7 @@ class RayPredictor(BasePredictor):
         with create_runner(**self.trainer_kwargs) as runner:
             # Collect eval metrics by distributing work across nodes / gpus with Horovod
             datasets = {"eval": dataset.ds}
-            stream_window_size = {
-                "eval": dataset.get_window_size_bytes(self.data_loader_kwargs.get("window_size_bytes", None))
-            }
+            stream_window_size = {"eval": dataset.window_size_bytes}
             predictor_kwargs = {**self.predictor_kwargs, "collect_predictions": False}
             eval_results = runner.run(
                 lambda config: eval_fn(**config),

--- a/ludwig/data/dataset/ray.py
+++ b/ludwig/data/dataset/ray.py
@@ -89,7 +89,7 @@ class RayDataset(Dataset):
         if isinstance(window_size_bytes, int):
             window_size = window_size_bytes
 
-        # If the user does not supply a window size and the dataset is large,
+        # If the user requests auto window sizing and the dataset is large,
         # set the window size to `<available memory> // 5`.
         elif window_size_bytes == "auto":
             ds_memory_size = self.in_memory_size_bytes
@@ -168,7 +168,7 @@ class RayDatasetManager(DatasetManager):
         training_set_metadata: TrainingSetMetadataDict,
     ) -> "RayDataset":
         """Create a new Ray dataset with config."""
-        window_size_bytes = config.get("backend", {}).get("loader", None).get("window_size_bytes", None)
+        window_size_bytes = self.backend._data_loader_kwargs.get("window_size_bytes", None)
         return RayDataset(
             dataset, get_proc_features(config), training_set_metadata, self.backend, window_size_bytes=window_size_bytes
         )

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -15,7 +15,7 @@
 import copy
 import os
 import tempfile
-from typing import Optional
+from typing import Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -987,13 +987,12 @@ class TestDatasetWindowAutosizing:
         return 100
 
     def create_dataset_pipeline(
-        self, size: int, auto_window: bool = True, window_size_bytes: Optional[int] = None
+        self, size: int, window_size_bytes: Optional[Union[int, Literal["auto"]]] = None
     ) -> "DatasetPipeline":
         """Create a dataset of specified size to test auto-sizing.
 
         Args:
             size: Total size of the dataset in bytes
-            auto_window: Flag determining whether autosizing is enabled
             window_size_bytes: Pass to override the auto_window size
 
         Returns:
@@ -1015,15 +1014,14 @@ class TestDatasetWindowAutosizing:
             "output_features": [{"name": "out_column", "type": "binary"}],
             TRAINER: {"epochs": 1, BATCH_SIZE: 128},
         }
-        backend_config = {**RAY_BACKEND_CONFIG}
+        backend_config = copy.deepcopy(RAY_BACKEND_CONFIG)
+        backend_config["loader"] = {"window_size_bytes": window_size_bytes}
         backend_config["preprocessor_kwargs"] = {"num_cpu": 1}
         model = LudwigModel(config, backend=backend_config)
 
         # Create a dataset using the model backend to ensure it
         # is initialized correctly.
-        ds = model.backend.dataset_manager.create(
-            df, config=model.config, training_set_metadata={}, auto_window=auto_window
-        )
+        ds = model.backend.dataset_manager.create(df, config=model.config, training_set_metadata={})
 
         # To window without using a training session, we configure `DataParallelIngestSpec` to use the specified window
         # size and turn off other features (e.g., shuffle) that may incur computational overhead.
@@ -1032,7 +1030,7 @@ class TestDatasetWindowAutosizing:
             split=False,
             transform=False,
             use_stream_api=True,
-            stream_window_size=ds.get_window_size_bytes(window_size_bytes=window_size_bytes),
+            stream_window_size=ds.window_size_bytes,
             global_shuffle=False,
         )
         spec = DataParallelIngestSpec({"train": dataset_config})
@@ -1055,13 +1053,13 @@ class TestDatasetWindowAutosizing:
         Without automatic window sizing, the number of blocks in the pipeline should match the number of partitions in
         the Dask dataframe.
         """
-        pipe = self.create_dataset_pipeline(self.auto_window_size // 2)
+        pipe = self.create_dataset_pipeline(self.auto_window_size // 2, window_size_bytes="auto")
         window = next(self.window_gen(pipe))
         assert window.num_blocks() == self.num_partitions
 
     def test_large_dataset(self, ray_cluster_2cpu):
         """A large dataset should trigger windowing."""
-        pipe = self.create_dataset_pipeline(self.auto_window_size * 2)
+        pipe = self.create_dataset_pipeline(self.auto_window_size * 2, window_size_bytes="auto")
         for i, window in enumerate(self.window_gen(pipe)):
             assert window.num_blocks() < self.num_partitions
             if i > 100:
@@ -1069,13 +1067,13 @@ class TestDatasetWindowAutosizing:
 
     def test_window_autosizing_disabled(self, ray_cluster_2cpu):
         """If window autosizing is disabled, no datasets should be windowed."""
-        pipe = self.create_dataset_pipeline(self.auto_window_size * 2, auto_window=False)
+        pipe = self.create_dataset_pipeline(self.auto_window_size * 2, window_size_bytes=None)
         window = next(self.window_gen(pipe))
         assert window.num_blocks() == self.num_partitions
 
     def test_user_window_size(self, ray_cluster_2cpu):
         """If the user supplies a window size, do not autosize."""
-        auto_pipe = self.create_dataset_pipeline(self.auto_window_size * 2)
+        auto_pipe = self.create_dataset_pipeline(self.auto_window_size * 2, window_size_bytes="auto")
         user_pipe = self.create_dataset_pipeline(self.auto_window_size * 2, window_size_bytes=self.auto_window_size * 4)
         windows = zip(self.window_gen(auto_pipe), self.window_gen(user_pipe))
 


### PR DESCRIPTION
This updates `RayDataset`, `RayDatasetManager`, and `RayBackend` to accept `"auto"` as a valid input for `window_size_bytes`, and consolidates `RayDataset` creation logic to handle auto-windowing.
