### PR TITLE
fix: [REBASE] Add config transformation that removes extra `type` param if it exists in the defaults config

### DIFF
--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -826,11 +826,11 @@ def upgrade_defaults_config_for_gbm(config: ModelConfigDict) -> ModelConfigDict:
 
 @register_config_transformation("0.7", "defaults")
 def remove_extra_type_param_in_defaults_config(defaults: FeatureTypeDefaultsDict) -> FeatureTypeDefaultsDict:
-    """#3223 and subsequent refactors accidentally introduced a bug where a `type` param was added to every feature
-    in the defaults config.
+    """Fixes a bug introduced before 0.7.3.
 
-    It was removed by #3258, but made it into one of the patch releases. This transformation removes the `type` param
-    from the defaults config if it exists.
+    https://github.com/ludwig-ai/ludwig/pull/3223 and subsequent refactors accidentally introduced a bug where a `type`
+    param was added to every feature in the defaults config. It was removed by #3258, but made it into one of the patch
+    releases. This transformation removes the `type` param from the defaults config if it exists.
     """
     defaults_copy = copy.deepcopy(defaults)
     for _, feature_config in defaults.items():

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -836,9 +836,9 @@ def remove_extra_type_param_in_defaults_config(defaults: FeatureTypeDefaultsDict
     [2]: https://github.com/ludwig-ai/ludwig/pull/3258
     """
     defaults_copy = copy.deepcopy(defaults)
-    for _, feature_config in defaults.items():
+    for feature_type, feature_config in defaults.items():
         if TYPE in feature_config:
-            del defaults_copy[TYPE]
+            del defaults_copy[feature_type][TYPE]
     return defaults_copy
 
 

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -829,8 +829,9 @@ def remove_extra_type_param_in_defaults_config(defaults: FeatureTypeDefaultsDict
     """Fixes a bug introduced before 0.7.3.
 
     https://github.com/ludwig-ai/ludwig/pull/3223 and subsequent refactors accidentally introduced a bug where a `type`
-    param was added to every feature in the defaults config. It was removed by #3258, but made it into one of the patch
-    releases. This transformation removes the `type` param from the defaults config if it exists.
+    param was added to every feature in the defaults config. It was removed by https://github.com/ludwig-
+    ai/ludwig/pull/3258, but made it into one of the patch releases. This transformation removes the `type` param from
+    the defaults config if it exists.
     """
     defaults_copy = copy.deepcopy(defaults)
     for _, feature_config in defaults.items():

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -73,6 +73,7 @@ from ludwig.schema.defaults.gbm import GBMDefaultsConfig
 from ludwig.schema.encoders.utils import get_encoder_cls
 from ludwig.types import (
     FeatureConfigDict,
+    FeatureTypeDefaultsDict,
     HyperoptConfigDict,
     ModelConfigDict,
     PreprocessingConfigDict,
@@ -821,6 +822,21 @@ def upgrade_defaults_config_for_gbm(config: ModelConfigDict) -> ModelConfigDict:
         defaults[feature_type].pop("loss", None)
     config[DEFAULTS] = defaults
     return config
+
+
+@register_config_transformation("0.7", "defaults")
+def remove_extra_type_param_in_defaults_config(defaults: FeatureTypeDefaultsDict) -> FeatureTypeDefaultsDict:
+    """#3223 and subsequent refactors accidentally introduced a bug where a `type` param was added to every feature
+    in the defaults config.
+
+    It was removed by #3258, but made it into one of the patch releases. This transformation removes the `type` param
+    from the defaults config if it exists.
+    """
+    defaults_copy = copy.deepcopy(defaults)
+    for _, feature_config in defaults.items():
+        if TYPE in feature_config:
+            del defaults_copy[TYPE]
+    return defaults_copy
 
 
 def upgrade_metadata(metadata: TrainingSetMetadataDict) -> TrainingSetMetadataDict:

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -828,10 +828,12 @@ def upgrade_defaults_config_for_gbm(config: ModelConfigDict) -> ModelConfigDict:
 def remove_extra_type_param_in_defaults_config(defaults: FeatureTypeDefaultsDict) -> FeatureTypeDefaultsDict:
     """Fixes a bug introduced before 0.7.3.
 
-    https://github.com/ludwig-ai/ludwig/pull/3223 and subsequent refactors accidentally introduced a bug where a `type`
-    param was added to every feature in the defaults config. It was removed by https://github.com/ludwig-
-    ai/ludwig/pull/3258, but made it into one of the patch releases. This transformation removes the `type` param from
-    the defaults config if it exists.
+    [1] and subsequent refactors accidentally introduced a bug where a `type` param was added to every feature in the
+    defaults config. It was removed by [2], but made it into one of the patch releases. This transformation removes that
+    `type` param from each section of the defaults config if it exists.
+
+    [1]: https://github.com/ludwig-ai/ludwig/pull/3223
+    [2]: https://github.com/ludwig-ai/ludwig/pull/3258
     """
     defaults_copy = copy.deepcopy(defaults)
     for _, feature_config in defaults.items():

--- a/tests/ludwig/utils/test_backward_compatibility.py
+++ b/tests/ludwig/utils/test_backward_compatibility.py
@@ -883,3 +883,49 @@ def test_defaults_gbm_config():
     for feature_type in config_obj["defaults"]:
         assert "decoder" not in config_obj["defaults"][feature_type]
         assert "loss" not in config_obj["defaults"][feature_type]
+
+
+def test_type_removed_from_defaults_config():
+    config = {
+        "input_features": [
+            {"name": "feature_1", "type": "category"},
+            {"name": "Sex", "type": "category"},
+        ],
+        "output_features": [
+            {"name": "Survived", "type": "category"},
+        ],
+        "defaults": {
+            "binary": {
+                "encoder": {
+                    "type": "passthrough",
+                },
+                "preprocessing": {
+                    "missing_value_strategy": "fill_with_false",
+                },
+                "type": "binary",
+            },
+            "category": {
+                "encoder": {
+                    "type": "onehot",
+                },
+                "preprocessing": {
+                    "missing_value_strategy": "fill_with_const",
+                    "most_common": 10000,
+                },
+                "type": "category",
+            },
+        },
+        "model_type": "ecd",
+    }
+
+    config_2 = copy.deepcopy(config)
+    config_2["model_type"] = "gbm"
+
+    config_obj = ModelConfig.from_dict(config).to_dict()
+    config_obj_2 = ModelConfig.from_dict(config_2).to_dict()
+
+    for feature_type in config_obj.get("defaults"):
+        assert "type" not in config_obj["defaults"][feature_type]
+
+    for feature_type in config_obj_2.get("defaults"):
+        assert "type" not in config_obj_2["defaults"][feature_type]


### PR DESCRIPTION
Had to rebase this PR because of the ongoing credential issues with my fork.