### PR TITLE
Skip sample_ratio validation when using Dask to prevent materialization of DF

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1140,14 +1140,14 @@ def build_dataset(
     if mode == "training":
         sample_ratio = global_preprocessing_parameters["sample_ratio"]
         if sample_ratio < 1.0:
-            if len(dataset_df) * sample_ratio < 1:
+            if not df_engine.partitioned and len(dataset_df) * sample_ratio < 1:
                 raise ValueError(
                     f"sample_ratio {sample_ratio} is too small for dataset of length {len(dataset_df)}. "
                     f"Please increase sample_ratio or use a larger dataset."
                 )
-            else:
-                logger.debug(f"sample {sample_ratio} of data")
-                dataset_df = dataset_df.sample(frac=sample_ratio)
+
+            logger.debug(f"sample {sample_ratio} of data")
+            dataset_df = dataset_df.sample(frac=sample_ratio)
 
     # If persisting DataFrames in memory is enabled, we want to do this after
     # each batch of parallel ops in order to avoid redundant computation


### PR DESCRIPTION
Calling `len(df)` forces materialization of the DF, which is something we want to avoid when using `sample_ratio`.