### PR TITLE
Downgrade docker images to use Python 3.8

### DIFF
--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM rayproject/ray:2.3.1-py39-cu118
+FROM rayproject/ray:2.3.1-py38-cu118
 
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
 RUN sudo apt-key del 7fa2af80 && \

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM rayproject/ray:2.3.1-py39
+FROM rayproject/ray:2.3.1-py38
 
 # https://github.com/kubernetes/release/issues/1982
 RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list && \


### PR DESCRIPTION
In https://github.com/ludwig-ai/ludwig/pull/3320, we update the docker images to use Python 3.9. 

In https://github.com/ludwig-ai/ludwig/pull/3324, we update the type hinting to match [what's accepted](https://docs.python.org/3/library/typing.html) in Python 3.9, we see the [following failure in the CI](https://github.com/ludwig-ai/ludwig/actions/runs/4626038215/jobs/8182367380) (failures for torchscript tests). By following the [torchscript typing guide](https://pytorch.org/docs/stable/jit_language_reference.html), it looks like only python 3.8-style type hints are accepted.

In this PR, we use Python 3.8 in the docker images.