### PR TITLE
Add -1 as a valid negative class for binary type inference

### DIFF
--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -34,7 +34,7 @@ PANDAS_TRUE_STRS = {"true"}
 PANDAS_FALSE_STRS = {"false"}
 
 BOOL_TRUE_STRS = {"yes", "y", "true", "t", "1", "1.0"}
-BOOL_FALSE_STRS = {"no", "n", "false", "f", "0", "0.0", "-1"}
+BOOL_FALSE_STRS = {"no", "n", "false", "f", "0", "0.0", "-1", "-1.0"}
 
 logger = logging.getLogger(__name__)
 

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -34,7 +34,7 @@ PANDAS_TRUE_STRS = {"true"}
 PANDAS_FALSE_STRS = {"false"}
 
 BOOL_TRUE_STRS = {"yes", "y", "true", "t", "1", "1.0"}
-BOOL_FALSE_STRS = {"no", "n", "false", "f", "0", "0.0"}
+BOOL_FALSE_STRS = {"no", "n", "false", "f", "0", "0.0", "-1"}
 
 logger = logging.getLogger(__name__)
 

--- a/tests/ludwig/utils/automl/test_type_inference.py
+++ b/tests/ludwig/utils/automl/test_type_inference.py
@@ -115,8 +115,8 @@ def test_should_exclude_text(column_count, avg_words, expected):
 
 
 def test_type_inference_with_negative_positive_binary_values():
-    """This test ensures that we infer binary type for a feature with negative
-    and positive values, specifically -1 and 1"""
+    """This test ensures that we infer binary type for a feature with negative and positive values, specifically -1
+    and 1."""
     field = FieldInfo(
         name="foo",
         dtype="object",

--- a/tests/ludwig/utils/automl/test_type_inference.py
+++ b/tests/ludwig/utils/automl/test_type_inference.py
@@ -114,14 +114,14 @@ def test_should_exclude_text(column_count, avg_words, expected):
     assert should_exclude(0, field, TEXT, column_count, ROW_COUNT, {TARGET_NAME}) == expected
 
 
-def test_type_inference_with_negative_positive_binary_values():
+@pytest.mark.parametrize("negative_class", ("-1", "-1.0"), ids=["-1", "-1.0"])
+def test_type_inference_with_negative_positive_binary_values(negative_class):
     """This test ensures that we infer binary type for a feature with negative and positive values, specifically -1
     and 1."""
     field = FieldInfo(
         name="foo",
         dtype="object",
         num_distinct_values=2,
-        distinct_values=["1", "-1"],
+        distinct_values=["1", negative_class],
     )
-
     assert infer_type(field=field, missing_value_percent=0, row_count=ROW_COUNT) == BINARY

--- a/tests/ludwig/utils/automl/test_type_inference.py
+++ b/tests/ludwig/utils/automl/test_type_inference.py
@@ -112,3 +112,14 @@ def test_auto_type_inference_single_value_binary_feature():
 def test_should_exclude_text(column_count, avg_words, expected):
     field = FieldInfo(name="sentence", dtype=TEXT, avg_words=avg_words, num_distinct_values=ROW_COUNT)
     assert should_exclude(0, field, TEXT, column_count, ROW_COUNT, {TARGET_NAME}) == expected
+
+
+def test_feature_with_negative_positive_binary_values():
+    field = FieldInfo(
+        name="foo",
+        dtype="object",
+        num_distinct_values=2,
+        distinct_values=["1", "-1"],
+    )
+
+    assert infer_type(field=field, missing_value_percent=0, row_count=ROW_COUNT) == BINARY

--- a/tests/ludwig/utils/automl/test_type_inference.py
+++ b/tests/ludwig/utils/automl/test_type_inference.py
@@ -114,7 +114,9 @@ def test_should_exclude_text(column_count, avg_words, expected):
     assert should_exclude(0, field, TEXT, column_count, ROW_COUNT, {TARGET_NAME}) == expected
 
 
-def test_feature_with_negative_positive_binary_values():
+def test_type_inference_with_negative_positive_binary_values():
+    """This test ensures that we infer binary type for a feature with negative
+    and positive values, specifically -1 and 1"""
     field = FieldInfo(
         name="foo",
         dtype="object",


### PR DESCRIPTION
While playing around with automl using the `ivory` dataset in the dataset zoo, I noticed that automl infers the `label` to be `number` since the labels are [-1, 1]. However, this is actually a classification problem, and this should be inferred as binary.

This PR updates the conventional bools to also allow -1 to be a valid negative class so we correctly infer the type as binary. 