### PR TITLE
Disallow GPU tensors in GBM training and eval

### DIFF
--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -200,7 +200,8 @@ def check_gbm_horovod_incompatibility(config: "ModelConfig") -> None:  # noqa: F
     """
     if config.backend is None:
         return
-    if config.model_type == MODEL_GBM and config.backend.type == "horovod":
+    # TODO (jeffkinnison): Revert to object access when https://github.com/ludwig-ai/ludwig/pull/3127 lands
+    if config.model_type == MODEL_GBM and config.backend.get("type") == "horovod":
         raise ConfigValidationError("Horovod backend does not support GBM models.")
 
 

--- a/ludwig/utils/gbm_utils.py
+++ b/ludwig/utils/gbm_utils.py
@@ -218,4 +218,5 @@ def get_targets(
     else:
         targets = lgb_train.get_data(actor_rank, 1)["label"].to_numpy()
     targets = targets.copy() if is_regression else targets.copy().astype(int)
-    return {output_feature.feature_name: torch.from_numpy(targets).to(device)}
+    # TODO (jeffkinnison): revert to use the requested device once torch device usage is standardized
+    return {output_feature.feature_name: torch.from_numpy(targets).cpu()}


### PR DESCRIPTION
Workaround for #3092 that prevents torch tensors from being placed on GPU when training with a GBM. There is an underlying inconsistency with tensor placement, where different functions place prediction and target tensors on  different devices when a GPU is available. This update moves all tensors to CPU for the time being.