### PR TITLE
Transformer divisibility error validation

### DIFF
--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -354,13 +354,6 @@ def check_stacked_transformer_requirements(config: "ModelConfig") -> None:  # no
         return hidden_size % num_heads == 0
 
     sequence_types = [SEQUENCE, TEXT, TIMESERIES]
-    for sequence_type in sequence_types:
-        encoder = config.defaults.__getattribute__(sequence_type).encoder
-        if encoder.type == "transformer" and not is_divisible(encoder.hidden_size, encoder.num_heads):
-            raise ConfigValidationError(
-                f"Default {sequence_type} transformer encoder requires encoder.hidden_size to be divisible by "
-                f"encoder.num_heads. Found hidden_size {encoder.hidden_size} and num_heads {encoder.num_heads}."
-            )
 
     for input_feature in config.input_features:
         if_type = input_feature.type

--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -23,6 +23,7 @@ from ludwig.constants import (
     SEQUENCE,
     SET,
     TEXT,
+    TIMESERIES,
     TRAINER,
     TYPE,
     VECTOR,
@@ -339,3 +340,34 @@ def check_hf_encoder_requirements(config: "ModelConfig") -> None:  # noqa: F821
                     raise ConfigValidationError(
                         "Pretrained model name or path must be specified for HuggingFace encoder."
                     )
+
+
+@register_config_check
+def check_stacked_transformer_requirements(config: "ModelConfig") -> None:  # noqa: F821
+    """Checks that the transformer encoder type correctly configures `num_heads` and `hidden_size`"""
+
+    def is_divisible(hidden_size: int, num_heads: int) -> bool:
+        """Checks that hidden_size is divisible by num_heads."""
+        return hidden_size % num_heads == 0
+
+    sequence_types = [SEQUENCE, TEXT, TIMESERIES]
+    for sequence_type in sequence_types:
+        encoder = config.defaults.__getattribute__(sequence_type).encoder
+        if encoder.type == "transformer" and not is_divisible(encoder.hidden_size, encoder.num_heads):
+            raise ConfigValidationError(
+                f"Default {sequence_type} transformer encoder requires encoder.hidden_size to be divisible by "
+                f"encoder.num_heads. Found hidden_size {encoder.hidden_size} and num_heads {encoder.num_heads}."
+            )
+
+    for input_feature in config.input_features:
+        if_type = input_feature.type
+        encoder = input_feature.encoder
+        if (
+            if_type in sequence_types
+            and encoder.type == "transformer"
+            and not is_divisible(encoder.hidden_size, encoder.num_heads)
+        ):
+            raise ConfigValidationError(
+                f"Input feature {input_feature.name} transformer encoder requires encoder.hidden_size to be divisible "
+                f"by encoder.num_heads. Found hidden_size {encoder.hidden_size} and num_heads {encoder.num_heads}."
+            )

--- a/tests/ludwig/config_validation/test_validate_config_encoder.py
+++ b/tests/ludwig/config_validation/test_validate_config_encoder.py
@@ -1,8 +1,8 @@
 import pytest
 
-from ludwig.config_validation.validation import validate_config
 from ludwig.constants import DEFAULTS, ENCODER, INPUT_FEATURES, OUTPUT_FEATURES, SEQUENCE, TEXT, TIMESERIES, TYPE
 from ludwig.error import ConfigValidationError
+from ludwig.schema.model_config import ModelConfig
 from tests.integration_tests.utils import (
     binary_feature,
     number_feature,
@@ -26,12 +26,13 @@ def test_default_transformer_encoder(feature_type):
     }
 
     with pytest.raises(ConfigValidationError):
-        validate_config(config)
+        m = ModelConfig.from_dict(config)
+        print(m)
 
     config[DEFAULTS][feature_type][ENCODER]["hidden_size"] = 18
     config[DEFAULTS][feature_type][ENCODER]["num_heads"] = 9
 
-    validate_config(config)
+    ModelConfig.from_dict(config)
 
 
 @pytest.mark.parametrize("feature_type", [sequence_feature, text_feature, timeseries_feature])
@@ -50,9 +51,9 @@ def test_input_feature_transformer_encoder(feature_type):
     }
 
     with pytest.raises(ConfigValidationError):
-        validate_config(config)
+        ModelConfig.from_dict(config)
 
     config[INPUT_FEATURES][1][ENCODER]["hidden_size"] = 18
     config[INPUT_FEATURES][1][ENCODER]["num_heads"] = 9
 
-    validate_config(config)
+    ModelConfig.from_dict(config)

--- a/tests/ludwig/config_validation/test_validate_config_encoder.py
+++ b/tests/ludwig/config_validation/test_validate_config_encoder.py
@@ -1,0 +1,58 @@
+import pytest
+
+from ludwig.config_validation.validation import validate_config
+from ludwig.constants import DEFAULTS, ENCODER, INPUT_FEATURES, OUTPUT_FEATURES, SEQUENCE, TEXT, TIMESERIES, TYPE
+from ludwig.error import ConfigValidationError
+from tests.integration_tests.utils import (
+    binary_feature,
+    number_feature,
+    sequence_feature,
+    text_feature,
+    timeseries_feature,
+)
+
+
+@pytest.mark.parametrize("feature_type", [SEQUENCE, TEXT, TIMESERIES])
+def test_default_transformer_encoder(feature_type):
+    """Tests that a transformer hyperparameter divisibility error is correctly recognized in feature defaults.
+
+    Transformers require that `hidden_size % num_heads == 0`. 9 and 18 were selected as test values because they were
+    the values from the original error.
+    """
+    config = {
+        INPUT_FEATURES: [number_feature(), sequence_feature(), text_feature(), timeseries_feature()],
+        OUTPUT_FEATURES: [binary_feature()],
+        DEFAULTS: {feature_type: {ENCODER: {TYPE: "transformer", "hidden_size": 9, "num_heads": 18}}},
+    }
+
+    with pytest.raises(ConfigValidationError):
+        validate_config(config)
+
+    config[DEFAULTS][feature_type][ENCODER]["hidden_size"] = 18
+    config[DEFAULTS][feature_type][ENCODER]["num_heads"] = 9
+
+    validate_config(config)
+
+
+@pytest.mark.parametrize("feature_type", [sequence_feature, text_feature, timeseries_feature])
+def test_input_feature_transformer_encoder(feature_type):
+    """Tests that a transformer hyperparameter divisibility error is correctly recognized for a specific feature.
+
+    Transformers require that `hidden_size % num_heads == 0`. 9 and 18 were selected as test values because they were
+    the values from the original error.
+    """
+    config = {
+        INPUT_FEATURES: [
+            number_feature(),
+            feature_type(**{ENCODER: {TYPE: "transformer", "hidden_size": 9, "num_heads": 18}}),
+        ],
+        OUTPUT_FEATURES: [binary_feature()],
+    }
+
+    with pytest.raises(ConfigValidationError):
+        validate_config(config)
+
+    config[INPUT_FEATURES][1][ENCODER]["hidden_size"] = 18
+    config[INPUT_FEATURES][1][ENCODER]["num_heads"] = 9
+
+    validate_config(config)

--- a/tests/ludwig/config_validation/test_validate_config_encoder.py
+++ b/tests/ludwig/config_validation/test_validate_config_encoder.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ludwig.constants import DEFAULTS, ENCODER, INPUT_FEATURES, OUTPUT_FEATURES, SEQUENCE, TEXT, TIMESERIES, TYPE
+from ludwig.constants import DEFAULTS, ENCODER, INPUT_FEATURES, NAME, OUTPUT_FEATURES, SEQUENCE, TEXT, TIMESERIES, TYPE
 from ludwig.error import ConfigValidationError
 from ludwig.schema.model_config import ModelConfig
 from tests.integration_tests.utils import (
@@ -20,7 +20,7 @@ def test_default_transformer_encoder(feature_type):
     the values from the original error.
     """
     config = {
-        INPUT_FEATURES: [number_feature(), sequence_feature(), text_feature(), timeseries_feature()],
+        INPUT_FEATURES: [number_feature(), {TYPE: feature_type, NAME: f"test_{feature_type}"}],
         OUTPUT_FEATURES: [binary_feature()],
         DEFAULTS: {feature_type: {ENCODER: {TYPE: "transformer", "hidden_size": 9, "num_heads": 18}}},
     }
@@ -35,8 +35,8 @@ def test_default_transformer_encoder(feature_type):
     ModelConfig.from_dict(config)
 
 
-@pytest.mark.parametrize("feature_type", [sequence_feature, text_feature, timeseries_feature])
-def test_input_feature_transformer_encoder(feature_type):
+@pytest.mark.parametrize("feature_gen", [sequence_feature, text_feature, timeseries_feature])
+def test_input_feature_transformer_encoder(feature_gen):
     """Tests that a transformer hyperparameter divisibility error is correctly recognized for a specific feature.
 
     Transformers require that `hidden_size % num_heads == 0`. 9 and 18 were selected as test values because they were
@@ -45,7 +45,7 @@ def test_input_feature_transformer_encoder(feature_type):
     config = {
         INPUT_FEATURES: [
             number_feature(),
-            feature_type(**{ENCODER: {TYPE: "transformer", "hidden_size": 9, "num_heads": 18}}),
+            feature_gen(**{ENCODER: {TYPE: "transformer", "hidden_size": 9, "num_heads": 18}}),
         ],
         OUTPUT_FEATURES: [binary_feature()],
     }


### PR DESCRIPTION
Followup to #3066 that adds a validation check for `encoder.hidden_size % encoder.num_heads == 0` for transformer encoders.