### PR TITLE
fix: [REBASE] Misc. JSON schema fixes

### DIFF
--- a/ludwig/config_validation/validation.py
+++ b/ludwig/config_validation/validation.py
@@ -13,7 +13,6 @@ from ludwig.error import ConfigValidationError
 from ludwig.schema.combiners.utils import get_combiner_jsonschema  # noqa
 from ludwig.schema.features.utils import get_input_feature_jsonschema, get_output_feature_jsonschema  # noqa
 from ludwig.schema.hyperopt import get_hyperopt_jsonschema  # noqa
-from ludwig.schema.preprocessing import get_preprocessing_jsonschema  # noqa
 from ludwig.schema.trainer import get_model_type_jsonschema, get_trainer_jsonschema  # noqa
 from ludwig.schema.utils import unload_jsonschema_from_marshmallow_class
 

--- a/ludwig/schema/__init__.py
+++ b/ludwig/schema/__init__.py
@@ -2,5 +2,4 @@
 from ludwig.schema.combiners.utils import get_combiner_jsonschema  # noqa
 from ludwig.schema.features.utils import get_input_feature_jsonschema, get_output_feature_jsonschema  # noqa
 from ludwig.schema.hyperopt import get_hyperopt_jsonschema  # noqa
-from ludwig.schema.preprocessing import get_preprocessing_jsonschema  # noqa
 from ludwig.schema.trainer import get_model_type_jsonschema, get_trainer_jsonschema  # noqa

--- a/ludwig/schema/combiners/utils.py
+++ b/ludwig/schema/combiners/utils.py
@@ -108,6 +108,5 @@ class CombinerSelection(schema_utils.TypeSelection):
     def get_schema_from_registry(self, key: str) -> Type[schema_utils.BaseMarshmallowConfig]:
         return self.registry[key].get_schema_cls()
 
-    @staticmethod
-    def _jsonschema_type_mapping():
+    def _jsonschema_type_mapping(self):
         return get_combiner_jsonschema()

--- a/ludwig/schema/decoders/utils.py
+++ b/ludwig/schema/decoders/utils.py
@@ -94,8 +94,7 @@ def DecoderDataclassField(feature_type: str, default: str) -> Field:
         def get_schema_from_registry(self, key: str) -> Type[schema_utils.BaseMarshmallowConfig]:
             return get_decoder_cls(feature_type, key)
 
-        @staticmethod
-        def _jsonschema_type_mapping():
+        def _jsonschema_type_mapping(self):
             return {
                 "type": "object",
                 "properties": {

--- a/ludwig/schema/defaults/ecd.py
+++ b/ludwig/schema/defaults/ecd.py
@@ -52,26 +52,6 @@ class ECDDefaultsConfig(BaseDefaultsConfig):
 
 
 @DeveloperAPI
-def get_ecd_defaults_jsonschema():
-    """Returns a JSON schema structured to only require a `type` key and then conditionally apply a corresponding
-    combiner's field constraints."""
-    preproc_schema = schema_utils.unload_jsonschema_from_marshmallow_class(ECDDefaultsConfig)
-    props = preproc_schema["properties"]
-
-    return {
-        "type": "object",
-        "properties": props,
-        "additionalProperties": False,
-        "title": "global_defaults_options",
-        "description": "Set global defaults for input and output features",
-    }
-
-
-@DeveloperAPI
 class ECDDefaultsField(schema_utils.DictMarshmallowField):
     def __init__(self):
         super().__init__(ECDDefaultsConfig)
-
-    @staticmethod
-    def _jsonschema_type_mapping():
-        return get_ecd_defaults_jsonschema()

--- a/ludwig/schema/defaults/gbm.py
+++ b/ludwig/schema/defaults/gbm.py
@@ -18,26 +18,6 @@ class GBMDefaultsConfig(BaseDefaultsConfig):
 
 
 @DeveloperAPI
-def get_gbm_defaults_jsonschema():
-    """Returns a JSON schema structured to only require a `type` key and then conditionally apply a corresponding
-    combiner's field constraints."""
-    preproc_schema = schema_utils.unload_jsonschema_from_marshmallow_class(GBMDefaultsConfig)
-    props = preproc_schema["properties"]
-
-    return {
-        "type": "object",
-        "properties": props,
-        "additionalProperties": False,
-        "title": "global_defaults_options",
-        "description": "Set global defaults for input and output features",
-    }
-
-
-@DeveloperAPI
 class GBMDefaultsField(schema_utils.DictMarshmallowField):
     def __init__(self):
         super().__init__(GBMDefaultsConfig)
-
-    @staticmethod
-    def _jsonschema_type_mapping():
-        return get_gbm_defaults_jsonschema()

--- a/ludwig/schema/defaults/utils.py
+++ b/ludwig/schema/defaults/utils.py
@@ -30,8 +30,7 @@ def DefaultsDataclassField(feature_type: str):
                     raise ValidationError(f"Invalid params: {value}, see `{attr}` definition. Error: {error}")
             raise ValidationError(f"Invalid params: {value}")
 
-        @staticmethod
-        def _jsonschema_type_mapping():
+        def _jsonschema_type_mapping(self):
             defaults_cls = defaults_config_registry[feature_type]
             props = schema_utils.unload_jsonschema_from_marshmallow_class(defaults_cls)["properties"]
             return {

--- a/ludwig/schema/encoders/utils.py
+++ b/ludwig/schema/encoders/utils.py
@@ -102,8 +102,7 @@ def EncoderDataclassField(model_type: str, feature_type: str, default: str, desc
         def get_schema_from_registry(self, key: str) -> Type[schema_utils.BaseMarshmallowConfig]:
             return encoder_registry[key]
 
-        @staticmethod
-        def _jsonschema_type_mapping():
+        def _jsonschema_type_mapping(self):
             return {
                 "type": "object",
                 "properties": {

--- a/ludwig/schema/features/augmentation/utils.py
+++ b/ludwig/schema/features/augmentation/utils.py
@@ -98,8 +98,7 @@ def AugmentationDataclassField(
                     )
             return augmentation_list
 
-        @staticmethod
-        def _jsonschema_type_mapping():
+        def _jsonschema_type_mapping(self):
             return get_augmentation_list_jsonschema(feature_type, default)
 
     try:

--- a/ludwig/schema/features/base.py
+++ b/ludwig/schema/features/base.py
@@ -250,8 +250,7 @@ class ECDInputFeatureSelection(FeaturesTypeSelection):
     def __init__(self):
         super().__init__(registry=ecd_input_config_registry, description="Type of the input feature")
 
-    @staticmethod
-    def _jsonschema_type_mapping():
+    def _jsonschema_type_mapping(self):
         return get_input_feature_jsonschema(MODEL_ECD)
 
 
@@ -259,8 +258,7 @@ class GBMInputFeatureSelection(FeaturesTypeSelection):
     def __init__(self):
         super().__init__(registry=gbm_input_config_registry, description="Type of the input feature")
 
-    @staticmethod
-    def _jsonschema_type_mapping():
+    def _jsonschema_type_mapping(self):
         return get_input_feature_jsonschema(MODEL_GBM)
 
 
@@ -268,8 +266,7 @@ class ECDOutputFeatureSelection(FeaturesTypeSelection):
     def __init__(self):
         super().__init__(registry=output_config_registry, description="Type of the output feature")
 
-    @staticmethod
-    def _jsonschema_type_mapping():
+    def _jsonschema_type_mapping(self):
         return get_output_feature_jsonschema(MODEL_ECD)
 
 
@@ -277,6 +274,5 @@ class GBMOutputFeatureSelection(FeaturesTypeSelection):
     def __init__(self):
         super().__init__(max_length=1, registry=output_config_registry, description="Type of the output feature")
 
-    @staticmethod
-    def _jsonschema_type_mapping():
+    def _jsonschema_type_mapping(self):
         return get_output_feature_jsonschema(MODEL_GBM)

--- a/ludwig/schema/features/loss/utils.py
+++ b/ludwig/schema/features/loss/utils.py
@@ -33,8 +33,7 @@ def LossDataclassField(feature_type: str, default: str) -> Field:
         def get_schema_from_registry(self, key: str) -> Type[schema_utils.BaseMarshmallowConfig]:
             return get_loss_cls(feature_type, key)
 
-        @staticmethod
-        def _jsonschema_type_mapping():
+        def _jsonschema_type_mapping(self):
             return {
                 "type": "object",
                 "properties": {

--- a/ludwig/schema/features/preprocessing/utils.py
+++ b/ludwig/schema/features/preprocessing/utils.py
@@ -48,8 +48,7 @@ def PreprocessingDataclassField(feature_type: str):
                 )
             raise ValidationError("Field should be None or dict")
 
-        @staticmethod
-        def _jsonschema_type_mapping():
+        def _jsonschema_type_mapping(self):
             preprocessor_cls = preprocessing_registry[feature_type]
             props = schema_utils.unload_jsonschema_from_marshmallow_class(preprocessor_cls)["properties"]
             return {

--- a/ludwig/schema/hyperopt/__init__.py
+++ b/ludwig/schema/hyperopt/__init__.py
@@ -85,6 +85,5 @@ class HyperoptField(schema_utils.DictMarshmallowField):
     def __init__(self):
         super().__init__(HyperoptConfig, default_missing=True)
 
-    @staticmethod
-    def _jsonschema_type_mapping():
+    def _jsonschema_type_mapping(self):
         return get_hyperopt_jsonschema()

--- a/ludwig/schema/hyperopt/scheduler.py
+++ b/ludwig/schema/hyperopt/scheduler.py
@@ -496,8 +496,7 @@ def SchedulerDataclassField(default={"type": "fifo"}, description="Hyperopt sche
                 )
             raise ValidationError("Field should be None or dict")
 
-        @staticmethod
-        def _jsonschema_type_mapping():
+        def _jsonschema_type_mapping(self):
             # Note that this uses the same conditional pattern as combiners:
             return {
                 "type": "object",

--- a/ludwig/schema/lr_scheduler.py
+++ b/ludwig/schema/lr_scheduler.py
@@ -133,8 +133,7 @@ def LRSchedulerDataclassField(description: str, default: Dict = None):
                     )
             raise ValidationError("Field should be None or dict")
 
-        @staticmethod
-        def _jsonschema_type_mapping():
+        def _jsonschema_type_mapping(self):
             return {
                 **schema_utils.unload_jsonschema_from_marshmallow_class(LRSchedulerConfig),
                 "title": "learning_rate_scheduler_options",

--- a/ludwig/schema/optimizers.py
+++ b/ludwig/schema/optimizers.py
@@ -449,8 +449,7 @@ def OptimizerDataclassField(default="adam", description="", parameter_metadata: 
         def get_schema_from_registry(self, key: str) -> Type[schema_utils.BaseMarshmallowConfig]:
             return get_optimizer_cls(key)
 
-        @staticmethod
-        def _jsonschema_type_mapping():
+        def _jsonschema_type_mapping(self):
             # Note that this uses the same conditional pattern as combiners:
             return {
                 "type": "object",
@@ -528,8 +527,7 @@ def GradientClippingDataclassField(description: str, default: Dict = {}):
                     )
             raise ValidationError("Field should be None or dict")
 
-        @staticmethod
-        def _jsonschema_type_mapping():
+        def _jsonschema_type_mapping(self):
             return {
                 "oneOf": [
                     {"type": "null", "title": "disabled", "description": "Disable gradient clipping."},

--- a/ludwig/schema/preprocessing.py
+++ b/ludwig/schema/preprocessing.py
@@ -40,25 +40,6 @@ class PreprocessingConfig(schema_utils.BaseMarshmallowConfig):
 
 
 @DeveloperAPI
-def get_preprocessing_jsonschema():
-    """Returns a JSON schema structured to only require a `type` key and then conditionally apply a corresponding
-    combiner's field constraints."""
-    preproc_schema = schema_utils.unload_jsonschema_from_marshmallow_class(PreprocessingConfig)
-    props = preproc_schema["properties"]
-    return {
-        "type": "object",
-        "properties": props,
-        "additionalProperties": True,
-        "title": "global_preprocessing_options",
-        "description": "Select the preprocessing type.",
-    }
-
-
-@DeveloperAPI
 class PreprocessingField(schema_utils.DictMarshmallowField):
     def __init__(self):
         super().__init__(PreprocessingConfig)
-
-    @staticmethod
-    def _jsonschema_type_mapping():
-        return get_preprocessing_jsonschema()

--- a/ludwig/schema/split.py
+++ b/ludwig/schema/split.py
@@ -179,8 +179,7 @@ def SplitDataclassField(default: str) -> Field:
         def get_schema_from_registry(self, key: str) -> Type[schema_utils.BaseMarshmallowConfig]:
             return split_config_registry.data[key]
 
-        @staticmethod
-        def _jsonschema_type_mapping():
+        def _jsonschema_type_mapping(self):
             return {
                 "type": "object",
                 "properties": {

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -691,8 +691,7 @@ class ECDTrainerField(schema_utils.DictMarshmallowField):
     def __init__(self):
         super().__init__(ECDTrainerConfig)
 
-    @staticmethod
-    def _jsonschema_type_mapping():
+    def _jsonschema_type_mapping(self):
         return get_trainer_jsonschema(MODEL_ECD)
 
 
@@ -701,6 +700,5 @@ class GBMTrainerField(schema_utils.DictMarshmallowField):
     def __init__(self):
         super().__init__(GBMTrainerConfig)
 
-    @staticmethod
-    def _jsonschema_type_mapping():
+    def _jsonschema_type_mapping(self):
         return get_trainer_jsonschema(MODEL_GBM)

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -1229,3 +1229,6 @@ class DictMarshmallowField(fields.Field):
             metadata={"marshmallow_field": self},
             default_factory=default_factory,
         )
+
+    def _jsonschema_type_mapping(self):
+        return unload_jsonschema_from_marshmallow_class(self.cls)


### PR DESCRIPTION
Redo of #3147  - this time from a native upstream branch rather than from my own fork.

--

* Removes unnecessary staticmethod decorators on JSON type mappings
* Removes `get_preprocessing_jsonschema`
* Adds a default `json_type_mapping` to `DictMarshmallowField`