### PR TITLE
Fix sequence decoder attribute error

### DIFF
--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -514,6 +514,6 @@ class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):
     def unflatten(self, df: DataFrame) -> DataFrame:
         probs_col = f"{self.feature_name}_{PROBABILITIES}"
         df[probs_col] = df[probs_col].apply(
-            lambda x: x.reshape(-1, self.decoder_obj.config.num_classes), meta=(probs_col, "object")
+            lambda x: x.reshape(-1, self.decoder_obj.config.vocab_size), meta=(probs_col, "object")
         )
         return df

--- a/tests/integration_tests/test_sequence_decoders.py
+++ b/tests/integration_tests/test_sequence_decoders.py
@@ -2,37 +2,50 @@ import os
 
 import pytest
 
-from ludwig.constants import COLUMN, DECODER, DEFAULTS, INPUT_FEATURES, NAME, OUTPUT_FEATURES, TEXT, TYPE
+from ludwig.constants import (
+    COLUMN,
+    DECODER,
+    DEFAULTS,
+    ENCODER,
+    INPUT_FEATURES,
+    NAME,
+    OUTPUT_FEATURES,
+    SEQUENCE,
+    TEXT,
+    TYPE,
+)
 from tests.integration_tests.utils import (
     create_data_set_to_use,
     generate_data,
     RAY_BACKEND_CONFIG,
+    sequence_feature,
     text_feature,
     train_with_backend,
 )
 
 
-# TODO: Add sequence feature and additional decoders
-@pytest.mark.parametrize("feature_type,feature_gen", [(TEXT, text_feature)])
-@pytest.mark.parametrize("decoder_type", ["generator"])
+@pytest.mark.parametrize("feature_type,feature_gen", [(TEXT, text_feature), (SEQUENCE, sequence_feature)])
+@pytest.mark.parametrize("decoder_type", ["generator", "tagger"])
 @pytest.mark.parametrize("use_defaults", [True, False])
 @pytest.mark.distributed
 def test_sequence_decoder_predictions(
     tmpdir, csv_filename, ray_cluster_2cpu, feature_type, feature_gen, use_defaults, decoder_type
 ):
     """Test that sequence decoders return the correct successfully predict."""
-    input_features = [feature_gen()]
+    input_feature = feature_gen()
     output_feature = feature_gen(output_feature=True)
+
+    input_feature[ENCODER] = {TYPE: "parallel_cnn", "reduce_output": None}
     output_feature[DECODER] = {TYPE: decoder_type}
 
     dataset_path = generate_data(
-        input_features=input_features,
+        input_features=[input_feature],
         output_features=[output_feature],
         filename=os.path.join(tmpdir, csv_filename),
     )
     dataset_path = create_data_set_to_use("csv", dataset_path)
 
-    config = {INPUT_FEATURES: input_features}
+    config = {INPUT_FEATURES: [input_feature]}
 
     # Ensure that the decoder outputs the correct predictions through both the default and feature-specific configs.
     if use_defaults:


### PR DESCRIPTION
`SequenceOutputFeature.unflatten` would try to reshape its output using `self.decoder_obj.config.num_classes` and throw an `AttributeError`. This PR updates the sequence decoder integration tests and fixes the error by reshaping with `self.decoder_obj.config.vocab_size` instead.