### PR TITLE
GBM horovod validation workaround

### DIFF
--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -200,7 +200,8 @@ def check_gbm_horovod_incompatibility(config: "ModelConfig") -> None:  # noqa: F
     """
     if config.backend is None:
         return
-    if config.model_type == MODEL_GBM and config.backend.type == "horovod":
+    # TODO (jeffkinnison): Revert to object access when https://github.com/ludwig-ai/ludwig/pull/3127 lands
+    if config.model_type == MODEL_GBM and config.backend.get("type") == "horovod":
         raise ConfigValidationError("Horovod backend does not support GBM models.")
 
 


### PR DESCRIPTION
The GBM aux validation checks for `config.backend.type == "horovod"`, and this leads to  the error reported in #3126. This happens because the backend config is a dictionary and needs to be updated to be a dataclass. This workaround should allow us to use GBMs until #3127 lands.