### PR TITLE
Fixed confidence_penalty for newer versions of pytorch

### DIFF
--- a/ludwig/utils/loss_utils.py
+++ b/ludwig/utils/loss_utils.py
@@ -17,7 +17,7 @@ def rmspe_loss(targets: torch.Tensor, predictions: torch.Tensor) -> torch.Tensor
 def mean_confidence_penalty(probabilities: torch.Tensor, num_classes: int) -> torch.Tensor:
     max_entropy = torch.log(torch.tensor(num_classes))
     # clipping needed for avoiding log(0) = -inf
-    entropy_per_class = torch.maximum(-probabilities * torch.log(torch.clamp(probabilities, 1e-10, 1)), 0)
+    entropy_per_class, _ = torch.max(-probabilities * torch.log(torch.clamp(probabilities, 1e-10, 1)), dim=0)
     entropy = torch.sum(entropy_per_class, -1)
     penalty = (max_entropy - entropy) / max_entropy
     return torch.mean(penalty)

--- a/tests/ludwig/modules/test_loss_modules.py
+++ b/tests/ludwig/modules/test_loss_modules.py
@@ -1,7 +1,12 @@
+from typing import Optional
 import pytest
 import torch
 
 from ludwig.modules import loss_modules
+
+
+def from_float(v: float) -> torch.Tensor:
+    return torch.tensor(v).float()
 
 
 @pytest.mark.parametrize("preds", [torch.arange(6).reshape(3, 2).float()])
@@ -44,11 +49,29 @@ def test_rmspe_loss_zero_targets(preds: torch.Tensor, target: torch.Tensor, outp
     assert torch.isclose(loss(preds, target), output, rtol=0.0001)
 
 
+@pytest.mark.parametrize(
+    "confidence_penalty,positive_class_weight,robust_lambda,output",
+    [
+        (0.0, None, 0, from_float(-21.4655)),
+        (2.0, None, 0, from_float(-21.1263)),
+        (0.0, 2.0, 0, from_float(-20.1222)),
+        (0.0, None, 2, from_float(22.4655)),
+        (2, 2, 2, from_float(21.4614)),
+    ],
+)
 @pytest.mark.parametrize("preds", [torch.arange(6).reshape(3, 2).float()])
 @pytest.mark.parametrize("target", [torch.arange(6, 12).reshape(3, 2).float()])
-@pytest.mark.parametrize("output", [torch.tensor(-21.4655).float()])
-def test_bwcew_loss(preds: torch.Tensor, target: torch.Tensor, output: torch.Tensor):
-    loss = loss_modules.BWCEWLoss()
+def test_bwcew_loss(
+    preds: torch.Tensor,
+    target: torch.Tensor,
+    confidence_penalty: float,
+    positive_class_weight: Optional[float],
+    robust_lambda: int,
+    output: torch.Tensor,
+):
+    loss = loss_modules.BWCEWLoss(
+        positive_class_weight=positive_class_weight, robust_lambda=robust_lambda, confidence_penalty=confidence_penalty
+    )
     assert torch.isclose(loss(preds, target), output)
 
 

--- a/tests/ludwig/modules/test_loss_modules.py
+++ b/tests/ludwig/modules/test_loss_modules.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 import pytest
 import torch
 


### PR DESCRIPTION
It looks like PyTorch changed the meaning of `torch.maximum` at some point, as setting `confidence_penalty` was causing the function to be called with invalid inputs. Unfortunately, we didn't have any tests using `confidence_penalty` to catch this, so fixed the issue and added some. We should also look to add tests in the future that verify correctness of these params, as the hardcoded expectations here are only based on the observed outputs, not first principles.