### PR TITLE
Implements `sequence_length` param

### DIFF
--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -374,20 +374,3 @@ def check_stacked_transformer_requirements(config: "ModelConfig") -> None:  # no
                 f"Input feature {input_feature.name} transformer encoder requires encoder.hidden_size to be divisible "
                 f"by encoder.num_heads. Found hidden_size {encoder.hidden_size} and num_heads {encoder.num_heads}."
             )
-
-
-@register_config_check
-def check_sequence_length(config: "ModelConfig") -> None:  # noqa: F821
-    """Checks that `sequence_length` is either None or less than `max_sequence_length`."""
-
-    types_with_sequence_length = [SEQUENCE, TEXT]
-    for input_feature in config.input_features:
-        if input_feature.type in types_with_sequence_length:
-            sequence_length = input_feature.preprocessing.sequence_length
-            max_sequence_length = input_feature.preprocessing.max_sequence_length
-            if sequence_length is not None and sequence_length > max_sequence_length:
-                raise ConfigValidationError(
-                    f"Input feature {input_feature.name} has sequence_length {sequence_length} which is greater than "
-                    f"`max_sequence_length` {max_sequence_length}. Consider setting "
-                    f"`max_sequence_length` to be greater than or equal to `sequence_length`."
-                )

--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -371,3 +371,20 @@ def check_stacked_transformer_requirements(config: "ModelConfig") -> None:  # no
                 f"Input feature {input_feature.name} transformer encoder requires encoder.hidden_size to be divisible "
                 f"by encoder.num_heads. Found hidden_size {encoder.hidden_size} and num_heads {encoder.num_heads}."
             )
+
+
+@register_config_check
+def check_sequence_length(config: "ModelConfig") -> None:  # noqa: F821
+    """Checks that `sequence_length` is either None or less than `max_sequence_length`."""
+
+    types_with_sequence_length = [SEQUENCE, TEXT]
+    for input_feature in config.input_features:
+        if input_feature.type in types_with_sequence_length:
+            sequence_length = input_feature.preprocessing.sequence_length
+            max_sequence_length = input_feature.preprocessing.max_sequence_length
+            if sequence_length is not None and sequence_length > max_sequence_length:
+                raise ConfigValidationError(
+                    f"Input feature {input_feature.name} has sequence_length {sequence_length} which is greater than "
+                    f"`max_sequence_length` {max_sequence_length}. Consider setting "
+                    f"`max_sequence_length` to be greater than or equal to `sequence_length`."
+                )

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -212,6 +212,7 @@ class SequenceFeatureMixin(BaseFeatureMixin):
             ngram_size=preprocessing_parameters["ngram_size"],
             processor=backend.df_engine,
         )
+        logger.info(f"Max length of dataset: {max_length} (without start and stop symbols)")
 
         # Use sequence_length if provided, otherwise use max length found in dataset.
         if preprocessing_parameters["sequence_length"] is not None:

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -212,7 +212,7 @@ class SequenceFeatureMixin(BaseFeatureMixin):
             ngram_size=preprocessing_parameters["ngram_size"],
             processor=backend.df_engine,
         )
-        logger.info(f"Max length of dataset: {max_length} (without start and stop symbols)")
+        logger.info(f"Max length of feature '{column.name}': {max_length} (without start and stop symbols)")
 
         # Use sequence_length if provided, otherwise use max length found in dataset.
         if preprocessing_parameters["sequence_length"] is not None:

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -213,15 +213,25 @@ class SequenceFeatureMixin(BaseFeatureMixin):
             processor=backend.df_engine,
         )
 
-        # Use max_sequence_length if provided, otherwise use max length found in dataset.
-        if preprocessing_parameters["max_sequence_length"] is not None:
-            logger.info("Using max_sequence_length provided in preprocessing parameters")
-            max_sequence_length = preprocessing_parameters["max_sequence_length"]
+        # Use sequence_length if provided, otherwise use max length found in dataset.
+        if preprocessing_parameters["sequence_length"] is not None:
+            logger.info(
+                f"Setting max length to sequence_length={preprocessing_parameters['sequence_length']} provided in "
+                f"preprocessing parameters"
+            )
+            max_sequence_length = preprocessing_parameters["sequence_length"]
         else:
-            logger.info("Inferring max_sequence_length from dataset")
             max_sequence_length = max_length + 2  # For start and stop symbols.
-        logger.info(f"Using max sequence length of {max_sequence_length} for feature '{column.name}'")
+            logger.info(f"Setting max length using dataset: {max_sequence_length} (including start and stop symbols)")
 
+            if preprocessing_parameters["max_sequence_length"] < max_sequence_length:
+                logger.info(
+                    f"Truncating max length with max_sequence_length={preprocessing_parameters['max_sequence_length']} "
+                    f"from preprocessing parameters"
+                )
+                max_sequence_length = preprocessing_parameters["max_sequence_length"]
+
+        logger.info(f"max sequence length is {max_sequence_length} for feature '{column.name}'")
         return {
             "idx2str": idx2str,
             "str2idx": str2idx,

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -224,7 +224,11 @@ class SequenceFeatureMixin(BaseFeatureMixin):
             max_sequence_length = max_length + 2  # For start and stop symbols.
             logger.info(f"Setting max length using dataset: {max_sequence_length} (including start and stop symbols)")
 
-            if preprocessing_parameters["max_sequence_length"] < max_sequence_length:
+            # If max_sequence_length is None, then use the max length found in the dataset.
+            if (
+                preprocessing_parameters["max_sequence_length"] is not None
+                and preprocessing_parameters["max_sequence_length"] < max_sequence_length
+            ):
                 logger.info(
                     f"Truncating max length with max_sequence_length={preprocessing_parameters['max_sequence_length']} "
                     f"from preprocessing parameters"

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -106,7 +106,7 @@ class TextFeatureMixin(BaseFeatureMixin):
             padding_symbol,
             unknown_symbol,
         ) = tf_meta
-        logger.info(f"Max length of dataset: {max_len} (without start and stop symbols)")
+        logger.info(f"Max length of feature '{column.name}': {max_len} (without start and stop symbols)")
 
         # Use sequence_length if provided, otherwise use max length found in dataset.
         if preprocessing_parameters["sequence_length"] is not None:

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -106,6 +106,7 @@ class TextFeatureMixin(BaseFeatureMixin):
             padding_symbol,
             unknown_symbol,
         ) = tf_meta
+        logger.info(f"Max length of dataset: {max_len} (without start and stop symbols)")
 
         # Use sequence_length if provided, otherwise use max length found in dataset.
         if preprocessing_parameters["sequence_length"] is not None:

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -120,7 +120,11 @@ class TextFeatureMixin(BaseFeatureMixin):
             max_sequence_length_99ptile = max_len_99ptile + 2  # For start and stop symbols.
             logger.info(f"Setting max length using dataset: {max_sequence_length} (including start and stop symbols)")
 
-            if preprocessing_parameters["max_sequence_length"] < max_sequence_length:
+            # If max_sequence_length is None, then use the max length found in the dataset.
+            if (
+                preprocessing_parameters["max_sequence_length"] is not None
+                and preprocessing_parameters["max_sequence_length"] < max_sequence_length
+            ):
                 logger.info(
                     f"Truncating max length with max_sequence_length={preprocessing_parameters['max_sequence_length']} "
                     f"from preprocessing parameters"

--- a/ludwig/schema/features/base.py
+++ b/ludwig/schema/features/base.py
@@ -110,7 +110,9 @@ class BaseInputFeatureConfig(BaseFeatureConfig):
         default=None,
         allow_none=True,
         description="Name of input feature to tie the weights of the encoder with.  It needs to be the name of a "
-        "feature of the same type and with the same encoder parameters.",
+        "feature of the same type and with the same encoder parameters. If text or sequence features are tied, "
+        "consider setting the `sequence_length` parameter in `preprocessing` to ensure that the tied features have "
+        "equal sized outputs. This is necessary when using the `sequence` combiner.",
     )
 
     def has_augmentation(self) -> bool:

--- a/ludwig/schema/features/preprocessing/sequence.py
+++ b/ludwig/schema/features/preprocessing/sequence.py
@@ -145,7 +145,7 @@ class SequenceOutputPreprocessingConfig(SequencePreprocessingConfig):
         description="The maximum length (number of tokens) of the sequence. Sequences that are longer than this value "
         "will be truncated. Useful as a stopgap measure if `sequence_length` is set to `None`. If `None`, max sequence "
         "length will be inferred from the training dataset.",
-        parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["max_sequence_length"],
+        parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["max_sequence_length"],
     )
 
     tokenizer: str = schema_utils.String(

--- a/ludwig/schema/features/preprocessing/sequence.py
+++ b/ludwig/schema/features/preprocessing/sequence.py
@@ -27,12 +27,20 @@ class SequencePreprocessingConfig(BasePreprocessingConfig):
         parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["vocab_file"],
     )
 
-    max_sequence_length: int = schema_utils.PositiveInteger(
+    sequence_length: int = schema_utils.PositiveInteger(
         default=None,
         allow_none=True,
-        description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
-        "truncated, while texts that are shorter will be padded. If None, max sequence length will be inferred from "
-        "the training dataset.",
+        description="The desired length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated and sequences shorter than this value will be padded. If None, sequence length will be "
+        "inferred from the training dataset.",
+    )
+
+    max_sequence_length: int = schema_utils.PositiveInteger(
+        default=256,
+        allow_none=True,
+        description="The maximum length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated. Useful as a stopgap measure if `sequence_length` is set to `None`. If `None`, max sequence "
+        "length will be inferred from the training dataset.",
         parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["max_sequence_length"],
     )
 
@@ -124,11 +132,10 @@ class SequenceOutputPreprocessingConfig(SequencePreprocessingConfig):
     )
 
     max_sequence_length: int = schema_utils.PositiveInteger(
-        default=None,
+        default=256,
         allow_none=True,
-        description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
-        "truncated, while texts that are shorter will be padded. If None, max sequence length will be inferred from "
-        "the training dataset.",
+        description="The maximum length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated. If None, max sequence length will be inferred from the training dataset.",
         parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["max_sequence_length"],
     )
 

--- a/ludwig/schema/features/preprocessing/sequence.py
+++ b/ludwig/schema/features/preprocessing/sequence.py
@@ -33,6 +33,7 @@ class SequencePreprocessingConfig(BasePreprocessingConfig):
         description="The desired length (number of tokens) of the sequence. Sequences that are longer than this value "
         "will be truncated and sequences shorter than this value will be padded. If None, sequence length will be "
         "inferred from the training dataset.",
+        parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["sequence_length"],
     )
 
     max_sequence_length: int = schema_utils.PositiveInteger(

--- a/ludwig/schema/features/preprocessing/sequence.py
+++ b/ludwig/schema/features/preprocessing/sequence.py
@@ -131,12 +131,21 @@ class SequenceOutputPreprocessingConfig(SequencePreprocessingConfig):
         parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["missing_value_strategy"],
     )
 
+    sequence_length: int = schema_utils.PositiveInteger(
+        default=None,
+        allow_none=True,
+        description="The desired length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated and sequences shorter than this value will be padded. If None, sequence length will be "
+        "inferred from the training dataset.",
+    )
+
     max_sequence_length: int = schema_utils.PositiveInteger(
         default=256,
         allow_none=True,
         description="The maximum length (number of tokens) of the sequence. Sequences that are longer than this value "
-        "will be truncated. If None, max sequence length will be inferred from the training dataset.",
-        parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["max_sequence_length"],
+        "will be truncated. Useful as a stopgap measure if `sequence_length` is set to `None`. If `None`, max sequence "
+        "length will be inferred from the training dataset.",
+        parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["max_sequence_length"],
     )
 
     tokenizer: str = schema_utils.String(

--- a/ludwig/schema/features/preprocessing/text.py
+++ b/ludwig/schema/features/preprocessing/text.py
@@ -38,12 +38,20 @@ class TextPreprocessingConfig(BasePreprocessingConfig):
         parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["vocab_file"],
     )
 
-    max_sequence_length: int = schema_utils.PositiveInteger(
+    sequence_length: int = schema_utils.PositiveInteger(
         default=None,
         allow_none=True,
-        description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
-        "truncated, while texts that are shorter will be padded. If None, max sequence length will be inferred from "
-        "the training dataset.",
+        description="The desired length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated and sequences shorter than this value will be padded. If None, sequence length will be "
+        "inferred from the training dataset.",
+    )
+
+    max_sequence_length: int = schema_utils.PositiveInteger(
+        default=256,
+        allow_none=True,
+        description="The maximum length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated. Useful as a stopgap measure if `sequence_length` is set to `None`. If `None`, max sequence "
+        "length will be inferred from the training dataset.",
         parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["max_sequence_length"],
     )
 
@@ -139,12 +147,20 @@ class TextOutputPreprocessingConfig(TextPreprocessingConfig):
         parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["missing_value_strategy"],
     )
 
-    max_sequence_length: int = schema_utils.PositiveInteger(
+    sequence_length: int = schema_utils.PositiveInteger(
         default=None,
         allow_none=True,
-        description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
-        "truncated, while texts that are shorter will be padded. If None, max sequence length will be inferred from "
-        "the training dataset.",
+        description="The desired length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated and sequences shorter than this value will be padded. If None, sequence length will be "
+        "inferred from the training dataset.",
+    )
+
+    max_sequence_length: int = schema_utils.PositiveInteger(
+        default=256,
+        allow_none=True,
+        description="The maximum length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated. Useful as a stopgap measure if `sequence_length` is set to `None`. If `None`, max sequence "
+        "length will be inferred from the training dataset.",
         parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["max_sequence_length"],
     )
 

--- a/ludwig/schema/features/preprocessing/text.py
+++ b/ludwig/schema/features/preprocessing/text.py
@@ -153,6 +153,7 @@ class TextOutputPreprocessingConfig(TextPreprocessingConfig):
         description="The desired length (number of tokens) of the sequence. Sequences that are longer than this value "
         "will be truncated and sequences shorter than this value will be padded. If None, sequence length will be "
         "inferred from the training dataset.",
+        parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["sequence_length"],
     )
 
     max_sequence_length: int = schema_utils.PositiveInteger(

--- a/ludwig/schema/metadata/configs/features.yaml
+++ b/ludwig/schema/metadata/configs/features.yaml
@@ -576,6 +576,23 @@ sequence:
         lowercase:
             ui_display_name: null
             expected_impact: 2
+        sequence_length:
+            default_value_reasoning:
+                The default value is `None`. Which means that the sequence length will be inferred from the dataset,
+                which may save you compute resources on datasets with short sequence samples.
+            description_implications:
+                A larger sequence length keeps more information
+                from the data, but also makes it more computationally expensive (more
+                memory and longer training time). A smaller sequence length keeps
+                less information from the data, but also makes it less computationally
+                expensive (less memory and shorter training time).
+            expected_impact: 3
+            related_parameters:
+                - max_sequence_length
+            suggested_values:
+                If tying the weights of multiple sequence encoders together,
+                this parameter may need to be set to ensure that all sequence features have the same sequence length.
+            ui_display_name: Sequence Length
         max_sequence_length:
             default_value_reasoning:
                 The default value is 256. Every sequence will
@@ -763,6 +780,23 @@ text:
                 words and lowercased words differently, then set this to False. Otherwise,
                 it is preferable to bucket the words and make the model case-insensitive.
             ui_display_name: Convert to lowercase
+        sequence_length:
+            default_value_reasoning:
+                The default value is `None`. Which means that the sequence length will be inferred from the dataset,
+                which may save you compute resources on datasets with short text samples.
+            description_implications:
+                A larger sequence length keeps more information
+                from the data, but also makes it more computationally expensive (more
+                memory and longer training time). A smaller sequence length keeps
+                less information from the data, but also makes it less computationally
+                expensive (less memory and shorter training time).
+            expected_impact: 3
+            related_parameters:
+                - max_sequence_length
+            suggested_values:
+                If tying the weights of multiple text encoders together,
+                this parameter may need to be set to ensure that all text features have the same sequence length.
+            ui_display_name: Sequence Length
         max_sequence_length:
             default_value_reasoning:
                 The default value is 256. Every sequence will

--- a/ludwig/schema/model_types/base.py
+++ b/ludwig/schema/model_types/base.py
@@ -19,6 +19,7 @@ from ludwig.schema.model_types.utils import (
     merge_with_defaults,
     set_derived_feature_columns_,
     set_hyperopt_defaults_,
+    set_preprocessing_parameters,
     set_validation_parameters,
 )
 from ludwig.schema.preprocessing import PreprocessingConfig
@@ -51,6 +52,9 @@ class ModelConfig(schema_utils.BaseMarshmallowConfig, ABC):
     def __post_init__(self):
         set_validation_parameters(self)
         set_hyperopt_defaults_(self)
+
+        # Reconcile conflicting preprocessing parameters
+        set_preprocessing_parameters(self)
 
         # Derive proc_col for each feature from the feature's preprocessing parameters
         # after all preprocessing parameters have been set

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ dataclasses-json
 jsonschema>=4.5.0,<4.7
 marshmallow
 marshmallow-jsonschema
-marshmallow-dataclass==8.5.5
+marshmallow-dataclass==8.5.4
 tensorboard
 torchmetrics>=0.11
 torchinfo

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -517,12 +517,12 @@ def test_experiment_tied_weights_sequence_combiner(csv_filename):
         text_feature(
             name="feature1",
             encoder={
-                "max_len": 7,
+                "max_len": 5,
                 "type": "auto_transformer",
                 "pretrained_model_name_or_path": "hf-internal-testing/tiny-bert-for-token-classification",
                 "reduce_output": None,
             },
-            preprocessing={"sequence_length": 50},
+            preprocessing={"sequence_length": 20},
         ),
         text_feature(
             name="feature2",
@@ -532,7 +532,7 @@ def test_experiment_tied_weights_sequence_combiner(csv_filename):
                 "pretrained_model_name_or_path": "hf-internal-testing/tiny-bert-for-token-classification",
                 "reduce_output": None,
             },
-            preprocessing={"sequence_length": 50},
+            preprocessing={"sequence_length": 20},
             tied="feature1",
         ),
     ]

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -518,21 +518,17 @@ def test_experiment_tied_weights_sequence_combiner(csv_filename):
             name="feature1",
             encoder={
                 "max_len": 5,
-                "type": "auto_transformer",
-                "pretrained_model_name_or_path": "hf-internal-testing/tiny-bert-for-token-classification",
                 "reduce_output": None,
             },
-            preprocessing={"sequence_length": 20},
+            preprocessing={"sequence_length": 10},
         ),
         text_feature(
             name="feature2",
             encoder={
                 "max_len": 3,
-                "type": "auto_transformer",
-                "pretrained_model_name_or_path": "hf-internal-testing/tiny-bert-for-token-classification",
                 "reduce_output": None,
             },
-            preprocessing={"sequence_length": 20},
+            preprocessing={"sequence_length": 10},
             tied="feature1",
         ),
     ]

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -15,6 +15,7 @@ from ludwig.callbacks import Callback
 from ludwig.constants import BATCH_SIZE, COLUMN, DECODER, FULL, NAME, PROC_COLUMN, TRAINER
 from ludwig.data.concatenate_datasets import concatenate_df
 from ludwig.data.preprocessing import preprocess_for_prediction
+from ludwig.error import ConfigValidationError
 from tests.integration_tests.utils import (
     assert_preprocessed_dataset_shape_and_dtype_for_feature,
     audio_feature,
@@ -394,9 +395,6 @@ def test_number_feature_wrong_dtype(csv_filename, tmpdir):
         # Case 4: set sequence_length explicitly and it is smaller than the dataset.
         # Expected: sequence_length is used, and the sequence length is sequence_length.
         (10, 8, 20, 8),
-        # Case 5: set sequence_length explicitly and it is larger than both the dataset and max_sequence_length.
-        # Expected: ??? TODO(geoffrey): determine expected behavior.
-        (10, 15, 12, 15),
     ],
 )
 @pytest.mark.parametrize(
@@ -409,7 +407,7 @@ def test_number_feature_wrong_dtype(csv_filename, tmpdir):
 def test_seq_features_max_sequence_length(
     csv_filename, tmpdir, feature_type, max_len, sequence_length, max_sequence_length, sequence_length_expected
 ):
-    """Tests that a text feature has the correct max_sequence_length."""
+    """Tests that a sequence feature has the correct max_sequence_length in metadata and prepocessed data."""
     feat = feature_type(
         encoder={"max_len": max_len},
         preprocessing={"sequence_length": sequence_length, "max_sequence_length": max_sequence_length},
@@ -433,6 +431,26 @@ def test_seq_features_max_sequence_length(
     all_df = concatenate_df(train_ds.to_df(), val_ds.to_df(), test_ds.to_df(), backend)
     proc_column_name = feat[PROC_COLUMN]
     assert all(len(x) == sequence_length_expected for x in all_df[proc_column_name])
+
+
+@pytest.mark.parametrize(
+    "feature_type",
+    [
+        sequence_feature,
+        text_feature,
+    ],
+)
+def test_seq_features_max_sequence_length_error(feature_type):
+    """Tests that a sequence feature with invalid `sequence_length` and `max_sequence_length` raises an error."""
+    feat = feature_type(
+        preprocessing={"sequence_length": 40, "max_sequence_length": 20},
+    )
+    input_features = [feat]
+    output_features = [binary_feature()]
+    config = {"input_features": input_features, "output_features": output_features}
+
+    with pytest.raises(ConfigValidationError):
+        LudwigModel(config, backend=LocalTestBackend())
 
 
 def test_column_feature_type_mismatch_fill():

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -436,26 +436,6 @@ def test_seq_features_max_sequence_length(
     assert all(len(x) == sequence_length_expected for x in all_df[proc_column_name])
 
 
-@pytest.mark.parametrize(
-    "feature_type",
-    [
-        sequence_feature,
-        text_feature,
-    ],
-)
-def test_seq_features_max_sequence_length_error(feature_type):
-    """Tests that a sequence feature with invalid `sequence_length` and `max_sequence_length` raises an error."""
-    feat = feature_type(
-        preprocessing={"sequence_length": 40, "max_sequence_length": 20},
-    )
-    input_features = [feat]
-    output_features = [binary_feature()]
-    config = {"input_features": input_features, "output_features": output_features}
-
-    with pytest.raises(ConfigValidationError):
-        LudwigModel(config, backend=LocalTestBackend())
-
-
 def test_column_feature_type_mismatch_fill():
     """Tests that we are able to fill missing values even in columns where the column dtype and desired feature
     dtype do not match."""

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -380,19 +380,41 @@ def test_number_feature_wrong_dtype(csv_filename, tmpdir):
 
 
 @pytest.mark.parametrize(
-    "max_len, max_sequence_length, max_sequence_length_expected",
+    "max_len, sequence_length, max_sequence_length, sequence_length_expected",
     [
-        (10, None, 12),  # None means to infer from the dataset. Add 2 to expected value for start and end tokens.
-        (10, 5, 5),
-        (10, 15, 15),
+        # Case 1: infer from the dataset, max_sequence_length is larger than the largest sequence length.
+        # Expected: max_sequence_length is ignored, and the sequence length is dataset+2 (include start/stop tokens).
+        (10, None, 15, 12),
+        # Case 2: infer from the dataset, max_sequence_length is smaller than the largest sequence length.
+        # Expected: max_sequence_length is used, and the sequence length is max_sequence_length.
+        (10, None, 8, 8),
+        # Case 3: set sequence_length explicitly and it is larger than the dataset.
+        # Expected: sequence_length is used, and the sequence length is sequence_length.
+        (10, 15, 20, 15),
+        # Case 4: set sequence_length explicitly and it is smaller than the dataset.
+        # Expected: sequence_length is used, and the sequence length is sequence_length.
+        (10, 8, 20, 8),
+        # Case 5: set sequence_length explicitly and it is larger than both the dataset and max_sequence_length.
+        # Expected: ??? TODO(geoffrey): determine expected behavior.
+        (10, 15, 12, 15),
     ],
 )
-def test_text_features_max_sequence_length(
-    csv_filename, tmpdir, max_len, max_sequence_length, max_sequence_length_expected
+@pytest.mark.parametrize(
+    "feature_type",
+    [
+        sequence_feature,
+        text_feature,
+    ],
+)
+def test_seq_features_max_sequence_length(
+    csv_filename, tmpdir, feature_type, max_len, sequence_length, max_sequence_length, sequence_length_expected
 ):
     """Tests that a text feature has the correct max_sequence_length."""
-    text_feat = text_feature(encoder={"max_len": max_len}, preprocessing={"max_sequence_length": max_sequence_length})
-    input_features = [text_feat]
+    feat = feature_type(
+        encoder={"max_len": max_len},
+        preprocessing={"sequence_length": sequence_length, "max_sequence_length": max_sequence_length},
+    )
+    input_features = [feat]
     output_features = [binary_feature()]
     config = {"input_features": input_features, "output_features": output_features}
 
@@ -402,15 +424,15 @@ def test_text_features_max_sequence_length(
 
     class CheckTrainingSetMetadataCallback(Callback):
         def on_preprocess_end(self, proc_training_set, proc_validation_set, proc_test_set, training_set_metadata):
-            assert training_set_metadata[text_feat[NAME]]["max_sequence_length"] == max_sequence_length_expected
+            assert training_set_metadata[feat[NAME]]["max_sequence_length"] == sequence_length_expected
 
     backend = LocalTestBackend()
     ludwig_model = LudwigModel(config, backend=backend, callbacks=[CheckTrainingSetMetadataCallback()])
     train_ds, val_ds, test_ds, _ = ludwig_model.preprocess(dataset=df)
 
     all_df = concatenate_df(train_ds.to_df(), val_ds.to_df(), test_ds.to_df(), backend)
-    proc_column_name = text_feat[PROC_COLUMN]
-    assert all(len(x) == max_sequence_length_expected for x in all_df[proc_column_name])
+    proc_column_name = feat[PROC_COLUMN]
+    assert all(len(x) == sequence_length_expected for x in all_df[proc_column_name])
 
 
 def test_column_feature_type_mismatch_fill():

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -389,10 +389,13 @@ def test_number_feature_wrong_dtype(csv_filename, tmpdir):
         # Case 2: infer from the dataset, max_sequence_length is smaller than the largest sequence length.
         # Expected: max_sequence_length is used, and the sequence length is max_sequence_length.
         (10, None, 8, 8),
-        # Case 3: set sequence_length explicitly and it is larger than the dataset.
+        # Case 3: infer from the dataset, max_sequence_length is not set.
+        # Expected: max_sequence_length is ignored, and the sequence length is dataset+2 (include start/stop tokens).
+        (10, None, None, 12),
+        # Case 4: set sequence_length explicitly and it is larger than the dataset.
         # Expected: sequence_length is used, and the sequence length is sequence_length.
         (10, 15, 20, 15),
-        # Case 4: set sequence_length explicitly and it is smaller than the dataset.
+        # Case 5: set sequence_length explicitly and it is smaller than the dataset.
         # Expected: sequence_length is used, and the sequence length is sequence_length.
         (10, 8, 20, 8),
     ],

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -15,7 +15,6 @@ from ludwig.callbacks import Callback
 from ludwig.constants import BATCH_SIZE, COLUMN, DECODER, FULL, NAME, PROC_COLUMN, TRAINER
 from ludwig.data.concatenate_datasets import concatenate_df
 from ludwig.data.preprocessing import preprocess_for_prediction
-from ludwig.error import ConfigValidationError
 from tests.integration_tests.utils import (
     assert_preprocessed_dataset_shape_and_dtype_for_feature,
     audio_feature,

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -682,3 +682,43 @@ def test_augmentation_pipeline(augmentation, expected):
     # Test the serializing and reloading yields the same results
     config_obj2 = ModelConfig.from_dict(config_dict)
     assert config_obj2.input_features[0].augmentation == config_obj.input_features[0].augmentation
+
+
+@pytest.mark.parametrize(
+    "sequence_length, max_sequence_length, max_sequence_length_expected",
+    [
+        (None, 100, 100),
+        (50, 100, 100),
+        (100, 50, 100),
+    ],
+)
+def test_preprocessing_max_sequence_length(sequence_length, max_sequence_length, max_sequence_length_expected):
+    config = {
+        "input_features": [
+            {
+                "name": "text1",
+                "type": "text",
+                "preprocessing": {
+                    "sequence_length": sequence_length,
+                    "max_sequence_length": max_sequence_length,
+                },
+            },
+            {
+                "name": "sequence1",
+                "type": "sequence",
+                "preprocessing": {
+                    "sequence_length": sequence_length,
+                    "max_sequence_length": max_sequence_length,
+                },
+            },
+        ],
+        "output_features": [
+            {
+                "name": "number1",
+                "type": "number",
+            },
+        ],
+    }
+    config_obj = ModelConfig.from_dict(config)
+    assert config_obj.input_features[0].preprocessing.max_sequence_length == max_sequence_length_expected
+    assert config_obj.input_features[1].preprocessing.max_sequence_length == max_sequence_length_expected


### PR DESCRIPTION
This PR implements a new config param for text and sequence features, `sequence_length`, a nullable positive integer.

`sequence_length` defaults to `None`. This means that the sequence length for a given feature will be inferred from the dataset. The inferred sequence length will be capped at `max_sequence_length`, which defaults to `256`.

If `sequence_length` is not `None`, then the sequence length for a given feature will be the specified value and samples will be padded and truncated as needed. If the specified value for `sequence_length` is greater than `max_sequence_length`, then experiment will fail fast with an error message recommending that you set `max_sequence_length` to a value greater than or equal to `sequence_length`.