### PR TITLE
fix: [REBASE] Hoist uniqueItemProperties to top of feature JSON schema

### DIFF
--- a/ludwig/schema/features/base.py
+++ b/ludwig/schema/features/base.py
@@ -219,7 +219,12 @@ class FeatureList(fields.List):
 
 class FeaturesTypeSelection(schema_utils.TypeSelection):
     def __init__(
-        self, *args, min_length: Optional[int] = 1, max_length: Optional[int] = 3, supplementary_metadata=None, **kwargs
+        self,
+        *args,
+        min_length: Optional[int] = 1,
+        max_length: Optional[int] = None,
+        supplementary_metadata=None,
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.min_length = min_length

--- a/ludwig/schema/features/base.py
+++ b/ludwig/schema/features/base.py
@@ -218,10 +218,13 @@ class FeatureList(fields.List):
 
 
 class FeaturesTypeSelection(schema_utils.TypeSelection):
-    def __init__(self, *args, min_length: Optional[int] = 1, max_length: Optional[int] = None, **kwargs):
+    def __init__(
+        self, *args, min_length: Optional[int] = 1, max_length: Optional[int] = 3, supplementary_metadata=None, **kwargs
+    ):
         super().__init__(*args, **kwargs)
         self.min_length = min_length
         self.max_length = max_length
+        self.supplementary_metadata = {} if supplementary_metadata is None else supplementary_metadata
 
     def get_list_field(self) -> Field:
         min_length = self.min_length
@@ -241,6 +244,7 @@ class FeaturesTypeSelection(schema_utils.TypeSelection):
                         max=max_length,
                         equal=equal,
                     ),
+                    metadata=self.supplementary_metadata,
                 )
             },
         )
@@ -248,10 +252,13 @@ class FeaturesTypeSelection(schema_utils.TypeSelection):
 
 class ECDInputFeatureSelection(FeaturesTypeSelection):
     def __init__(self):
-        super().__init__(registry=ecd_input_config_registry, description="Type of the input feature")
+        super().__init__(
+            registry=ecd_input_config_registry,
+            description="Type of the input feature",
+            supplementary_metadata={"uniqueItemProperties": ["name"]},
+        )
 
-    @staticmethod
-    def _jsonschema_type_mapping():
+    def _jsonschema_type_mapping(self):
         return get_input_feature_jsonschema(MODEL_ECD)
 
 

--- a/ludwig/schema/features/utils.py
+++ b/ludwig/schema/features/utils.py
@@ -51,7 +51,6 @@ def get_input_feature_jsonschema(model_type: str):
             },
             "column": {"type": "string", "title": "column", "description": "Name of the column."},
         },
-        "uniqueItemProperties": ["name"],
         "additionalProperties": True,
         "allOf": get_input_feature_conds(model_type),
         "required": ["name", "type"],


### PR DESCRIPTION
Redo of #3159 - this time from a native upstream branch rather than from my own fork.

--

Though this PR is just about moving one line of the schema (which is only relevant for AJV validation) one level up in its tree and the real issue at hand is that I'm working against marshmallow_jsonschema's rules (see this comment: https://github.com/ludwig-ai/ludwig/pull/2906#discussion_r1119576691), this change got me thinking about how we might want to deal with post-generation schema changes in the future.

I thought about tackling this a couple of different ways:

* some kind of post-generation decorator that can be added to a schema
* define a suite of schema transformations (like we already do for backwards compatibility)
* should we maintain separate schema transformations for usage with AJV?
* Ultimately I settled on a lightweight solution for now, but it's not ideal IMO.