### PR TITLE
Add `PROBABILITIES` and `PREDICTIONS` to the prediction set for the sequence tagger decoder.

### DIFF
--- a/ludwig/decoders/sequence_tagger.py
+++ b/ludwig/decoders/sequence_tagger.py
@@ -4,7 +4,7 @@ from typing import Dict
 import torch
 
 from ludwig.api_annotations import DeveloperAPI
-from ludwig.constants import HIDDEN, LOGITS, SEQUENCE, TEXT
+from ludwig.constants import HIDDEN, LOGITS, SEQUENCE, TEXT, PROBABILITIES, PREDICTIONS
 from ludwig.decoders.base import Decoder
 from ludwig.decoders.registry import register_decoder
 from ludwig.modules.attention_modules import MultiHeadSelfAttention
@@ -77,7 +77,7 @@ class SequenceTaggerDecoder(Decoder):
         return {LOGITS: logits}
 
     def get_prediction_set(self):
-        return {LOGITS}
+        return {LOGITS, PROBABILITIES, PREDICTIONS}
 
     @staticmethod
     def get_schema_cls():

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -234,7 +234,10 @@ class OutputFeature(BaseFeature, LudwigModule, ABC):
 
     @abstractmethod
     def get_prediction_set(self):
-        """Returns the set of prediction keys returned by this feature's PredictModule."""
+        """Returns the set of tensor keys returned by this feature's PredictModule.
+
+        TODO(Justin): Move this to the PredictModule.
+        """
         raise NotImplementedError("OutputFeature is missing implementation for get_prediction_set.")
 
     @classmethod

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -234,7 +234,7 @@ class OutputFeature(BaseFeature, LudwigModule, ABC):
 
     @abstractmethod
     def get_prediction_set(self):
-        """Returns the set of prediction keys returned by this feature."""
+        """Returns the set of prediction keys returned by this feature's PredictModule."""
         raise NotImplementedError("OutputFeature is missing implementation for get_prediction_set.")
 
     @classmethod

--- a/ludwig/features/feature_utils.py
+++ b/ludwig/features/feature_utils.py
@@ -60,11 +60,21 @@ def compute_token_probabilities(
         An np.ndarray with shape (sequence_length,) containing the maximum probability for each timestep.
     """
     if isinstance(probabilities, (list, tuple)):
+        if not hasattr(probabilities[0], "len"):
+            raise ValueError(
+                "Received token probabilities as a flat 1D list. Expected list of list of probabilities "
+                "(sequence_length, vocab_size)."
+            )
         max_probs = []
         for timestep_probs in probabilities:
             max_probs.append(np.max(timestep_probs))
         max_probs = np.array(max_probs)
     elif isinstance(probabilities, np.ndarray):
+        if len(probabilities.shape) != 2:
+            raise ValueError(
+                f"Received token probabilities with non 2D shape: {probabilities.shape}. Expected shape: "
+                "(sequence_length, vocab_size)."
+            )
         max_probs = np.max(probabilities, axis=-1)
     else:
         raise ValueError(f"probabilities type must be in [list, tuple, np.ndarray]. Got {type(probabilities)}")

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -323,10 +323,24 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
 
         probs_col = f"{self.feature_name}_{PROBABILITIES}"
         prob_col = f"{self.feature_name}_{PROBABILITY}"
+
+        # "Summarizes" the `result`'s probability-related output:
+        # - result[probs_col]:
+        #       Each row is now a list of "max" probabilities. Each element is the probability of the argmax token for
+        #       the given time step.
+        #
+        #       Note that we intentionally do not return full list of probabilties for each time step because the output
+        #       of postprocess_predictions is saved to disk and the full probability distribution can be huge,
+        #       especially for large vocab sizes:
+        #           dataset_size x sequence_length x vocab_size
+        #
+        #       TODO: Add a mechanism that lets the user save the full probability distribution if they want.
+        # - result[prob_col]:
+        #       Each row is the overall probability of the sequence. This is the product of the max probabilities over
+        #       all time steps.
         if probs_col in result:
-            # currently does not return full probabilties because usually it is huge:
-            # dataset x length x classes
-            # TODO: add a mechanism for letting the user decide to save it
+            # result[probs_col]: From PredictModule, each row has a list of size (sequence_length) of a list of
+            # probabiltiies of (vocab_size). compute_token_probabilities gets the maximum probability per timestep.
             result[probs_col] = result[probs_col].map(compute_token_probabilities)
             result[prob_col] = result[probs_col].map(
                 partial(

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -582,6 +582,23 @@ def test_sequence_tagger_text(csv_filename):
     run_experiment(input_features, output_features, dataset=rel_path)
 
 
+def test_sequence_tagger_text_ray(csv_filename, ray_cluster_2cpu):
+    # Define input and output features
+    input_features = [text_feature(encoder={"max_len": 10, "type": "rnn", "reduce_output": None})]
+    output_features = [
+        sequence_feature(
+            decoder={"max_len": 10, "type": "tagger"},
+            reduce_input=None,
+        )
+    ]
+
+    # Generate test data
+    rel_path = generate_data(input_features, output_features, csv_filename)
+
+    # run the experiment
+    run_experiment(input_features, output_features, dataset=rel_path, backend="ray")
+
+
 def test_experiment_sequence_combiner_with_reduction_fails(csv_filename):
     config = {
         "input_features": [


### PR DESCRIPTION
This is necessary to enable prediction/inference using models trained with the ray backend, which uses `get_prediction_set()` to determine which tensors are returned from the OutputFeature's `PredictModule`.