### PR TITLE
Added `prompt_template` preprocessing param for text features

### DIFF
--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -76,6 +76,7 @@ class TextFeatureMixin(BaseFeatureMixin):
             pretrained_model_name_or_path=preprocessing_parameters["pretrained_model_name_or_path"],
             ngram_size=preprocessing_parameters["ngram_size"],
             compute_idf=preprocessing_parameters["compute_idf"],
+            prompt_template=preprocessing_parameters["prompt_template"],
             processor=backend.df_engine,
         )
 
@@ -150,8 +151,13 @@ class TextFeatureMixin(BaseFeatureMixin):
         ):
             preprocessing_parameters["computed_fill_value"] = preprocessing_parameters["unknown_symbol"]
 
+        sequences = column
+        prompt_template = preprocessing_parameters["prompt_template"]
+        if prompt_template is not None:
+            sequences = backend.df_engine.map_objects(sequences, lambda x: prompt_template.format(input=x))
+
         return build_sequence_matrix(
-            sequences=column,
+            sequences=sequences,
             inverse_vocabulary=metadata[f"{prefix}str2idx"],
             tokenizer_type=preprocessing_parameters[f"{prefix}tokenizer"],
             length_limit=metadata[f"{prefix}max_sequence_length"],

--- a/ludwig/models/embedder.py
+++ b/ludwig/models/embedder.py
@@ -105,7 +105,7 @@ def create_embed_transform_fn(
             with torch.no_grad():
                 encoder_outputs = self.embedder(inputs)
 
-            encoded = {name_to_proc[k]: v.detach().cpu().numpy() for k, v in encoder_outputs.items()}
+            encoded = {name_to_proc[k]: v.detach().cpu().float().numpy() for k, v in encoder_outputs.items()}
             output_df = from_numpy_dataset(encoded)
 
             for c in output_df.columns:

--- a/ludwig/schema/features/preprocessing/text.py
+++ b/ludwig/schema/features/preprocessing/text.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import DROP_ROW, FILL_WITH_CONST, MISSING_VALUE_STRATEGY_OPTIONS, PREPROCESSING, TEXT
 from ludwig.schema import utils as schema_utils
@@ -138,6 +139,17 @@ class TextPreprocessingConfig(BasePreprocessingConfig):
     compute_idf: bool = schema_utils.Boolean(
         default=False,
         parameter_metadata=INTERNAL_ONLY,
+    )
+
+    prompt_template: Optional[str] = schema_utils.String(
+        default=None,
+        allow_none=True,
+        description=(
+            "Template used to construct a prompt for the model given an input feature. If None, the input feature "
+            "will be passed to the model as-is. The prompt must be of the form `prefix {input} suffix` where `{input}` "
+            "is the placeholder for the input feature. Prompting is useful when fine-tuning pretrained large language "
+            "models, where providing a relevant prompt to the model can improve its performance."
+        ),
     )
 
 

--- a/ludwig/schema/metadata/configs/encoders.yaml
+++ b/ludwig/schema/metadata/configs/encoders.yaml
@@ -22,6 +22,17 @@ HFEncoder:
             [catastrophic forgettng](https://en.wikipedia.org/wiki/Catastrophic_interference), whereby the
             model forgets all of the valuable information it learned during pretraining."
         expected_impact: 3
+        literature_references:
+            - http://d2l.ai/chapter_computer-vision/fine-tuning.html"
+        related_parameters:
+            - use_pretrained, pretrained_model, saved_weights_in_checkpoint
+        suggested_values:
+            - false
+        suggested_values_reasoning:
+            Freezing the weights (i.e. `trainable = False`)
+            is only worth trying if you are loading in pretrained weights. In that
+            case, check to see if your model is overfitting. If so, freezing the weights
+            (and therefore reducing model complexity) may be beneficial.
         ui_display_name: Trainable
     use_pretrained:
         default_value_reasoning:
@@ -43,6 +54,31 @@ HFEncoder:
             have data that differs from the typical distribution, then it might be
             worth training the model from scratch.
         ui_display_name: Use Pretrained
+    reduce_output:
+        default_value_reasoning: Sums the tensors along the sequence dimension.
+        description_implications:
+            "\"last\", \"sum\", \"mean\", and \"max\" are the\
+            \ fastest and most memory-efficient operations\u2013 they result in tensors\
+            \ that are the same-size as a single item in the input sequence. However,\
+            \ these are simple aggregation operations, therefore some information\
+            \ may be lost. \n\n\"concat\" concatenates each tensor together, creating\
+            \ a `(sequence length)*(tensor size)`-element tensor. \"concat\" preserves\
+            \ this information, but can be very memory-intensive and should only be\
+            \ applied if the sequence length and/or tensor size is small. \n\n\"attention\"\
+            \ takes a weighted sum of the items in the sequence, where the weights\
+            \ for each item in the sequence are determined by the model on-the-fly\
+            \ based on the features of the item itself. This is both slower and and\
+            \ more memory-intensive than the other operations; however, it can also\
+            \ provide a richer \"global\" representation of the sequence."
+        expected_impact: 1
+        related_parameters:
+            - max_sequence_length
+        suggested_values: '"attention". This and the default covers 95% of use cases.'
+        suggested_values_reasoning:
+            If you would like better performance and are not
+            compute/memory-constrained, attention-based reduction can potentially
+            provide a richer global representation than the default.
+        ui_display_name: Sequence Reducer
 ALBERT:
     type:
         short_description: Similar to BERT with lower memory footprint and faster training.


### PR DESCRIPTION
Useful when fine-tuning large language models (LLMs) that benefit from providing additional context to improve the quality of the embeddings they generate. Particularly valuable when using fixed weights (`trainable=false`).