### PR TITLE
Unpin `transformers`

### DIFF
--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -1231,14 +1231,13 @@ def _get_bert_config(hf_name):
     initialize the tokenizer object. If no `tokenizer_config.json` is found, then we instantiate the tokenizer with
     default arguments.
     """
-    from transformers.utils.hub import cached_path, EntryNotFoundError
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.utils import EntryNotFoundError
 
-    vocab_file = cached_path(f"https://huggingface.co/{hf_name}/resolve/main/vocab.txt")
+    vocab_file = hf_hub_download(repo_id=hf_name, filename="vocab.txt")
 
     try:
-        tokenizer_config = load_json(
-            cached_path(f"https://huggingface.co/{hf_name}/resolve/main/tokenizer_config.json")
-        )
+        tokenizer_config = load_json(hf_hub_download(repo_id=hf_name, filename="tokenizer_config.json"))
     except EntryNotFoundError:
         tokenizer_config = {}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ torch>=1.13.0
 torchaudio
 torchtext
 torchvision
-transformers>=4.10.1,<4.22
+transformers>=4.10.1
 spacy>=2.3
 PyYAML>=3.12
 absl-py


### PR DESCRIPTION
This PR unpins `transformers` in the requirements and ensures we are using [the HuggingFace default method of downloading single files](https://huggingface.co/docs/huggingface_hub/v0.13.3/guides/download).