### PR TITLE
Allow providing a Ludwig dataset as a URI of the form `ludwig://<dataset>`

### DIFF
--- a/ludwig/automl/automl.py
+++ b/ludwig/automl/automl.py
@@ -50,6 +50,7 @@ from ludwig.constants import (
     TYPE,
 )
 from ludwig.contrib import add_contrib_callback_args
+from ludwig.datasets import load_dataset_uris
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.hyperopt.run import hyperopt
 from ludwig.profiling import dataset_profile_pb2
@@ -264,6 +265,8 @@ def create_auto_config(
     backend = initialize_backend(backend)
 
     if not isinstance(dataset, DatasetInfo):
+        # preload ludwig datasets
+        dataset, _, _, _ = load_dataset_uris(dataset, None, None, None, backend)
         dataset = load_dataset(dataset, df_lib=backend.df_engine.df_lib)
 
     dataset_info = get_dataset_info(dataset) if not isinstance(dataset, DatasetInfo) else dataset

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -27,6 +27,7 @@ import torch
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.backend.utils.storage import StorageManager
 from ludwig.data.cache.manager import CacheManager
+from ludwig.data.dataframe.base import DataFrameEngine
 from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.data.dataset.base import DatasetManager
 from ludwig.data.dataset.pandas import PandasDatasetManager
@@ -94,7 +95,7 @@ class Backend(ABC):
 
     @property
     @abstractmethod
-    def df_engine(self):
+    def df_engine(self) -> DataFrameEngine:
         raise NotImplementedError()
 
     @property

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1954,6 +1954,9 @@ def preprocess_for_prediction(
     if isinstance(dataset, Dataset):
         return dataset, training_set_metadata
 
+    # preload ludwig datasets
+    dataset, _, _, _ = load_dataset_uris(dataset, None, None, None, backend)
+
     # determine data format if not provided or auto
     if not data_format or data_format == "auto":
         data_format = figure_data_format(dataset)

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -59,6 +59,7 @@ from ludwig.data.concatenate_datasets import concatenate_df, concatenate_files, 
 from ludwig.data.dataset.base import Dataset
 from ludwig.data.split import get_splitter, split_dataset
 from ludwig.data.utils import set_fixed_split
+from ludwig.datasets import load_dataset_uris
 from ludwig.features.feature_registries import get_base_type_registry
 from ludwig.models.embedder import create_embed_batch_size_evaluator, create_embed_transform_fn
 from ludwig.schema.encoders.utils import get_encoder_cls
@@ -1613,6 +1614,11 @@ def preprocess_for_training(
     if dataset is None and training_set is None:
         raise ValueError("No training data is provided!")
 
+    # preload ludwig datasets
+    dataset, training_set, validation_set, test_set = load_dataset_uris(
+        dataset, training_set, validation_set, test_set, backend
+    )
+
     # determine data format if not provided or auto
     if not data_format or data_format == "auto":
         data_format = figure_data_format(dataset, training_set, validation_set, test_set)
@@ -1666,7 +1672,7 @@ def preprocess_for_training(
                     else:
                         logger.info(
                             "Found cached dataset and meta.json with the same filename "
-                            "of the dataset, but checksum don't match, "
+                            "of the dataset, but checksums don't match, "
                             "if saving of processed input is not skipped "
                             "they will be overridden"
                         )

--- a/ludwig/datasets/__init__.py
+++ b/ludwig/datasets/__init__.py
@@ -19,7 +19,7 @@ from ludwig.globals import LUDWIG_VERSION
 from ludwig.utils.print_utils import print_ludwig
 from ludwig.utils.types import DataFrame
 
-# PublicApi
+# PublicAPI
 from ludwig.datasets.utils import model_configs_for_dataset  # noqa
 
 URI_PREFIX = "ludwig://"
@@ -90,13 +90,13 @@ def load_dataset_uris(
         if isinstance(dataset, str) and dataset.startswith(URI_PREFIX):
             dataset_out = _load_cacheable_dataset(dataset, backend)
     elif training_set is not None:
-        train_df = val_df = test_df = None
+        train_df = test_df = val_df = None
         training_set_checksum = None
         if isinstance(training_set, str) and training_set.startswith(URI_PREFIX):
             # For the training set, we only want to use the TRAINING split of the dataset
             dataset_name = training_set[len(URI_PREFIX) :]
             loader = get_dataset(dataset_name)
-            train_df, val_df, test_df = loader.load(split=True)
+            train_df, test_df, val_df = loader.load(split=True)
             training_set_checksum = str(loader.get_mtime())
             train_df = backend.df_engine.from_pandas(train_df)
             training_set_out = CacheableDataframe(df=train_df, name=training_set, checksum=training_set_checksum)

--- a/ludwig/datasets/__init__.py
+++ b/ludwig/datasets/__init__.py
@@ -19,7 +19,6 @@ from ludwig.globals import LUDWIG_VERSION
 from ludwig.utils.print_utils import print_ludwig
 from ludwig.utils.types import DataFrame
 
-
 URI_PREFIX = "ludwig://"
 
 

--- a/ludwig/datasets/loaders/dataset_loader.py
+++ b/ludwig/datasets/loaders/dataset_loader.py
@@ -449,6 +449,10 @@ class DatasetLoader:
         """Load processed dataset into a dataframe."""
         return pd.read_parquet(self.processed_dataset_path)
 
+    def get_mtime(self) -> float:
+        """Last modified time of the processed dataset after downloading successfully."""
+        return os.path.getmtime(self.processed_dataset_path)
+
     def split(self, dataset: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         if SPLIT in dataset:
             dataset[SPLIT] = pd.to_numeric(dataset[SPLIT])

--- a/ludwig/datasets/loaders/dataset_loader.py
+++ b/ludwig/datasets/loaders/dataset_loader.py
@@ -28,10 +28,10 @@ from tqdm import tqdm
 
 from ludwig.api_annotations import DeveloperAPI, PublicAPI
 from ludwig.constants import SPLIT
-from ludwig.datasets import model_configs_for_dataset
 from ludwig.datasets.archives import extract_archive, is_archive, list_archive
 from ludwig.datasets.dataset_config import DatasetConfig
 from ludwig.datasets.kaggle import download_kaggle_dataset
+from ludwig.datasets.utils import model_configs_for_dataset
 from ludwig.utils.strings_utils import make_safe_filename
 
 logger = logging.getLogger(__name__)

--- a/ludwig/datasets/utils.py
+++ b/ludwig/datasets/utils.py
@@ -1,0 +1,43 @@
+from functools import lru_cache
+import os
+from typing import Dict
+
+import yaml
+
+from ludwig.api_annotations import PublicAPI
+from ludwig.datasets import model_configs
+
+
+@PublicAPI
+def model_configs_for_dataset(dataset_name: str) -> Dict[str, Dict]:
+    """Returns a dictionary of built-in model configs for the specified dataset.
+
+    Maps config name to ludwig config dict.
+    """
+    return _get_model_configs(dataset_name)
+
+
+@lru_cache(maxsize=3)
+def _get_model_configs(dataset_name: str) -> Dict[str, Dict]:
+    """Returns all model configs for the specified dataset.
+
+    Model configs are named <dataset_name>_<config_name>.yaml
+    """
+    import importlib.resources
+
+    config_filenames = [
+        f for f in importlib.resources.contents(model_configs) if f.endswith(".yaml") and f.startswith(dataset_name)
+    ]
+    configs = {}
+    for config_filename in config_filenames:
+        basename = os.path.splitext(config_filename)[0]
+        config_name = basename[len(dataset_name) + 1 :]
+        configs[config_name] = _load_model_config(config_filename)
+    return configs
+
+
+def _load_model_config(model_config_filename: str):
+    """Loads a model config."""
+    model_config_path = os.path.join(os.path.dirname(model_configs.__file__), model_config_filename)
+    with open(model_config_path) as f:
+        return yaml.safe_load(f)

--- a/tests/ludwig/datasets/test_datasets.py
+++ b/tests/ludwig/datasets/test_datasets.py
@@ -1,9 +1,11 @@
 import io
 import os
 from unittest import mock
+import uuid
 
 import pandas as pd
 import pytest
+from ludwig.api import LudwigModel
 
 import ludwig.datasets
 from ludwig.datasets.dataset_config import DatasetConfig
@@ -125,3 +127,65 @@ def test_get_dataset_buffer():
     buffer = ludwig.datasets.get_buffer("iris")
 
     assert isinstance(buffer, io.BytesIO)
+
+
+def test_preprocess_dataset_uri(tmpdir):
+    input_df = pd.DataFrame(
+        {
+            "input": ["a", "b", "a", "b", "a", "b", "c", "c", "a", "b"],
+            "output": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            "split": [0, 0, 0, 0, 0, 0, 0, 1, 2, 2],
+        }
+    )
+
+    extracted_filename = "input.csv"
+    compression_opts = dict(method="zip", archive_name=extracted_filename)
+
+    archive_filename = os.path.join(tmpdir, "archive.zip")
+    input_df.to_csv(archive_filename, index=False, compression=compression_opts)
+
+    dataset_name = f"fake_csv_dataset_{uuid.uuid4().hex}"
+    config = DatasetConfig(
+        version=1.0,
+        name=dataset_name,
+        download_urls=["file://" + archive_filename],
+    )
+
+    model_config = {
+        "input_features": [{"name": "input", "type": "category"}],
+        "output_features": [{"name": "output", "type": "number"}],
+        "preprocessing": {"split": {"type": "fixed"}},
+    }
+
+    ludwig.datasets._get_dataset_configs.cache_clear()
+    with mock.patch("ludwig.datasets._load_dataset_config", return_value=config):
+        with mock.patch("ludwig.datasets.loaders.dataset_loader.get_default_cache_location", return_value=str(tmpdir)):
+            model = LudwigModel(model_config, backend="local")
+
+            proc_result = model.preprocess(dataset=f"ludwig://{dataset_name}")
+            train_df1 = proc_result.training_set.to_df()
+            val_df1 = proc_result.validation_set.to_df()
+            test_df1 = proc_result.test_set.to_df()
+
+            assert len(train_df1) == 7
+            assert len(val_df1) == 1
+            assert len(test_df1) == 2
+
+            proc_result_split = model.preprocess(
+                training_set=f"ludwig://{dataset_name}",
+                validation_set=f"ludwig://{dataset_name}",
+                test_set=f"ludwig://{dataset_name}",
+            )
+            train_df2 = proc_result_split.training_set.to_df()
+            val_df2 = proc_result_split.validation_set.to_df()
+            test_df2 = proc_result_split.test_set.to_df()
+
+            assert len(train_df2) == 7
+            assert len(val_df2) == 1
+            assert len(test_df2) == 2
+
+            assert train_df1.equals(train_df2)
+            assert val_df1.equals(val_df2)
+            assert test_df1.equals(test_df2)
+
+    ludwig.datasets._get_dataset_configs.cache_clear()


### PR DESCRIPTION
Example:

```
ludwig train --dataset ludwig://titanic --config config.yaml
```

To use an individual split:

```
ludwig train --training_set ludwig://titanic --test_set ludwig://titanic
```

The latter form will only use the `train` and `test` splits from the dataset and discard the validation set.