### PR TITLE
Replace NaN in timeseries rows with `padding_value`

### DIFF
--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -127,7 +127,9 @@ class TimeseriesFeatureMixin(BaseFeatureMixin):
     def build_matrix(timeseries, tokenizer_name, length_limit, padding_value, padding, backend):
         tokenizer = get_tokenizer_from_registry(tokenizer_name)()
 
-        ts_vectors = backend.df_engine.map_objects(timeseries, lambda ts: np.array(tokenizer(ts)).astype(np.float32))
+        ts_vectors = backend.df_engine.map_objects(
+            timeseries, lambda ts: np.nan_to_num(np.array(tokenizer(ts)).astype(np.float32), nan=padding_value)
+        )
 
         max_length = backend.df_engine.compute(ts_vectors.map(len).max())
         if max_length < length_limit:

--- a/ludwig/schema/features/preprocessing/timeseries.py
+++ b/ludwig/schema/features/preprocessing/timeseries.py
@@ -58,7 +58,7 @@ class TimeseriesPreprocessingConfig(BasePreprocessingConfig):
         default="",
         allow_none=False,
         description=(
-            "The value to replace missing values with in case the `missing_value_strategy` is `fill_with_const`"
+            "The value to replace missing values with in case the `missing_value_strategy` is `fill_with_const`."
         ),
         parameter_metadata=FEATURE_METADATA[TIMESERIES][PREPROCESSING]["fill_value"],
     )
@@ -66,7 +66,9 @@ class TimeseriesPreprocessingConfig(BasePreprocessingConfig):
     computed_fill_value: str = schema_utils.String(
         default="",
         allow_none=False,
-        description="The internally computed fill value to replace missing values with in case the "
-        "missing_value_strategy is fill_with_mode or fill_with_mean",
+        description=(
+            "The internally computed fill value to replace missing values with in case the "
+            "`missing_value_strategy` is `fill_with_mode` or `fill_with_mean`."
+        ),
         parameter_metadata=FEATURE_METADATA[TIMESERIES][PREPROCESSING]["computed_fill_value"],
     )

--- a/ludwig/schema/features/preprocessing/timeseries.py
+++ b/ludwig/schema/features/preprocessing/timeseries.py
@@ -30,7 +30,7 @@ class TimeseriesPreprocessingConfig(BasePreprocessingConfig):
     padding_value: float = schema_utils.NonNegativeFloat(
         default=0.0,
         allow_none=False,
-        description="Float value that is used for padding.",
+        description="Float value that is used for padding and replacing missing values within a row.",
         parameter_metadata=FEATURE_METADATA[TIMESERIES][PREPROCESSING]["padding_value"],
     )
 
@@ -46,14 +46,20 @@ class TimeseriesPreprocessingConfig(BasePreprocessingConfig):
         MISSING_VALUE_STRATEGY_OPTIONS,
         default=FILL_WITH_CONST,
         allow_none=False,
-        description="What strategy to follow when there's a missing value in a text column",
+        description=(
+            "What strategy to follow when there's a missing value in a column. Currently applies only to a row missing "
+            "in its entirety, not invididual elements within the row. For now, `NaN` values within a row are filled "
+            "using the `padding_value`."
+        ),
         parameter_metadata=FEATURE_METADATA[TIMESERIES][PREPROCESSING]["missing_value_strategy"],
     )
 
     fill_value: str = schema_utils.String(
         default="",
         allow_none=False,
-        description="The value to replace missing values with in case the missing_value_strategy is fill_with_const",
+        description=(
+            "The value to replace missing values with in case the `missing_value_strategy` is `fill_with_const`"
+        ),
         parameter_metadata=FEATURE_METADATA[TIMESERIES][PREPROCESSING]["fill_value"],
     )
 


### PR DESCRIPTION
Closes #3236.

Follow-up: apply missing value strategy to NaNs at a per-row level for timeseries and vector types.