### PR TITLE
Ensure that `iq` and all number feature preprocessing normalizations work on dask backends.

### DIFF
--- a/ludwig/data/dataframe/dask.py
+++ b/ludwig/data/dataframe/dask.py
@@ -145,9 +145,7 @@ class DaskEngine(DataFrameEngine):
         return self.df_lib.multi.concat(dfs)
 
     def compute(self, data):
-        if hasattr(data, "compute"):
-            return data.compute()
-        return data
+        return data.compute()
 
     def from_pandas(self, df):
         parallelism = self._parallelism or 1

--- a/ludwig/data/dataframe/dask.py
+++ b/ludwig/data/dataframe/dask.py
@@ -145,7 +145,9 @@ class DaskEngine(DataFrameEngine):
         return self.df_lib.multi.concat(dfs)
 
     def compute(self, data):
-        return data.compute()
+        if hasattr(data, "compute"):
+            return data.compute()
+        return data
 
     def from_pandas(self, df):
         parallelism = self._parallelism or 1

--- a/ludwig/features/number_feature.py
+++ b/ludwig/features/number_feature.py
@@ -163,11 +163,10 @@ class InterQuartileTransformer(NumberTransformer):
 
     @staticmethod
     def fit_transform_params(column: np.ndarray, backend: "Backend") -> Dict[str, Any]:  # noqa
-        compute = backend.df_engine.compute
         return {
-            "q1": compute(np.percentile(column.astype(np.float32), 25)),
-            "q2": compute(np.percentile(column.astype(np.float32), 50)),
-            "q3": compute(np.percentile(column.astype(np.float32), 75)),
+            "q1": backend.df_engine.compute(np.percentile(column.astype(np.float32), 25)),
+            "q2": backend.df_engine.compute(np.percentile(column.astype(np.float32), 50)),
+            "q3": backend.df_engine.compute(np.percentile(column.astype(np.float32), 75)),
         }
 
 

--- a/ludwig/features/number_feature.py
+++ b/ludwig/features/number_feature.py
@@ -163,10 +163,12 @@ class InterQuartileTransformer(NumberTransformer):
 
     @staticmethod
     def fit_transform_params(column: np.ndarray, backend: "Backend") -> Dict[str, Any]:  # noqa
+        # backend.df_engine.compute is not used here because `percentile` is not parallelized in dask.
+        # We compute the percentile directly.
         return {
-            "q1": backend.df_engine.compute(np.percentile(column.astype(np.float32), 25)),
-            "q2": backend.df_engine.compute(np.percentile(column.astype(np.float32), 50)),
-            "q3": backend.df_engine.compute(np.percentile(column.astype(np.float32), 75)),
+            "q1": np.percentile(column.astype(np.float32), 25),
+            "q2": np.percentile(column.astype(np.float32), 50),
+            "q3": np.percentile(column.astype(np.float32), 75),
         }
 
 

--- a/tests/ludwig/utils/test_normalization.py
+++ b/tests/ludwig/utils/test_normalization.py
@@ -18,11 +18,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ludwig.utils.types import DataFrame
 from ludwig.backend import initialize_backend
 from ludwig.constants import COLUMN, NAME, PROC_COLUMN
 from ludwig.features.feature_utils import compute_feature_hash
 from ludwig.features.number_feature import NumberFeatureMixin, numeric_transformation_registry
+from ludwig.utils.types import DataFrame
 
 
 def number_feature():


### PR DESCRIPTION
`iq` preprocessing for number features fails when using a ray/dask backend, with the following error:

```
RuntimeError: Caught exception during model preprocessing: 'numpy.float64' object has no attribute 'compute' (type: RayTaskError(RuntimeError), retryable: true)
```

The `InterQuartileTransformer` uses `np.percentile`, which computes the percentile directly without deferring to the dask backend to execute the computation. This seems like the right thing to do as it looks like unlike `column.mean()`, dask does not have a parallelized implementation of `np.percentile`.

This PR removes the call to `.compute()` in `InterQuartileTransformer.fit_transform_params()`, and adds tests to make sure that all preprocessing options in the registry succeed on both pandas and ray/dask backends.