### PR TITLE
Add auxiliary validation for all features to be present in comparator combiner entities

### DIFF
--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -261,10 +261,10 @@ def check_comparator_combiner_requirements(config: "ModelConfig") -> None:  # no
     """Checks that all of the feature names for entity_1 and entity_2 are valid features."""
     if config.model_type != MODEL_ECD:
         return
-    if config.combiner != "comparator":
+    if config.combiner.type != "comparator":
         return
 
-    input_feature_names = {input_feature.name for input_feature in config.input_features}
+    input_feature_names = [input_feature.name for input_feature in config.input_features]
     for feature_name in config.combiner.entity_1:
         if feature_name not in input_feature_names:
             raise ConfigValidationError(
@@ -275,6 +275,9 @@ def check_comparator_combiner_requirements(config: "ModelConfig") -> None:  # no
             raise ConfigValidationError(
                 f"Feature {feature_name} in entity_2 for the comparator combiner is not a valid " "input feature name."
             )
+
+    if sorted(config.combiner.entity_1 + config.combiner.entity_2) != sorted(input_feature_names):
+        raise ConfigValidationError("Not all input features are present as entities in the comparator combiner.")
 
 
 @register_config_check

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -35,6 +35,35 @@ def test_balance_multiple_class_failure():
         ModelConfig.from_dict(config)
 
 
+def test_all_features_present_in_comparator_entities():
+    config = {
+        "combiner": {
+            "dropout": 0.20198506770751617,
+            "entity_1": ["Age"],
+            "entity_2": ["Sex", "Pclass"],
+            "norm": "batch",
+            "num_fc_layers": 1,
+            "output_size": 256,
+            "type": "comparator",
+        },
+        "input_features": [
+            {"column": "Pclass", "name": "Pclass", "type": "category"},
+            {"column": "Sex", "name": "Sex", "type": "category"},
+            {"column": "Age", "name": "Age", "type": "number"},
+            {"column": "SibSp", "name": "SibSp", "type": "number"},
+            {"column": "Parch", "name": "Parch", "type": "number"},
+            {"column": "Fare", "name": "Fare", "type": "number"},
+            {"column": "Embarked", "name": "Embarked", "type": "category"},
+        ],
+        "model_type": "ecd",
+        "output_features": [{"column": "Survived", "name": "Survived", "type": "category"}],
+        "trainer": {"train_steps": 1},
+    }
+
+    with pytest.raises(ConfigValidationError):
+        ModelConfig.from_dict(config)
+
+
 def test_balance_non_binary_failure():
     config = {
         "input_features": [


### PR DESCRIPTION
When using a comparator combiner, every input feature needs to be present in either `entity_1` or `entity_2`.
This PR adds an auxiliary check for that.