### PR TITLE
Allow encoders for GBMs

### DIFF
--- a/ludwig/schema/features/audio_feature.py
+++ b/ludwig/schema/features/audio_feature.py
@@ -18,8 +18,6 @@ class AudioInputFeatureConfigMixin(BaseMarshmallowConfig):
     """AudioInputFeatureConfigMixin is a dataclass that configures the parameters used in both the audio input
     feature and the audio global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(AUDIO)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=AUDIO)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -35,4 +33,4 @@ class AudioInputFeatureConfigMixin(BaseMarshmallowConfig):
 class AudioInputFeatureConfig(AudioInputFeatureConfigMixin, BaseInputFeatureConfig):
     """AudioInputFeatureConfig is a dataclass that configures the parameters used for an audio input feature."""
 
-    pass
+    type: str = schema_utils.ProtectedString(AUDIO)

--- a/ludwig/schema/features/bag_feature.py
+++ b/ludwig/schema/features/bag_feature.py
@@ -18,8 +18,6 @@ class BagInputFeatureConfigMixin(BaseMarshmallowConfig):
     """BagInputFeatureConfigMixin is a dataclass that configures the parameters used in both the bag input feature
     and the bag global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(BAG)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=BAG)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -35,4 +33,4 @@ class BagInputFeatureConfigMixin(BaseMarshmallowConfig):
 class BagInputFeatureConfig(BagInputFeatureConfigMixin, BaseInputFeatureConfig):
     """BagInputFeatureConfig is a dataclass that configures the parameters used for a bag input feature."""
 
-    pass
+    type: str = schema_utils.ProtectedString(BAG)

--- a/ludwig/schema/features/binary_feature.py
+++ b/ludwig/schema/features/binary_feature.py
@@ -32,8 +32,6 @@ class BinaryInputFeatureConfigMixin(BaseMarshmallowConfig):
     """BinaryInputFeatureConfigMixin is a dataclass that configures the parameters used in both the binary input
     feature and the binary global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(BINARY)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=BINARY)
 
 
@@ -41,6 +39,8 @@ class BinaryInputFeatureConfigMixin(BaseMarshmallowConfig):
 @ludwig_dataclass
 class BinaryInputFeatureConfig(BinaryInputFeatureConfigMixin, BaseInputFeatureConfig):
     """BinaryInputFeatureConfig is a dataclass that configures the parameters used for a binary input feature."""
+
+    type: str = schema_utils.ProtectedString(BINARY)
 
     encoder: BaseEncoderConfig = None
 
@@ -74,8 +74,6 @@ class BinaryOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """BinaryOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the binary output
     feature and the binary global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(BINARY)
-
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=BINARY,
         default="regressor",
@@ -92,6 +90,8 @@ class BinaryOutputFeatureConfigMixin(BaseMarshmallowConfig):
 @ludwig_dataclass
 class BinaryOutputFeatureConfig(BinaryOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """BinaryOutputFeatureConfig is a dataclass that configures the parameters used for a binary output feature."""
+
+    type: str = schema_utils.ProtectedString(BINARY)
 
     calibration: bool = schema_utils.Boolean(
         default=False,

--- a/ludwig/schema/features/binary_feature.py
+++ b/ludwig/schema/features/binary_feature.py
@@ -25,7 +25,6 @@ from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 
 
 @DeveloperAPI
-@gbm_defaults_config_registry.register(BINARY)
 @input_mixin_registry.register(BINARY)
 @ludwig_dataclass
 class BinaryInputFeatureConfigMixin(BaseMarshmallowConfig):
@@ -60,6 +59,17 @@ class ECDBinaryInputFeatureConfig(BinaryInputFeatureConfig):
 @gbm_input_config_registry.register(BINARY)
 @ludwig_dataclass
 class GBMBinaryInputFeatureConfig(BinaryInputFeatureConfig):
+    encoder: BaseEncoderConfig = EncoderDataclassField(
+        MODEL_GBM,
+        feature_type=BINARY,
+        default="passthrough",
+    )
+
+
+@DeveloperAPI
+@gbm_defaults_config_registry.register(BINARY)
+@ludwig_dataclass
+class GBMBinaryDefaultsConfig(BinaryInputFeatureConfigMixin):
     encoder: BaseEncoderConfig = EncoderDataclassField(
         MODEL_GBM,
         feature_type=BINARY,

--- a/ludwig/schema/features/category_feature.py
+++ b/ludwig/schema/features/category_feature.py
@@ -32,8 +32,6 @@ class CategoryInputFeatureConfigMixin(BaseMarshmallowConfig):
     """CategoryInputFeatureConfigMixin is a dataclass that configures the parameters used in both the category
     input feature and the category global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(CATEGORY)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=CATEGORY)
 
 
@@ -42,6 +40,8 @@ class CategoryInputFeatureConfigMixin(BaseMarshmallowConfig):
 class CategoryInputFeatureConfig(CategoryInputFeatureConfigMixin, BaseInputFeatureConfig):
     """CategoryInputFeatureConfig is a dataclass that configures the parameters used for a category input
     feature."""
+
+    type: str = schema_utils.ProtectedString(CATEGORY)
 
     encoder: BaseEncoderConfig = None
 
@@ -75,8 +75,6 @@ class CategoryOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """CategoryOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the category
     output feature and the category global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(CATEGORY)
-
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=CATEGORY,
         default="classifier",
@@ -94,6 +92,8 @@ class CategoryOutputFeatureConfigMixin(BaseMarshmallowConfig):
 class CategoryOutputFeatureConfig(CategoryOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """CategoryOutputFeatureConfig is a dataclass that configures the parameters used for a category output
     feature."""
+
+    type: str = schema_utils.ProtectedString(CATEGORY)
 
     calibration: bool = schema_utils.Boolean(
         default=False,

--- a/ludwig/schema/features/category_feature.py
+++ b/ludwig/schema/features/category_feature.py
@@ -26,7 +26,6 @@ from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 
 @DeveloperAPI
 @input_mixin_registry.register(CATEGORY)
-@gbm_defaults_config_registry.register(CATEGORY)
 @ludwig_dataclass
 class CategoryInputFeatureConfigMixin(BaseMarshmallowConfig):
     """CategoryInputFeatureConfigMixin is a dataclass that configures the parameters used in both the category
@@ -61,6 +60,17 @@ class ECDCategoryInputFeatureConfig(CategoryInputFeatureConfig):
 @gbm_input_config_registry.register(CATEGORY)
 @ludwig_dataclass
 class GBMCategoryInputFeatureConfig(CategoryInputFeatureConfig):
+    encoder: BaseEncoderConfig = EncoderDataclassField(
+        MODEL_GBM,
+        feature_type=CATEGORY,
+        default="passthrough",
+    )
+
+
+@DeveloperAPI
+@gbm_defaults_config_registry.register(CATEGORY)
+@ludwig_dataclass
+class GBMCategoryDefaultsConfig(CategoryInputFeatureConfigMixin):
     encoder: BaseEncoderConfig = EncoderDataclassField(
         MODEL_GBM,
         feature_type=CATEGORY,

--- a/ludwig/schema/features/date_feature.py
+++ b/ludwig/schema/features/date_feature.py
@@ -18,8 +18,6 @@ class DateInputFeatureConfigMixin(BaseMarshmallowConfig):
     """DateInputFeatureConfigMixin is a dataclass that configures the parameters used in both the date input
     feature and the date global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(DATE)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=DATE)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -35,4 +33,4 @@ class DateInputFeatureConfigMixin(BaseMarshmallowConfig):
 class DateInputFeatureConfig(DateInputFeatureConfigMixin, BaseInputFeatureConfig):
     """DateInputFeature is a dataclass that configures the parameters used for a date input feature."""
 
-    pass
+    type: str = schema_utils.ProtectedString(DATE)

--- a/ludwig/schema/features/h3_feature.py
+++ b/ludwig/schema/features/h3_feature.py
@@ -18,8 +18,6 @@ class H3InputFeatureConfigMixin(BaseMarshmallowConfig):
     """H3InputFeatureConfigMixin is a dataclass that configures the parameters used in both the h3 input feature
     and the h3 global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(H3)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=H3)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -35,4 +33,4 @@ class H3InputFeatureConfigMixin(BaseMarshmallowConfig):
 class H3InputFeatureConfig(H3InputFeatureConfigMixin, BaseInputFeatureConfig):
     """H3InputFeatureConfig is a dataclass that configures the parameters used for an h3 input feature."""
 
-    pass
+    type: str = schema_utils.ProtectedString(H3)

--- a/ludwig/schema/features/image_feature.py
+++ b/ludwig/schema/features/image_feature.py
@@ -29,8 +29,6 @@ class ImageInputFeatureConfigMixin(BaseMarshmallowConfig):
     """ImageInputFeatureConfigMixin is a dataclass that configures the parameters used in both the image input
     feature and the image global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(IMAGE)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=IMAGE)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -57,4 +55,4 @@ class ImageInputFeatureConfigMixin(BaseMarshmallowConfig):
 class ImageInputFeatureConfig(ImageInputFeatureConfigMixin, BaseInputFeatureConfig):
     """ImageInputFeatureConfig is a dataclass that configures the parameters used for an image input feature."""
 
-    pass
+    type: str = schema_utils.ProtectedString(IMAGE)

--- a/ludwig/schema/features/number_feature.py
+++ b/ludwig/schema/features/number_feature.py
@@ -34,8 +34,6 @@ class NumberInputFeatureConfigMixin(BaseMarshmallowConfig):
     """NumberInputFeatureConfigMixin is a dataclass that configures the parameters used in both the number input
     feature and the number global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(NUMBER)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=NUMBER)
 
 
@@ -43,6 +41,8 @@ class NumberInputFeatureConfigMixin(BaseMarshmallowConfig):
 @ludwig_dataclass
 class NumberInputFeatureConfig(NumberInputFeatureConfigMixin, BaseInputFeatureConfig):
     """NumberInputFeatureConfig is a dataclass that configures the parameters used for a number input feature."""
+
+    type: str = schema_utils.ProtectedString(NUMBER)
 
     encoder: BaseEncoderConfig = None
 
@@ -76,8 +76,6 @@ class NumberOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """NumberOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the number output
     feature and the number global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(NUMBER)
-
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=NUMBER,
         default="regressor",
@@ -95,6 +93,8 @@ class NumberOutputFeatureConfigMixin(BaseMarshmallowConfig):
 class NumberOutputFeatureConfig(NumberOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """NumberOutputFeatureConfig is a dataclass that configures the parameters used for a category output
     feature."""
+
+    type: str = schema_utils.ProtectedString(NUMBER)
 
     clip: Union[List[int], Tuple[int]] = schema_utils.FloatRangeTupleDataclassField(
         n=2,

--- a/ludwig/schema/features/number_feature.py
+++ b/ludwig/schema/features/number_feature.py
@@ -28,7 +28,6 @@ from ludwig.schema.utils import BaseMarshmallowConfig, ludwig_dataclass
 
 @DeveloperAPI
 @input_mixin_registry.register(NUMBER)
-@gbm_defaults_config_registry.register(NUMBER)
 @ludwig_dataclass
 class NumberInputFeatureConfigMixin(BaseMarshmallowConfig):
     """NumberInputFeatureConfigMixin is a dataclass that configures the parameters used in both the number input
@@ -62,6 +61,17 @@ class ECDNumberInputFeatureConfig(NumberInputFeatureConfig):
 @gbm_input_config_registry.register(NUMBER)
 @ludwig_dataclass
 class GBMNumberInputFeatureConfig(NumberInputFeatureConfig):
+    encoder: BaseEncoderConfig = EncoderDataclassField(
+        MODEL_GBM,
+        feature_type=NUMBER,
+        default="passthrough",
+    )
+
+
+@DeveloperAPI
+@gbm_defaults_config_registry.register(NUMBER)
+@ludwig_dataclass
+class GBMNumberDefaultsConfig(NumberInputFeatureConfigMixin):
     encoder: BaseEncoderConfig = EncoderDataclassField(
         MODEL_GBM,
         feature_type=NUMBER,

--- a/ludwig/schema/features/sequence_feature.py
+++ b/ludwig/schema/features/sequence_feature.py
@@ -29,8 +29,6 @@ class SequenceInputFeatureConfigMixin(BaseMarshmallowConfig):
     """SequenceInputFeatureConfigMixin is a dataclass that configures the parameters used in both the sequence
     input feature and the sequence global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(SEQUENCE)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=SEQUENCE)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -47,7 +45,7 @@ class SequenceInputFeatureConfig(SequenceInputFeatureConfigMixin, BaseInputFeatu
     """SequenceInputFeatureConfig is a dataclass that configures the parameters used for a sequence input
     feature."""
 
-    pass
+    type: str = schema_utils.ProtectedString(SEQUENCE)
 
 
 @DeveloperAPI
@@ -56,8 +54,6 @@ class SequenceInputFeatureConfig(SequenceInputFeatureConfigMixin, BaseInputFeatu
 class SequenceOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """SequenceOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the sequence
     output feature and the sequence global defaults section of the Ludwig Config."""
-
-    type: str = schema_utils.ProtectedString(SEQUENCE)
 
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=SEQUENCE,
@@ -76,6 +72,8 @@ class SequenceOutputFeatureConfigMixin(BaseMarshmallowConfig):
 class SequenceOutputFeatureConfig(SequenceOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """SequenceOutputFeatureConfig is a dataclass that configures the parameters used for a sequence output
     feature."""
+
+    type: str = schema_utils.ProtectedString(SEQUENCE)
 
     default_validation_metric: str = schema_utils.StringOptions(
         [LOSS],

--- a/ludwig/schema/features/set_feature.py
+++ b/ludwig/schema/features/set_feature.py
@@ -29,8 +29,6 @@ class SetInputFeatureConfigMixin(BaseMarshmallowConfig):
     """SetInputFeatureConfigMixin is a dataclass that configures the parameters used in both the set input feature
     and the set global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(SET)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=SET)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -46,7 +44,7 @@ class SetInputFeatureConfigMixin(BaseMarshmallowConfig):
 class SetInputFeatureConfig(SetInputFeatureConfigMixin, BaseInputFeatureConfig):
     """SetInputFeatureConfig is a dataclass that configures the parameters used for a set input feature."""
 
-    pass
+    type: str = schema_utils.ProtectedString(SET)
 
 
 @DeveloperAPI
@@ -55,8 +53,6 @@ class SetInputFeatureConfig(SetInputFeatureConfigMixin, BaseInputFeatureConfig):
 class SetOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """SetOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the set output
     feature and the set global defaults section of the Ludwig Config."""
-
-    type: str = schema_utils.ProtectedString(SET)
 
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=SET,
@@ -74,6 +70,8 @@ class SetOutputFeatureConfigMixin(BaseMarshmallowConfig):
 @ludwig_dataclass
 class SetOutputFeatureConfig(SetOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """SetOutputFeatureConfig is a dataclass that configures the parameters used for a set output feature."""
+
+    type: str = schema_utils.ProtectedString(SET)
 
     default_validation_metric: str = schema_utils.StringOptions(
         [JACCARD],

--- a/ludwig/schema/features/text_feature.py
+++ b/ludwig/schema/features/text_feature.py
@@ -30,8 +30,6 @@ class TextInputFeatureConfigMixin(BaseMarshmallowConfig):
     """TextInputFeatureConfigMixin is a dataclass that configures the parameters used in both the text input
     feature and the text global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(TEXT)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=TEXT)
 
 
@@ -39,6 +37,8 @@ class TextInputFeatureConfigMixin(BaseMarshmallowConfig):
 @ludwig_dataclass
 class TextInputFeatureConfig(TextInputFeatureConfigMixin, BaseInputFeatureConfig):
     """TextInputFeatureConfig is a dataclass that configures the parameters used for a text input feature."""
+
+    type: str = schema_utils.ProtectedString(TEXT)
 
     encoder: BaseEncoderConfig = None
 
@@ -72,8 +72,6 @@ class TextOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """TextOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the text output
     feature and the text global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(TEXT)
-
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=TEXT,
         default="generator",
@@ -90,6 +88,8 @@ class TextOutputFeatureConfigMixin(BaseMarshmallowConfig):
 @ludwig_dataclass
 class TextOutputFeatureConfig(TextOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """TextOutputFeatureConfig is a dataclass that configures the parameters used for a text output feature."""
+
+    type: str = schema_utils.ProtectedString(TEXT)
 
     class_similarities: list = schema_utils.List(
         list,

--- a/ludwig/schema/features/text_feature.py
+++ b/ludwig/schema/features/text_feature.py
@@ -13,6 +13,7 @@ from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassFie
 from ludwig.schema.features.utils import (
     ecd_defaults_config_registry,
     ecd_input_config_registry,
+    gbm_defaults_config_registry,
     gbm_input_config_registry,
     input_mixin_registry,
     output_config_registry,
@@ -58,6 +59,17 @@ class ECDTextInputFeatureConfig(TextInputFeatureConfig):
 @gbm_input_config_registry.register(TEXT)
 @ludwig_dataclass
 class GBMTextInputFeatureConfig(TextInputFeatureConfig):
+    encoder: BaseEncoderConfig = EncoderDataclassField(
+        MODEL_GBM,
+        feature_type=TEXT,
+        default="tf_idf",
+    )
+
+
+@DeveloperAPI
+@gbm_defaults_config_registry.register(TEXT)
+@ludwig_dataclass
+class GBMTextDefaultsConfig(TextInputFeatureConfigMixin):
     encoder: BaseEncoderConfig = EncoderDataclassField(
         MODEL_GBM,
         feature_type=TEXT,

--- a/ludwig/schema/features/timeseries_feature.py
+++ b/ludwig/schema/features/timeseries_feature.py
@@ -29,8 +29,6 @@ class TimeseriesInputFeatureConfigMixin(BaseMarshmallowConfig):
     """TimeseriesInputFeatureConfigMixin is a dataclass that configures the parameters used in both the timeseries
     input feature and the timeseries global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(TIMESERIES)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=TIMESERIES)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -47,7 +45,7 @@ class TimeseriesInputFeatureConfig(TimeseriesInputFeatureConfigMixin, BaseInputF
     """TimeseriesInputFeatureConfig is a dataclass that configures the parameters used for a timeseries input
     feature."""
 
-    pass
+    type: str = schema_utils.ProtectedString(TIMESERIES)
 
 
 @DeveloperAPI
@@ -73,6 +71,8 @@ class TimeseriesOutputFeatureConfigMixin(BaseMarshmallowConfig):
 @ludwig_dataclass
 class TimeseriesOutputFeatureConfig(BaseOutputFeatureConfig, TimeseriesOutputFeatureConfigMixin):
     """TimeseriesOutputFeatureConfig configures the parameters used for a timeseries output feature."""
+
+    type: str = schema_utils.ProtectedString(TIMESERIES)
 
     dependencies: list = schema_utils.List(
         default=[],

--- a/ludwig/schema/features/vector_feature.py
+++ b/ludwig/schema/features/vector_feature.py
@@ -29,8 +29,6 @@ class VectorInputFeatureConfigMixin(BaseMarshmallowConfig):
     """VectorInputFeatureConfigMixin is a dataclass that configures the parameters used in both the vector input
     feature and the vector global defaults section of the Ludwig Config."""
 
-    type: str = schema_utils.ProtectedString(VECTOR)
-
     preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type=VECTOR)
 
     encoder: BaseEncoderConfig = EncoderDataclassField(
@@ -46,7 +44,7 @@ class VectorInputFeatureConfigMixin(BaseMarshmallowConfig):
 class VectorInputFeatureConfig(VectorInputFeatureConfigMixin, BaseInputFeatureConfig):
     """VectorInputFeatureConfig is a dataclass that configures the parameters used for a vector input feature."""
 
-    pass
+    type: str = schema_utils.ProtectedString(VECTOR)
 
 
 @DeveloperAPI
@@ -55,8 +53,6 @@ class VectorInputFeatureConfig(VectorInputFeatureConfigMixin, BaseInputFeatureCo
 class VectorOutputFeatureConfigMixin(BaseMarshmallowConfig):
     """VectorOutputFeatureConfigMixin is a dataclass that configures the parameters used in both the vector output
     feature and the vector global defaults section of the Ludwig Config."""
-
-    type: str = schema_utils.ProtectedString(VECTOR)
 
     decoder: BaseDecoderConfig = DecoderDataclassField(
         feature_type=VECTOR,
@@ -74,6 +70,8 @@ class VectorOutputFeatureConfigMixin(BaseMarshmallowConfig):
 @ludwig_dataclass
 class VectorOutputFeatureConfig(VectorOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """VectorOutputFeatureConfig is a dataclass that configures the parameters used for a vector output feature."""
+
+    type: str = schema_utils.ProtectedString(VECTOR)
 
     dependencies: list = schema_utils.List(
         default=[],

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -570,8 +570,10 @@ def test_defaults_mixins():
 
     config_obj = ModelConfig.from_dict(config)
 
-    assert config_obj.defaults.audio.to_dict().keys() == {TYPE, ENCODER, PREPROCESSING}
-    assert config_obj.defaults.category.to_dict().keys() == {TYPE, ENCODER, PREPROCESSING, DECODER, LOSS}
+    print(config_obj.defaults)
+
+    assert config_obj.defaults.audio.to_dict().keys() == {ENCODER, PREPROCESSING}
+    assert config_obj.defaults.category.to_dict().keys() == {ENCODER, PREPROCESSING, DECODER, LOSS}
 
 
 def test_initializer_recursion():
@@ -722,3 +724,48 @@ def test_preprocessing_max_sequence_length(sequence_length, max_sequence_length,
     config_obj = ModelConfig.from_dict(config)
     assert config_obj.input_features[0].preprocessing.max_sequence_length == max_sequence_length_expected
     assert config_obj.input_features[1].preprocessing.max_sequence_length == max_sequence_length_expected
+
+
+def test_gbm_encoders():
+    config = {
+        "input_features": [
+            {"name": "feature_1", "type": "category"},
+            {"name": "Sex", "type": "category"},
+        ],
+        "output_features": [
+            {"name": "Survived", "type": "category"},
+        ],
+        "defaults": {
+            "binary": {
+                "encoder": {
+                    "type": "passthrough",
+                },
+                "preprocessing": {
+                    "missing_value_strategy": "fill_with_false",
+                },
+            },
+            "category": {
+                "encoder": {
+                    "type": "onehot",
+                },
+                "preprocessing": {
+                    "missing_value_strategy": "fill_with_const",
+                    "most_common": 10000,
+                },
+            },
+            "number": {
+                "encoder": {
+                    "type": "passthrough",
+                },
+                "preprocessing": {
+                    "missing_value_strategy": "fill_with_const",
+                },
+            },
+        },
+        "model_type": "gbm",
+    }
+
+    config_obj = ModelConfig.from_dict(config).to_dict()
+
+    for feature_type in config_obj.get("defaults"):
+        assert "encoder" in config_obj["defaults"][feature_type]


### PR DESCRIPTION
This PR enables binary, category, number, and text features to allow encoders in the defaults section of the Ludwig config.
