### PR TITLE
Only show drop row logging if rows are dropped

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1228,10 +1228,11 @@ def build_dataset(
     dataset = dataset.dropna()
     len_dataset_after_drop_rows = len(dataset)
 
-    logger.warning(
-        f"Dropped a total of {len_dataset_before_drop_rows - len_dataset_after_drop_rows} rows out of "
-        f"{len_dataset_before_drop_rows} due to missing values"
-    )
+    if len_dataset_before_drop_rows != len_dataset_after_drop_rows:
+        logger.warning(
+            f"Dropped a total of {len_dataset_before_drop_rows - len_dataset_after_drop_rows} rows out of "
+            f"{len_dataset_before_drop_rows} due to missing values"
+        )
 
     # NaNs introduced by outer join change dtype of dataset cols (upcast to float64), so we need to cast them back.
     col_name_to_dtype = {}
@@ -1569,11 +1570,12 @@ def handle_missing_values(dataset_cols, feature, preprocessing_parameters: Prepr
         dataset_cols[feature[COLUMN]] = dataset_cols[feature[COLUMN]].dropna()
         len_after_dropped_rows = len(dataset_cols[feature[COLUMN]])
 
-        logger.warning(
-            f"DROP_ROW missing value strategy applied. Dropped {len_before_dropped_rows - len_after_dropped_rows} "
-            f"samples out of {len_before_dropped_rows} from column {feature[COLUMN]}. The rows containing these "
-            f"samples will ultimately be dropped from the dataset."
-        )
+        if len_before_dropped_rows != len_after_dropped_rows:
+            logger.warning(
+                f"DROP_ROW missing value strategy applied. Dropped {len_before_dropped_rows - len_after_dropped_rows} "
+                f"samples out of {len_before_dropped_rows} from column {feature[COLUMN]}. The rows containing these "
+                f"samples will ultimately be dropped from the dataset."
+            )
     else:
         raise ValueError(f"Invalid missing value strategy {missing_value_strategy}")
 


### PR DESCRIPTION
Otherwise this always gets printed, which I don't think is very helpful. We should only show it if rows actually end up getting dropped, so I added this gate.