### PR TITLE
fix: transform `onehot` encoder outputs to float32 tensor

### DIFF
--- a/ludwig/encoders/category_encoders.py
+++ b/ludwig/encoders/category_encoders.py
@@ -199,7 +199,9 @@ class CategoricalOneHotEncoder(Encoder):
                Shape: [batch, 1] or [batch]
         """
         t = inputs.reshape(-1).long()
-        return torch.nn.functional.one_hot(t, num_classes=self.vocab_size)
+        # the output of this must be a float so that it can be concatenated with other
+        # encoder outputs and passed to dense layers in the combiner, decoder, etc.
+        return torch.nn.functional.one_hot(t, num_classes=self.vocab_size).float()
 
     @staticmethod
     def get_schema_cls():

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -198,20 +198,3 @@ def test_dense_binary_encoder_0_layer():
     }
     with pytest.raises(ConfigValidationError):
         ModelConfig.from_dict(config)
-
-
-def test_onehot_category_encoder():
-    config = {
-        "defaults": {"category": {"encoder": {"type": "onehot"}}},
-        "input_features": [
-            {"name": "MSSubClass", "type": "category"},
-            {"name": "MSZoning", "type": "category"},
-            {"name": "Street", "type": "category"},
-            {"name": "Neighborhood", "type": "category"},
-        ],
-        "model_type": "ecd",
-        "output_features": [{"name": "SalePrice", "type": "number"}],
-        "trainer": {"train_steps": 1},
-        "combiner": {"type": "concat", "num_fc_layers": 2},
-    }
-    ModelConfig.from_dict(config)

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -198,3 +198,20 @@ def test_dense_binary_encoder_0_layer():
     }
     with pytest.raises(ConfigValidationError):
         ModelConfig.from_dict(config)
+
+
+def test_onehot_category_encoder():
+    config = {
+        "defaults": {"category": {"encoder": {"type": "onehot"}}},
+        "input_features": [
+            {"name": "MSSubClass", "type": "category"},
+            {"name": "MSZoning", "type": "category"},
+            {"name": "Street", "type": "category"},
+            {"name": "Neighborhood", "type": "category"},
+        ],
+        "model_type": "ecd",
+        "output_features": [{"name": "SalePrice", "type": "number"}],
+        "trainer": {"train_steps": 1},
+        "combiner": {"type": "concat", "num_fc_layers": 2},
+    }
+    ModelConfig.from_dict(config)


### PR DESCRIPTION
When we specify a `onehot` encoder for category features and have dense layers down the line, we get the following error
```
RuntimeError: mat1 and mat2 must have the same dtype
```
This PR makes sure to convert the outputs of the `onehot` encoder to `float32`