### PR TITLE
Add `non_zero` to `common_fields.NumFCLayersField`

### DIFF
--- a/ludwig/schema/common_fields.py
+++ b/ludwig/schema/common_fields.py
@@ -48,6 +48,8 @@ def NumFCLayersField(
         " Increasing layers adds capacity to the model, enabling it to learn more complex feature interactions."
     )
     parameter_metadata = parameter_metadata or COMMON_METADATA["num_fc_layers"]
+
+    # When using a dense encoder, the number of fully connected layers must be strictly greater than 0.
     if non_zero:
         return schema_utils.PositiveInteger(
             default=default, allow_none=False, description=full_description, parameter_metadata=parameter_metadata

--- a/ludwig/schema/common_fields.py
+++ b/ludwig/schema/common_fields.py
@@ -41,6 +41,8 @@ def ResidualField(
 def NumFCLayersField(
     default: int = 0, description: str = None, parameter_metadata: ParameterMetadata = None, non_zero=False
 ) -> Field:
+    assert (not non_zero) or (default > 0 and non_zero)
+
     description = description or "Number of stacked fully connected layers to apply."
     full_description = description + (
         " Increasing layers adds capacity to the model, enabling it to learn more complex feature interactions."

--- a/ludwig/schema/common_fields.py
+++ b/ludwig/schema/common_fields.py
@@ -38,12 +38,18 @@ def ResidualField(
     )
 
 
-def NumFCLayersField(default: int = 0, description: str = None, parameter_metadata: ParameterMetadata = None) -> Field:
+def NumFCLayersField(
+    default: int = 0, description: str = None, parameter_metadata: ParameterMetadata = None, non_zero=False
+) -> Field:
     description = description or "Number of stacked fully connected layers to apply."
     full_description = description + (
         " Increasing layers adds capacity to the model, enabling it to learn more complex feature interactions."
     )
     parameter_metadata = parameter_metadata or COMMON_METADATA["num_fc_layers"]
+    if non_zero:
+        return schema_utils.PositiveInteger(
+            default=default, allow_none=False, description=full_description, parameter_metadata=parameter_metadata
+        )
     return schema_utils.NonNegativeInteger(
         default=default,
         allow_none=False,

--- a/ludwig/schema/encoders/base.py
+++ b/ludwig/schema/encoders/base.py
@@ -95,6 +95,6 @@ class DenseEncoderConfig(BaseEncoderConfig):
 
     norm_params: dict = common_fields.NormParamsField()
 
-    num_layers: int = common_fields.NumFCLayersField(default=1)
+    num_layers: int = common_fields.NumFCLayersField(default=1, non_zero=True)
 
     fc_layers: List[dict] = common_fields.FCLayersField()

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -120,7 +120,7 @@ def test_comparator_fc_layer_config(
         ModelConfig.from_dict(config)
 
 
-def test_dense_binary_encoder_1_layer():
+def test_dense_binary_encoder_0_layer():
     config = {
         "defaults": {"binary": {"encoder": {"norm": "ghost", "num_layers": 0, "output_size": 128, "type": "dense"}}},
         "input_features": [
@@ -128,7 +128,7 @@ def test_dense_binary_encoder_1_layer():
             {"name": "X1", "type": "category"},
             {"name": "X10", "type": "binary"},
             {"name": "X11", "type": "binary"},
-            {"name": "X14", "type": "binary"},
+            {"name": "X14", "type": "binary", "encoder": {"num_layers": 0}},
         ],
         "model_type": "ecd",
         "output_features": [{"name": "y", "type": "number"}],

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -117,3 +117,21 @@ def test_comparator_fc_layer_config(
 
     with pytest.raises(ConfigValidationError) if not expect_success else contextlib.nullcontext():
         ModelConfig.from_dict(config)
+
+
+def test_dense_binary_encoder_1_layer():
+    config = {
+        "defaults": {"binary": {"encoder": {"norm": "ghost", "num_layers": 0, "output_size": 128, "type": "dense"}}},
+        "input_features": [
+            {"name": "X0", "type": "category"},
+            {"name": "X1", "type": "category"},
+            {"name": "X10", "type": "binary"},
+            {"name": "X11", "type": "binary"},
+            {"name": "X14", "type": "binary"},
+        ],
+        "model_type": "ecd",
+        "output_features": [{"name": "y", "type": "number"}],
+        "trainer": {"train_steps": 1},
+    }
+    with pytest.raises(ConfigValidationError):
+        ModelConfig.from_dict(config)

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -11,6 +11,7 @@ import contextlib
 from typing import Any, Dict, Optional
 
 import pytest
+from marshmallow import ValidationError
 
 from ludwig.error import ConfigValidationError
 from ludwig.schema.model_types.base import ModelConfig
@@ -133,5 +134,5 @@ def test_dense_binary_encoder_1_layer():
         "output_features": [{"name": "y", "type": "number"}],
         "trainer": {"train_steps": 1},
     }
-    with pytest.raises(ConfigValidationError):
+    with pytest.raises(ValidationError):
         ModelConfig.from_dict(config)


### PR DESCRIPTION
A dense encoder with 0 `num_layer`s doesn't make sense. This PR adds the option for specifying a `non_zero` argument in `common_fields.NumFCLayersField`.