### PR TITLE
feat: Allow users to change validation strictness policy

### DIFF
--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import field, Field
@@ -158,7 +159,9 @@ class BaseMarshmallowConfig(ABC):
         filled in as necessary.
         """
 
-        unknown = INCLUDE  # TODO: Change to RAISE and update descriptions once we want to enforce strict schemas.
+        # TODO: Change to just RAISE and update descriptions once we want to enforce strict schemas.
+        unknown = os.environ.get("LUDWIG_SCHEMA_POLICY", "").lower() or INCLUDE
+
         "Flag that sets marshmallow `load` calls to ignore unknown properties passed as a parameter."
 
         ordered = True


### PR DESCRIPTION
Resolves https://github.com/ludwig-ai/ludwig/issues/3218

Needs more testing atm.
--

Ludwig will now check if a user has an environment variable called `LUDWIG_SCHEMA_POLICY` set and, if so, use its value as the strictness policy for validation.

The only supported values are `include`, `exclude`, and `raise`. Is there a slick way to raise an error or otherwise warn the user about this in the CLI?