### PR TITLE
Add fallback mirrors to dataset API

### DIFF
--- a/ludwig/datasets/__init__.py
+++ b/ludwig/datasets/__init__.py
@@ -29,7 +29,7 @@ def _load_dataset_config(config_filename: str):
     """Loads a dataset config."""
     config_path = os.path.join(os.path.dirname(configs.__file__), config_filename)
     with open(config_path) as f:
-        return DatasetConfig(**yaml.safe_load(f))
+        return DatasetConfig.from_dict(yaml.safe_load(f))
 
 
 @lru_cache(maxsize=1)

--- a/ludwig/datasets/configs/ames_housing.yaml
+++ b/ludwig/datasets/configs/ames_housing.yaml
@@ -14,4 +14,4 @@ output_features:
     type: number
 fallback_mirrors:
   - name: predibase
-    download_paths: s3://datasets.us-west-2.predibase.com/ludwig_backup/house-prices-advanced-regression-techniques.zip
+    download_paths: s3://ludwig-tests/ludwig_backup/house-prices-advanced-regression-techniques.zip

--- a/ludwig/datasets/configs/ames_housing.yaml
+++ b/ludwig/datasets/configs/ames_housing.yaml
@@ -12,3 +12,6 @@ description: |
 output_features:
   - name: SalePrice
     type: number
+fallback_mirrors:
+  - name: predibase
+    download_paths: s3://datasets.us-west-2.predibase.com/ludwig_backup/house-prices-advanced-regression-techniques.zip

--- a/ludwig/datasets/configs/mercedes_benz_greener.yaml
+++ b/ludwig/datasets/configs/mercedes_benz_greener.yaml
@@ -12,3 +12,6 @@ description: |
 output_features:
   - name: y
     type: number
+fallback_mirrors:
+  - name: predibase
+    download_paths: s3://datasets.us-west-2.predibase.com/ludwig_backup/mercedes-benz-greener-manufacturing.zip

--- a/ludwig/datasets/configs/mercedes_benz_greener.yaml
+++ b/ludwig/datasets/configs/mercedes_benz_greener.yaml
@@ -14,4 +14,4 @@ output_features:
     type: number
 fallback_mirrors:
   - name: predibase
-    download_paths: s3://datasets.us-west-2.predibase.com/ludwig_backup/mercedes-benz-greener-manufacturing.zip
+    download_paths: s3://ludwig-tests/ludwig_backup/mercedes-benz-greener-manufacturing.zip

--- a/ludwig/datasets/configs/sarcos.yaml
+++ b/ludwig/datasets/configs/sarcos.yaml
@@ -22,5 +22,5 @@ output_features:
 fallback_mirrors:
   - name: predibase
     download_paths:
-      - s3://datasets.us-west-2.predibase.com/ludwig_backup/sarcos_inv.mat
-      - s3://datasets.us-west-2.predibase.com/ludwig_backup/sarcos_inv_test.mat
+      - s3://ludwig-tests/ludwig_backup/sarcos_inv.mat
+      - s3://ludwig-tests/ludwig_backup/sarcos_inv_test.mat

--- a/ludwig/datasets/configs/sarcos.yaml
+++ b/ludwig/datasets/configs/sarcos.yaml
@@ -19,3 +19,8 @@ description: |
 output_features:
 - name: torque_1
   type: number
+fallback_mirrors:
+  - name: predibase
+    download_paths:
+      - s3://datasets.us-west-2.predibase.com/ludwig_backup/sarcos_inv.mat
+      - s3://datasets.us-west-2.predibase.com/ludwig_backup/sarcos_inv_test.mat

--- a/ludwig/datasets/dataset_config.py
+++ b/ludwig/datasets/dataset_config.py
@@ -15,7 +15,21 @@
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
+from dataclasses_json import dataclass_json
 
+
+@dataclass_json
+@dataclass
+class DatasetFallbackMirror:
+    # Name of the mirror
+    name: str
+
+    # List of paths to download from. Must map 1:1 to DatasetConfig.download_urls or to the archive_filenames
+    # that we get from Kaggle.
+    download_paths: Union[str, List[str]]
+
+
+@dataclass_json
 @dataclass
 class DatasetConfig:
     """The configuration of a Ludwig dataset."""
@@ -28,6 +42,9 @@ class DatasetConfig:
 
     # The readable description of the dataset
     description: str = ""
+
+    # Fallback mirrors. Paths must be in local/remote filesystems.
+    fallback_mirrors: Optional[List[DatasetFallbackMirror]] = None
 
     # Optional. The (suggested) output features for this dataset. Helps users discover new datasets and filter for
     # relevance to a specific machine learning setting.

--- a/ludwig/datasets/loaders/dataset_loader.py
+++ b/ludwig/datasets/loaders/dataset_loader.py
@@ -29,9 +29,10 @@ from tqdm import tqdm
 from ludwig.api_annotations import DeveloperAPI, PublicAPI
 from ludwig.constants import SPLIT
 from ludwig.datasets.archives import extract_archive, is_archive, list_archive
-from ludwig.datasets.dataset_config import DatasetConfig
+from ludwig.datasets.dataset_config import DatasetConfig, DatasetFallbackMirror
 from ludwig.datasets.kaggle import download_kaggle_dataset
 from ludwig.datasets.utils import model_configs_for_dataset
+from ludwig.utils.fs_utils import get_fs_and_path
 from ludwig.utils.strings_utils import make_safe_filename
 
 logger = logging.getLogger(__name__)
@@ -206,6 +207,16 @@ class DatasetLoader:
             return _list_of_strings(self.config.archive_filenames)
         return [os.path.basename(urlparse(url).path) for url in self.download_urls]
 
+    def get_mirror_download_paths(self, mirror: DatasetFallbackMirror):
+        """Filenames for downloaded files inferred from mirror download_paths."""
+        return _list_of_strings(mirror.download_paths)
+
+    def get_mirror_download_filenames(self, mirror: DatasetFallbackMirror):
+        """Filenames for downloaded files inferred from mirror download_paths."""
+        if self.config.archive_filenames:
+            return _list_of_strings(self.config.archive_filenames)
+        return [os.path.basename(path) for path in mirror.download_paths]
+
     def description(self) -> str:
         """Returns human-readable description of the dataset."""
         return f"{self.config.name} {self.config.version}\n{self.config.description}"
@@ -259,8 +270,15 @@ class DatasetLoader:
         if self.state == DatasetState.NOT_LOADED:
             try:
                 self.download(kaggle_username=kaggle_username, kaggle_key=kaggle_key)
-            except Exception:
-                logger.exception("Failed to download dataset")
+            except Exception as e:
+                logger.warning(
+                    f"Finding fallback mirrors to download the dataset. Downloading from "
+                    f"the original source failed with the following error {e}."
+                )
+                if not self.config.fallback_mirrors:
+                    logger.exception(f"No fallback mirror found. Failed to download dataset {self.config.name}.")
+                else:
+                    self.download_from_fallback_mirrors()
         self.verify()
         if self.state == DatasetState.DOWNLOADED:
             # Extract dataset
@@ -308,6 +326,21 @@ class DatasetLoader:
                 downloaded_file_path = os.path.join(self.raw_dataset_dir, filename)
                 with TqdmUpTo(unit="B", unit_scale=True, unit_divisor=1024, miniters=1, desc=filename) as t:
                     urllib.request.urlretrieve(url, downloaded_file_path, t.update_to)
+
+    def download_from_fallback_mirrors(self):
+        for mirror in self.config.fallback_mirrors:
+            logger.info(f"Attempting download from mirror {mirror.name}.")
+            try:
+                download_paths = self.get_mirror_download_paths(mirror)
+                filenames = self.get_mirror_download_filenames(mirror)
+                for path, filename in zip(download_paths, filenames):
+                    downloaded_file_path = os.path.join(self.raw_dataset_dir, filename)
+                    with TqdmUpTo(unit="B", unit_scale=True, unit_divisor=1024, miniters=1, desc=filename):
+                        fs, path = get_fs_and_path(path)
+                        fs.get(path, downloaded_file_path)
+                return
+            except Exception:
+                logger.exception(f"Download from mirror `{mirror.name}` failed.")
 
     def verify(self) -> None:
         """Verifies checksums for dataset."""

--- a/tests/ludwig/datasets/test_datasets.py
+++ b/tests/ludwig/datasets/test_datasets.py
@@ -189,3 +189,12 @@ def test_preprocess_dataset_uri(tmpdir):
             assert test_df1.equals(test_df2)
 
     ludwig.datasets._get_dataset_configs.cache_clear()
+
+
+@pytest.mark.parametrize("dataset_name,shape", [("mercedes_benz_greener", (8418, 379)), ("ames_housing", (2919, 82))])
+def test_dataset_fallback_mirror(dataset_name, shape):
+    dataset_module = ludwig.datasets.get_dataset(dataset_name)
+    dataset = dataset_module.load(kaggle_key="dummy_key", kaggle_username="dummy_username")
+
+    assert isinstance(dataset, pd.DataFrame)
+    assert dataset.shape == shape


### PR DESCRIPTION
To mitigate the flakiness of external APIs and downtime from the main mirrors, this PR introduces fallback mirrors to the dataset API. These mirrors are defined in the dataset configs under `ludwig/datasets/configs` by adding
```
fallback_mirrors:
  - name: mirror_1
    download_paths:
      - path/to/dataset/file_1.json
      - path/to/dataset/file_2.json
  - name: mirror_2
    download_paths: 
     - ...
```
Only paths to filesystems are supported.

When downloading the dataset, the loader will try to retrieve the dataset from the main source (`download_urls` or `kaggle_competition`). If any exception is encountered, it will attempt to load the dataset from the mirror in the order specified.