### PR TITLE
Fixed ethos_binary dataset to threshold the label at 0.5

### DIFF
--- a/ludwig/datasets/configs/ethos_binary.yaml
+++ b/ludwig/datasets/configs/ethos_binary.yaml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 1.1
 name: ethos_binary
 download_urls:
   - https://raw.githubusercontent.com/intelligence-csd-auth-gr/Ethos-Hate-Speech-Dataset/master/ethos/ethos_data/Ethos_Dataset_Binary.csv

--- a/ludwig/datasets/loaders/ethos_binary.py
+++ b/ludwig/datasets/loaders/ethos_binary.py
@@ -25,5 +25,6 @@ class EthosBinaryLoader(DatasetLoader):
     def transform_dataframe(self, dataframe: pd.DataFrame) -> pd.DataFrame:
         processed_df = super().transform_dataframe(dataframe)
         # convert float labels (0.0, 1.0) to binary labels
+        processed_df["isHate"] = processed_df["isHate"] >= 0.5
         processed_df["isHate"] = processed_df["isHate"].astype(int)
         return processed_df


### PR DESCRIPTION
According to the paper (https://arxiv.org/pdf/2006.08328v2.pdf), the authors defined `isHate` to be anything with label agreement >= 0.5. In the previous version of our dataset, we were only considering values exactly equal to 1 to be `isHate` leading to many false negatives.