### PR TITLE
Skip batch norm when chunk size is 1 in GhostBatchNorm

### DIFF
--- a/ludwig/modules/normalization_modules.py
+++ b/ludwig/modules/normalization_modules.py
@@ -25,8 +25,8 @@ class GhostBatchNormalization(LudwigModule):
             if batch_size == 1:
                 # Skip batch normalization if the batch size is 1.
                 return torch.cat(splits, 0)
-            x = [self.bn(x) for x in splits]
-            return torch.cat(x, 0)
+            splits_with_bn = [self.bn(x) if x.shape[0] > 1 else x for x in splits]
+            return torch.cat(splits_with_bn, 0)
 
         if batch_size != 1 or not self.training:
             return self.bn(inputs)

--- a/ludwig/modules/normalization_modules.py
+++ b/ludwig/modules/normalization_modules.py
@@ -28,6 +28,7 @@ class GhostBatchNormalization(LudwigModule):
             if batch_size == 1:
                 logger.warning(
                     "Batch size is 1, but batch normalization requires batch size >= 2. Skipping batch normalization."
+                    "Make sure to set `batch_size` to a value greater than 1."
                 )
                 # Skip batch normalization if the batch size is 1.
                 return torch.cat(splits, 0)

--- a/tests/ludwig/modules/test_normalization_modules.py
+++ b/tests/ludwig/modules/test_normalization_modules.py
@@ -38,3 +38,20 @@ def test_ghostbatchnormalization(mode: bool, virtual_batch_size: Optional[int]) 
 
     assert isinstance(ghost_batch_norm.moving_variance, torch.Tensor)
     assert ghost_batch_norm.moving_variance.shape == (OUTPUT_SIZE,)
+
+
+def test_ghostbatchnormalization_chunk_size_2() -> None:
+    """Test GhostBatchNormalization with virtual_batch_size=2 and batch_size=7 This creates chunks of size 2, 2, 2,
+    1 which should be handled correctly since we should skip applying batch norm to the last chunk since it is size
+    1."""
+    # setup up GhostBatchNormalization layer
+    ghost_batch_norm = GhostBatchNormalization(6, virtual_batch_size=2)
+
+    # setup inputs to test
+    inputs = torch.randn([7, 6], dtype=torch.float32)
+
+    # Set to training mode
+    ghost_batch_norm.train(mode=True)
+
+    # run tensor through
+    ghost_batch_norm(inputs)


### PR DESCRIPTION
Causes the following error otherwise:

```
ValueError: Expected more than 1 value per channel when training, got input size torch.Size([1, 6])
```