### PR TITLE
Allow providing encoders / decoder params as strings

### DIFF
--- a/ludwig/schema/decoders/utils.py
+++ b/ludwig/schema/decoders/utils.py
@@ -89,7 +89,7 @@ def DecoderDataclassField(feature_type: str, default: str) -> Field:
 
     class DecoderSelection(schema_utils.TypeSelection):
         def __init__(self):
-            super().__init__(registry=decoder_registry, default_value=default)
+            super().__init__(registry=decoder_registry, default_value=default, allow_str_value=True)
 
         def get_schema_from_registry(self, key: str) -> Type[schema_utils.BaseMarshmallowConfig]:
             return get_decoder_cls(feature_type, key)

--- a/ludwig/schema/encoders/utils.py
+++ b/ludwig/schema/encoders/utils.py
@@ -99,7 +99,9 @@ def EncoderDataclassField(
 
     class EncoderSelection(schema_utils.TypeSelection):
         def __init__(self):
-            super().__init__(registry=encoder_registry, default_value=default, description=description)
+            super().__init__(
+                registry=encoder_registry, default_value=default, description=description, allow_str_value=True
+            )
 
         def get_schema_from_registry(self, key: str) -> Type[schema_utils.BaseMarshmallowConfig]:
             return encoder_registry[key]

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -1138,10 +1138,12 @@ class TypeSelection(fields.Field):
         key: str = "type",
         description: str = "",
         parameter_metadata: ParameterMetadata = None,
+        allow_str_value: bool = False,
     ):
         self.registry = registry
         self.default_value = default_value
         self.key = key
+        self.allow_str_value = allow_str_value
 
         dump_default = missing
         load_default = missing
@@ -1163,6 +1165,11 @@ class TypeSelection(fields.Field):
     def _deserialize(self, value, attr, data, **kwargs):
         if value is None:
             return None
+
+        if self.allow_str_value and isinstance(value, str):
+            # If user provided the value as a string, assume they were providing the type
+            value = {self.key: value}
+
         if isinstance(value, dict):
             cls_type = value.get(self.key)
             cls_type = cls_type.lower() if cls_type else self.default_value

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -1180,7 +1180,7 @@ class TypeSelection(fields.Field):
                 except (TypeError, ValidationError) as e:
                     raise ValidationError(f"Invalid params: {value}, see `{cls}` definition") from e
             raise ValidationError(f"Invalid type: '{cls_type}', expected one of: {list(self.registry.keys())}")
-            
+
         maybe_str = ", `str`," if self.allow_str_value else ""
         raise ValidationError(f"Invalid param {value}, expected `None`{maybe_str} or `dict`")
 

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -1180,7 +1180,9 @@ class TypeSelection(fields.Field):
                 except (TypeError, ValidationError) as e:
                     raise ValidationError(f"Invalid params: {value}, see `{cls}` definition") from e
             raise ValidationError(f"Invalid type: '{cls_type}', expected one of: {list(self.registry.keys())}")
-        raise ValidationError(f"Invalid param {value}, expected `None` or `dict`")
+            
+        maybe_str = ", `str`," if self.allow_str_value else ""
+        raise ValidationError(f"Invalid param {value}, expected `None`{maybe_str} or `dict`")
 
     def get_schema_from_registry(self, key: str) -> Type[BaseMarshmallowConfig]:
         return self.registry[key]

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -32,6 +32,8 @@ from ludwig.constants import (
     TRAINER,
     TYPE,
 )
+from ludwig.schema.decoders.base import ClassifierConfig
+from ludwig.schema.encoders.text_encoders import BERTConfig
 from ludwig.schema.features.augmentation.image import RandomBlurConfig, RandomRotateConfig
 from ludwig.schema.features.image_feature import AUGMENTATION_DEFAULT_OPERATIONS
 from ludwig.schema.features.number_feature import NumberOutputFeatureConfig
@@ -767,3 +769,18 @@ def test_gbm_encoders():
 
     for feature_type in config_obj.get("defaults"):
         assert "encoder" in config_obj["defaults"][feature_type]
+
+
+def test_encoder_decoder_values_as_str():
+    """Tests that encoder / decoder params provided as strings are properly converted to the correct type."""
+    config = {
+        "input_features": [
+            {"name": "text_input", "type": "text", "encoder": "bert"},
+        ],
+        "output_features": [{"name": "cat_output", "type": "category", "decoder": "classifier"}],
+    }
+
+    config_obj = ModelConfig.from_dict(config)
+
+    assert isinstance(config_obj.input_features[0].encoder, BERTConfig)
+    assert isinstance(config_obj.output_features[0].decoder, ClassifierConfig)


### PR DESCRIPTION
Note that this currently works due to backward compatibility logic, but we may remove this at some point in the future, so worth supporting it officially.