### PR TITLE
Deflake the lbgfs optimizer test

### DIFF
--- a/tests/integration_tests/test_model_training_options.py
+++ b/tests/integration_tests/test_model_training_options.py
@@ -247,9 +247,11 @@ def test_optimizers(optimizer_type, tmp_path):
         TRAINER: {"epochs": 5, "batch_size": 16, "evaluate_training_set": True, "optimizer": {"type": optimizer_type}},
     }
 
-    # special handling for adadelta, break out of local minima
+    # special handling for adadelta and lbfgs, break out of local minima
     if optimizer_type == "adadelta":
         config[TRAINER]["learning_rate"] = 0.1
+    if optimizer_type == "lbfgs":
+        config[TRAINER]["learning_rate"] = 0.05
 
     model = LudwigModel(config)
 


### PR DESCRIPTION
[Example of flakiness](https://github.com/ludwig-ai/ludwig/actions/runs/4177152055/jobs/7234368909)

Note that I'm not able to reproduce the `nan <= nan` error locally with --count=1000, but empirically the loss values that come from the lower LR seem more tractable. Hopefully the lower LR helps with flakiness.

I'm also not opposed to removing the test altogether for the lbfgs optimizer as we're still testing that we're functionally registering and referencing the torch implementation correctly, which is covered by tests for other optimizers.