### PR TITLE
Define two separate steps for tests and benchmark tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -167,15 +167,17 @@ jobs:
           horovodrun --check-build
         shell: bash
 
-      - name: Tests
-        run: |
-          RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=4500 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow" --junitxml pytest.xml tests
+#      - name: Tests
+#        run: |
+#          RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=4500 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow" --junitxml pytest.xml tests
 
       - name: Benchmark Tests
         env:
           KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
           KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
         run: |
+          mkdir .kaggle
+          echo '{"'"username"'":"'"${{ secrets.KAGGLE_USERNAME }}"'","'"key"'":"'"${{ secrets.KAGGLE_KEY }}"'"}' > .kaggle/kaggle.json
           RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=4500 pytest -v --timeout 300 --durations 100 -m "benchmark" --junitxml pytest-benchmark.xml tests
 
       - name: Upload Unit Test Results

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -167,9 +167,9 @@ jobs:
           horovodrun --check-build
         shell: bash
 
-#      - name: Tests
-#        run: |
-#          RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=4500 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow" --junitxml pytest.xml tests
+      - name: Tests
+        run: |
+          RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=4500 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow" --junitxml pytest.xml tests
 
       - name: Benchmark Tests
         env:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -171,14 +171,20 @@ jobs:
 
       - name: Tests
         run: |
-          RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=4500 pytest -v --timeout 300 --durations 100 -m "benchmark" --junitxml pytest.xml tests
+          RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=4500 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow" --junitxml pytest.xml tests
+
+      - name: Benchmark Tests
+        run: |
+          RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=4500 pytest -v --timeout 300 --durations 100 -m "benchmark" --junitxml pytest-benchmark.xml tests
 
       - name: Upload Unit Test Results
         if: ${{ always() && !env.ACT }}
         uses: actions/upload-artifact@v2
         with:
           name: Unit Test Results (Python ${{ matrix.python-version }} ${{ matrix.test-markers }})
-          path: pytest.xml
+          path: |
+            pytest.xml
+            pytest-benchmark.xml
 
   # start-runner:
   #   name: Start self-hosted EC2 runner

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Tests
         run: |
-          RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=4500 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow or benchmark" --junitxml pytest.xml tests
+          RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=4500 pytest -v --timeout 300 --durations 100 -m "benchmark" --junitxml pytest.xml tests
 
       - name: Upload Unit Test Results
         if: ${{ always() && !env.ACT }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -46,8 +46,6 @@ jobs:
       RAY_VERSION: ${{ matrix.ray-version }}
       AWS_ACCESS_KEY_ID: ${{ secrets.LUDWIG_TESTS_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.LUDWIG_TESTS_AWS_SECRET_ACCESS_KEY }}
-      KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
-      KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
 
     name: py${{ matrix.python-version  }}, torch-${{ matrix.pytorch-version }}, ${{ matrix.test-markers }}, ${{ matrix.os }}, ray ${{ matrix.ray-version }}
     services:
@@ -174,6 +172,9 @@ jobs:
           RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=4500 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow" --junitxml pytest.xml tests
 
       - name: Benchmark Tests
+        env:
+          KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
+          KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
         run: |
           RUN_PRIVATE=1 LUDWIG_TEST_SUITE_TIMEOUT_S=4500 pytest -v --timeout 300 --durations 100 -m "benchmark" --junitxml pytest-benchmark.xml tests
 


### PR DESCRIPTION
Fix as indicated by the title to the [flakiness](https://github.com/ludwig-ai/ludwig/actions/runs/4258193551/jobs/7410122890) seen around Kaggle datasets downloads.