### PR TITLE
Persist Dask Dataframe after binary image/audio reads

### DIFF
--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -862,6 +862,8 @@ class RayBackend(RemoteTrainingMixin, Backend):
             # The resulting column is named "value", which is a dict with two keys: "idx" and "data".
             ds = ray.data.read_datasource(BinaryIgnoreNoneTypeDatasource(), **read_datasource_fn_kwargs)
             df = self.df_engine.from_ray_dataset(ds)
+            # Persist the dataframe to prevent re-reading binary files on each subsequent map_objects call
+            df = self.df_engine.persist(df)
             df["idx"] = self.df_engine.map_objects(df["value"], lambda row: int(row["idx"]))
             df["value"] = self.df_engine.map_objects(df["value"], lambda row: row["data"])
             df = df.rename(columns={"value": column.name})


### PR DESCRIPTION
If we don't persist, it causes multiple re-reads of binary files for each `map_objects` operation which makes reading binary files really slow, and may cause unwanted memory spikes that leads to a large amount of disk spillage.