### PR TITLE
fix: Updated Learning Rate decay_rate to use corresponding Metadata.

### DIFF
--- a/ludwig/schema/lr_scheduler.py
+++ b/ludwig/schema/lr_scheduler.py
@@ -29,7 +29,7 @@ class LRSchedulerConfig(schema_utils.BaseMarshmallowConfig, ABC):
         min=0,
         max=1,
         description="Decay per epoch (%): Factor to decrease the Learning rate.",
-        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["decay_steps"],
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["decay_rate"],
     )
 
     decay_steps: int = schema_utils.PositiveInteger(


### PR DESCRIPTION
`decay_rate` was using `decay_steps` metadata when generating the JSON Schema. Updated the reference to point to `decay_rate`'s metadata. This was resulting in JSON schemas that had suggested ranges larger than 1.