### PR TITLE
Decode bytes to strings for DatasetInfo avg_words

### DIFF
--- a/ludwig/utils/automl/utils.py
+++ b/ludwig/utils/automl/utils.py
@@ -28,13 +28,22 @@ logger = logging.getLogger(__name__)
 
 
 @DeveloperAPI
+def avg_num_tokens_decoder(x):
+    if x is None:
+        return None
+    if type(x) == bytes:
+        return x.decode("utf-8")
+    return str(x)
+
+
+@DeveloperAPI
 def avg_num_tokens(field: Series) -> int:
     # sample a subset if dataframe is large
     field_size = len(field)
     if field_size > 5000:
         frac = 5000 / field_size
         field = field.sample(frac=frac, random_state=40)
-    field = field.apply(lambda x: x.decode("utf-8") if x and type(x) == bytes else x)
+    field = field.apply(avg_num_tokens_decoder)
     unique_entries = field.unique()
     avg_words = round(nan_to_num(Series(unique_entries).str.split().str.len().mean()))
     return avg_words

--- a/ludwig/utils/automl/utils.py
+++ b/ludwig/utils/automl/utils.py
@@ -35,7 +35,7 @@ def avg_num_tokens(field: Series) -> int:
         frac = 5000 / field_size
         field = field.sample(frac=frac, random_state=40)
     unique_entries = field.unique()
-    avg_words = round(nan_to_num(Series(unique_entries).str.split().str.len().mean()))
+    avg_words = round(nan_to_num(Series(unique_entries).str.decode('utf-8').split().str.len().mean()))
     return avg_words
 
 

--- a/ludwig/utils/automl/utils.py
+++ b/ludwig/utils/automl/utils.py
@@ -34,8 +34,9 @@ def avg_num_tokens(field: Series) -> int:
     if field_size > 5000:
         frac = 5000 / field_size
         field = field.sample(frac=frac, random_state=40)
+    field = field.apply(lambda x: x.decode("utf-8") if x and type(x) == bytes else x)
     unique_entries = field.unique()
-    avg_words = round(nan_to_num(Series(unique_entries).str.decode('utf-8').split().str.len().mean()))
+    avg_words = round(nan_to_num(Series(unique_entries).str.split().str.len().mean()))
     return avg_words
 
 

--- a/tests/ludwig/utils/automl/test_utils.py
+++ b/tests/ludwig/utils/automl/test_utils.py
@@ -8,7 +8,9 @@ from ludwig.utils.automl.utils import avg_num_tokens
     (pd.Series([None]), 0),
     (pd.Series(["string1", "string2", "string3"]), 1),
     (pd.Series([b'string1', b'string2', b'string3']), 1),
-    (pd.Series([b'string1 string1', b'string2 string2', b'string3 string3']), 2)
+    (pd.Series([b'string1 string1', b'string2 string2', b'string3 string3']), 2),
+    (pd.Series([1, 2, 3]), 1)
+
 ])
 def test_avg_num_tokens(field, expected):
     assert avg_num_tokens(field) == expected

--- a/tests/ludwig/utils/automl/test_utils.py
+++ b/tests/ludwig/utils/automl/test_utils.py
@@ -4,13 +4,15 @@ import pytest
 from ludwig.utils.automl.utils import avg_num_tokens
 
 
-@pytest.mark.parametrize("field,expected", [
-    (pd.Series([None]), 0),
-    (pd.Series(["string1", "string2", "string3"]), 1),
-    (pd.Series([b'string1', b'string2', b'string3']), 1),
-    (pd.Series([b'string1 string1', b'string2 string2', b'string3 string3']), 2),
-    (pd.Series([1, 2, 3]), 1)
-
-])
+@pytest.mark.parametrize(
+    "field,expected",
+    [
+        (pd.Series([None]), 0),
+        (pd.Series(["string1", "string2", "string3"]), 1),
+        (pd.Series([b"string1", b"string2", b"string3"]), 1),
+        (pd.Series([b"string1 string1", b"string2 string2", b"string3 string3"]), 2),
+        (pd.Series([1, 2, 3]), 1),
+    ],
+)
 def test_avg_num_tokens(field, expected):
     assert avg_num_tokens(field) == expected

--- a/tests/ludwig/utils/automl/test_utils.py
+++ b/tests/ludwig/utils/automl/test_utils.py
@@ -4,6 +4,11 @@ import pytest
 from ludwig.utils.automl.utils import avg_num_tokens
 
 
-@pytest.mark.parametrize("field,expected", [(pd.Series([None]), 0), (pd.Series(["string1", "string2", "string3"]), 1)])
+@pytest.mark.parametrize("field,expected", [
+    (pd.Series([None]), 0),
+    (pd.Series(["string1", "string2", "string3"]), 1),
+    (pd.Series([b'string1', b'string2', b'string3']), 1),
+    (pd.Series([b'string1 string1', b'string2 string2', b'string3 string3']), 2)
+])
 def test_avg_num_tokens(field, expected):
     assert avg_num_tokens(field) == expected


### PR DESCRIPTION
`get_dataset_info_from_source avg_words = source.get_avg_num_tokens(field) File "/src/predibase_engine/sources/dask_util.py", line 59, in get_avg_num_tokens return avg_num_tokens(self.sample[column]) File "/home/ray/anaconda3/lib/python3.8/site-packages/ludwig/utils/automl/utils.py", line 36, in avg_num_tokens avg_words = round(nan_to_num(Series(unique_entries).str.split().str.len().mean())) File "/home/ray/anaconda3/lib/python3.8/site-packages/pandas/core/strings/accessor.py", line 124, in wrapper raise TypeError(msg) TypeError: Cannot use .str.split with values of inferred dtype 'bytes'. (type: RayTaskError(TypeError), retryable: true)`