### PR TITLE
Schemafy merge_fixed_preprocessing_params

### DIFF
--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -10,7 +10,6 @@ from ludwig.constants import (
     CATEGORY,
     COMBINER,
     DECODER,
-    ENCODER,
     IMAGE,
     IN_MEMORY,
     INPUT_FEATURES,
@@ -29,10 +28,8 @@ from ludwig.constants import (
     VECTOR,
 )
 from ludwig.decoders.registry import get_decoder_registry
-from ludwig.encoders.registry import get_encoder_registry
 from ludwig.error import ConfigValidationError
 from ludwig.schema.combiners.utils import get_combiner_registry
-from ludwig.schema.features.utils import input_config_registry
 from ludwig.schema.optimizers import optimizer_registry
 from ludwig.types import ModelConfigDict
 from ludwig.utils.metric_utils import get_feature_to_metric_names_map_from_feature_collection
@@ -84,28 +81,12 @@ class ConfigCheck(ABC):
 
 def check_basic_required_parameters(config: ModelConfigDict) -> None:
     """Checks basic required parameters like that all features have names and types, and all types are valid."""
-    model_type = config["model_type"]
-
     # Check input features.
     for input_feature in config[INPUT_FEATURES]:
         if NAME not in input_feature:
             raise ConfigValidationError("All input features must have a name.")
         if TYPE not in input_feature:
             raise ConfigValidationError(f"Input feature {input_feature[NAME]} must have a type.")
-        if input_feature[TYPE] not in input_config_registry(model_type):
-            raise ConfigValidationError(
-                f"Input feature {input_feature[NAME]} uses an invalid/unsupported type "
-                f"'{input_feature[TYPE]}'. Input feature types: {list(get_encoder_registry().keys())}."
-            )
-        if ENCODER in input_feature:
-            if (
-                TYPE in input_feature[ENCODER]
-                and input_feature[ENCODER][TYPE] not in get_encoder_registry()[input_feature[TYPE]]
-            ):
-                raise ConfigValidationError(
-                    f"Encoder type '{input_feature[ENCODER][TYPE]}' for input feature {input_feature[NAME]} must be "
-                    f"one of: {list(get_encoder_registry()[input_feature[TYPE]].keys())}."
-                )
 
     # Check output features.
     for output_feature in config[OUTPUT_FEATURES]:

--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -8,30 +8,18 @@ from ludwig.constants import (
     AUDIO,
     BINARY,
     CATEGORY,
-    COMBINER,
-    DECODER,
     IMAGE,
     IN_MEMORY,
-    INPUT_FEATURES,
     MODEL_ECD,
     MODEL_GBM,
-    MODEL_TYPE,
-    NAME,
     NUMBER,
-    OUTPUT_FEATURES,
     SEQUENCE,
     SET,
     TEXT,
     TIMESERIES,
-    TRAINER,
-    TYPE,
     VECTOR,
 )
-from ludwig.decoders.registry import get_decoder_registry
 from ludwig.error import ConfigValidationError
-from ludwig.schema.combiners.utils import get_combiner_registry
-from ludwig.schema.optimizers import optimizer_registry
-from ludwig.types import ModelConfigDict
 from ludwig.utils.metric_utils import get_feature_to_metric_names_map_from_feature_collection
 
 if TYPE_CHECKING:
@@ -77,60 +65,6 @@ class ConfigCheck(ABC):
     def check(config: "ModelConfig") -> None:  # noqa: F821
         """Checks config for validity."""
         raise NotImplementedError
-
-
-def check_basic_required_parameters(config: ModelConfigDict) -> None:
-    """Checks basic required parameters like that all features have names and types, and all types are valid."""
-    # Check input features.
-    for input_feature in config[INPUT_FEATURES]:
-        if NAME not in input_feature:
-            raise ConfigValidationError("All input features must have a name.")
-        if TYPE not in input_feature:
-            raise ConfigValidationError(f"Input feature {input_feature[NAME]} must have a type.")
-
-    # Check output features.
-    for output_feature in config[OUTPUT_FEATURES]:
-        if NAME not in output_feature:
-            raise ConfigValidationError("All output features must have a name.")
-        if TYPE not in output_feature:
-            raise ConfigValidationError(f"Output feature {output_feature[NAME]} must have a type.")
-        if output_feature[TYPE] not in get_decoder_registry():
-            raise ConfigValidationError(
-                f"Output feature {output_feature[NAME]} uses an invalid/unsupported output type "
-                f"'{output_feature[TYPE]}'. Supported output features: {list(get_decoder_registry().keys())}."
-            )
-        if DECODER in output_feature:
-            if (
-                TYPE in output_feature[DECODER]
-                and output_feature[DECODER][TYPE] not in get_decoder_registry()[output_feature[TYPE]]
-            ):
-                raise ConfigValidationError(
-                    f"Decoder type for output feature {output_feature[NAME]} must be one of: "
-                    f"{list(get_decoder_registry()[output_feature[TYPE]].keys())}."
-                )
-
-    # Check combiners.
-    if config.get(MODEL_TYPE, MODEL_ECD) == MODEL_ECD:
-        if COMBINER not in config:
-            return
-        if TYPE not in config[COMBINER]:
-            raise ConfigValidationError("Combiner must have a type.")
-        if config[COMBINER][TYPE] not in get_combiner_registry():
-            raise ConfigValidationError(f"Combiner type must be one of: {list(get_combiner_registry().keys())}.")
-
-    # Check trainer.
-    if TRAINER in config and config[TRAINER] is None:
-        raise ConfigValidationError("Trainer cannot be None.")
-
-    # Check optimizer.
-    if TRAINER in config and "optimizer" in config[TRAINER]:
-        if config[TRAINER]["optimizer"] is None:
-            raise ConfigValidationError("Trainer.optimizer cannot be None.")
-        if TYPE in config[TRAINER]["optimizer"]:
-            if config[TRAINER]["optimizer"][TYPE] not in optimizer_registry:
-                raise ConfigValidationError(
-                    f"Trainer.optimizer.type must be one of: {list(optimizer_registry.keys())}."
-                )
 
 
 @register_config_check

--- a/ludwig/schema/encoders/base.py
+++ b/ludwig/schema/encoders/base.py
@@ -1,11 +1,12 @@
 from abc import ABC
-from typing import Any, Dict, List, Union
+from typing import List, Union
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import BINARY, MODEL_ECD, MODEL_GBM, NUMBER, VECTOR
 from ludwig.schema import common_fields
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.utils import register_encoder_config
+from ludwig.schema.features.preprocessing.base import BasePreprocessingConfig
 from ludwig.schema.metadata import ENCODER_METADATA
 from ludwig.schema.utils import ludwig_dataclass
 
@@ -23,8 +24,8 @@ class BaseEncoderConfig(schema_utils.BaseMarshmallowConfig, ABC):
         parameter_metadata=ENCODER_METADATA["BaseEncoder"]["skip"],
     )
 
-    def get_fixed_preprocessing_params(self, model_type: str) -> Dict[str, Any]:
-        return {}
+    def set_fixed_preprocessing_params(self, model_type: str, preprocessing: BasePreprocessingConfig):
+        pass
 
     def is_pretrained(self) -> bool:
         return False

--- a/ludwig/schema/encoders/category_encoders.py
+++ b/ludwig/schema/encoders/category_encoders.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import List
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import CATEGORY, MODEL_ECD, MODEL_GBM
@@ -6,6 +6,7 @@ from ludwig.schema import common_fields
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.base import BaseEncoderConfig
 from ludwig.schema.encoders.utils import register_encoder_config
+from ludwig.schema.features.preprocessing.category import CategoryPreprocessingConfig
 from ludwig.schema.metadata import ENCODER_METADATA
 from ludwig.schema.utils import ludwig_dataclass
 
@@ -105,13 +106,9 @@ class CategoricalOneHotEncoderConfig(BaseEncoderConfig):
 
     vocab: List[str] = common_fields.VocabField()
 
-    def get_fixed_preprocessing_params(self, model_type: str) -> Dict[str, Any]:
+    def set_fixed_preprocessing_params(self, model_type: str, preprocessing: CategoryPreprocessingConfig):
         if model_type == MODEL_GBM:
-            return {
-                "cache_encoder_embeddings": True,
-            }
-
-        return {}
+            preprocessing.cache_encoder_embeddings = True
 
     def can_cache_embeddings(self) -> bool:
         return True

--- a/ludwig/schema/encoders/image/base.py
+++ b/ludwig/schema/encoders/image/base.py
@@ -1,22 +1,21 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ludwig.api_annotations import DeveloperAPI
-from ludwig.constants import HEIGHT, IMAGE, REQUIRES_EQUAL_DIMENSIONS, WIDTH
+from ludwig.constants import IMAGE
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.base import BaseEncoderConfig
 from ludwig.schema.encoders.utils import register_encoder_config
+from ludwig.schema.features.preprocessing.image import ImagePreprocessingConfig
 from ludwig.schema.metadata import ENCODER_METADATA
 from ludwig.schema.utils import ludwig_dataclass
 from ludwig.utils.torch_utils import initializer_registry
 
 
 class ImageEncoderConfig(BaseEncoderConfig):
-    def get_fixed_preprocessing_params(self, model_type: str) -> Dict[str, Any]:
-        return {
-            REQUIRES_EQUAL_DIMENSIONS: False,
-            HEIGHT: None,
-            WIDTH: None,
-        }
+    def set_fixed_preprocessing_params(self, model_type: str, preprocessing: ImagePreprocessingConfig):
+        preprocessing.requires_equal_dimensions = False
+        preprocessing.height = None
+        preprocessing.width = None
 
 
 @DeveloperAPI
@@ -692,18 +691,16 @@ class ViTConfig(ImageEncoderConfig):
         parameter_metadata=ENCODER_METADATA["ViT"]["pretrained_model"],
     )
 
-    def get_fixed_preprocessing_params(self, model_type: str) -> Dict[str, Any]:
+    def set_fixed_preprocessing_params(self, model_type: str, preprocessing: ImagePreprocessingConfig):
         """If the encoder is not in trainable mode, override the image width and height to be compatible with the
         pretrained encoder image dimension requirements."""
         if self.requires_equal_dimensions() and self.required_width() != self.required_height():
-            raise ValueError("Invalid definition. required_width and required_height are not equal")
+            raise ValueError("Invalid definition. `required_width` and `required_height` are not equal")
 
-        preprocessing_parameters = {REQUIRES_EQUAL_DIMENSIONS: self.requires_equal_dimensions()}
+        preprocessing.requires_equal_dimensions = self.requires_equal_dimensions()
         if not self.trainable or self.use_pretrained:
-            preprocessing_parameters[HEIGHT] = self.required_height()
-            preprocessing_parameters[WIDTH] = self.required_width()
-            return preprocessing_parameters
-        return preprocessing_parameters
+            preprocessing.height = self.required_height()
+            preprocessing.width = self.required_width()
 
     @classmethod
     def requires_equal_dimensions(cls) -> bool:

--- a/ludwig/schema/encoders/sequence_encoders.py
+++ b/ludwig/schema/encoders/sequence_encoders.py
@@ -1,5 +1,5 @@
 from dataclasses import Field
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import AUDIO, SEQUENCE, TEXT, TIMESERIES
@@ -7,6 +7,7 @@ from ludwig.schema import common_fields
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.base import BaseEncoderConfig
 from ludwig.schema.encoders.utils import register_encoder_config
+from ludwig.schema.features.preprocessing.sequence import SequencePreprocessingConfig
 from ludwig.schema.metadata import ENCODER_METADATA
 from ludwig.schema.utils import ludwig_dataclass
 
@@ -70,8 +71,8 @@ def PoolSizeField(default: Optional[int] = None) -> Field:
 class SequenceEncoderConfig(BaseEncoderConfig):
     """Base class for sequence encoders."""
 
-    def get_fixed_preprocessing_params(self, model_type: str) -> Dict[str, Any]:
-        return {"cache_encoder_embeddings": False}
+    def set_fixed_preprocessing_params(self, model_type: str, preprocessing: SequencePreprocessingConfig):
+        preprocessing.cache_encoder_embeddings = False
 
 
 @DeveloperAPI

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -1,10 +1,11 @@
-from typing import Any, Callable, Dict, List, Union
+from typing import Callable, List, Union
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import TEXT
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.sequence_encoders import SequenceEncoderConfig
 from ludwig.schema.encoders.utils import register_encoder_config
+from ludwig.schema.features.preprocessing.text import TextPreprocessingConfig
 from ludwig.schema.metadata import ENCODER_METADATA
 from ludwig.schema.metadata.parameter_metadata import ParameterMetadata
 from ludwig.schema.utils import ludwig_dataclass
@@ -16,7 +17,7 @@ class HFEncoderConfig(SequenceEncoderConfig):
     pretrained_model_name_or_path: str
     reduce_output: str
 
-    def get_fixed_preprocessing_params(self, model_type: str) -> Dict[str, Any]:
+    def set_fixed_preprocessing_params(self, model_type: str, preprocessing: TextPreprocessingConfig):
         model_name = self.pretrained_model_name_or_path
         if model_name is None and self.use_pretrained:
             # no default model name, so model name is required by the subclass
@@ -24,15 +25,10 @@ class HFEncoderConfig(SequenceEncoderConfig):
                 f"Missing required parameter for `{self.type}` encoder: `pretrained_model_name_or_path` when "
                 "`use_pretrained` is True."
             )
-        params = {
-            "tokenizer": "hf_tokenizer",
-            "pretrained_model_name_or_path": model_name,
-        }
-
+        preprocessing.tokenizer = "hf_tokenizer"
+        preprocessing.pretrained_model_name_or_path = model_name
         if not self.can_cache_embeddings():
-            params["cache_encoder_embeddings"] = False
-
-        return params
+            preprocessing.cache_encoder_embeddings = False
 
     def is_pretrained(self) -> bool:
         return self.use_pretrained

--- a/ludwig/schema/features/audio_feature.py
+++ b/ludwig/schema/features/audio_feature.py
@@ -32,7 +32,7 @@ class AudioInputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @ecd_input_config_registry.register(AUDIO)
 @ludwig_dataclass
-class AudioInputFeatureConfig(BaseInputFeatureConfig, AudioInputFeatureConfigMixin):
+class AudioInputFeatureConfig(AudioInputFeatureConfigMixin, BaseInputFeatureConfig):
     """AudioInputFeatureConfig is a dataclass that configures the parameters used for an audio input feature."""
 
     pass

--- a/ludwig/schema/features/audio_feature.py
+++ b/ludwig/schema/features/audio_feature.py
@@ -1,5 +1,6 @@
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import AUDIO, MODEL_ECD
+from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.base import BaseEncoderConfig
 from ludwig.schema.encoders.utils import EncoderDataclassField
 from ludwig.schema.features.base import BaseInputFeatureConfig
@@ -16,6 +17,8 @@ from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 class AudioInputFeatureConfigMixin(BaseMarshmallowConfig):
     """AudioInputFeatureConfigMixin is a dataclass that configures the parameters used in both the audio input
     feature and the audio global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(AUDIO)
 
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=AUDIO)
 

--- a/ludwig/schema/features/bag_feature.py
+++ b/ludwig/schema/features/bag_feature.py
@@ -1,5 +1,6 @@
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import BAG, MODEL_ECD
+from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.base import BaseEncoderConfig
 from ludwig.schema.encoders.utils import EncoderDataclassField
 from ludwig.schema.features.base import BaseInputFeatureConfig
@@ -16,6 +17,8 @@ from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 class BagInputFeatureConfigMixin(BaseMarshmallowConfig):
     """BagInputFeatureConfigMixin is a dataclass that configures the parameters used in both the bag input feature
     and the bag global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(BAG)
 
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=BAG)
 

--- a/ludwig/schema/features/bag_feature.py
+++ b/ludwig/schema/features/bag_feature.py
@@ -32,7 +32,7 @@ class BagInputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @ecd_input_config_registry.register(BAG)
 @ludwig_dataclass
-class BagInputFeatureConfig(BaseInputFeatureConfig, BagInputFeatureConfigMixin):
+class BagInputFeatureConfig(BagInputFeatureConfigMixin, BaseInputFeatureConfig):
     """BagInputFeatureConfig is a dataclass that configures the parameters used for a bag input feature."""
 
     pass

--- a/ludwig/schema/features/base.py
+++ b/ludwig/schema/features/base.py
@@ -23,6 +23,7 @@ from ludwig.constants import (
     TIMESERIES,
     VECTOR,
 )
+from ludwig.error import ConfigValidationError
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.features.utils import (
     ecd_input_config_registry,
@@ -43,6 +44,14 @@ _info_console = Console(stderr=True, style="bold green")
 @ludwig_dataclass
 class BaseFeatureConfig(schema_utils.BaseMarshmallowConfig):
     """Base class for feature configs."""
+
+    def __post_init__(self):
+        # TODO(travis): this should be done through marshmallow dataclass' `required` field param,
+        # but requires a refactor`
+        if self.name is None:
+            raise ConfigValidationError("All features must have a name.")
+        if self.type is None:
+            raise ConfigValidationError(f"Feature {self.name} must have a type.")
 
     active: bool = True
 

--- a/ludwig/schema/features/binary_feature.py
+++ b/ludwig/schema/features/binary_feature.py
@@ -32,6 +32,8 @@ class BinaryInputFeatureConfigMixin(BaseMarshmallowConfig):
     """BinaryInputFeatureConfigMixin is a dataclass that configures the parameters used in both the binary input
     feature and the binary global defaults section of the Ludwig Config."""
 
+    type: str = schema_utils.ProtectedString(BINARY)
+
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=BINARY)
 
 
@@ -71,6 +73,8 @@ class GBMBinaryInputFeatureConfig(BinaryInputFeatureConfig):
 class BinaryOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """BinaryOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the binary output
     feature and the binary global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(BINARY)
 
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=BINARY,

--- a/ludwig/schema/features/binary_feature.py
+++ b/ludwig/schema/features/binary_feature.py
@@ -39,7 +39,7 @@ class BinaryInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @ludwig_dataclass
-class BinaryInputFeatureConfig(BaseInputFeatureConfig, BinaryInputFeatureConfigMixin):
+class BinaryInputFeatureConfig(BinaryInputFeatureConfigMixin, BaseInputFeatureConfig):
     """BinaryInputFeatureConfig is a dataclass that configures the parameters used for a binary input feature."""
 
     encoder: BaseEncoderConfig = None
@@ -90,7 +90,7 @@ class BinaryOutputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @output_config_registry.register(BINARY)
 @ludwig_dataclass
-class BinaryOutputFeatureConfig(BaseOutputFeatureConfig, BinaryOutputFeatureConfigMixin):
+class BinaryOutputFeatureConfig(BinaryOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """BinaryOutputFeatureConfig is a dataclass that configures the parameters used for a binary output feature."""
 
     calibration: bool = schema_utils.Boolean(

--- a/ludwig/schema/features/category_feature.py
+++ b/ludwig/schema/features/category_feature.py
@@ -32,6 +32,8 @@ class CategoryInputFeatureConfigMixin(BaseMarshmallowConfig):
     """CategoryInputFeatureConfigMixin is a dataclass that configures the parameters used in both the category
     input feature and the category global defaults section of the Ludwig Config."""
 
+    type: str = schema_utils.ProtectedString(CATEGORY)
+
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=CATEGORY)
 
 
@@ -72,6 +74,8 @@ class GBMCategoryInputFeatureConfig(CategoryInputFeatureConfig):
 class CategoryOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """CategoryOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the category
     output feature and the category global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(CATEGORY)
 
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=CATEGORY,

--- a/ludwig/schema/features/category_feature.py
+++ b/ludwig/schema/features/category_feature.py
@@ -39,7 +39,7 @@ class CategoryInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @ludwig_dataclass
-class CategoryInputFeatureConfig(BaseInputFeatureConfig, CategoryInputFeatureConfigMixin):
+class CategoryInputFeatureConfig(CategoryInputFeatureConfigMixin, BaseInputFeatureConfig):
     """CategoryInputFeatureConfig is a dataclass that configures the parameters used for a category input
     feature."""
 
@@ -91,7 +91,7 @@ class CategoryOutputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @output_config_registry.register(CATEGORY)
 @ludwig_dataclass
-class CategoryOutputFeatureConfig(BaseOutputFeatureConfig, CategoryOutputFeatureConfigMixin):
+class CategoryOutputFeatureConfig(CategoryOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """CategoryOutputFeatureConfig is a dataclass that configures the parameters used for a category output
     feature."""
 

--- a/ludwig/schema/features/date_feature.py
+++ b/ludwig/schema/features/date_feature.py
@@ -1,5 +1,6 @@
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import DATE, MODEL_ECD
+from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.base import BaseEncoderConfig
 from ludwig.schema.encoders.utils import EncoderDataclassField
 from ludwig.schema.features.base import BaseInputFeatureConfig
@@ -16,6 +17,8 @@ from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 class DateInputFeatureConfigMixin(BaseMarshmallowConfig):
     """DateInputFeatureConfigMixin is a dataclass that configures the parameters used in both the date input
     feature and the date global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(DATE)
 
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=DATE)
 

--- a/ludwig/schema/features/date_feature.py
+++ b/ludwig/schema/features/date_feature.py
@@ -32,7 +32,7 @@ class DateInputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @ecd_input_config_registry.register(DATE)
 @ludwig_dataclass
-class DateInputFeatureConfig(BaseInputFeatureConfig, DateInputFeatureConfigMixin):
+class DateInputFeatureConfig(DateInputFeatureConfigMixin, BaseInputFeatureConfig):
     """DateInputFeature is a dataclass that configures the parameters used for a date input feature."""
 
     pass

--- a/ludwig/schema/features/h3_feature.py
+++ b/ludwig/schema/features/h3_feature.py
@@ -1,5 +1,6 @@
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import H3, MODEL_ECD
+from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.base import BaseEncoderConfig
 from ludwig.schema.encoders.utils import EncoderDataclassField
 from ludwig.schema.features.base import BaseInputFeatureConfig
@@ -16,6 +17,8 @@ from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 class H3InputFeatureConfigMixin(BaseMarshmallowConfig):
     """H3InputFeatureConfigMixin is a dataclass that configures the parameters used in both the h3 input feature
     and the h3 global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(H3)
 
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=H3)
 

--- a/ludwig/schema/features/h3_feature.py
+++ b/ludwig/schema/features/h3_feature.py
@@ -32,7 +32,7 @@ class H3InputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @ecd_input_config_registry.register(H3)
 @ludwig_dataclass
-class H3InputFeatureConfig(BaseInputFeatureConfig, H3InputFeatureConfigMixin):
+class H3InputFeatureConfig(H3InputFeatureConfigMixin, BaseInputFeatureConfig):
     """H3InputFeatureConfig is a dataclass that configures the parameters used for an h3 input feature."""
 
     pass

--- a/ludwig/schema/features/image_feature.py
+++ b/ludwig/schema/features/image_feature.py
@@ -2,6 +2,7 @@ from typing import List
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import IMAGE, MODEL_ECD
+from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.base import BaseEncoderConfig
 from ludwig.schema.encoders.utils import EncoderDataclassField
 from ludwig.schema.features.augmentation.base import BaseAugmentationConfig
@@ -27,6 +28,8 @@ AUGMENTATION_DEFAULT_OPERATIONS = [
 class ImageInputFeatureConfigMixin(BaseMarshmallowConfig):
     """ImageInputFeatureConfigMixin is a dataclass that configures the parameters used in both the image input
     feature and the image global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(IMAGE)
 
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=IMAGE)
 

--- a/ludwig/schema/features/number_feature.py
+++ b/ludwig/schema/features/number_feature.py
@@ -34,6 +34,8 @@ class NumberInputFeatureConfigMixin(BaseMarshmallowConfig):
     """NumberInputFeatureConfigMixin is a dataclass that configures the parameters used in both the number input
     feature and the number global defaults section of the Ludwig Config."""
 
+    type: str = schema_utils.ProtectedString(NUMBER)
+
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=NUMBER)
 
 
@@ -73,6 +75,8 @@ class GBMNumberInputFeatureConfig(NumberInputFeatureConfig):
 class NumberOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """NumberOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the number output
     feature and the number global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(NUMBER)
 
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=NUMBER,

--- a/ludwig/schema/features/number_feature.py
+++ b/ludwig/schema/features/number_feature.py
@@ -41,7 +41,7 @@ class NumberInputFeatureConfigMixin(BaseMarshmallowConfig):
 
 @DeveloperAPI
 @ludwig_dataclass
-class NumberInputFeatureConfig(BaseInputFeatureConfig, NumberInputFeatureConfigMixin):
+class NumberInputFeatureConfig(NumberInputFeatureConfigMixin, BaseInputFeatureConfig):
     """NumberInputFeatureConfig is a dataclass that configures the parameters used for a number input feature."""
 
     encoder: BaseEncoderConfig = None
@@ -92,7 +92,7 @@ class NumberOutputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @output_config_registry.register(NUMBER)
 @ludwig_dataclass
-class NumberOutputFeatureConfig(BaseOutputFeatureConfig, NumberOutputFeatureConfigMixin):
+class NumberOutputFeatureConfig(NumberOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """NumberOutputFeatureConfig is a dataclass that configures the parameters used for a category output
     feature."""
 

--- a/ludwig/schema/features/preprocessing/image.py
+++ b/ludwig/schema/features/preprocessing/image.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import BFILL, IMAGE, IMAGENET1K, MISSING_VALUE_STRATEGY_OPTIONS, PREPROCESSING
@@ -37,7 +37,7 @@ class ImagePreprocessingConfig(BasePreprocessingConfig):
         parameter_metadata=FEATURE_METADATA[IMAGE][PREPROCESSING]["computed_fill_value"],
     )
 
-    height: int = schema_utils.PositiveInteger(
+    height: Optional[int] = schema_utils.PositiveInteger(
         default=None,
         allow_none=True,
         description="The image height in pixels. If this parameter is set, images will be resized to the specified "
@@ -46,7 +46,7 @@ class ImagePreprocessingConfig(BasePreprocessingConfig):
         parameter_metadata=FEATURE_METADATA[IMAGE][PREPROCESSING]["height"],
     )
 
-    width: int = schema_utils.PositiveInteger(
+    width: Optional[int] = schema_utils.PositiveInteger(
         default=None,
         allow_none=True,
         description="The image width in pixels. If this parameter is set, images will be resized to the specified "

--- a/ludwig/schema/features/sequence_feature.py
+++ b/ludwig/schema/features/sequence_feature.py
@@ -43,7 +43,7 @@ class SequenceInputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @ecd_input_config_registry.register(SEQUENCE)
 @ludwig_dataclass
-class SequenceInputFeatureConfig(BaseInputFeatureConfig, SequenceInputFeatureConfigMixin):
+class SequenceInputFeatureConfig(SequenceInputFeatureConfigMixin, BaseInputFeatureConfig):
     """SequenceInputFeatureConfig is a dataclass that configures the parameters used for a sequence input
     feature."""
 
@@ -73,7 +73,7 @@ class SequenceOutputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @output_config_registry.register(SEQUENCE)
 @ludwig_dataclass
-class SequenceOutputFeatureConfig(BaseOutputFeatureConfig, SequenceOutputFeatureConfigMixin):
+class SequenceOutputFeatureConfig(SequenceOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """SequenceOutputFeatureConfig is a dataclass that configures the parameters used for a sequence output
     feature."""
 

--- a/ludwig/schema/features/sequence_feature.py
+++ b/ludwig/schema/features/sequence_feature.py
@@ -29,6 +29,8 @@ class SequenceInputFeatureConfigMixin(BaseMarshmallowConfig):
     """SequenceInputFeatureConfigMixin is a dataclass that configures the parameters used in both the sequence
     input feature and the sequence global defaults section of the Ludwig Config."""
 
+    type: str = schema_utils.ProtectedString(SEQUENCE)
+
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=SEQUENCE)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -54,6 +56,8 @@ class SequenceInputFeatureConfig(BaseInputFeatureConfig, SequenceInputFeatureCon
 class SequenceOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """SequenceOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the sequence
     output feature and the sequence global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(SEQUENCE)
 
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=SEQUENCE,

--- a/ludwig/schema/features/set_feature.py
+++ b/ludwig/schema/features/set_feature.py
@@ -29,6 +29,8 @@ class SetInputFeatureConfigMixin(BaseMarshmallowConfig):
     """SetInputFeatureConfigMixin is a dataclass that configures the parameters used in both the set input feature
     and the set global defaults section of the Ludwig Config."""
 
+    type: str = schema_utils.ProtectedString(SET)
+
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=SET)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -53,6 +55,8 @@ class SetInputFeatureConfig(BaseInputFeatureConfig, SetInputFeatureConfigMixin):
 class SetOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """SetOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the set output
     feature and the set global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(SET)
 
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=SET,

--- a/ludwig/schema/features/set_feature.py
+++ b/ludwig/schema/features/set_feature.py
@@ -43,7 +43,7 @@ class SetInputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @ecd_input_config_registry.register(SET)
 @ludwig_dataclass
-class SetInputFeatureConfig(BaseInputFeatureConfig, SetInputFeatureConfigMixin):
+class SetInputFeatureConfig(SetInputFeatureConfigMixin, BaseInputFeatureConfig):
     """SetInputFeatureConfig is a dataclass that configures the parameters used for a set input feature."""
 
     pass
@@ -72,7 +72,7 @@ class SetOutputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @output_config_registry.register(SET)
 @ludwig_dataclass
-class SetOutputFeatureConfig(BaseOutputFeatureConfig, SetOutputFeatureConfigMixin):
+class SetOutputFeatureConfig(SetOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """SetOutputFeatureConfig is a dataclass that configures the parameters used for a set output feature."""
 
     default_validation_metric: str = schema_utils.StringOptions(

--- a/ludwig/schema/features/text_feature.py
+++ b/ludwig/schema/features/text_feature.py
@@ -43,7 +43,7 @@ class TextInputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @ecd_input_config_registry.register(TEXT)
 @ludwig_dataclass
-class TextInputFeatureConfig(BaseInputFeatureConfig, TextInputFeatureConfigMixin):
+class TextInputFeatureConfig(TextInputFeatureConfigMixin, BaseInputFeatureConfig):
     """TextInputFeatureConfig is a dataclass that configures the parameters used for a text input feature."""
 
     pass
@@ -72,7 +72,7 @@ class TextOutputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @output_config_registry.register(TEXT)
 @ludwig_dataclass
-class TextOutputFeatureConfig(BaseOutputFeatureConfig, TextOutputFeatureConfigMixin):
+class TextOutputFeatureConfig(TextOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """TextOutputFeatureConfig is a dataclass that configures the parameters used for a text output feature."""
 
     class_similarities: list = schema_utils.List(

--- a/ludwig/schema/features/text_feature.py
+++ b/ludwig/schema/features/text_feature.py
@@ -29,6 +29,8 @@ class TextInputFeatureConfigMixin(BaseMarshmallowConfig):
     """TextInputFeatureConfigMixin is a dataclass that configures the parameters used in both the text input
     feature and the text global defaults section of the Ludwig Config."""
 
+    type: str = schema_utils.ProtectedString(TEXT)
+
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=TEXT)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -53,6 +55,8 @@ class TextInputFeatureConfig(BaseInputFeatureConfig, TextInputFeatureConfigMixin
 class TextOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """TextOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the text output
     feature and the text global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(TEXT)
 
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=TEXT,

--- a/ludwig/schema/features/timeseries_feature.py
+++ b/ludwig/schema/features/timeseries_feature.py
@@ -32,7 +32,7 @@ class TimeseriesInputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @ecd_input_config_registry.register(TIMESERIES)
 @ludwig_dataclass
-class TimeseriesInputFeatureConfig(BaseInputFeatureConfig, TimeseriesInputFeatureConfigMixin):
+class TimeseriesInputFeatureConfig(TimeseriesInputFeatureConfigMixin, BaseInputFeatureConfig):
     """TimeseriesInputFeatureConfig is a dataclass that configures the parameters used for a timeseries input
     feature."""
 

--- a/ludwig/schema/features/timeseries_feature.py
+++ b/ludwig/schema/features/timeseries_feature.py
@@ -1,5 +1,6 @@
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import MODEL_ECD, TIMESERIES
+from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.base import BaseEncoderConfig
 from ludwig.schema.encoders.utils import EncoderDataclassField
 from ludwig.schema.features.base import BaseInputFeatureConfig
@@ -16,6 +17,8 @@ from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 class TimeseriesInputFeatureConfigMixin(BaseMarshmallowConfig):
     """TimeseriesInputFeatureConfigMixin is a dataclass that configures the parameters used in both the timeseries
     input feature and the timeseries global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(TIMESERIES)
 
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=TIMESERIES)
 

--- a/ludwig/schema/features/vector_feature.py
+++ b/ludwig/schema/features/vector_feature.py
@@ -29,6 +29,8 @@ class VectorInputFeatureConfigMixin(BaseMarshmallowConfig):
     """VectorInputFeatureConfigMixin is a dataclass that configures the parameters used in both the vector input
     feature and the vector global defaults section of the Ludwig Config."""
 
+    type: str = schema_utils.ProtectedString(VECTOR)
+
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=VECTOR)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -53,6 +55,8 @@ class VectorInputFeatureConfig(BaseInputFeatureConfig, VectorInputFeatureConfigM
 class VectorOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """VectorOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the vector output
     feature and the vector global defaults section of the Ludwig Config."""
+
+    type: str = schema_utils.ProtectedString(VECTOR)
 
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=VECTOR,

--- a/ludwig/schema/features/vector_feature.py
+++ b/ludwig/schema/features/vector_feature.py
@@ -43,7 +43,7 @@ class VectorInputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @ecd_input_config_registry.register(VECTOR)
 @ludwig_dataclass
-class VectorInputFeatureConfig(BaseInputFeatureConfig, VectorInputFeatureConfigMixin):
+class VectorInputFeatureConfig(VectorInputFeatureConfigMixin, BaseInputFeatureConfig):
     """VectorInputFeatureConfig is a dataclass that configures the parameters used for a vector input feature."""
 
     pass
@@ -72,7 +72,7 @@ class VectorOutputFeatureConfigMixin(BaseMarshmallowConfig):
 @DeveloperAPI
 @output_config_registry.register(VECTOR)
 @ludwig_dataclass
-class VectorOutputFeatureConfig(BaseOutputFeatureConfig, VectorOutputFeatureConfigMixin):
+class VectorOutputFeatureConfig(VectorOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """VectorOutputFeatureConfig is a dataclass that configures the parameters used for a vector output feature."""
 
     dependencies: list = schema_utils.List(

--- a/ludwig/schema/model_types/base.py
+++ b/ludwig/schema/model_types/base.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Set
 from marshmallow import ValidationError
 
 from ludwig.api_annotations import DeveloperAPI
-from ludwig.config_validation.checks import check_basic_required_parameters, get_config_check_registry
+from ludwig.config_validation.checks import get_config_check_registry
 from ludwig.config_validation.validation import check_schema
 from ludwig.constants import BACKEND, ENCODER, MODEL_ECD
 from ludwig.error import ConfigValidationError
@@ -72,7 +72,6 @@ class ModelConfig(schema_utils.BaseMarshmallowConfig, ABC):
                 f"Invalid model type: '{model_type}', expected one of: {list(model_type_schema_registry.keys())}"
             )
 
-        check_basic_required_parameters(config)
         config = merge_with_defaults(config)
 
         # TODO(travis): handle this with helper function

--- a/ludwig/schema/model_types/base.py
+++ b/ludwig/schema/model_types/base.py
@@ -7,7 +7,7 @@ from marshmallow import ValidationError
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.config_validation.checks import check_basic_required_parameters, get_config_check_registry
 from ludwig.config_validation.validation import check_schema
-from ludwig.constants import BACKEND, ENCODER, INPUT_FEATURES, MODEL_ECD, PREPROCESSING, TYPE
+from ludwig.constants import BACKEND, ENCODER, MODEL_ECD
 from ludwig.error import ConfigValidationError
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.schema import utils as schema_utils
@@ -49,6 +49,7 @@ class ModelConfig(schema_utils.BaseMarshmallowConfig, ABC):
     ludwig_version: str = schema_utils.ProtectedString(LUDWIG_VERSION)
 
     def __post_init__(self):
+        merge_fixed_preprocessing_params(self)
         set_validation_parameters(self)
         set_hyperopt_defaults_(self)
 
@@ -73,21 +74,6 @@ class ModelConfig(schema_utils.BaseMarshmallowConfig, ABC):
 
         check_basic_required_parameters(config)
         config = merge_with_defaults(config)
-
-        # TODO(travis): move this into helper function
-        # Update preprocessing parameters if encoders require fixed preprocessing parameters
-        for feature_config in config.get(INPUT_FEATURES, []):
-            if TYPE not in feature_config:
-                continue
-
-            preprocessing_parameters = feature_config.get(PREPROCESSING, {})
-            preprocessing_parameters = merge_fixed_preprocessing_params(
-                model_type, feature_config[TYPE], preprocessing_parameters, feature_config.get(ENCODER, {})
-            )
-            preprocessing_parameters = _merge_encoder_cache_params(
-                preprocessing_parameters, feature_config.get(ENCODER, {})
-            )
-            feature_config[PREPROCESSING] = preprocessing_parameters
 
         # TODO(travis): handle this with helper function
         backend = config.get(BACKEND)

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -22,12 +22,10 @@ from ludwig.constants import (
     TYPE,
 )
 from ludwig.features.feature_utils import compute_feature_hash
-from ludwig.schema.encoders.utils import get_encoder_cls
-from ludwig.schema.features.utils import input_config_registry, output_config_registry
+from ludwig.schema.features.utils import output_config_registry
 from ludwig.schema.hyperopt.scheduler import BaseHyperbandSchedulerConfig
 from ludwig.schema.trainer import ECDTrainerConfig
 from ludwig.types import HyperoptConfigDict, ModelConfigDict
-from ludwig.utils.misc_utils import merge_dict
 
 if TYPE_CHECKING:
     from ludwig.schema.model_types.base import ModelConfig
@@ -85,15 +83,10 @@ def _merge_dict_with_types(dct: Dict[str, Any], merge_dct: Dict[str, Any], exclu
 
 
 @DeveloperAPI
-def merge_fixed_preprocessing_params(
-    model_type: str, feature_type: str, preprocessing_params: Dict[str, Any], encoder_params: Dict[str, Any]
-) -> Dict[str, Any]:
+def merge_fixed_preprocessing_params(config: "ModelConfig"):
     """Update preprocessing parameters if encoders require fixed preprocessing parameters."""
-    feature_cls = input_config_registry(model_type)[feature_type]
-    encoder_type = encoder_params.get(TYPE, feature_cls().encoder.type)
-    encoder_class = get_encoder_cls(model_type, feature_type, encoder_type)
-    encoder = encoder_class.from_dict(encoder_params)
-    return merge_dict(preprocessing_params, encoder.get_fixed_preprocessing_params(model_type))
+    for feature in config.input_features:
+        feature.encoder.set_fixed_preprocessing_params(config.model_type, feature.preprocessing)
 
 
 def set_validation_parameters(config: "ModelConfig"):

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -35,8 +35,9 @@ logger = logging.getLogger(__name__)
 default_random_seed = 42
 
 # Still needed for preprocessing  TODO(Connor): Refactor ludwig/data/preprocessing to use schema
+# TODO(travis): remove this, make type a protected string for each subclass
 default_feature_specific_preprocessing_parameters = {
-    name: preproc_sect.get_schema_cls()().preprocessing.to_dict()
+    name: preproc_sect.get_schema_cls()(name="__tmp__", type=name).preprocessing.to_dict()
     for name, preproc_sect in get_input_type_registry().items()
 }
 

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -37,7 +37,7 @@ default_random_seed = 42
 # Still needed for preprocessing  TODO(Connor): Refactor ludwig/data/preprocessing to use schema
 # TODO(travis): remove this, make type a protected string for each subclass
 default_feature_specific_preprocessing_parameters = {
-    name: preproc_sect.get_schema_cls()(name="__tmp__").preprocessing.to_dict()
+    name: preproc_sect.get_schema_cls()(name="__tmp__", type=name).preprocessing.to_dict()
     for name, preproc_sect in get_input_type_registry().items()
 }
 

--- a/ludwig/utils/defaults.py
+++ b/ludwig/utils/defaults.py
@@ -37,7 +37,7 @@ default_random_seed = 42
 # Still needed for preprocessing  TODO(Connor): Refactor ludwig/data/preprocessing to use schema
 # TODO(travis): remove this, make type a protected string for each subclass
 default_feature_specific_preprocessing_parameters = {
-    name: preproc_sect.get_schema_cls()(name="__tmp__", type=name).preprocessing.to_dict()
+    name: preproc_sect.get_schema_cls()(name="__tmp__").preprocessing.to_dict()
     for name, preproc_sect in get_input_type_registry().items()
 }
 

--- a/tests/ludwig/augmentation/test_augmentation_pipeline.py
+++ b/tests/ludwig/augmentation/test_augmentation_pipeline.py
@@ -171,7 +171,9 @@ def run_augmentation_training(
 # test image augmentation pipeline
 def test_image_augmentation(test_image, augmentation_pipeline_ops):
     # define augmentation pipeline
-    feature = ImageInputFeatureConfig.from_dict({"augmentation": augmentation_pipeline_ops})
+    feature = ImageInputFeatureConfig.from_dict(
+        {"name": "foo", "type": "image", "augmentation": augmentation_pipeline_ops}
+    )
     augmentation_pipeline = ImageAugmentation(feature.augmentation)
     # apply augmentation pipeline to batch of test images
     augmentation_pipeline(test_image)

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -11,7 +11,6 @@ import contextlib
 from typing import Any, Dict, Optional
 
 import pytest
-from marshmallow import ValidationError
 
 from ludwig.error import ConfigValidationError
 from ludwig.schema.model_types.base import ModelConfig
@@ -197,5 +196,5 @@ def test_dense_binary_encoder_0_layer():
         "output_features": [{"name": "y", "type": "number"}],
         "trainer": {"train_steps": 1},
     }
-    with pytest.raises(ValidationError):
+    with pytest.raises(ConfigValidationError):
         ModelConfig.from_dict(config)

--- a/tests/ludwig/features/test_category_feature.py
+++ b/tests/ludwig/features/test_category_feature.py
@@ -43,7 +43,7 @@ def test_category_input_feature(
     category_def[ENCODER][TYPE] = encoder
 
     # pickup any other missing parameters
-    defaults = ECDCategoryInputFeatureConfig(name="foo", type="category").to_dict()
+    defaults = ECDCategoryInputFeatureConfig(name="foo").to_dict()
     category_def = merge_dict(defaults, category_def)
 
     # ensure no exceptions raised during build

--- a/tests/ludwig/features/test_category_feature.py
+++ b/tests/ludwig/features/test_category_feature.py
@@ -43,7 +43,7 @@ def test_category_input_feature(
     category_def[ENCODER][TYPE] = encoder
 
     # pickup any other missing parameters
-    defaults = ECDCategoryInputFeatureConfig().to_dict()
+    defaults = ECDCategoryInputFeatureConfig(name="foo", type="category").to_dict()
     category_def = merge_dict(defaults, category_def)
 
     # ensure no exceptions raised during build

--- a/tests/ludwig/features/test_date_feature.py
+++ b/tests/ludwig/features/test_date_feature.py
@@ -27,7 +27,7 @@ def test_date_input_feature(date_config: FeatureConfigDict):
     feature_def = deepcopy(date_config)
 
     # pickup any other missing parameters
-    defaults = DateInputFeatureConfig().to_dict()
+    defaults = DateInputFeatureConfig(name="foo", type="date").to_dict()
     set_def = merge_dict(defaults, feature_def)
 
     # ensure no exceptions raised during build

--- a/tests/ludwig/features/test_date_feature.py
+++ b/tests/ludwig/features/test_date_feature.py
@@ -27,7 +27,7 @@ def test_date_input_feature(date_config: FeatureConfigDict):
     feature_def = deepcopy(date_config)
 
     # pickup any other missing parameters
-    defaults = DateInputFeatureConfig(name="foo", type="date").to_dict()
+    defaults = DateInputFeatureConfig(name="foo").to_dict()
     set_def = merge_dict(defaults, feature_def)
 
     # ensure no exceptions raised during build

--- a/tests/ludwig/features/test_image_feature.py
+++ b/tests/ludwig/features/test_image_feature.py
@@ -77,7 +77,7 @@ def test_image_input_feature(image_config: Dict, encoder: str, height: int, widt
     image_def[ENCODER]["num_channels"] = num_channels
 
     # pickup any other missing parameters
-    defaults = ImageInputFeatureConfig(name="foo", type="image").to_dict()
+    defaults = ImageInputFeatureConfig(name="foo").to_dict()
     set_def = merge_dict(defaults, image_def)
 
     # ensure no exceptions raised during build

--- a/tests/ludwig/features/test_image_feature.py
+++ b/tests/ludwig/features/test_image_feature.py
@@ -77,7 +77,7 @@ def test_image_input_feature(image_config: Dict, encoder: str, height: int, widt
     image_def[ENCODER]["num_channels"] = num_channels
 
     # pickup any other missing parameters
-    defaults = ImageInputFeatureConfig().to_dict()
+    defaults = ImageInputFeatureConfig(name="foo", type="image").to_dict()
     set_def = merge_dict(defaults, image_def)
 
     # ensure no exceptions raised during build

--- a/tests/ludwig/features/test_number_feature.py
+++ b/tests/ludwig/features/test_number_feature.py
@@ -27,7 +27,7 @@ def test_number_input_feature(
     number_def = deepcopy(number_config)
 
     # pickup any other missing parameters
-    defaults = ECDNumberInputFeatureConfig(name="foo", type="number").to_dict()
+    defaults = ECDNumberInputFeatureConfig(name="foo").to_dict()
     set_def = merge_dict(defaults, number_def)
 
     # ensure no exceptions raised during build

--- a/tests/ludwig/features/test_number_feature.py
+++ b/tests/ludwig/features/test_number_feature.py
@@ -27,7 +27,7 @@ def test_number_input_feature(
     number_def = deepcopy(number_config)
 
     # pickup any other missing parameters
-    defaults = ECDNumberInputFeatureConfig().to_dict()
+    defaults = ECDNumberInputFeatureConfig(name="foo", type="number").to_dict()
     set_def = merge_dict(defaults, number_def)
 
     # ensure no exceptions raised during build

--- a/tests/ludwig/features/test_sequence_features.py
+++ b/tests/ludwig/features/test_sequence_features.py
@@ -8,7 +8,6 @@ import torchtext
 from ludwig.constants import LAST_HIDDEN, LOGITS, SEQUENCE, TEXT, TYPE
 from ludwig.features.sequence_feature import _SequencePreprocessing, SequenceInputFeature, SequenceOutputFeature
 from ludwig.features.text_feature import TextInputFeature, TextOutputFeature
-from ludwig.schema.utils import load_config_with_kwargs
 from ludwig.utils.torch_utils import get_torch_device
 from tests.integration_tests.utils import ENCODERS, sequence_feature
 

--- a/tests/ludwig/features/test_set_feature.py
+++ b/tests/ludwig/features/test_set_feature.py
@@ -48,7 +48,7 @@ def test_set_input_feature(set_config: Dict) -> None:
     set_def = deepcopy(set_config)
 
     # pickup any other missing parameters
-    defaults = SetInputFeatureConfig(name="foo", type="set").to_dict()
+    defaults = SetInputFeatureConfig(name="foo").to_dict()
     set_def = merge_dict(defaults, set_def)
 
     # ensure no exceptions raised during build

--- a/tests/ludwig/features/test_set_feature.py
+++ b/tests/ludwig/features/test_set_feature.py
@@ -48,7 +48,7 @@ def test_set_input_feature(set_config: Dict) -> None:
     set_def = deepcopy(set_config)
 
     # pickup any other missing parameters
-    defaults = SetInputFeatureConfig().to_dict()
+    defaults = SetInputFeatureConfig(name="foo", type="set").to_dict()
     set_def = merge_dict(defaults, set_def)
 
     # ensure no exceptions raised during build

--- a/tests/ludwig/modules/test_lr_scheduler.py
+++ b/tests/ludwig/modules/test_lr_scheduler.py
@@ -16,7 +16,7 @@ def test_lr_scheduler_warmup_decay():
     base_lr = 1.0
     warmup_fraction = 0.1
 
-    module = NumberInputFeature(NumberInputFeatureConfig(name="num1", encoder=DenseEncoderConfig()))
+    module = NumberInputFeature(NumberInputFeatureConfig(name="num1", type="number", encoder=DenseEncoderConfig()))
 
     const_optimizer = SGD(module.parameters(), lr=base_lr)
     const_config = LRSchedulerConfig(warmup_evaluations=0)
@@ -66,8 +66,10 @@ def test_lr_scheduler_reduce_on_plateau():
     base_lr = 1.0
     reduce_limit = 3
 
-    module = NumberInputFeature(NumberInputFeatureConfig(name="num1", encoder=DenseEncoderConfig()))
-    output1 = NumberOutputFeature(NumberOutputFeatureConfig(name="output1", input_size=10), output_features={})
+    module = NumberInputFeature(NumberInputFeatureConfig(name="num1", type="number", encoder=DenseEncoderConfig()))
+    output1 = NumberOutputFeature(
+        NumberOutputFeatureConfig(name="output1", type="number", input_size=10), output_features={}
+    )
 
     optimizer = SGD(module.parameters(), lr=base_lr)
     config = LRSchedulerConfig(
@@ -125,8 +127,10 @@ def test_lr_scheduler_save_load():
     base_lr = 1.0
     reduce_limit = 3
 
-    module = NumberInputFeature(NumberInputFeatureConfig(name="num1", encoder=DenseEncoderConfig()))
-    output1 = NumberOutputFeature(NumberOutputFeatureConfig(name="output1", input_size=10), output_features={})
+    module = NumberInputFeature(NumberInputFeatureConfig(name="num1", type="number", encoder=DenseEncoderConfig()))
+    output1 = NumberOutputFeature(
+        NumberOutputFeatureConfig(name="output1", type="number", input_size=10), output_features={}
+    )
 
     optimizer = SGD(module.parameters(), lr=base_lr)
     config = LRSchedulerConfig(warmup_fraction=0.2, reduce_on_plateau=reduce_limit)

--- a/tests/ludwig/modules/test_lr_scheduler.py
+++ b/tests/ludwig/modules/test_lr_scheduler.py
@@ -16,7 +16,7 @@ def test_lr_scheduler_warmup_decay():
     base_lr = 1.0
     warmup_fraction = 0.1
 
-    module = NumberInputFeature(NumberInputFeatureConfig(name="num1", type="number", encoder=DenseEncoderConfig()))
+    module = NumberInputFeature(NumberInputFeatureConfig(name="num1", encoder=DenseEncoderConfig()))
 
     const_optimizer = SGD(module.parameters(), lr=base_lr)
     const_config = LRSchedulerConfig(warmup_evaluations=0)
@@ -66,10 +66,8 @@ def test_lr_scheduler_reduce_on_plateau():
     base_lr = 1.0
     reduce_limit = 3
 
-    module = NumberInputFeature(NumberInputFeatureConfig(name="num1", type="number", encoder=DenseEncoderConfig()))
-    output1 = NumberOutputFeature(
-        NumberOutputFeatureConfig(name="output1", type="number", input_size=10), output_features={}
-    )
+    module = NumberInputFeature(NumberInputFeatureConfig(name="num1", encoder=DenseEncoderConfig()))
+    output1 = NumberOutputFeature(NumberOutputFeatureConfig(name="output1", input_size=10), output_features={})
 
     optimizer = SGD(module.parameters(), lr=base_lr)
     config = LRSchedulerConfig(
@@ -127,10 +125,8 @@ def test_lr_scheduler_save_load():
     base_lr = 1.0
     reduce_limit = 3
 
-    module = NumberInputFeature(NumberInputFeatureConfig(name="num1", type="number", encoder=DenseEncoderConfig()))
-    output1 = NumberOutputFeature(
-        NumberOutputFeatureConfig(name="output1", type="number", input_size=10), output_features={}
-    )
+    module = NumberInputFeature(NumberInputFeatureConfig(name="num1", encoder=DenseEncoderConfig()))
+    output1 = NumberOutputFeature(NumberOutputFeatureConfig(name="output1", input_size=10), output_features={})
 
     optimizer = SGD(module.parameters(), lr=base_lr)
     config = LRSchedulerConfig(warmup_fraction=0.2, reduce_on_plateau=reduce_limit)

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -570,8 +570,8 @@ def test_defaults_mixins():
 
     config_obj = ModelConfig.from_dict(config)
 
-    assert config_obj.defaults.audio.to_dict().keys() == {ENCODER, PREPROCESSING}
-    assert config_obj.defaults.category.to_dict().keys() == {ENCODER, PREPROCESSING, DECODER, LOSS}
+    assert config_obj.defaults.audio.to_dict().keys() == {TYPE, ENCODER, PREPROCESSING}
+    assert config_obj.defaults.category.to_dict().keys() == {TYPE, ENCODER, PREPROCESSING, DECODER, LOSS}
 
 
 def test_initializer_recursion():

--- a/tests/ludwig/utils/test_config_utils.py
+++ b/tests/ludwig/utils/test_config_utils.py
@@ -11,7 +11,7 @@ from ludwig.schema.model_types.utils import merge_fixed_preprocessing_params
     [None, "bert-large-uncased"],
     ids=["default_model", "override_model"],
 )
-def test_merge_fixed_preprocessing_params(pretrained_model_name_or_path: str):
+def test_set_fixed_preprocessing_params(pretrained_model_name_or_path: str):
     expected_model_name = "bert-base-uncased"
 
     preprocessing = {

--- a/tests/ludwig/utils/test_config_utils.py
+++ b/tests/ludwig/utils/test_config_utils.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, Optional
 import pytest
 
 from ludwig.constants import MODEL_ECD
+from ludwig.schema.encoders.text_encoders import BERTConfig
+from ludwig.schema.features.preprocessing.text import TextPreprocessingConfig
 from ludwig.schema.model_types.utils import merge_fixed_preprocessing_params
 
 
@@ -14,22 +16,24 @@ from ludwig.schema.model_types.utils import merge_fixed_preprocessing_params
 def test_set_fixed_preprocessing_params(pretrained_model_name_or_path: str):
     expected_model_name = "bert-base-uncased"
 
-    preprocessing = {
-        "tokenizer": "space",
-        "lowercase": True,
-    }
+    preprocessing = TextPreprocessingConfig.from_dict(
+        {
+            "tokenizer": "space",
+            "lowercase": True,
+        }
+    )
 
-    encoder = {"type": "bert"}
+    encoder_params = {}
     if pretrained_model_name_or_path is not None:
-        encoder["pretrained_model_name_or_path"] = pretrained_model_name_or_path
+        encoder_params["pretrained_model_name_or_path"] = pretrained_model_name_or_path
         expected_model_name = pretrained_model_name_or_path
 
-    merged_params = merge_fixed_preprocessing_params(MODEL_ECD, "text", preprocessing, encoder)
-    assert merged_params == {
-        "tokenizer": "hf_tokenizer",
-        "lowercase": True,
-        "pretrained_model_name_or_path": expected_model_name,
-    }
+    encoder = BERTConfig.from_dict(encoder_params)
+    encoder.set_fixed_preprocessing_params(MODEL_ECD, preprocessing)
+
+    assert preprocessing.tokenizer == "hf_tokenizer"
+    assert preprocessing.lowercase
+    assert preprocessing.pretrained_model_name_or_path == expected_model_name
 
 
 @pytest.mark.parametrize(

--- a/tests/ludwig/utils/test_config_utils.py
+++ b/tests/ludwig/utils/test_config_utils.py
@@ -2,10 +2,10 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from ludwig.constants import MODEL_ECD
+from ludwig.constants import MODEL_ECD, TEXT, TYPE
 from ludwig.schema.encoders.text_encoders import BERTConfig
+from ludwig.schema.encoders.utils import get_encoder_cls
 from ludwig.schema.features.preprocessing.text import TextPreprocessingConfig
-from ludwig.schema.model_types.utils import merge_fixed_preprocessing_params
 
 
 @pytest.mark.parametrize(
@@ -37,19 +37,23 @@ def test_set_fixed_preprocessing_params(pretrained_model_name_or_path: str):
 
 
 @pytest.mark.parametrize(
-    "encoder,expected",
+    "encoder_params,expected",
     [
         ({"type": "parallel_cnn"}, False),
-        ({"type": "bert", "trainable": False}, None),
+        ({"type": "bert", "trainable": False}, True),
         ({"type": "bert", "trainable": True}, False),
     ],
     ids=["parallel_cnn", "bert_fixed", "bert_trainable"],
 )
-def test_merge_fixed_preprocessing_params_cache_embeddings(encoder: Dict[str, Any], expected: Optional[bool]):
-    preprocessing = {
-        "tokenizer": "space",
-        "lowercase": True,
-    }
+def test_set_fixed_preprocessing_params_cache_embeddings(encoder_params: Dict[str, Any], expected: Optional[bool]):
+    preprocessing = TextPreprocessingConfig.from_dict(
+        {
+            "tokenizer": "space",
+            "lowercase": True,
+            "cache_encoder_embeddings": True,
+        }
+    )
 
-    merged_params = merge_fixed_preprocessing_params(MODEL_ECD, "text", preprocessing, encoder)
-    assert merged_params.get("cache_encoder_embeddings") == expected
+    encoder = get_encoder_cls(MODEL_ECD, TEXT, encoder_params[TYPE]).from_dict(encoder_params)
+    encoder.set_fixed_preprocessing_params(MODEL_ECD, preprocessing)
+    assert preprocessing.cache_encoder_embeddings == expected

--- a/tests/ludwig/utils/test_trainer_utils.py
+++ b/tests/ludwig/utils/test_trainer_utils.py
@@ -71,6 +71,7 @@ def test_progress_tracker_empty():
         CategoryOutputFeatureConfig,
         {
             "name": "category_feature",
+            "type": "category",
             "decoder": {
                 "type": "classifier",
             },
@@ -111,6 +112,7 @@ def test_progress_tracker():
         CategoryOutputFeatureConfig,
         {
             "name": "category_feature",
+            "type": "category",
             "decoder": {
                 "type": "classifier",
             },


### PR DESCRIPTION
Also removes checks on config dict that are covered by existing marshmallow schema validation. These checks were only needed for the merge logic.