### PR TITLE
Sanitize GBM feature names to remove JSON special characters

### DIFF
--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -153,6 +153,10 @@ class LightGBMTrainer(BaseTrainer):
         # and before set_steps_to_1_or_quit returns
         self.original_sigint_handler = None
 
+        # LGBM Datasets do not allow JSON special characters in feature names. We sanitize the feature names before
+        # dataset construction but keep references to the original names to be able to cast back if needed.
+        self.feature_names_map: Dict[str, str] = None
+
     @staticmethod
     def get_schema_cls() -> BaseTrainerConfig:
         return GBMTrainerConfig
@@ -823,8 +827,8 @@ class LightGBMTrainer(BaseTrainer):
         validation_set: Optional["Dataset"] = None,  # noqa: F821
         test_set: Optional["Dataset"] = None,  # noqa: F821
     ) -> Tuple[lgb.Dataset, List[lgb.Dataset], List[str]]:
-        X_train = training_set.to_scalar_df(self.model.input_features.values())
-        y_train = training_set.to_scalar_df(self.model.output_features.values())
+        X_train = self.sanitize_feature_names(training_set.to_scalar_df(self.model.input_features.values()))
+        y_train = self.sanitize_feature_names(training_set.to_scalar_df(self.model.output_features.values()))
 
         # create dataset for lightgbm
         # keep raw data for continued training https://github.com/microsoft/LightGBM/issues/4965#issuecomment-1019344293
@@ -842,8 +846,8 @@ class LightGBMTrainer(BaseTrainer):
         eval_sets = [lgb_train]
         eval_names = [LightGBMTrainer.TRAIN_KEY]
         if validation_set is not None:
-            X_val = validation_set.to_scalar_df(self.model.input_features.values())
-            y_val = validation_set.to_scalar_df(self.model.output_features.values())
+            X_val = self.sanitize_feature_names(validation_set.to_scalar_df(self.model.input_features.values()))
+            y_val = self.sanitize_feature_names(validation_set.to_scalar_df(self.model.output_features.values()))
             try:
                 lgb_val = lgb.Dataset(X_val, label=y_val, reference=lgb_train, free_raw_data=False).construct()
             except lgb.basic.LightGBMError as e:
@@ -861,8 +865,8 @@ class LightGBMTrainer(BaseTrainer):
             pass
 
         if test_set is not None:
-            X_test = test_set.to_scalar_df(self.model.input_features.values())
-            y_test = test_set.to_scalar_df(self.model.output_features.values())
+            X_test = self.sanitize_feature_names(test_set.to_scalar_df(self.model.input_features.values()))
+            y_test = self.sanitize_feature_names(test_set.to_scalar_df(self.model.output_features.values()))
             try:
                 lgb_test = lgb.Dataset(X_test, label=y_test, reference=lgb_train, free_raw_data=False).construct()
             except lgb.basic.LightGBMError as e:
@@ -885,6 +889,22 @@ class LightGBMTrainer(BaseTrainer):
         if not coordinator_only or self.is_coordinator():
             for callback in self.callbacks:
                 fn(callback)
+
+    def sanitize_feature_names(self, df: "DataFrame") -> "DataFrame":  # noqa: F821
+        """"""
+        sanitizer = lambda k: re.sub(r"[\W]", "_", k)
+
+        if self.feature_names_map is None:
+            self.feature_names_map = {k: sanitizer(k) for k in df.columns}
+
+        return df.rename(columns=self.feature_names_map)
+
+    def desanitize_feature_names(self, df: "DataFrame") -> "DataFrame":  # noqa: F821
+        """"""
+        if self.feature_names_map is None:
+            return df
+        else:
+            return df.rename(columns={v: k for k, v in self.feature_names_map.items()})
 
 
 def _map_to_lgb_ray_params(params: Dict[str, Any]) -> "RayParams":  # noqa

--- a/ludwig/trainers/trainer_lightgbm.py
+++ b/ludwig/trainers/trainer_lightgbm.py
@@ -891,7 +891,19 @@ class LightGBMTrainer(BaseTrainer):
                 fn(callback)
 
     def sanitize_feature_names(self, df: "DataFrame") -> "DataFrame":  # noqa: F821
-        """"""
+        """Remove JSON special characters from feature names.
+
+        LightGBM Datasets raise an error when processing feature names with JSON special characters (e.g., ".", "{",
+        "}", "[", "]"). This method replaces non-word characters in DataFrame column names with "_" and creates a map
+        of `feature_name` -> `sanitized_feature_name`. Assumes that repeated calls will operate on dataframes with the
+        same columns.
+
+        Args:
+            df: The dataframe to sanitize.
+
+        Returns:
+            A copy of `df` with non-word characters removed from the column names.
+        """
         sanitizer = lambda k: re.sub(r"[\W]", "_", k)
 
         if self.feature_names_map is None:
@@ -900,7 +912,17 @@ class LightGBMTrainer(BaseTrainer):
         return df.rename(columns=self.feature_names_map)
 
     def desanitize_feature_names(self, df: "DataFrame") -> "DataFrame":  # noqa: F821
-        """"""
+        """Restore original feature names to a df.
+
+        The inverse of `LightGBMTrainer.sanitize_feature_names`, this method maps sanitized feature names back to their
+        original formats. Assumes that repeated calls will operate on dataframes with the same columns.
+
+        Args:
+            df: A dataframe previously run through `LightGBMTrainer.sanitize_feature_names`.
+
+        Returns:
+            A copy of `df` with the original feature names restored.
+        """
         if self.feature_names_map is None:
             return df
         else:

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -429,13 +429,14 @@ def test_gbm_text_tfidf(tmpdir, backend, ray_cluster_4cpu):
     "backend",
     [
         pytest.param(LOCAL_BACKEND, id="local"),
-        # pytest.param(RAY_BACKEND, id="ray", marks=pytest.mark.distributed),
+        pytest.param(RAY_BACKEND, id="ray", marks=pytest.mark.distributed),
     ],
 )
 def test_gbm_feature_name_special_characters(tmpdir, feature_name, feature_type, backend, ray_cluster_4cpu):
     """Test that feature names containing JSON special characters are properly sanitized.
 
-    LGBM Datasets do not support feature names with JSON special characters. This tests that LightGBM
+    LGBM Datasets do not support feature names with JSON special characters. This tests that our sanitizer both solves
+    the special character error and also does not impede training.
     """
     input_features = [binary_feature(name=feature_name)] if feature_name == "input" else [binary_feature()]
     output_features = [binary_feature(name=feature_name)] if feature_type == "output" else [binary_feature()]

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -1,11 +1,10 @@
 import os
-import re
 
 import numpy as np
 import pytest
 
 from ludwig.api import LudwigModel
-from ludwig.constants import COLUMN, INPUT_FEATURES, MODEL_TYPE, NAME, OUTPUT_FEATURES, TRAINER
+from ludwig.constants import INPUT_FEATURES, MODEL_TYPE, OUTPUT_FEATURES, TRAINER
 from ludwig.error import ConfigValidationError
 from tests.integration_tests import synthetic_test_data
 from tests.integration_tests.utils import binary_feature
@@ -284,25 +283,6 @@ def test_save_load(tmpdir, local_backend):
     preds, _ = model.predict(dataset=os.path.join(tmpdir, "training.csv"), split="test")
 
     assert init_preds.equals(preds)
-
-
-def test_lgbm_dataset_setup(tmpdir, local_backend):
-    """Test that LGBM dataset column name errors are handled."""
-    input_features = [number_feature()]
-    output_features = [binary_feature()]
-
-    # Overwrite the automatically generated feature/column name with an invalid string.
-    input_features[0][NAME] = ",Unnamed: 0"
-    input_features[0][COLUMN] = input_features[0][NAME]
-
-    # Test that the custom error is raised (lightgbm.basic.LightGBMError -> ValueError)
-    with pytest.raises(ValueError):
-        try:
-            _train_and_predict_gbm(input_features, output_features, tmpdir, local_backend)
-        except ValueError as e:
-            # Check that the intended ValueError was raised
-            assert re.search("Some column names in the training set contain invalid characters", str(e))
-            raise
 
 
 def test_boosting_type_rf_invalid(tmpdir, local_backend):

--- a/tests/integration_tests/test_gbm.py
+++ b/tests/integration_tests/test_gbm.py
@@ -441,3 +441,22 @@ def test_gbm_text_tfidf(tmpdir, backend, ray_cluster_4cpu):
 #         prob_col = prob_col.compute()
 #     assert len(prob_col.iloc[0]) == 2
 #     assert prob_col.apply(sum).mean() == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("feature_name", ["valid_feature_name", "Unnamed: 0", "{", "}", "[", "]"])
+@pytest.mark.parametrize("feature_type", ["input", "output"])
+@pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param(LOCAL_BACKEND, id="local"),
+        # pytest.param(RAY_BACKEND, id="ray", marks=pytest.mark.distributed),
+    ],
+)
+def test_gbm_feature_name_special_characters(tmpdir, feature_name, feature_type, backend, ray_cluster_4cpu):
+    """Test that feature names containing JSON special characters are properly sanitized.
+
+    LGBM Datasets do not support feature names with JSON special characters. This tests that LightGBM
+    """
+    input_features = [binary_feature(name=feature_name)] if feature_name == "input" else [binary_feature()]
+    output_features = [binary_feature(name=feature_name)] if feature_type == "output" else [binary_feature()]
+    _train_and_predict_gbm(input_features, output_features, tmpdir, backend)


### PR DESCRIPTION
LGBM Dataseta are incmpatible with features with JSON special characters in their names (e.g. `:`, `[`, `]`, `{`, `}`). Currently, we raise an exception when Dataset creation fails in this way. This update adds feature name sanitizers local to `LGBMTrainer` and `LGBMRayTrainer` that cleans the feature names for Dataset creation without altering the names globally.