### PR TITLE
GBM: remove distributed=False from RayDMatrix

### DIFF
--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -1031,7 +1031,6 @@ class LightGBMRayTrainer(LightGBMTrainer):
             # Need num_blocks to equal num_actors in order to feed all actors.
             training_set.ds.map_batches(lambda df: df[feat_cols], batch_size=None),
             label=label_col,
-            distributed=False,
         )
 
         eval_sets = [lgb_train]
@@ -1044,7 +1043,6 @@ class LightGBMRayTrainer(LightGBMTrainer):
             lgb_val = RayDMatrix(
                 validation_set.ds.map_batches(lambda df: df[feat_cols], batch_size=None),
                 label=label_col,
-                distributed=False,
             )
             eval_sets.append(lgb_val)
             eval_names.append(LightGBMTrainer.VALID_KEY)
@@ -1057,7 +1055,6 @@ class LightGBMRayTrainer(LightGBMTrainer):
             lgb_test = RayDMatrix(
                 test_set.ds.map_batches(lambda df: df[feat_cols], batch_size=None),
                 label=label_col,
-                distributed=False,
             )
             eval_sets.append(lgb_test)
             eval_names.append(LightGBMTrainer.TEST_KEY)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,6 +151,12 @@ def ray_cluster_4cpu(request):
 
 
 @pytest.fixture(scope="module")
+def ray_cluster_5cpu(request):
+    with _ray_start(request, num_cpus=5):
+        yield
+
+
+@pytest.fixture(scope="module")
 def ray_cluster_7cpu(request):
     with _ray_start(request, num_cpus=7):
         yield

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -33,7 +33,7 @@ def ray_backend():
     return {
         "type": "ray",
         "processor": {
-            "parallelism": num_cpus_per_worker * num_workers,
+            "parallelism": 1,
         },
         "trainer": {
             "use_gpu": False,

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -100,7 +100,7 @@ def test_local_gbm_output_not_supported(tmpdir, local_backend):
 
 
 @pytest.mark.distributed
-def test_ray_gbm_output_not_supported(tmpdir, ray_backend, ray_cluster_4cpu):
+def test_ray_gbm_output_not_supported(tmpdir, ray_backend, ray_cluster_5cpu):
     run_test_gbm_output_not_supported(tmpdir, ray_backend)
 
 
@@ -122,7 +122,7 @@ def test_local_gbm_multiple_outputs(tmpdir, local_backend):
 
 
 @pytest.mark.distributed
-def test_ray_gbm_multiple_outputs(tmpdir, ray_backend, ray_cluster_4cpu):
+def test_ray_gbm_multiple_outputs(tmpdir, ray_backend, ray_cluster_5cpu):
     run_test_gbm_multiple_outputs(tmpdir, ray_backend)
 
 
@@ -146,7 +146,7 @@ def test_local_gbm_binary(tmpdir, local_backend):
 
 
 @pytest.mark.distributed
-def test_ray_gbm_binary(tmpdir, ray_backend, ray_cluster_4cpu):
+def test_ray_gbm_binary(tmpdir, ray_backend, ray_cluster_5cpu):
     run_test_gbm_binary(tmpdir, ray_backend)
 
 
@@ -170,7 +170,7 @@ def test_local_gbm_non_number_inputs(tmpdir, local_backend):
 
 
 @pytest.mark.distributed
-def test_ray_gbm_non_number_inputs(tmpdir, ray_backend, ray_cluster_4cpu):
+def test_ray_gbm_non_number_inputs(tmpdir, ray_backend, ray_cluster_5cpu):
     run_test_gbm_non_number_inputs(tmpdir, ray_backend)
 
 
@@ -196,7 +196,7 @@ def test_local_gbm_category(vocab_size, tmpdir, local_backend):
 
 @pytest.mark.distributed
 @pytest.mark.parametrize("vocab_size", [2, 3])
-def test_ray_gbm_category(vocab_size, tmpdir, ray_backend, ray_cluster_4cpu):
+def test_ray_gbm_category(vocab_size, tmpdir, ray_backend, ray_cluster_5cpu):
     run_test_gbm_category(vocab_size, tmpdir, ray_backend)
 
 
@@ -222,7 +222,7 @@ def test_local_gbm_number(tmpdir, local_backend):
 
 
 @pytest.mark.distributed
-def test_ray_gbm_number(tmpdir, ray_backend, ray_cluster_4cpu):
+def test_ray_gbm_number(tmpdir, ray_backend, ray_cluster_5cpu):
     run_test_gbm_number(tmpdir, ray_backend)
 
 


### PR DESCRIPTION
Ray Datasets are distributed by nature, there should be no need to set this to False
