### PR TITLE
Cherry-pick 0.7: `sequence_length` capability

### DIFF
--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -212,16 +212,31 @@ class SequenceFeatureMixin(BaseFeatureMixin):
             ngram_size=preprocessing_parameters["ngram_size"],
             processor=backend.df_engine,
         )
+        logger.info(f"Max length of feature '{column.name}': {max_length} (without start and stop symbols)")
 
-        # Use max_sequence_length if provided, otherwise use max length found in dataset.
-        if preprocessing_parameters["max_sequence_length"] is not None:
-            logger.info("Using max_sequence_length provided in preprocessing parameters")
-            max_sequence_length = preprocessing_parameters["max_sequence_length"]
+        # Use sequence_length if provided, otherwise use max length found in dataset.
+        if preprocessing_parameters["sequence_length"] is not None:
+            logger.info(
+                f"Setting max length to sequence_length={preprocessing_parameters['sequence_length']} provided in "
+                f"preprocessing parameters"
+            )
+            max_sequence_length = preprocessing_parameters["sequence_length"]
         else:
-            logger.info("Inferring max_sequence_length from dataset")
             max_sequence_length = max_length + 2  # For start and stop symbols.
-        logger.info(f"Using max sequence length of {max_sequence_length} for feature '{column.name}'")
+            logger.info(f"Setting max length using dataset: {max_sequence_length} (including start and stop symbols)")
 
+            # If max_sequence_length is None, then use the max length found in the dataset.
+            if (
+                preprocessing_parameters["max_sequence_length"] is not None
+                and preprocessing_parameters["max_sequence_length"] < max_sequence_length
+            ):
+                logger.info(
+                    f"Truncating max length with max_sequence_length={preprocessing_parameters['max_sequence_length']} "
+                    f"from preprocessing parameters"
+                )
+                max_sequence_length = preprocessing_parameters["max_sequence_length"]
+
+        logger.info(f"max sequence length is {max_sequence_length} for feature '{column.name}'")
         return {
             "idx2str": idx2str,
             "str2idx": str2idx,

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -212,13 +212,22 @@ class SequenceFeatureMixin(BaseFeatureMixin):
             ngram_size=preprocessing_parameters["ngram_size"],
             processor=backend.df_engine,
         )
-        max_length = min(preprocessing_parameters["max_sequence_length"], max_length)
+
+        # Use max_sequence_length if provided, otherwise use max length found in dataset.
+        if preprocessing_parameters["max_sequence_length"] is not None:
+            logger.info("Using max_sequence_length provided in preprocessing parameters")
+            max_sequence_length = preprocessing_parameters["max_sequence_length"]
+        else:
+            logger.info("Inferring max_sequence_length from dataset")
+            max_sequence_length = max_length + 2  # For start and stop symbols.
+        logger.info(f"Using max sequence length of {max_sequence_length} for feature '{column.name}'")
+
         return {
             "idx2str": idx2str,
             "str2idx": str2idx,
             "str2freq": str2freq,
             "vocab_size": len(idx2str),
-            "max_sequence_length": max_length + 2,  # For start and end symbol.
+            "max_sequence_length": max_sequence_length,
         }
 
     @staticmethod

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -106,17 +106,34 @@ class TextFeatureMixin(BaseFeatureMixin):
             padding_symbol,
             unknown_symbol,
         ) = tf_meta
-        # Use max_sequence_length if provided, otherwise use max length found in dataset.
-        if preprocessing_parameters["max_sequence_length"] is not None:
-            logger.info("Using max_sequence_length provided in preprocessing parameters")
-            max_sequence_length = preprocessing_parameters["max_sequence_length"]
-            max_sequence_length_99ptile = max_sequence_length
+        logger.info(f"Max length of feature '{column.name}': {max_len} (without start and stop symbols)")
+
+        # Use sequence_length if provided, otherwise use max length found in dataset.
+        if preprocessing_parameters["sequence_length"] is not None:
+            logger.info(
+                f"Setting max length to sequence_length={preprocessing_parameters['sequence_length']} provided in "
+                f"preprocessing parameters"
+            )
+            max_sequence_length = preprocessing_parameters["sequence_length"]
+            max_sequence_length_99ptile = preprocessing_parameters["sequence_length"]
         else:
-            logger.info("Inferring max_sequence_length from dataset")
             max_sequence_length = max_len + 2  # For start and stop symbols.
             max_sequence_length_99ptile = max_len_99ptile + 2  # For start and stop symbols.
-        logger.info(f"Using max sequence length of {max_sequence_length} for feature '{column.name}'")
+            logger.info(f"Setting max length using dataset: {max_sequence_length} (including start and stop symbols)")
 
+            # If max_sequence_length is None, then use the max length found in the dataset.
+            if (
+                preprocessing_parameters["max_sequence_length"] is not None
+                and preprocessing_parameters["max_sequence_length"] < max_sequence_length
+            ):
+                logger.info(
+                    f"Truncating max length with max_sequence_length={preprocessing_parameters['max_sequence_length']} "
+                    f"from preprocessing parameters"
+                )
+                max_sequence_length = preprocessing_parameters["max_sequence_length"]
+                max_sequence_length_99ptile = min(max_len_99ptile, max_sequence_length)
+
+        logger.info(f"max sequence length is {max_sequence_length} for feature '{column.name}'")
         return {
             "idx2str": idx2str,
             "str2idx": str2idx,

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -106,15 +106,24 @@ class TextFeatureMixin(BaseFeatureMixin):
             padding_symbol,
             unknown_symbol,
         ) = tf_meta
-        max_len = min(preprocessing_parameters["max_sequence_length"], max_len)
-        max_len_99ptile = min(max_len, max_len_99ptile)
+        # Use max_sequence_length if provided, otherwise use max length found in dataset.
+        if preprocessing_parameters["max_sequence_length"] is not None:
+            logger.info("Using max_sequence_length provided in preprocessing parameters")
+            max_sequence_length = preprocessing_parameters["max_sequence_length"]
+            max_sequence_length_99ptile = max_sequence_length
+        else:
+            logger.info("Inferring max_sequence_length from dataset")
+            max_sequence_length = max_len + 2  # For start and stop symbols.
+            max_sequence_length_99ptile = max_len_99ptile + 2  # For start and stop symbols.
+        logger.info(f"Using max sequence length of {max_sequence_length} for feature '{column.name}'")
+
         return {
             "idx2str": idx2str,
             "str2idx": str2idx,
             "str2freq": str2freq,
             "vocab_size": len(idx2str),
-            "max_sequence_length": max_len + 2,  # For start and stop symbols.
-            "max_sequence_length_99ptile": max_len_99ptile + 2,  # For start and stop symbols.
+            "max_sequence_length": max_sequence_length,
+            "max_sequence_length_99ptile": max_sequence_length_99ptile,
             "pad_idx": pad_idx,
             "padding_symbol": padding_symbol,
             "unknown_symbol": unknown_symbol,

--- a/ludwig/schema/encoders/sequence_encoders.py
+++ b/ludwig/schema/encoders/sequence_encoders.py
@@ -87,7 +87,7 @@ class SequencePassthroughConfig(SequenceEncoderConfig):
         description=ENCODER_METADATA["SequencePassthrough"]["type"].long_description,
     )
 
-    max_sequence_length: int = common_fields.MaxSequenceLengthField(default=256)
+    max_sequence_length: int = common_fields.MaxSequenceLengthField()
 
     encoding_size: int = schema_utils.PositiveInteger(
         default=None,

--- a/ludwig/schema/features/base.py
+++ b/ludwig/schema/features/base.py
@@ -110,7 +110,9 @@ class BaseInputFeatureConfig(BaseFeatureConfig):
         default=None,
         allow_none=True,
         description="Name of input feature to tie the weights of the encoder with.  It needs to be the name of a "
-        "feature of the same type and with the same encoder parameters.",
+        "feature of the same type and with the same encoder parameters. If text or sequence features are tied, "
+        "consider setting the `sequence_length` parameter in `preprocessing` to ensure that the tied features have "
+        "equal sized outputs. This is necessary when using the `sequence` combiner.",
     )
 
     def has_augmentation(self) -> bool:

--- a/ludwig/schema/features/preprocessing/sequence.py
+++ b/ludwig/schema/features/preprocessing/sequence.py
@@ -28,10 +28,11 @@ class SequencePreprocessingConfig(BasePreprocessingConfig):
     )
 
     max_sequence_length: int = schema_utils.PositiveInteger(
-        default=256,
-        allow_none=False,
+        default=None,
+        allow_none=True,
         description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
-        "truncated, while texts that are shorter will be padded.",
+        "truncated, while texts that are shorter will be padded. If None, max sequence length will be inferred from "
+        "the training dataset.",
         parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["max_sequence_length"],
     )
 
@@ -123,10 +124,11 @@ class SequenceOutputPreprocessingConfig(SequencePreprocessingConfig):
     )
 
     max_sequence_length: int = schema_utils.PositiveInteger(
-        default=256,
-        allow_none=False,
+        default=None,
+        allow_none=True,
         description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
-        "truncated, while texts that are shorter will be padded.",
+        "truncated, while texts that are shorter will be padded. If None, max sequence length will be inferred from "
+        "the training dataset.",
         parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["max_sequence_length"],
     )
 

--- a/ludwig/schema/features/preprocessing/sequence.py
+++ b/ludwig/schema/features/preprocessing/sequence.py
@@ -27,12 +27,21 @@ class SequencePreprocessingConfig(BasePreprocessingConfig):
         parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["vocab_file"],
     )
 
-    max_sequence_length: int = schema_utils.PositiveInteger(
+    sequence_length: int = schema_utils.PositiveInteger(
         default=None,
         allow_none=True,
-        description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
-        "truncated, while texts that are shorter will be padded. If None, max sequence length will be inferred from "
-        "the training dataset.",
+        description="The desired length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated and sequences shorter than this value will be padded. If None, sequence length will be "
+        "inferred from the training dataset.",
+        parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["sequence_length"],
+    )
+
+    max_sequence_length: int = schema_utils.PositiveInteger(
+        default=256,
+        allow_none=True,
+        description="The maximum length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated. Useful as a stopgap measure if `sequence_length` is set to `None`. If `None`, max sequence "
+        "length will be inferred from the training dataset.",
         parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["max_sequence_length"],
     )
 
@@ -123,12 +132,20 @@ class SequenceOutputPreprocessingConfig(SequencePreprocessingConfig):
         parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["missing_value_strategy"],
     )
 
-    max_sequence_length: int = schema_utils.PositiveInteger(
+    sequence_length: int = schema_utils.PositiveInteger(
         default=None,
         allow_none=True,
-        description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
-        "truncated, while texts that are shorter will be padded. If None, max sequence length will be inferred from "
-        "the training dataset.",
+        description="The desired length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated and sequences shorter than this value will be padded. If None, sequence length will be "
+        "inferred from the training dataset.",
+    )
+
+    max_sequence_length: int = schema_utils.PositiveInteger(
+        default=256,
+        allow_none=True,
+        description="The maximum length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated. Useful as a stopgap measure if `sequence_length` is set to `None`. If `None`, max sequence "
+        "length will be inferred from the training dataset.",
         parameter_metadata=FEATURE_METADATA[SEQUENCE][PREPROCESSING]["max_sequence_length"],
     )
 

--- a/ludwig/schema/features/preprocessing/text.py
+++ b/ludwig/schema/features/preprocessing/text.py
@@ -38,12 +38,20 @@ class TextPreprocessingConfig(BasePreprocessingConfig):
         parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["vocab_file"],
     )
 
-    max_sequence_length: int = schema_utils.PositiveInteger(
+    sequence_length: int = schema_utils.PositiveInteger(
         default=None,
         allow_none=True,
-        description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
-        "truncated, while texts that are shorter will be padded. If None, max sequence length will be inferred from "
-        "the training dataset.",
+        description="The desired length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated and sequences shorter than this value will be padded. If None, sequence length will be "
+        "inferred from the training dataset.",
+    )
+
+    max_sequence_length: int = schema_utils.PositiveInteger(
+        default=256,
+        allow_none=True,
+        description="The maximum length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated. Useful as a stopgap measure if `sequence_length` is set to `None`. If `None`, max sequence "
+        "length will be inferred from the training dataset.",
         parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["max_sequence_length"],
     )
 
@@ -139,12 +147,21 @@ class TextOutputPreprocessingConfig(TextPreprocessingConfig):
         parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["missing_value_strategy"],
     )
 
-    max_sequence_length: int = schema_utils.PositiveInteger(
+    sequence_length: int = schema_utils.PositiveInteger(
         default=None,
         allow_none=True,
-        description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
-        "truncated, while texts that are shorter will be padded. If None, max sequence length will be inferred from "
-        "the training dataset.",
+        description="The desired length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated and sequences shorter than this value will be padded. If None, sequence length will be "
+        "inferred from the training dataset.",
+        parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["sequence_length"],
+    )
+
+    max_sequence_length: int = schema_utils.PositiveInteger(
+        default=256,
+        allow_none=True,
+        description="The maximum length (number of tokens) of the sequence. Sequences that are longer than this value "
+        "will be truncated. Useful as a stopgap measure if `sequence_length` is set to `None`. If `None`, max sequence "
+        "length will be inferred from the training dataset.",
         parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["max_sequence_length"],
     )
 

--- a/ludwig/schema/features/preprocessing/text.py
+++ b/ludwig/schema/features/preprocessing/text.py
@@ -39,10 +39,11 @@ class TextPreprocessingConfig(BasePreprocessingConfig):
     )
 
     max_sequence_length: int = schema_utils.PositiveInteger(
-        default=256,
-        allow_none=False,
+        default=None,
+        allow_none=True,
         description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
-        "truncated, while texts that are shorter will be padded.",
+        "truncated, while texts that are shorter will be padded. If None, max sequence length will be inferred from "
+        "the training dataset.",
         parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["max_sequence_length"],
     )
 
@@ -139,10 +140,11 @@ class TextOutputPreprocessingConfig(TextPreprocessingConfig):
     )
 
     max_sequence_length: int = schema_utils.PositiveInteger(
-        default=256,
-        allow_none=False,
+        default=None,
+        allow_none=True,
         description="The maximum length (number of tokens) of the text. Texts that are longer than this value will be "
-        "truncated, while texts that are shorter will be padded.",
+        "truncated, while texts that are shorter will be padded. If None, max sequence length will be inferred from "
+        "the training dataset.",
         parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["max_sequence_length"],
     )
 

--- a/ludwig/schema/metadata/configs/features.yaml
+++ b/ludwig/schema/metadata/configs/features.yaml
@@ -576,6 +576,23 @@ sequence:
         lowercase:
             ui_display_name: null
             expected_impact: 2
+        sequence_length:
+            default_value_reasoning:
+                The default value is `None`. Which means that the sequence length will be inferred from the dataset,
+                which may save you compute resources on datasets with short sequence samples.
+            description_implications:
+                A larger sequence length keeps more information
+                from the data, but also makes it more computationally expensive (more
+                memory and longer training time). A smaller sequence length keeps
+                less information from the data, but also makes it less computationally
+                expensive (less memory and shorter training time).
+            expected_impact: 3
+            related_parameters:
+                - max_sequence_length
+            suggested_values:
+                If tying the weights of multiple sequence encoders together,
+                this parameter may need to be set to ensure that all sequence features have the same sequence length.
+            ui_display_name: Sequence Length
         max_sequence_length:
             default_value_reasoning:
                 The default value is 256. Every sequence will
@@ -763,6 +780,23 @@ text:
                 words and lowercased words differently, then set this to False. Otherwise,
                 it is preferable to bucket the words and make the model case-insensitive.
             ui_display_name: Convert to lowercase
+        sequence_length:
+            default_value_reasoning:
+                The default value is `None`. Which means that the sequence length will be inferred from the dataset,
+                which may save you compute resources on datasets with short text samples.
+            description_implications:
+                A larger sequence length keeps more information
+                from the data, but also makes it more computationally expensive (more
+                memory and longer training time). A smaller sequence length keeps
+                less information from the data, but also makes it less computationally
+                expensive (less memory and shorter training time).
+            expected_impact: 3
+            related_parameters:
+                - max_sequence_length
+            suggested_values:
+                If tying the weights of multiple text encoders together,
+                this parameter may need to be set to ensure that all text features have the same sequence length.
+            ui_display_name: Sequence Length
         max_sequence_length:
             default_value_reasoning:
                 The default value is 256. Every sequence will

--- a/ludwig/schema/model_types/base.py
+++ b/ludwig/schema/model_types/base.py
@@ -19,6 +19,7 @@ from ludwig.schema.model_types.utils import (
     merge_with_defaults,
     set_derived_feature_columns_,
     set_hyperopt_defaults_,
+    set_preprocessing_parameters,
     set_validation_parameters,
 )
 from ludwig.schema.preprocessing import PreprocessingConfig
@@ -51,6 +52,9 @@ class ModelConfig(schema_utils.BaseMarshmallowConfig, ABC):
     def __post_init__(self):
         set_validation_parameters(self)
         set_hyperopt_defaults_(self)
+
+        # Reconcile conflicting preprocessing parameters
+        set_preprocessing_parameters(self)
 
         # Derive proc_col for each feature from the feature's preprocessing parameters
         # after all preprocessing parameters have been set

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ dataclasses-json
 jsonschema>=4.5.0,<4.7
 marshmallow
 marshmallow-jsonschema
-marshmallow-dataclass==8.5.5
+marshmallow-dataclass==8.5.4
 tensorboard
 torchmetrics>=0.11
 torchinfo

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -506,6 +506,43 @@ def test_experiment_tied_weights(csv_filename):
         run_experiment(input_features, output_features, dataset=rel_path)
 
 
+def test_experiment_tied_weights_sequence_combiner(csv_filename):
+    """Tests that tied weights work with sequence combiners if `sequence_length` is provided.
+
+    Addresses https://github.com/ludwig-ai/ludwig/issues/3220
+    """
+    input_features = [
+        text_feature(
+            name="feature1",
+            encoder={
+                "max_len": 5,
+                "reduce_output": None,
+            },
+            preprocessing={"sequence_length": 10},
+        ),
+        text_feature(
+            name="feature2",
+            encoder={
+                "max_len": 3,
+                "reduce_output": None,
+            },
+            preprocessing={"sequence_length": 10},
+            tied="feature1",
+        ),
+    ]
+    output_features = [category_feature(decoder={"reduce_input": "sum", "vocab_size": 2})]
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        "combiner": {"type": "sequence"},
+        TRAINER: {"epochs": 2, BATCH_SIZE: 128},
+    }
+
+    # Generate test data
+    rel_path = generate_data(input_features, output_features, csv_filename)
+    run_experiment(config=config, dataset=rel_path)
+
+
 @pytest.mark.parametrize("enc_cell_type", ["lstm", "rnn", "gru"])
 @pytest.mark.parametrize("attention", [False, True])
 def test_sequence_tagger(enc_cell_type, attention, csv_filename):

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -11,6 +11,7 @@ from PIL import Image
 
 import ludwig
 from ludwig.api import LudwigModel
+from ludwig.callbacks import Callback
 from ludwig.constants import BATCH_SIZE, COLUMN, DECODER, FULL, NAME, PROC_COLUMN, TRAINER
 from ludwig.data.concatenate_datasets import concatenate_df
 from ludwig.data.preprocessing import preprocess_for_prediction
@@ -24,6 +25,7 @@ from tests.integration_tests.utils import (
     LocalTestBackend,
     number_feature,
     sequence_feature,
+    text_feature,
 )
 
 NUM_EXAMPLES = 20
@@ -375,6 +377,40 @@ def test_number_feature_wrong_dtype(csv_filename, tmpdir):
     # check that train_ds had invalid values replaced with the missing value
     assert len(concatenated_df) == len(df)
     assert np.all(concatenated_df[num_feat[PROC_COLUMN]] == 0.0)
+
+
+@pytest.mark.parametrize(
+    "max_len, max_sequence_length, max_sequence_length_expected",
+    [
+        (10, None, 12),  # None means to infer from the dataset. Add 2 to expected value for start and end tokens.
+        (10, 5, 5),
+        (10, 15, 15),
+    ],
+)
+def test_text_features_max_sequence_length(
+    csv_filename, tmpdir, max_len, max_sequence_length, max_sequence_length_expected
+):
+    """Tests that a text feature has the correct max_sequence_length."""
+    text_feat = text_feature(encoder={"max_len": max_len}, preprocessing={"max_sequence_length": max_sequence_length})
+    input_features = [text_feat]
+    output_features = [binary_feature()]
+    config = {"input_features": input_features, "output_features": output_features}
+
+    data_csv_path = os.path.join(tmpdir, csv_filename)
+    training_data_csv_path = generate_data(input_features, output_features, data_csv_path)
+    df = pd.read_csv(training_data_csv_path)
+
+    class CheckTrainingSetMetadataCallback(Callback):
+        def on_preprocess_end(self, proc_training_set, proc_validation_set, proc_test_set, training_set_metadata):
+            assert training_set_metadata[text_feat[NAME]]["max_sequence_length"] == max_sequence_length_expected
+
+    backend = LocalTestBackend()
+    ludwig_model = LudwigModel(config, backend=backend, callbacks=[CheckTrainingSetMetadataCallback()])
+    train_ds, val_ds, test_ds, _ = ludwig_model.preprocess(dataset=df)
+
+    all_df = concatenate_df(train_ds.to_df(), val_ds.to_df(), test_ds.to_df(), backend)
+    proc_column_name = text_feat[PROC_COLUMN]
+    assert all(len(x) == max_sequence_length_expected for x in all_df[proc_column_name])
 
 
 def test_column_feature_type_mismatch_fill():

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -682,3 +682,43 @@ def test_augmentation_pipeline(augmentation, expected):
     # Test the serializing and reloading yields the same results
     config_obj2 = ModelConfig.from_dict(config_dict)
     assert config_obj2.input_features[0].augmentation == config_obj.input_features[0].augmentation
+
+
+@pytest.mark.parametrize(
+    "sequence_length, max_sequence_length, max_sequence_length_expected",
+    [
+        (None, 100, 100),
+        (50, 100, 100),
+        (100, 50, 100),
+    ],
+)
+def test_preprocessing_max_sequence_length(sequence_length, max_sequence_length, max_sequence_length_expected):
+    config = {
+        "input_features": [
+            {
+                "name": "text1",
+                "type": "text",
+                "preprocessing": {
+                    "sequence_length": sequence_length,
+                    "max_sequence_length": max_sequence_length,
+                },
+            },
+            {
+                "name": "sequence1",
+                "type": "sequence",
+                "preprocessing": {
+                    "sequence_length": sequence_length,
+                    "max_sequence_length": max_sequence_length,
+                },
+            },
+        ],
+        "output_features": [
+            {
+                "name": "number1",
+                "type": "number",
+            },
+        ],
+    }
+    config_obj = ModelConfig.from_dict(config)
+    assert config_obj.input_features[0].preprocessing.max_sequence_length == max_sequence_length_expected
+    assert config_obj.input_features[1].preprocessing.max_sequence_length == max_sequence_length_expected


### PR DESCRIPTION
Adds the following two PRs:

https://github.com/ludwig-ai/ludwig/pull/3205: https://github.com/ludwig-ai/ludwig/commit/e3a9416d640821b88494adce63f7f5db882296b5
https://github.com/ludwig-ai/ludwig/pull/3221: https://github.com/ludwig-ai/ludwig/commit/75b1941b65bb0a14c7a594e8a25e8fee13ecae2f

These two PRs will enable users to fix the sequence length of text features using the new `sequence_length` parameter, which is particularly useful when using the `sequence` combiner (https://github.com/ludwig-ai/ludwig/issues/3220).