### PR TITLE
Fix TorchVision channel preprocessing

### DIFF
--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -749,7 +749,7 @@ class ImageFeatureMixin(BaseFeatureMixin):
 
         if torchvision_parameters:
             logger.warning(
-                f"Using the transforms specified for the torchvision model {model_type} {model_variant}"
+                f"Using the transforms specified for the torchvision model {model_type} {model_variant} "
                 f"This includes setting the number of channels is 3 and resizing the image to the needs of the model."
             )
 

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -47,6 +47,7 @@ from ludwig.constants import (
     WIDTH,
 )
 from ludwig.data.cache.types import wrap
+from ludwig.encoders.image.torchvision import TVModelVariant
 from ludwig.features.base_feature import BaseFeatureMixin, InputFeature
 from ludwig.schema.features.augmentation.base import BaseAugmentationConfig
 from ludwig.schema.features.augmentation.image import (
@@ -71,6 +72,7 @@ from ludwig.utils.image_utils import (
     read_image_from_bytes_obj,
     read_image_from_path,
     resize_image,
+    ResizeChannels,
     torchvision_model_registry,
 )
 from ludwig.utils.misc_utils import set_default_value
@@ -241,16 +243,52 @@ class ImageAugmentation(torch.nn.Module):
             return images.type(torch.float32).div(255.0)
 
 
+def _get_torchvision_transform(torchvision_parameters: TVModelVariant) -> torch.nn.Module:
+    """Returns a torchvision transform that is compatible with the model variant.
+
+    Args:
+        torchvision_parameters: The parameters for the torchvision model variant.
+    Returns:
+        (torchvision_transform, transform_metadata): A torchvision transform and the metadata for the transform.
+    """
+    torchvision_transform_raw = torchvision_parameters.model_weights.DEFAULT.transforms()
+    torchvision_transform = torch.nn.Sequential(
+        ResizeChannels(num_channels=3),
+        torchvision_transform_raw,
+    )
+    transform_metadata = {
+        "height": torchvision_transform_raw.crop_size[0],
+        "width": torchvision_transform_raw.crop_size[0],
+        "num_channels": len(torchvision_transform_raw.mean),
+    }
+    return (torchvision_transform, transform_metadata)
+
+
+def _get_torchvision_parameters(model_type: str, model_variant: str) -> TVModelVariant:
+    return torchvision_model_registry.get(model_type).get(model_variant)
+
+
 class _ImagePreprocessing(torch.nn.Module):
     """Torchscript-enabled version of preprocessing done by ImageFeatureMixin.add_feature_data."""
 
-    def __init__(self, metadata: TrainingSetMetadataDict, tv_transforms: Optional[torch.nn.Module] = None):
+    def __init__(
+        self,
+        metadata: TrainingSetMetadataDict,
+        torchvision_transform: Optional[torch.nn.Module] = None,
+        transform_metadata: Optional[Dict[str, Any]] = None,
+    ):
         super().__init__()
-        self.height = metadata["preprocessing"]["height"]
-        self.width = metadata["preprocessing"]["width"]
-        self.num_channels = metadata["preprocessing"]["num_channels"]
+
         self.resize_method = metadata["preprocessing"]["resize_method"]
-        self.tv_transforms = tv_transforms
+        self.torchvision_transform = torchvision_transform
+        if transform_metadata is not None:
+            self.height = transform_metadata["height"]
+            self.width = transform_metadata["width"]
+            self.num_channels = transform_metadata["num_channels"]
+        else:
+            self.height = metadata["preprocessing"]["height"]
+            self.width = metadata["preprocessing"]["width"]
+            self.num_channels = metadata["preprocessing"]["num_channels"]
 
     def forward(self, v: TorchscriptPreprocessingInput) -> torch.Tensor:
         """Takes a list of images and adjusts the size and number of channels as specified in the metadata.
@@ -262,14 +300,14 @@ class _ImagePreprocessing(torch.nn.Module):
             if not torch.jit.isinstance(v, torch.Tensor):
                 raise ValueError(f"Unsupported input: {v}")
 
-        if self.tv_transforms is not None:
+        if self.torchvision_transform is not None:
             # perform pre-processing for torchvision pretrained model encoders
             if torch.jit.isinstance(v, List[torch.Tensor]):
-                imgs = [self.tv_transforms(img) for img in v]
+                imgs = [self.torchvision_transform(img) for img in v]
             else:
                 # convert batch of image tensors to a list and then run torchvision pretrained
                 # model transforms on each image
-                imgs = [self.tv_transforms(img) for img in torch.unbind(v)]
+                imgs = [self.torchvision_transform(img) for img in torch.unbind(v)]
 
             # collect the list of images into a batch
             imgs_stacked = torch.stack(imgs)
@@ -701,16 +739,23 @@ class ImageFeatureMixin(BaseFeatureMixin):
         model_type = feature_config[ENCODER].get("type", None)
         model_variant = feature_config[ENCODER].get("model_variant")
         if model_variant:
-            torchvision_parameters = torchvision_model_registry.get(model_type).get(model_variant)
+            torchvision_parameters = _get_torchvision_parameters(model_type, model_variant)
         else:
             torchvision_parameters = None
 
         if torchvision_parameters:
+            logger.warning(
+                f"Using the transforms specified for the torchvision model {model_type} {model_variant}"
+                f"This includes setting the number of channels is 3 and resizing the image to the needs of the model."
+            )
+
+            torchvision_transform, transform_metadata = _get_torchvision_transform(torchvision_parameters)
+
             # torchvision_parameters is not None
             # perform torchvision model transformations
             read_image_if_bytes_obj_and_resize = partial(
                 ImageFeatureMixin._read_image_with_pretrained_transform,
-                transform_fn=torchvision_parameters.model_weights.DEFAULT.transforms(),
+                transform_fn=torchvision_transform,
             )
             average_file_size = None
 
@@ -724,8 +769,9 @@ class ImageFeatureMixin(BaseFeatureMixin):
             preprocessing_parameters["torchvision_model_variant"] = model_variant
 
             # get required setup parameters for in_memory = False processing
-            width = height = read_image_if_bytes_obj_and_resize.keywords["transform_fn"].crop_size[0]
-            num_channels = len(read_image_if_bytes_obj_and_resize.keywords["transform_fn"].mean)
+            height = transform_metadata["height"]
+            width = transform_metadata["width"]
+            num_channels = transform_metadata["num_channels"]
         else:
             # torchvision_parameters is None
             # perform Ludwig specified transformations
@@ -885,16 +931,18 @@ class ImageInputFeature(ImageFeatureMixin, InputFeature):
         model_type = metadata["preprocessing"].get("torchvision_model_type")
         model_variant = metadata["preprocessing"].get("torchvision_model_variant")
         if model_variant:
-            torchvision_parameters = torchvision_model_registry.get(model_type).get(model_variant)
+            torchvision_parameters = _get_torchvision_parameters(model_type, model_variant)
         else:
             torchvision_parameters = None
 
         if torchvision_parameters:
-            tv_transforms = torchvision_parameters.model_weights.DEFAULT.transforms()
+            torchvision_transform, transform_metadata = _get_torchvision_transform(torchvision_parameters)
         else:
-            tv_transforms = None
+            torchvision_transform = None
 
-        return _ImagePreprocessing(metadata, tv_transforms=tv_transforms)
+        return _ImagePreprocessing(
+            metadata, torchvision_transform=torchvision_transform, transform_metadata=transform_metadata
+        )
 
     def get_augmentation_pipeline(self):
         return self.augmentation_pipeline

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -943,6 +943,7 @@ class ImageInputFeature(ImageFeatureMixin, InputFeature):
             torchvision_transform, transform_metadata = _get_torchvision_transform(torchvision_parameters)
         else:
             torchvision_transform = None
+            transform_metadata = None
 
         return _ImagePreprocessing(
             metadata, torchvision_transform=torchvision_transform, transform_metadata=transform_metadata

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -246,6 +246,10 @@ class ImageAugmentation(torch.nn.Module):
 def _get_torchvision_transform(torchvision_parameters: TVModelVariant) -> torch.nn.Module:
     """Returns a torchvision transform that is compatible with the model variant.
 
+    Note that the raw torchvision transform is not returned. Instead, a Sequential module that includes
+    image resizing is returned. This is because the raw torchvision transform assumes that the input image has
+    three channels, which is not always the case with images input into Ludwig.
+
     Args:
         torchvision_parameters: The parameters for the torchvision model variant.
     Returns:

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -52,6 +52,30 @@ IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".tiff", ".bmp", ".gif")
 
 
 @DeveloperAPI
+class ResizeChannels(torch.nn.Module):
+    def __init__(self, num_channels: int):
+        super().__init__()
+        self.num_channels = num_channels
+
+    def forward(self, imgs: torch.Tensor):
+        original_imgs_shape = imgs.shape
+        if len(original_imgs_shape) == 3:  # if shape is (C, H, W), add batch dimension
+            imgs = imgs.unsqueeze(0)
+
+        channels = imgs.shape[1]
+        if channels > self.num_channels:
+            # take the first `self.num_channels` channels
+            imgs = imgs[:, : self.num_channels, :, :]
+        elif channels < self.num_channels:
+            # repeat and use the first `self.num_channels` channels
+            imgs = imgs.repeat(1, (self.num_channels // channels) + 1, 1, 1)[:, : self.num_channels, :, :]
+
+        if len(original_imgs_shape) == 3:  # if shape was (C, H, W), remove batch dimension
+            return imgs[0]
+        return imgs
+
+
+@DeveloperAPI
 def get_gray_default_image(num_channels: int, height: int, width: int) -> np.ndarray:
     return np.full((num_channels, height, width), 128, dtype=np.float32)
 

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -566,7 +566,7 @@ def test_category_feature_vocab_size_1(feature_type, tmpdir) -> None:
 
 
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["false", "true"])
-def test_image_encoder_different_dimension_image(tmpdir, csv_filename, use_pretrained: bool):
+def test_vit_encoder_different_dimension_image(tmpdir, csv_filename, use_pretrained: bool):
     input_features = [
         image_feature(
             os.path.join(tmpdir, "generated_output"),

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -565,13 +565,14 @@ def test_category_feature_vocab_size_1(feature_type, tmpdir) -> None:
         ludwig_model.train(dataset=training_data_csv_path)
 
 
-@pytest.mark.parametrize("use_pretrained", [False, True], ids=["false", "true"])
-def test_vit_encoder_different_dimension_image(tmpdir, csv_filename, use_pretrained: bool):
+@pytest.mark.parametrize("encoder", ["efficientnet"])
+# @pytest.mark.parametrize("use_pretrained", [False, True], ids=["false", "true"])
+def test_image_encoder_different_dimension_image(tmpdir, csv_filename, encoder: str):
     input_features = [
         image_feature(
             os.path.join(tmpdir, "generated_output"),
-            preprocessing={"in_memory": True, "height": 224, "width": 206, "num_channels": 3},
-            encoder={"type": "_vit_legacy", "use_pretrained": use_pretrained},
+            preprocessing={"in_memory": True, "height": 224, "width": 206, "num_channels": 1},
+            encoder={"type": encoder},
         )
     ]
     output_features = [category_feature(decoder={"vocab_size": 5}, reduce_input="sum")]

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -565,14 +565,40 @@ def test_category_feature_vocab_size_1(feature_type, tmpdir) -> None:
         ludwig_model.train(dataset=training_data_csv_path)
 
 
-@pytest.mark.parametrize("encoder", ["efficientnet"])
-# @pytest.mark.parametrize("use_pretrained", [False, True], ids=["false", "true"])
-def test_image_encoder_different_dimension_image(tmpdir, csv_filename, encoder: str):
+@pytest.mark.parametrize("use_pretrained", [False, True], ids=["false", "true"])
+def test_image_encoder_different_dimension_image(tmpdir, csv_filename, use_pretrained: bool):
+    input_features = [
+        image_feature(
+            os.path.join(tmpdir, "generated_output"),
+            preprocessing={"in_memory": True, "height": 224, "width": 206, "num_channels": 3},
+            encoder={"type": "_vit_legacy", "use_pretrained": use_pretrained},
+        )
+    ]
+    output_features = [category_feature(decoder={"vocab_size": 5}, reduce_input="sum")]
+
+    data_csv = generate_data(
+        input_features, output_features, os.path.join(tmpdir, csv_filename), num_examples=NUM_EXAMPLES
+    )
+
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        "trainer": {"train_steps": 1},
+    }
+
+    model = LudwigModel(config)
+
+    # Failure happens post preprocessing but before training during the ECD model creation phase
+    # so make sure the model can be created properly and training can proceed
+    model.train(dataset=data_csv)
+
+
+def test_image_encoder_torchvision_different_num_channels(tmpdir, csv_filename):
     input_features = [
         image_feature(
             os.path.join(tmpdir, "generated_output"),
             preprocessing={"in_memory": True, "height": 224, "width": 206, "num_channels": 1},
-            encoder={"type": encoder},
+            encoder={"type": "efficientnet"},
         )
     ]
     output_features = [category_feature(decoder={"vocab_size": 5}, reduce_input="sum")]

--- a/tests/integration_tests/test_torchscript.py
+++ b/tests/integration_tests/test_torchscript.py
@@ -356,7 +356,7 @@ def test_torchscript_e2e_audio(csv_filename, tmpdir):
     "kwargs",
     [
         {"encoder": {"type": "stacked_cnn"}},  # Ludwig custom encoder
-        {"encoder": {"type": "alexnet", "use_pretrained": False}},  # TorchVisio pretrained model encoder
+        {"encoder": {"type": "alexnet", "use_pretrained": False}},  # TorchVision pretrained model encoder
     ],
 )
 def test_torchscript_e2e_image(tmpdir, csv_filename, kwargs):


### PR DESCRIPTION
This PR introduces automatic channel resizing for torchvision models to ensure that images fed into torchvision encoders always have 3 channels. Closes #3170.