### PR TITLE
Removes invalid keys from GBM defaults in the schema

### DIFF
--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -811,8 +811,15 @@ def upgrade_defaults_config_for_gbm(config: ModelConfigDict) -> ModelConfigDict:
     defaults = copy.deepcopy(defaults_ref)
     gbm_feature_types = GBMDefaultsConfig.Schema().fields.keys()
     for feature_type in defaults_ref:
+        # GBM only supports binary, number, category and text features
         if feature_type not in gbm_feature_types:
             del defaults[feature_type]
+            continue
+
+        # Remove encoder, decoder and loss from defaults since they only apply to ECD
+        defaults[feature_type].pop("encoder", None)
+        defaults[feature_type].pop("decoder", None)
+        defaults[feature_type].pop("loss", None)
     config[DEFAULTS] = defaults
     return config
 

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -816,8 +816,7 @@ def upgrade_defaults_config_for_gbm(config: ModelConfigDict) -> ModelConfigDict:
             del defaults[feature_type]
             continue
 
-        # Remove encoder, decoder and loss from defaults since they only apply to ECD
-        defaults[feature_type].pop("encoder", None)
+        # Remove decoder and loss from defaults since they only apply to ECD
         defaults[feature_type].pop("decoder", None)
         defaults[feature_type].pop("loss", None)
     config[DEFAULTS] = defaults

--- a/tests/ludwig/utils/test_backward_compatibility.py
+++ b/tests/ludwig/utils/test_backward_compatibility.py
@@ -851,7 +851,7 @@ def test_defaults_gbm_config():
             },
             "category": {
                 "decoder": {"type": "classifier", "num_fc_layers": 0},
-                "encoder": {"type": "dense"},
+                "encoder": {"type": "onehot"},
                 "loss": {"confidence_penalty": 0},
                 "preprocessing": {
                     "missing_value_strategy": "fill_with_const",
@@ -881,6 +881,5 @@ def test_defaults_gbm_config():
 
     # Ensure defaults only have relevant keys
     for feature_type in config_obj["defaults"]:
-        assert "encoder" not in config_obj["defaults"][feature_type]
         assert "decoder" not in config_obj["defaults"][feature_type]
         assert "loss" not in config_obj["defaults"][feature_type]

--- a/tests/ludwig/utils/test_backward_compatibility.py
+++ b/tests/ludwig/utils/test_backward_compatibility.py
@@ -824,3 +824,63 @@ def test_load_config_missing_hyperopt():
     config_obj = ModelConfig.from_dict(old_valid_config)
     assert config_obj.hyperopt is None
     assert config_obj.to_dict()[HYPEROPT] is None
+
+
+def test_defaults_gbm_config():
+    old_valid_config = {
+        "input_features": [
+            {"name": "feature_1", "type": "category"},
+            {"name": "Sex", "type": "category"},
+        ],
+        "output_features": [
+            {"name": "Survived", "type": "category"},
+        ],
+        "defaults": {
+            "binary": {
+                "decoder": {
+                    "type": "regressor",
+                    "num_fc_layers": 0,
+                },
+                "encoder": {"type": "passthrough"},
+                "loss": {
+                    "weight": 1.0,
+                },
+                "preprocessing": {
+                    "missing_value_strategy": "fill_with_false",
+                },
+            },
+            "category": {
+                "decoder": {"type": "classifier", "num_fc_layers": 0},
+                "encoder": {"type": "dense"},
+                "loss": {"confidence_penalty": 0},
+                "preprocessing": {
+                    "missing_value_strategy": "fill_with_const",
+                    "most_common": 10000,
+                },
+            },
+            "number": {
+                "decoder": {"type": "regressor"},
+                "encoder": {"type": "passthrough"},
+                "loss": {"type": "mean_squared_error"},
+                "preprocessing": {"missing_value_strategy": "fill_with_const"},
+            },
+            "sequence": {
+                "decoder": {},
+                "loss": {},
+                "preprocessing": {},
+                "encoder": {},
+            },
+        },
+        "model_type": "gbm",
+    }
+
+    config_obj = ModelConfig.from_dict(old_valid_config).to_dict()
+
+    # Non GBM supported feature so shouldn't exist in defaults
+    assert "sequence" not in config_obj["defaults"]
+
+    # Ensure defaults only have relevant keys
+    for feature_type in config_obj["defaults"]:
+        assert "encoder" not in config_obj["defaults"][feature_type]
+        assert "decoder" not in config_obj["defaults"][feature_type]
+        assert "loss" not in config_obj["defaults"][feature_type]


### PR DESCRIPTION
Title :) 

Essentially `encoder`, `decoder` and `loss` are not valid keys for GBMs.