### PR TITLE
Disable XLM Text Encoder because of host memory pressure issues

### DIFF
--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -717,8 +717,9 @@ class BERTConfig(HFEncoderConfig):
     )
 
 
+# TODO: uncomment once we figure out host memory issue: https://github.com/ludwig-ai/ludwig/issues/3107
 @DeveloperAPI
-@register_encoder_config("xlm", TEXT)
+# @register_encoder_config("xlm", TEXT)
 @ludwig_dataclass
 class XLMConfig(HFEncoderConfig):
     """This dataclass configures the schema used for an XLM encoder."""

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -241,7 +241,8 @@ class ALBERTConfig(HFEncoderConfig):
 
 
 # TODO: uncomment when sentencepiece doesn't cause segfaults: https://github.com/ludwig-ai/ludwig/issues/2983
-# @register_encoder_config("mt5", TEXT)
+# @register_encoder_config("mt5", TEXT) 
+# quick test
 @DeveloperAPI
 @register_encoder_config("mt5", TEXT)
 @ludwig_dataclass

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -241,8 +241,7 @@ class ALBERTConfig(HFEncoderConfig):
 
 
 # TODO: uncomment when sentencepiece doesn't cause segfaults: https://github.com/ludwig-ai/ludwig/issues/2983
-# @register_encoder_config("mt5", TEXT) 
-# quick test
+# @register_encoder_config("mt5", TEXT)
 @DeveloperAPI
 @register_encoder_config("mt5", TEXT)
 @ludwig_dataclass


### PR DESCRIPTION
See the associated issue for more information - we can re-enable this in the future. 

Issue: https://github.com/ludwig-ai/ludwig/issues/3107