### PR TITLE
[LLM] Fix tokenizer padding, target/tensor alignment and enable Ray backend support for text generation tasks

### DIFF
--- a/examples/llm_text_generation/simple_model_training.py
+++ b/examples/llm_text_generation/simple_model_training.py
@@ -53,11 +53,9 @@ config = yaml.safe_load(
               type: text
         model_type: llm
         generation_config:
-            temperature: 0.1
-            top_p: 0.75
-            top_k: 40
+            temperature: 1.0
             num_beams: 4
-            max_new_tokens: 5
+            max_new_tokens: 20
         model_name: facebook/opt-350m
     """
 )
@@ -71,7 +69,11 @@ model = LudwigModel(config=config, logging_level=logging.INFO)
     preprocessed_data,  # tuple Ludwig Dataset objects of pre-processed training data
     output_directory,  # location of training results stored on disk
 ) = model.train(
-    dataset=df, experiment_name="simple_experiment", model_name="simple_model", skip_save_processed_input=True
+    dataset=df,
+    experiment_name="simple_experiment",
+    model_name="simple_model",
+    skip_save_processed_input=True,
+    skip_save_model=True,
 )
 
 training_set, val_set, test_set, _ = preprocessed_data

--- a/examples/llm_zero_shot_learning/simple_model_training.py
+++ b/examples/llm_zero_shot_learning/simple_model_training.py
@@ -53,6 +53,12 @@ df = pd.DataFrame(review_label_pairs)
 
 config = yaml.safe_load(
     """
+        model_type: llm
+        model_name: bigscience/bloomz-560m
+        generation_config:
+            temperature: 1.0
+            num_beams: 4
+            max_new_tokens: 10
         input_features:
             - name: review
               type: text
@@ -74,7 +80,7 @@ config = yaml.safe_load(
                         type: contains
                         value: positive
                     neutral:
-                        type: regex
+                        type: contains
                         value: neutral
                     negative:
                         type: contains
@@ -83,12 +89,6 @@ config = yaml.safe_load(
             split:
                 type: fixed
                 column: split
-        model_type: llm
-        model_name: bigscience/bloomz-560m
-        generation_config:
-            temperature: 1.0
-            num_beams: 4
-            max_new_tokens: 10
     """
 )
 

--- a/ludwig/decoders/llm_decoders.py
+++ b/ludwig/decoders/llm_decoders.py
@@ -170,7 +170,7 @@ class CategoryParserDecoder(Decoder):
 
         # Decode generated outputs from the LLM's generate function.
         decoded_outputs = self.tokenizer.tokenizer.batch_decode(generated_outputs, skip_special_tokens=True)
-        logger.info(f"Decoded output: {decoded_outputs}")
+        logger.info(f"Generated output: {decoded_outputs}")
 
         # Parse labels based on matching criteria and return probability vectors
         matched_labels = []

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -251,6 +251,8 @@ class LLM(BaseModel):
         Returns:
             The realigned target tensor.
         """
+        # TODO(Arnav): Realign both target and prediction tensors.
+        # If the prediction tensor is shorter, also realign the probability and logit tensors
         _targets = copy.deepcopy(targets)
         _targets[of_name] = torch.nn.functional.pad(
             _targets.get(of_name),

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -793,6 +793,7 @@ class HFTokenizer(BaseTokenizer):
         super().__init__()
         self.pretrained_model_name_or_path = pretrained_model_name_or_path
         self.tokenizer = load_pretrained_hf_tokenizer(self.pretrained_model_name_or_path)
+        self.set_pad_token_id()
 
     def __call__(self, text):
         return self.tokenizer.encode(text, truncation=True)
@@ -810,6 +811,10 @@ class HFTokenizer(BaseTokenizer):
 
     def get_unk_token(self) -> str:
         return self.tokenizer.unk_token
+
+    def set_pad_token_id(self):
+        if hasattr(self.tokenizer, "pad_token_id") and self.tokenizer.pad_token_id is None:
+            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
 
 
 tokenizer_registry = {

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -58,10 +58,10 @@ def convert_preds(backend: dict, preds: DataFrame):
     "backend",
     [
         pytest.param(LOCAL_BACKEND, id="local"),
-        # pytest.param(RAY_BACKEND, id="ray", marks=pytest.mark.distributed),
+        pytest.param(RAY_BACKEND, id="ray", marks=pytest.mark.distributed),
     ],
 )
-def test_llm_text_to_text(tmpdir, backend):  # , ray_cluster_4cpu)
+def test_llm_text_to_text(tmpdir, backend, ray_cluster_4cpu):
     """Test that the LLM model can train and predict with text inputs and text outputs."""
     input_features = [{"name": "Question", "type": "text"}]
     output_features = [text_feature(output_feature=True, name="Answer", decoder={"type": "text_parser"})]


### PR DESCRIPTION
1. Fixes an issue when tokenizers for LLMs don't have pad_token_ids set
2. Improves the example LLM notebooks
3. Fixes an issue with tensor alignment where the probability/logit tensors weren't being re-aligned