### PR TITLE
Update Ludwig version to 0.7

### DIFF
--- a/ludwig/globals.py
+++ b/ludwig/globals.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-LUDWIG_VERSION = "0.7.beta"
+LUDWIG_VERSION = "0.7"
 
 MODEL_WEIGHTS_FILE_NAME = "model_weights"
 MODEL_HYPERPARAMETERS_FILE_NAME = "model_hyperparameters.json"

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ with open(path.join(here, "requirements_test.txt"), encoding="utf-8") as f:
 
 setup(
     name="ludwig",
-    version="0.7.beta",
+    version="0.7",
     description="Declarative machine learning: End-to-end machine learning pipelines using data-driven configurations.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR changes the Ludwig version from `0.7.beta` to `0.7`.

I will rebase off of master once #3009's tests finish running and it is merged in.