### PR TITLE
Handle `np.bool` to JSON `NumpyEncoder`

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -772,6 +772,8 @@ class NumpyEncoder(json.JSONEncoder):
             return float(obj)
         elif isinstance(obj, np.ndarray):
             return obj.tolist()
+        elif isinstance(obj, np.bool_):
+            return bool(obj)
         elif dataclasses.is_dataclass(obj):
             return dataclasses.asdict(obj)
         else:


### PR DESCRIPTION
Fix for the following failure
`RuntimeError: Caught exception during model preprocessing: Object of type bool_ is not JSON serializable`
with the following config
```
{'defaults': {'binary': {'preprocessing': {'missing_value_strategy': 'fill_with_mode'}}},
 'input_features': [{'name': 'binary_1', 'type': 'binary'}],
 'model_type': 'ecd',
 'output_features': [{'decoder': {'idx2str': ['lwrVkpk',
                                              'ztHj',
                                              'dQxBJ',
                                              'mLFhKPHrTn',
                                              'iBjnr',
                                              'Pb',
                                              'qyiL',
                                              'VEQv',
                                              'zLol',
                                              'SBpN'],
                                  'vocab_size': 10},
                      'name': 'category_output_1',
                      'type': 'category'}],
 'trainer': {'train_steps': 1}}
```

The `np.bool_` exists in `training_set_metadata` after the data has been preprocessed and is being cached.