### PR TITLE
fix: add pytest to hashfiles to be more selective about caching

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -84,7 +84,7 @@ jobs:
           brew install libuv
 
       - name: pip cache
-        if: ${{ !env.ACT && "$PYTORCH" != "nightly" }}
+        if: ${{ !env.ACT }}
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -84,13 +84,11 @@ jobs:
           brew install libuv
 
       - name: pip cache
-        if: ${{ !env.ACT }}
+        if: ${{ !env.ACT && "$PYTORCH" != "nightly" }}
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-torch${{ matrix.pytorch-version }}-${{ matrix.test-markers }}-${{ hashFiles('requirements*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-py${{ matrix.python-version }}-torch${{ matrix.pytorch-version }}-${{ matrix.test-markers }}-
+          key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-torch${{ matrix.pytorch-version }}-${{ matrix.test-markers }}-${{ hashFiles('requirements*.txt', '.github/workflows/pytest.yml') }}
 
       - name: Install dependencies
         env:


### PR DESCRIPTION
Only specifying `${{ hashFiles('requirements*.txt') }}` in the pip cache `key` doesn't account for cases where we update the `pytest.yml` workflow (esp. the Install Dependencies part), leading us to get a cache hit based on the key provided instead of reinstalling dependencies even when we update the install steps. This could lead to flakiness in tests as seen [here](https://github.com/ludwig-ai/ludwig/actions/runs/4198687893/jobs/7282653752) (success) and [here](https://github.com/ludwig-ai/ludwig/actions/runs/4199203681/jobs/7283778534) (failure).

This PR adds `'.github/workflows/pytest.yml'` as an input to the hash function.