### PR TITLE
Fix dependency install in CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -122,6 +122,8 @@ jobs:
             pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
           fi
           pip install protobuf==3.20.1 # https://github.com/databrickslabs/dbx/issues/257
+          pip install numpy
+          pip show numpy
 
           if [ "$MARKERS" == "distributed" ]; then
             if [ "$RAY_VERSION" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -105,6 +105,10 @@ jobs:
           python -m pip install -U pip
           cmake --version
 
+          # Install numpy early.
+          pip install numpy
+          pip show numpy
+
           if [ "$MARKERS" != "distributed" ]; then
             # Skip distributed and hyperopt requirements to test optional imports
             echo > requirements-temp && mv requirements-temp requirements_distributed.txt
@@ -122,8 +126,6 @@ jobs:
             pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
           fi
           pip install protobuf==3.20.1 # https://github.com/databrickslabs/dbx/issues/257
-          pip install numpy
-          pip show numpy
 
           if [ "$MARKERS" == "distributed" ]; then
             if [ "$RAY_VERSION" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -137,7 +137,6 @@ jobs:
 
           torch_expected=$(python -c "import torch; print(torch.__version__)")
 
-          pip install --no-build-isolation --no-use-pep517 ConfigSpace # temporary fix: https://github.com/automl/ConfigSpace/issues/173
           pip install '.[test]' --extra-index-url $extra_index_url
           pip list
 
@@ -235,7 +234,6 @@ jobs:
       - name: Combinatorial Tests
         run: |
           pytest -rx --durations 100 -m "combinatorial" --junitxml pytest.xml tests/training_success
-
 
   test-minimal-install:
     name: Test Minimal Install
@@ -388,7 +386,6 @@ jobs:
   #         fi
   #         # pip install --no-cache-dir git+https://github.com/horovod/horovod.git@master
   #         pip install dulwich==0.20.26 # workaround for `/usr/bin/ld: cannot find -lpython3.7m`
-  #         pip install --no-build-isolation --no-use-pep517 ConfigSpace # temporary fix: https://github.com/automl/ConfigSpace/issues/173
   #         pip install '.[test]'
   #         pip list
   #       shell: bash

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,6 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+# debug
 
 name: pytest
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -116,7 +116,7 @@ jobs:
           if [ "$PYTORCH" == "nightly" ]; then
             cat requirements.txt | sed '/^torch[>=<]/d' | sed '/^torchtext[>=<]/d' | sed '/^torchvision[>=<]/d' | sed '/^torchaudio[>=<]/d' > requirements-temp && mv requirements-temp requirements.txt
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch==2.0.0.dev20230213+cpu torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            pip install --pre torch==2.1.0.dev20230418+cpu torchtext torchvision torchaudio --extra-index-url $extra_index_url
           else
             extra_index_url=https://download.pytorch.org/whl/cpu
             pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -100,10 +100,6 @@ jobs:
           python -m pip install -U pip
           cmake --version
 
-          # Install numpy early.
-          pip install numpy
-          pip show numpy
-
           if [ "$MARKERS" != "distributed" ]; then
             # Skip distributed and hyperopt requirements to test optional imports
             echo > requirements-temp && mv requirements-temp requirements_distributed.txt
@@ -115,12 +111,12 @@ jobs:
           if [ "$PYTORCH" == "nightly" ]; then
             cat requirements.txt | sed '/^torch[>=<]/d' | sed '/^torchtext[>=<]/d' | sed '/^torchvision[>=<]/d' | sed '/^torchaudio[>=<]/d' > requirements-temp && mv requirements-temp requirements.txt
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
+            # torch "nightly" version may need to be updated as dated dev releases go out of date.
             pip install --pre torch==2.1.0.dev20230418+cpu torchtext torchvision torchaudio --extra-index-url $extra_index_url
           else
             extra_index_url=https://download.pytorch.org/whl/cpu
             pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
           fi
-          # pip install protobuf==3.20.1 # https://github.com/databrickslabs/dbx/issues/257
 
           if [ "$MARKERS" == "distributed" ]; then
             if [ "$RAY_VERSION" == "nightly" ]; then

--- a/.github/workflows/pytest_slow.yml
+++ b/.github/workflows/pytest_slow.yml
@@ -124,7 +124,6 @@ jobs:
             extra_index_url=https://download.pytorch.org/whl/cpu
             pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
           fi
-          pip install protobuf==3.20.1 # https://github.com/databrickslabs/dbx/issues/257
 
           if [ "$RAY_VERSION" == "nightly" ]; then
             # NOTE: hardcoded for python 3.9 on Linux

--- a/.github/workflows/pytest_slow.yml
+++ b/.github/workflows/pytest_slow.yml
@@ -138,7 +138,6 @@ jobs:
 
           torch_expected=$(python -c "import torch; print(torch.__version__)")
 
-          pip install --no-build-isolation --no-use-pep517 ConfigSpace # temporary fix: https://github.com/automl/ConfigSpace/issues/173
           pip install '.[test]' --extra-index-url $extra_index_url
           pip list
 
@@ -185,7 +184,7 @@ jobs:
     if: always() && needs.start-runner.result != 'skipped'
     needs:
       - start-runner # required to get output from the start-runner job
-      - slow-pytest  # required to wait when the main job is done
+      - slow-pytest # required to wait when the main job is done
     runs-on: ubuntu-latest
 
     steps:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -22,6 +22,10 @@ bayesian-optimization
 # search_alg: cfo and blendsearch
 flaml[blendsearch]
 
+# Disabling due to numpy installation failure https://github.com/ludwig-ai/ludwig/actions/runs/4737879639/jobs/8411146481
+# search_alg: dragonfly
+# dragonfly-opt
+
 # search_alg: hebo
 HEBO
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -22,9 +22,6 @@ bayesian-optimization
 # search_alg: cfo and blendsearch
 flaml[blendsearch]
 
-# search_alg: dragonfly
-dragonfly-opt
-
 # search_alg: hebo
 HEBO
 


### PR DESCRIPTION
A collection of CI fixes/improvements:
- For torch nightly tests, pin to `torch==2.1.0.dev20230418+cpu`. `2.0.0.dev20230213+cpu` is out of commission.
- Remove `pip install protobuf==3.20.1` workaround for https://github.com/databrickslabs/dbx/issues/257
- Remove horovod-related env variables.
    ```
    env:
      HOROVOD_WITH_PYTORCH: 1
      HOROVOD_WITHOUT_MPI: 1
      HOROVOD_WITHOUT_TENSORFLOW: 1
      HOROVOD_WITHOUT_MXNET: 1
    ```
- Remove `--no-use-pep517` and remove `ConfigSpace` custom installation workaround for https://github.com/automl/ConfigSpace/issues/173
- Remove `dragonfly-opt` from requirements, which causes a numpy installation failure (https://github.com/ludwig-ai/ludwig/actions/runs/4737879639/jobs/8411146481)