### PR TITLE
fix: Add separate output config registries for ECD and GBM

### DIFF
--- a/ludwig/schema/features/base.py
+++ b/ludwig/schema/features/base.py
@@ -27,10 +27,11 @@ from ludwig.error import ConfigValidationError
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.features.utils import (
     ecd_input_config_registry,
+    ecd_output_config_registry,
     gbm_input_config_registry,
+    gbm_output_config_registry,
     get_input_feature_jsonschema,
     get_output_feature_jsonschema,
-    output_config_registry,
 )
 from ludwig.schema.metadata.parameter_metadata import INTERNAL_ONLY, ParameterMetadata
 from ludwig.schema.utils import ludwig_dataclass
@@ -288,7 +289,7 @@ class GBMInputFeatureSelection(FeaturesTypeSelection):
 
 class ECDOutputFeatureSelection(FeaturesTypeSelection):
     def __init__(self):
-        super().__init__(registry=output_config_registry, description="Type of the output feature")
+        super().__init__(registry=ecd_output_config_registry, description="Type of the output feature")
 
     def _jsonschema_type_mapping(self):
         return get_output_feature_jsonschema(MODEL_ECD)
@@ -296,7 +297,7 @@ class ECDOutputFeatureSelection(FeaturesTypeSelection):
 
 class GBMOutputFeatureSelection(FeaturesTypeSelection):
     def __init__(self):
-        super().__init__(max_length=1, registry=output_config_registry, description="Type of the output feature")
+        super().__init__(max_length=1, registry=gbm_output_config_registry, description="Type of the output feature")
 
     def _jsonschema_type_mapping(self):
         return get_output_feature_jsonschema(MODEL_GBM)

--- a/ludwig/schema/features/binary_feature.py
+++ b/ludwig/schema/features/binary_feature.py
@@ -13,10 +13,11 @@ from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassFie
 from ludwig.schema.features.utils import (
     ecd_defaults_config_registry,
     ecd_input_config_registry,
+    ecd_output_config_registry,
     gbm_defaults_config_registry,
     gbm_input_config_registry,
+    gbm_output_config_registry,
     input_mixin_registry,
-    output_config_registry,
     output_mixin_registry,
 )
 from ludwig.schema.metadata import FEATURE_METADATA
@@ -96,7 +97,8 @@ class BinaryOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 
 @DeveloperAPI
-@output_config_registry.register(BINARY)
+@ecd_output_config_registry.register(BINARY)
+@gbm_output_config_registry.register(BINARY)
 @ludwig_dataclass
 class BinaryOutputFeatureConfig(BinaryOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """BinaryOutputFeatureConfig is a dataclass that configures the parameters used for a binary output feature."""

--- a/ludwig/schema/features/category_feature.py
+++ b/ludwig/schema/features/category_feature.py
@@ -13,10 +13,11 @@ from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassFie
 from ludwig.schema.features.utils import (
     ecd_defaults_config_registry,
     ecd_input_config_registry,
+    ecd_output_config_registry,
     gbm_defaults_config_registry,
     gbm_input_config_registry,
+    gbm_output_config_registry,
     input_mixin_registry,
-    output_config_registry,
     output_mixin_registry,
 )
 from ludwig.schema.metadata import FEATURE_METADATA
@@ -97,7 +98,8 @@ class CategoryOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 
 @DeveloperAPI
-@output_config_registry.register(CATEGORY)
+@ecd_output_config_registry.register(CATEGORY)
+@gbm_output_config_registry.register(CATEGORY)
 @ludwig_dataclass
 class CategoryOutputFeatureConfig(CategoryOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """CategoryOutputFeatureConfig is a dataclass that configures the parameters used for a category output
@@ -149,7 +151,7 @@ class CategoryOutputFeatureConfig(CategoryOutputFeatureConfigMixin, BaseOutputFe
 
 
 @DeveloperAPI
-@output_config_registry.register(CATEGORY_DISTRIBUTION)
+@ecd_output_config_registry.register(CATEGORY_DISTRIBUTION)
 @ludwig_dataclass
 class CategoryDistributionOutputFeatureConfig(CategoryOutputFeatureConfig):
     """CategoryDistributionOutputFeatureConfig is a dataclass that configures the parameters used for a

--- a/ludwig/schema/features/number_feature.py
+++ b/ludwig/schema/features/number_feature.py
@@ -15,10 +15,11 @@ from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassFie
 from ludwig.schema.features.utils import (
     ecd_defaults_config_registry,
     ecd_input_config_registry,
+    ecd_output_config_registry,
     gbm_defaults_config_registry,
     gbm_input_config_registry,
+    gbm_output_config_registry,
     input_mixin_registry,
-    output_config_registry,
     output_mixin_registry,
 )
 from ludwig.schema.metadata import FEATURE_METADATA
@@ -98,7 +99,8 @@ class NumberOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 
 @DeveloperAPI
-@output_config_registry.register(NUMBER)
+@ecd_output_config_registry.register(NUMBER)
+@gbm_output_config_registry.register(NUMBER)
 @ludwig_dataclass
 class NumberOutputFeatureConfig(NumberOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """NumberOutputFeatureConfig is a dataclass that configures the parameters used for a category output

--- a/ludwig/schema/features/sequence_feature.py
+++ b/ludwig/schema/features/sequence_feature.py
@@ -13,8 +13,8 @@ from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassFie
 from ludwig.schema.features.utils import (
     ecd_defaults_config_registry,
     ecd_input_config_registry,
+    ecd_output_config_registry,
     input_mixin_registry,
-    output_config_registry,
     output_mixin_registry,
 )
 from ludwig.schema.metadata import FEATURE_METADATA
@@ -67,7 +67,7 @@ class SequenceOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 
 @DeveloperAPI
-@output_config_registry.register(SEQUENCE)
+@ecd_output_config_registry.register(SEQUENCE)
 @ludwig_dataclass
 class SequenceOutputFeatureConfig(SequenceOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """SequenceOutputFeatureConfig is a dataclass that configures the parameters used for a sequence output

--- a/ludwig/schema/features/set_feature.py
+++ b/ludwig/schema/features/set_feature.py
@@ -13,8 +13,8 @@ from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassFie
 from ludwig.schema.features.utils import (
     ecd_defaults_config_registry,
     ecd_input_config_registry,
+    ecd_output_config_registry,
     input_mixin_registry,
-    output_config_registry,
     output_mixin_registry,
 )
 from ludwig.schema.metadata import FEATURE_METADATA
@@ -66,7 +66,7 @@ class SetOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 
 @DeveloperAPI
-@output_config_registry.register(SET)
+@ecd_output_config_registry.register(SET)
 @ludwig_dataclass
 class SetOutputFeatureConfig(SetOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """SetOutputFeatureConfig is a dataclass that configures the parameters used for a set output feature."""

--- a/ludwig/schema/features/text_feature.py
+++ b/ludwig/schema/features/text_feature.py
@@ -13,10 +13,10 @@ from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassFie
 from ludwig.schema.features.utils import (
     ecd_defaults_config_registry,
     ecd_input_config_registry,
+    ecd_output_config_registry,
     gbm_defaults_config_registry,
     gbm_input_config_registry,
     input_mixin_registry,
-    output_config_registry,
     output_mixin_registry,
 )
 from ludwig.schema.metadata import FEATURE_METADATA
@@ -96,7 +96,7 @@ class TextOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 
 @DeveloperAPI
-@output_config_registry.register(TEXT)
+@ecd_output_config_registry.register(TEXT)
 @ludwig_dataclass
 class TextOutputFeatureConfig(TextOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """TextOutputFeatureConfig is a dataclass that configures the parameters used for a text output feature."""

--- a/ludwig/schema/features/timeseries_feature.py
+++ b/ludwig/schema/features/timeseries_feature.py
@@ -13,8 +13,8 @@ from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassFie
 from ludwig.schema.features.utils import (
     ecd_defaults_config_registry,
     ecd_input_config_registry,
+    ecd_output_config_registry,
     input_mixin_registry,
-    output_config_registry,
     output_mixin_registry,
 )
 from ludwig.schema.metadata import FEATURE_METADATA
@@ -67,7 +67,7 @@ class TimeseriesOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 
 @DeveloperAPI
-@output_config_registry.register(TIMESERIES)
+@ecd_output_config_registry.register(TIMESERIES)
 @ludwig_dataclass
 class TimeseriesOutputFeatureConfig(BaseOutputFeatureConfig, TimeseriesOutputFeatureConfigMixin):
     """TimeseriesOutputFeatureConfig configures the parameters used for a timeseries output feature."""

--- a/ludwig/schema/features/vector_feature.py
+++ b/ludwig/schema/features/vector_feature.py
@@ -13,8 +13,8 @@ from ludwig.schema.features.preprocessing.utils import PreprocessingDataclassFie
 from ludwig.schema.features.utils import (
     ecd_defaults_config_registry,
     ecd_input_config_registry,
+    ecd_output_config_registry,
     input_mixin_registry,
-    output_config_registry,
     output_mixin_registry,
 )
 from ludwig.schema.metadata import FEATURE_METADATA
@@ -66,7 +66,7 @@ class VectorOutputFeatureConfigMixin(BaseMarshmallowConfig):
 
 
 @DeveloperAPI
-@output_config_registry.register(VECTOR)
+@ecd_output_config_registry.register(VECTOR)
 @ludwig_dataclass
 class VectorOutputFeatureConfig(VectorOutputFeatureConfigMixin, BaseOutputFeatureConfig):
     """VectorOutputFeatureConfig is a dataclass that configures the parameters used for a vector output feature."""

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -151,7 +151,7 @@ def set_validation_parameters(config: "ModelConfig"):
         # The user has not explicitly set any validation fields.
         # Default to using the first output feature's default validation metric.
         out_type = validation_feature.type
-        config.trainer.validation_metric = output_config_registry[out_type].default_validation_metric
+        config.trainer.validation_metric = output_config_registry(config.model_type)[out_type].default_validation_metric
 
 
 def set_derived_feature_columns_(config_obj: "ModelConfig"):


### PR DESCRIPTION
Separate `output_config_registry` into `ecd_output_config_registry` and `gbm_output_config_registry`.