### PR TITLE
Re-enable benchmark tests on `Sarcos` dataset

### DIFF
--- a/tests/regression_tests/benchmark/test_model_performance.py
+++ b/tests/regression_tests/benchmark/test_model_performance.py
@@ -9,8 +9,6 @@ from ludwig.utils.data_utils import load_yaml
 
 SKIPPED_CONFIG_ISSUES = {
     "mercedes_benz_greener.ecd.yaml": "https://github.com/ludwig-ai/ludwig/issues/2978",
-    "sarcos.ecd.yaml": "https://github.com/ludwig-ai/ludwig/issues/3019",
-    "sarcos.gbm.yaml": "https://github.com/ludwig-ai/ludwig/issues/3019",
 }
 
 

--- a/tests/regression_tests/benchmark/test_model_performance.py
+++ b/tests/regression_tests/benchmark/test_model_performance.py
@@ -9,6 +9,7 @@ from ludwig.utils.data_utils import load_yaml
 
 SKIPPED_CONFIG_ISSUES = {
     "mercedes_benz_greener.ecd.yaml": "https://github.com/ludwig-ai/ludwig/issues/2978",
+    "sarcos.ecd.yaml": "Takes more than 300s",
 }
 
 


### PR DESCRIPTION
Dataset links seem to be back. https://github.com/ludwig-ai/ludwig/pull/3168 will allow us to retrieve the dataset even if they're down again.