### PR TITLE
Update SequenceGeneratorDecoder to output predictions and probabilities

### DIFF
--- a/ludwig/decoders/sequence_decoders.py
+++ b/ludwig/decoders/sequence_decoders.py
@@ -19,7 +19,7 @@ import torch
 import torch.nn as nn
 
 from ludwig.api_annotations import DeveloperAPI
-from ludwig.constants import LOGITS, SEQUENCE, TEXT
+from ludwig.constants import LOGITS, PREDICTIONS, PROBABILITIES, SEQUENCE, TEXT
 from ludwig.decoders.base import Decoder
 from ludwig.decoders.registry import register_decoder
 from ludwig.decoders.sequence_decoder_utils import get_lstm_init_state, get_rnn_init_state
@@ -321,7 +321,7 @@ class SequenceGeneratorDecoder(Decoder):
         return {LOGITS: logits}
 
     def get_prediction_set(self):
-        return {LOGITS}
+        return {LOGITS, PREDICTIONS, PROBABILITIES}
 
     @staticmethod
     def get_schema_cls():


### PR DESCRIPTION
`Predictor` looks for `<output_feature>.predictions` and `<output_feature>.probabilities` in model output, however `SequenceGeneratorDecoder.get_prediction_set` only included logits. Excluding the others led to a KeyError when unflattening output features

``` 
File "/home/ray/anaconda3/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3623, in get_loc
    raise KeyError(key) from err
KeyError: 'title_probabilities' (type: RayTaskError(KeyError), retryable: true)
```

This update adds predictions and probabilities to `get_prediction_set`.