### PR TITLE
Fixed handling of datetime types in input parquet files

### DIFF
--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -315,15 +315,22 @@ def get_dataset_info_from_source(source: DataSource) -> DatasetInfo:
         nonnull_values = source.get_nonnull_values(field)
         image_values = source.get_image_values(field)
         audio_values = source.get_audio_values(field)
-        avg_words = None
+
         if dtype == "object":
             # Check if it is a nullboolean field. We do this since if you read a csv with
             # pandas that has a column of booleans and some missing values, the column is
             # interpreted as object dtype instead of bool
             if is_field_boolean(source, field):
                 dtype = "bool"
+
+        avg_words = None
         if source.is_string_type(dtype):
-            avg_words = source.get_avg_num_tokens(field)
+            try:
+                avg_words = source.get_avg_num_tokens(field)
+            except AttributeError:
+                # Series is not actually a string type despite being an object, e.g., Decimal, Datetime, etc.
+                avg_words = None
+
         fields.append(
             FieldInfo(
                 name=field,

--- a/ludwig/data/split.py
+++ b/ludwig/data/split.py
@@ -269,8 +269,15 @@ class DatetimeSplitter(Splitter):
         # In case the split column was preprocessed by Ludwig into a list, convert it back to a
         # datetime string for the sort and split
         def list_to_date_str(x):
-            if not isinstance(x, list) and len(x) != 9:
-                return x
+            if not isinstance(x, list):
+                if not isinstance(x, str):
+                    # Convert timestamps, etc. to strings and return so it can direct cast to epoch time
+                    return str(x)
+
+                if len(x) != 9:
+                    # Strings not in the expected format, so assume it's a formatted datetime and return
+                    return x
+
             return f"{x[0]}-{x[1]}-{x[2]} {x[5]}:{x[6]}:{x[7]}"
 
         df[TMP_SPLIT_COL] = backend.df_engine.map_objects(df[self.column], list_to_date_str)

--- a/ludwig/utils/automl/type_inference.py
+++ b/ludwig/utils/automl/type_inference.py
@@ -27,7 +27,7 @@ def infer_type(field: FieldInfo, missing_value_percent: float, row_count: int) -
     # Return
     :return: (str) feature type
     """
-    if field.dtype == DATE:
+    if field.dtype == DATE or field.dtype.startswith("datetime"):
         return DATE
 
     num_distinct_values = field.num_distinct_values
@@ -46,6 +46,9 @@ def infer_type(field: FieldInfo, missing_value_percent: float, row_count: int) -
 
     if field.audio_values >= 3:
         return AUDIO
+
+    if strings_utils.are_all_datetimes(distinct_values):
+        return DATE
 
     # Use CATEGORY if:
     # - The number of distinct values is significantly less than the total number of examples.

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -130,6 +130,9 @@ def is_number(s: Union[str, int, float]):
 
 def is_datetime(s: Union[str, int, float]):
     """Returns whether specified value is datetime."""
+    if is_number(s):
+        return False
+
     try:
         parse_datetime(s)
         return True

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -22,6 +22,7 @@ from enum import Enum
 from typing import Dict, List, Optional, Set, Union
 
 import numpy as np
+from dateutil.parser import parse as parse_datetime
 
 from ludwig.constants import PADDING_SYMBOL, START_SYMBOL, STOP_SYMBOL, UNKNOWN_SYMBOL
 from ludwig.data.dataframe.base import DataFrameEngine
@@ -125,6 +126,23 @@ def is_number(s: Union[str, int, float]):
         return True
     except ValueError:
         return False
+
+
+def is_datetime(s: Union[str, int, float]):
+    """Returns whether specified value is datetime."""
+    try:
+        parse_datetime(s)
+        return True
+    except Exception:
+        return False
+
+
+def are_all_datetimes(values: List[Union[str, int, float]]):
+    """Returns whether all values are datetimes."""
+    for value in values:
+        if not is_datetime(value):
+            return False
+    return True
 
 
 def are_all_numbers(values: List[Union[str, int, float]]):

--- a/tests/ludwig/automl/test_base_config.py
+++ b/tests/ludwig/automl/test_base_config.py
@@ -164,6 +164,8 @@ def test_infer_parquet_types(tmpdir):
               type: date
             - name: category
               type: category
+            - name: date
+              type: date
         output_features:
             - name: bool
               type: binary

--- a/tests/ludwig/automl/test_base_config.py
+++ b/tests/ludwig/automl/test_base_config.py
@@ -1,14 +1,23 @@
+from decimal import Decimal
+import os
 import numpy as np
 import pandas as pd
 import pytest
+import yaml
 
 ray = pytest.importorskip("ray")  # noqa
 
-from ludwig.automl.base_config import get_dataset_info, get_reference_configs, is_field_boolean  # noqa
+from ludwig.automl.base_config import (  # noqa
+    get_dataset_info,
+    get_dataset_info_from_source,
+    get_field_metadata,
+    get_reference_configs,
+    is_field_boolean,
+)
 from ludwig.data.dataframe.dask import DaskEngine  # noqa
 from ludwig.data.dataframe.pandas import PandasEngine  # noqa
 from ludwig.schema.model_types.base import ModelConfig  # noqa
-from ludwig.utils.automl.data_source import wrap_data_source  # noqa
+from ludwig.utils.automl.data_source import DataframeSource, wrap_data_source  # noqa
 
 pytestmark = pytest.mark.distributed
 
@@ -104,3 +113,69 @@ def test_reference_configs():
 
         # Ensure config is valid with the latest Ludwig schema
         ModelConfig.from_dict(config)
+
+
+def repeat(df, n):
+    """Repeat a dataframe n times."""
+    return pd.concat([df] * n, ignore_index=True)
+
+
+def test_infer_parquet_types(tmpdir):
+    """Test type inference works properly for a parquet file with unconventional types types."""
+    # Create a temporary directory to store the parquet file
+    tmpdir = str(tmpdir)
+
+    # Create a dataframe with all the types
+    df = pd.DataFrame(
+        {
+            "int": [1, 2, 3],
+            "float": [1.1, 2.2, 3.3],
+            "string": ["a", "b", "c"],
+            "datetime": pd.date_range("20130101", periods=3),
+            "category": pd.Series(["a", "b", "c"], dtype="category"),
+            "bool": [True, False, True],
+        }
+    )
+    df = repeat(df, 10)
+    df["float"] = df["float"].apply(Decimal)
+    df["date"] = df["datetime"].apply(str)
+
+    # Write the dataframe to parquet and read it back
+    dataset_path = os.path.join(tmpdir, "dataset.parquet")
+    df.to_parquet(dataset_path)
+    df = pd.read_parquet(dataset_path)
+
+    # Test type inference
+    ds = DataframeSource(df)
+    ds_info = get_dataset_info_from_source(ds)
+    metas = get_field_metadata(ds_info.fields, ds_info.row_count, targets=["bool"])
+
+    config = yaml.safe_load(
+        """
+        input_features:
+            - name: int
+              type: category
+            - name: float
+              type: number
+            - name: string
+              type: category
+            - name: datetime
+              type: date
+            - name: category
+              type: category
+        output_features:
+            - name: bool
+              type: binary
+        combiner:
+            type: concat
+            output_size: 14
+        trainer:
+            epochs: 2
+            batch_size: 8
+        """
+    )
+
+    meta_dict = {meta.config.name: meta for meta in metas}
+    for feature in config["input_features"] + config["output_features"]:
+        meta = meta_dict[feature["name"]]
+        assert feature["type"] == meta.config.type, f"{feature['name']}: {feature['type']} != {meta.config.type}"

--- a/tests/ludwig/automl/test_base_config.py
+++ b/tests/ludwig/automl/test_base_config.py
@@ -1,5 +1,6 @@
-from decimal import Decimal
 import os
+from decimal import Decimal
+
 import numpy as np
 import pandas as pd
 import pytest

--- a/tests/ludwig/data/test_split.py
+++ b/tests/ludwig/data/test_split.py
@@ -279,7 +279,8 @@ def test_single_occurrence_stratified_split(df_engine, atol, ray_cluster_2cpu):
         pytest.param(DaskEngine(_use_ray=False), id="dask", marks=pytest.mark.distributed),
     ],
 )
-def test_datetime_split(df_engine, ray_cluster_2cpu):
+@pytest.mark.parametrize("format", ["str", "datetime"])
+def test_datetime_split(format, df_engine, ray_cluster_2cpu):
     nrows = 100
     npartitions = 10
 
@@ -291,7 +292,8 @@ def test_datetime_split(df_engine, ray_cluster_2cpu):
         delta = end - start
         int_delta = (delta.days * 24 * 60 * 60) + delta.seconds
         random_second = randrange(int_delta)
-        return str(start + timedelta(seconds=random_second))
+        t = start + timedelta(seconds=random_second)
+        return str(t) if format == "str" else t
 
     df["date_col"] = df["C"].map(random_date)
 


### PR DESCRIPTION
- Fixes issue with datetime splitting on timestamp type columns
- Fixes issue with automl type inference for datetime types
- Fixes issue with automl type inference for datetimes formatted as strings