### PR TITLE
Use tmpdir for more files generated during tests

### DIFF
--- a/tests/integration_tests/scripts/run_train_aim.py
+++ b/tests/integration_tests/scripts/run_train_aim.py
@@ -1,7 +1,7 @@
 import argparse
 import os
-import shutil
 import sys
+import tempfile
 from unittest.mock import Mock
 
 # Comet must be imported before the libraries it wraps
@@ -23,9 +23,9 @@ def run(csv_filename):
     callback.on_train_start = Mock(side_effect=callback.on_train_start)
 
     # Image Inputs
-    image_dest_folder = os.path.join(os.getcwd(), "generated_images")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        image_dest_folder = os.path.join(tmpdir, "generated_images")
 
-    try:
         # Inputs & Outputs
         input_features = [image_feature(folder=image_dest_folder)]
         output_features = [category_feature(output_feature=True)]
@@ -33,9 +33,6 @@ def run(csv_filename):
 
         # Run experiment
         run_experiment(input_features, output_features, dataset=rel_path, callbacks=[callback])
-    finally:
-        # Delete the temporary data created
-        shutil.rmtree(image_dest_folder, ignore_errors=True)
 
     # Check that these methods were called at least once
     callback.on_train_init.assert_called()

--- a/tests/integration_tests/scripts/run_train_comet.py
+++ b/tests/integration_tests/scripts/run_train_comet.py
@@ -9,8 +9,8 @@
 
 import argparse
 import os
-import shutil
 import sys
+import tempfile
 from unittest.mock import Mock, patch
 
 # Comet must be imported before the libraries it wraps
@@ -35,37 +35,33 @@ parser.add_argument("--csv-filename", required=True)
 
 
 def run(csv_filename):
-    # Image Inputs
-    image_dest_folder = os.path.join(os.getcwd(), "generated_images")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Image Inputs
+        image_dest_folder = os.path.join(tmpdir, "generated_images")
 
-    # Inputs & Outputs
-    input_features = [image_feature(folder=image_dest_folder)]
-    output_features = [category_feature(output_feature=True)]
-    data_csv = generate_data(input_features, output_features, csv_filename)
+        # Inputs & Outputs
+        input_features = [image_feature(folder=image_dest_folder)]
+        output_features = [category_feature(output_feature=True)]
+        data_csv = generate_data(input_features, output_features, csv_filename)
 
-    config = {
-        "input_features": input_features,
-        "output_features": output_features,
-        "combiner": {"type": "concat", "output_size": 14},
-        TRAINER: {"epochs": 2, BATCH_SIZE: 128},
-    }
+        config = {
+            "input_features": input_features,
+            "output_features": output_features,
+            "combiner": {"type": "concat", "output_size": 14},
+            TRAINER: {"epochs": 2, BATCH_SIZE: 128},
+        }
 
-    callback = CometCallback()
-    model = LudwigModel(config, callbacks=[callback])
-    output_dir = None
+        callback = CometCallback()
+        model = LudwigModel(config, callbacks=[callback])
 
-    # Wrap these methods so we can check that they were called
-    callback.on_train_init = Mock(side_effect=callback.on_train_init)
-    callback.on_train_start = Mock(side_effect=callback.on_train_start)
+        # Wrap these methods so we can check that they were called
+        callback.on_train_init = Mock(side_effect=callback.on_train_init)
+        callback.on_train_start = Mock(side_effect=callback.on_train_start)
 
-    with patch("comet_ml.Experiment.log_asset_data") as mock_log_asset_data:
-        try:
+        with patch("comet_ml.Experiment.log_asset_data") as mock_log_asset_data:
             # Training with csv
-            _, _, output_dir = model.train(dataset=data_csv)
+            _, _, _ = model.train(dataset=data_csv, output_directory=os.path.join(tmpdir, "output"))
             model.predict(dataset=data_csv)
-        finally:
-            if output_dir:
-                shutil.rmtree(output_dir, ignore_errors=True)
 
     # Verify that the experiment was created successfully
     assert callback.cometml_experiment is not None

--- a/tests/integration_tests/scripts/run_train_wandb.py
+++ b/tests/integration_tests/scripts/run_train_wandb.py
@@ -8,8 +8,8 @@
 
 import argparse
 import os
-import shutil
 import sys
+import tempfile
 from unittest.mock import Mock
 
 from ludwig.contribs.wandb import WandbCallback
@@ -34,10 +34,10 @@ def run(csv_filename):
     # disable sync to cloud
     os.environ["WANDB_MODE"] = "dryrun"
 
-    # Image Inputs
-    image_dest_folder = os.path.join(os.getcwd(), "generated_images")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Image Inputs
+        image_dest_folder = os.path.join(tmpdir, "generated_images")
 
-    try:
         # Inputs & Outputs
         input_features = [image_feature(folder=image_dest_folder)]
         output_features = [category_feature(output_feature=True)]
@@ -45,9 +45,6 @@ def run(csv_filename):
 
         # Run experiment
         run_experiment(input_features, output_features, dataset=rel_path, callbacks=[callback])
-    finally:
-        # Delete the temporary data created
-        shutil.rmtree(image_dest_folder, ignore_errors=True)
 
     # Check that these methods were called at least once
     callback.on_train_init.assert_called()

--- a/tests/integration_tests/test_model_save_and_load.py
+++ b/tests/integration_tests/test_model_save_and_load.py
@@ -36,8 +36,8 @@ def test_model_save_reload_api(tmpdir, csv_filename, tmp_path):
     random.seed(1)
     np.random.seed(1)
 
-    image_dest_folder = os.path.join(os.getcwd(), "generated_images")
-    audio_dest_folder = os.path.join(os.getcwd(), "generated_audio")
+    image_dest_folder = os.path.join(tmpdir, "generated_images")
+    audio_dest_folder = os.path.join(tmpdir, "generated_audio")
 
     input_features = [
         binary_feature(),
@@ -280,7 +280,7 @@ def test_model_save_reload_tv_model(torch_encoder, variant, tmpdir, csv_filename
     random.seed(1)
     np.random.seed(1)
 
-    image_dest_folder = os.path.join(os.getcwd(), "generated_images")
+    image_dest_folder = os.path.join(tmpdir, "generated_images")
 
     input_features = [
         image_feature(image_dest_folder),

--- a/tests/ludwig/augmentation/test_augmentation_pipeline.py
+++ b/tests/ludwig/augmentation/test_augmentation_pipeline.py
@@ -139,14 +139,14 @@ def run_augmentation_training(
         },
     }
 
-    model = LudwigModel(config, logging_level=logging.INFO)
-    model.experiment(
-        dataset=train_fp,
-        skip_save_processed_input=True,
-        skip_save_model=True,
-    )
-    return model
-
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = LudwigModel(config, logging_level=logging.INFO)
+        model.experiment(
+            dataset=train_fp,
+            skip_save_processed_input=True,
+            skip_save_model=True,
+            output_directory=os.path.join(tmpdir, "output"),
+        )
     return model
 
 


### PR DESCRIPTION
We should try and fine a way to do this at a global level for all tests, probably by mocking `get_output_directory` in some form.