### PR TITLE
fix: Streamline GBM defaults schema

### DIFF
--- a/ludwig/schema/defaults/gbm.py
+++ b/ludwig/schema/defaults/gbm.py
@@ -4,17 +4,24 @@ from ludwig.schema import utils as schema_utils
 from ludwig.schema.defaults.base import BaseDefaultsConfig
 from ludwig.schema.defaults.utils import DefaultsDataclassField
 from ludwig.schema.features.base import BaseFeatureConfig
+from ludwig.schema.features.utils import gbm_defaults_config_registry
 from ludwig.schema.utils import ludwig_dataclass
 
 
 @DeveloperAPI
 @ludwig_dataclass
 class GBMDefaultsConfig(BaseDefaultsConfig):
-    binary: BaseFeatureConfig = DefaultsDataclassField(feature_type=BINARY)
+    binary: BaseFeatureConfig = DefaultsDataclassField(
+        feature_type=BINARY, defaults_registry=gbm_defaults_config_registry
+    )
 
-    category: BaseFeatureConfig = DefaultsDataclassField(feature_type=CATEGORY)
+    category: BaseFeatureConfig = DefaultsDataclassField(
+        feature_type=CATEGORY, defaults_registry=gbm_defaults_config_registry
+    )
 
-    number: BaseFeatureConfig = DefaultsDataclassField(feature_type=NUMBER)
+    number: BaseFeatureConfig = DefaultsDataclassField(
+        feature_type=NUMBER, defaults_registry=gbm_defaults_config_registry
+    )
 
 
 @DeveloperAPI

--- a/ludwig/schema/defaults/utils.py
+++ b/ludwig/schema/defaults/utils.py
@@ -4,7 +4,7 @@ from marshmallow import fields, ValidationError
 
 import ludwig.schema.utils as schema_utils
 from ludwig.api_annotations import DeveloperAPI
-from ludwig.schema.features.utils import defaults_config_registry
+from ludwig.schema.features.utils import ecd_defaults_config_registry
 
 
 @DeveloperAPI
@@ -23,7 +23,7 @@ def DefaultsDataclassField(feature_type: str):
             if value is None:
                 return None
             if isinstance(value, dict):
-                defaults_class = defaults_config_registry[feature_type]
+                defaults_class = ecd_defaults_config_registry[feature_type]
                 try:
                     return defaults_class.Schema().load(value)
                 except (TypeError, ValidationError) as error:
@@ -32,7 +32,7 @@ def DefaultsDataclassField(feature_type: str):
 
         @staticmethod
         def _jsonschema_type_mapping():
-            defaults_cls = defaults_config_registry[feature_type]
+            defaults_cls = ecd_defaults_config_registry[feature_type]
             props = schema_utils.unload_jsonschema_from_marshmallow_class(defaults_cls)["properties"]
             return {
                 "type": "object",
@@ -42,7 +42,7 @@ def DefaultsDataclassField(feature_type: str):
             }
 
     try:
-        defaults_cls = defaults_config_registry[feature_type]
+        defaults_cls = ecd_defaults_config_registry[feature_type]
         dump_default = defaults_cls.Schema().dump({})
         load_default = lambda: defaults_cls.Schema().load({})
 

--- a/ludwig/schema/features/audio_feature.py
+++ b/ludwig/schema/features/audio_feature.py
@@ -5,12 +5,12 @@ from ludwig.schema.encoders.utils import EncoderDataclassField
 from ludwig.schema.features.base import BaseInputFeatureConfig
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
-from ludwig.schema.features.utils import defaults_config_registry, ecd_input_config_registry, input_mixin_registry
+from ludwig.schema.features.utils import ecd_defaults_config_registry, ecd_input_config_registry, input_mixin_registry
 from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 
 
 @DeveloperAPI
-@defaults_config_registry.register(AUDIO)
+@ecd_defaults_config_registry.register(AUDIO)
 @input_mixin_registry.register(AUDIO)
 @ludwig_dataclass
 class AudioInputFeatureConfigMixin(BaseMarshmallowConfig):

--- a/ludwig/schema/features/bag_feature.py
+++ b/ludwig/schema/features/bag_feature.py
@@ -5,12 +5,12 @@ from ludwig.schema.encoders.utils import EncoderDataclassField
 from ludwig.schema.features.base import BaseInputFeatureConfig
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
-from ludwig.schema.features.utils import defaults_config_registry, ecd_input_config_registry, input_mixin_registry
+from ludwig.schema.features.utils import ecd_defaults_config_registry, ecd_input_config_registry, input_mixin_registry
 from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 
 
 @DeveloperAPI
-@defaults_config_registry.register(BAG)
+@ecd_defaults_config_registry.register(BAG)
 @input_mixin_registry.register(BAG)
 @ludwig_dataclass
 class BagInputFeatureConfigMixin(BaseMarshmallowConfig):

--- a/ludwig/schema/features/binary_feature.py
+++ b/ludwig/schema/features/binary_feature.py
@@ -13,6 +13,7 @@ from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassFie
 from ludwig.schema.features.utils import (
     ecd_defaults_config_registry,
     ecd_input_config_registry,
+    gbm_defaults_config_registry,
     gbm_input_config_registry,
     input_mixin_registry,
     output_config_registry,
@@ -24,6 +25,7 @@ from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 
 
 @DeveloperAPI
+@gbm_defaults_config_registry.register(BINARY)
 @input_mixin_registry.register(BINARY)
 @ludwig_dataclass
 class BinaryInputFeatureConfigMixin(BaseMarshmallowConfig):

--- a/ludwig/schema/features/binary_feature.py
+++ b/ludwig/schema/features/binary_feature.py
@@ -11,7 +11,7 @@ from ludwig.schema.features.loss.utils import LossDataclassField
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
 from ludwig.schema.features.utils import (
-    defaults_config_registry,
+    ecd_defaults_config_registry,
     ecd_input_config_registry,
     gbm_input_config_registry,
     input_mixin_registry,
@@ -132,7 +132,7 @@ class BinaryOutputFeatureConfig(BaseOutputFeatureConfig, BinaryOutputFeatureConf
 
 
 @DeveloperAPI
-@defaults_config_registry.register(BINARY)
+@ecd_defaults_config_registry.register(BINARY)
 @ludwig_dataclass
 class BinaryDefaultsConfig(BinaryInputFeatureConfigMixin, BinaryOutputFeatureConfigMixin):
     # NOTE(travis): defaults use ECD input feature as it contains all the encoders

--- a/ludwig/schema/features/category_feature.py
+++ b/ludwig/schema/features/category_feature.py
@@ -13,6 +13,7 @@ from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassFie
 from ludwig.schema.features.utils import (
     ecd_defaults_config_registry,
     ecd_input_config_registry,
+    gbm_defaults_config_registry,
     gbm_input_config_registry,
     input_mixin_registry,
     output_config_registry,
@@ -25,6 +26,7 @@ from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 
 @DeveloperAPI
 @input_mixin_registry.register(CATEGORY)
+@gbm_defaults_config_registry.register(CATEGORY)
 @ludwig_dataclass
 class CategoryInputFeatureConfigMixin(BaseMarshmallowConfig):
     """CategoryInputFeatureConfigMixin is a dataclass that configures the parameters used in both the category

--- a/ludwig/schema/features/category_feature.py
+++ b/ludwig/schema/features/category_feature.py
@@ -11,7 +11,7 @@ from ludwig.schema.features.loss.utils import LossDataclassField
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
 from ludwig.schema.features.utils import (
-    defaults_config_registry,
+    ecd_defaults_config_registry,
     ecd_input_config_registry,
     gbm_input_config_registry,
     input_mixin_registry,
@@ -133,7 +133,7 @@ class CategoryOutputFeatureConfig(BaseOutputFeatureConfig, CategoryOutputFeature
 
 
 @DeveloperAPI
-@defaults_config_registry.register(CATEGORY)
+@ecd_defaults_config_registry.register(CATEGORY)
 @ludwig_dataclass
 class CategoryDefaultsConfig(CategoryInputFeatureConfigMixin, CategoryOutputFeatureConfigMixin):
     encoder: BaseEncoderConfig = EncoderDataclassField(

--- a/ludwig/schema/features/date_feature.py
+++ b/ludwig/schema/features/date_feature.py
@@ -5,12 +5,12 @@ from ludwig.schema.encoders.utils import EncoderDataclassField
 from ludwig.schema.features.base import BaseInputFeatureConfig
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
-from ludwig.schema.features.utils import defaults_config_registry, ecd_input_config_registry, input_mixin_registry
+from ludwig.schema.features.utils import ecd_defaults_config_registry, ecd_input_config_registry, input_mixin_registry
 from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 
 
 @DeveloperAPI
-@defaults_config_registry.register(DATE)
+@ecd_defaults_config_registry.register(DATE)
 @input_mixin_registry.register(DATE)
 @ludwig_dataclass
 class DateInputFeatureConfigMixin(BaseMarshmallowConfig):

--- a/ludwig/schema/features/h3_feature.py
+++ b/ludwig/schema/features/h3_feature.py
@@ -5,12 +5,12 @@ from ludwig.schema.encoders.utils import EncoderDataclassField
 from ludwig.schema.features.base import BaseInputFeatureConfig
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
-from ludwig.schema.features.utils import defaults_config_registry, ecd_input_config_registry, input_mixin_registry
+from ludwig.schema.features.utils import ecd_defaults_config_registry, ecd_input_config_registry, input_mixin_registry
 from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 
 
 @DeveloperAPI
-@defaults_config_registry.register(H3)
+@ecd_defaults_config_registry.register(H3)
 @input_mixin_registry.register(H3)
 @ludwig_dataclass
 class H3InputFeatureConfigMixin(BaseMarshmallowConfig):

--- a/ludwig/schema/features/image_feature.py
+++ b/ludwig/schema/features/image_feature.py
@@ -10,7 +10,7 @@ from ludwig.schema.features.augmentation.utils import AugmentationDataclassField
 from ludwig.schema.features.base import BaseInputFeatureConfig
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
-from ludwig.schema.features.utils import defaults_config_registry, ecd_input_config_registry, input_mixin_registry
+from ludwig.schema.features.utils import ecd_defaults_config_registry, ecd_input_config_registry, input_mixin_registry
 from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 
 # Augmentation operations when augmentation is set to True
@@ -21,7 +21,7 @@ AUGMENTATION_DEFAULT_OPERATIONS = [
 
 
 @DeveloperAPI
-@defaults_config_registry.register(IMAGE)
+@ecd_defaults_config_registry.register(IMAGE)
 @input_mixin_registry.register(IMAGE)
 @ludwig_dataclass
 class ImageInputFeatureConfigMixin(BaseMarshmallowConfig):

--- a/ludwig/schema/features/number_feature.py
+++ b/ludwig/schema/features/number_feature.py
@@ -15,6 +15,7 @@ from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassFie
 from ludwig.schema.features.utils import (
     ecd_defaults_config_registry,
     ecd_input_config_registry,
+    gbm_defaults_config_registry,
     gbm_input_config_registry,
     input_mixin_registry,
     output_config_registry,
@@ -27,6 +28,7 @@ from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 
 @DeveloperAPI
 @input_mixin_registry.register(NUMBER)
+@gbm_defaults_config_registry.register(NUMBER)
 @ludwig_dataclass
 class NumberInputFeatureConfigMixin(BaseMarshmallowConfig):
     """NumberInputFeatureConfigMixin is a dataclass that configures the parameters used in both the number input

--- a/ludwig/schema/features/number_feature.py
+++ b/ludwig/schema/features/number_feature.py
@@ -13,7 +13,7 @@ from ludwig.schema.features.loss.utils import LossDataclassField
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
 from ludwig.schema.features.utils import (
-    defaults_config_registry,
+    ecd_defaults_config_registry,
     ecd_input_config_registry,
     gbm_input_config_registry,
     input_mixin_registry,
@@ -130,7 +130,7 @@ class NumberOutputFeatureConfig(BaseOutputFeatureConfig, NumberOutputFeatureConf
 
 
 @DeveloperAPI
-@defaults_config_registry.register(NUMBER)
+@ecd_defaults_config_registry.register(NUMBER)
 @ludwig_dataclass
 class NumberDefaultsConfig(NumberInputFeatureConfigMixin, NumberOutputFeatureConfigMixin):
     encoder: BaseEncoderConfig = EncoderDataclassField(

--- a/ludwig/schema/features/sequence_feature.py
+++ b/ludwig/schema/features/sequence_feature.py
@@ -11,7 +11,7 @@ from ludwig.schema.features.loss.utils import LossDataclassField
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
 from ludwig.schema.features.utils import (
-    defaults_config_registry,
+    ecd_defaults_config_registry,
     ecd_input_config_registry,
     input_mixin_registry,
     output_config_registry,
@@ -103,7 +103,7 @@ class SequenceOutputFeatureConfig(BaseOutputFeatureConfig, SequenceOutputFeature
 
 
 @DeveloperAPI
-@defaults_config_registry.register(SEQUENCE)
+@ecd_defaults_config_registry.register(SEQUENCE)
 @ludwig_dataclass
 class SequenceDefaultsConfig(SequenceInputFeatureConfigMixin, SequenceOutputFeatureConfigMixin):
     pass

--- a/ludwig/schema/features/set_feature.py
+++ b/ludwig/schema/features/set_feature.py
@@ -11,7 +11,7 @@ from ludwig.schema.features.loss.utils import LossDataclassField
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
 from ludwig.schema.features.utils import (
-    defaults_config_registry,
+    ecd_defaults_config_registry,
     ecd_input_config_registry,
     input_mixin_registry,
     output_config_registry,
@@ -110,7 +110,7 @@ class SetOutputFeatureConfig(BaseOutputFeatureConfig, SetOutputFeatureConfigMixi
 
 
 @DeveloperAPI
-@defaults_config_registry.register(SET)
+@ecd_defaults_config_registry.register(SET)
 @ludwig_dataclass
 class SetDefaultsConfig(SetInputFeatureConfigMixin, SetOutputFeatureConfigMixin):
     pass

--- a/ludwig/schema/features/text_feature.py
+++ b/ludwig/schema/features/text_feature.py
@@ -11,7 +11,7 @@ from ludwig.schema.features.loss.utils import LossDataclassField
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
 from ludwig.schema.features.utils import (
-    defaults_config_registry,
+    ecd_defaults_config_registry,
     ecd_input_config_registry,
     input_mixin_registry,
     output_config_registry,
@@ -109,7 +109,7 @@ class TextOutputFeatureConfig(BaseOutputFeatureConfig, TextOutputFeatureConfigMi
 
 
 @DeveloperAPI
-@defaults_config_registry.register(TEXT)
+@ecd_defaults_config_registry.register(TEXT)
 @ludwig_dataclass
 class TextDefaultsConfig(TextInputFeatureConfigMixin, TextOutputFeatureConfigMixin):
     loss: BaseLossConfig = LossDataclassField(

--- a/ludwig/schema/features/timeseries_feature.py
+++ b/ludwig/schema/features/timeseries_feature.py
@@ -5,12 +5,12 @@ from ludwig.schema.encoders.utils import EncoderDataclassField
 from ludwig.schema.features.base import BaseInputFeatureConfig
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
-from ludwig.schema.features.utils import defaults_config_registry, ecd_input_config_registry, input_mixin_registry
+from ludwig.schema.features.utils import ecd_defaults_config_registry, ecd_input_config_registry, input_mixin_registry
 from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 
 
 @DeveloperAPI
-@defaults_config_registry.register(TIMESERIES)
+@ecd_defaults_config_registry.register(TIMESERIES)
 @input_mixin_registry.register(TIMESERIES)
 @ludwig_dataclass
 class TimeseriesInputFeatureConfigMixin(BaseMarshmallowConfig):

--- a/ludwig/schema/features/utils.py
+++ b/ludwig/schema/features/utils.py
@@ -13,7 +13,8 @@ input_mixin_registry = Registry()
 output_config_registry = Registry()
 output_mixin_registry = Registry()
 
-defaults_config_registry = Registry()
+ecd_defaults_config_registry = Registry()
+gbm_defaults_config_registry = Registry()
 
 
 def input_config_registry(model_type: str) -> Registry:

--- a/ludwig/schema/features/vector_feature.py
+++ b/ludwig/schema/features/vector_feature.py
@@ -11,7 +11,7 @@ from ludwig.schema.features.loss.utils import LossDataclassField
 from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassField
 from ludwig.schema.features.utils import (
-    defaults_config_registry,
+    ecd_defaults_config_registry,
     ecd_input_config_registry,
     input_mixin_registry,
     output_config_registry,
@@ -115,7 +115,7 @@ class VectorOutputFeatureConfig(BaseOutputFeatureConfig, VectorOutputFeatureConf
 
 
 @DeveloperAPI
-@defaults_config_registry.register(VECTOR)
+@ecd_defaults_config_registry.register(VECTOR)
 @ludwig_dataclass
 class VectorDefaultsConfig(VectorInputFeatureConfigMixin, VectorOutputFeatureConfigMixin):
     pass

--- a/tests/ludwig/config_validation/test_validate_config_misc.py
+++ b/tests/ludwig/config_validation/test_validate_config_misc.py
@@ -259,8 +259,8 @@ def test_ecd_defaults_schema():
 def test_gbm_defaults_schema():
     schema = GBMDefaultsConfig()
     assert AUDIO not in schema.to_dict()
-    assert schema.category.encoder.dropout == 0.0
-    assert ENCODER in schema.category.to_dict()
+    assert schema.binary.preprocessing.missing_value_strategy == "fill_with_false"
+    assert PREPROCESSING in schema.binary.to_dict()
 
 
 def test_validate_defaults_schema():


### PR DESCRIPTION
Creates two separate defaults config registries and sets GBM defaults to only include `preprocessing`

Test failures are happening on benchmarking, idk why but unrelated to any of these changes.