### PR TITLE
Use `dist.barrier` instead of horovod legacy code

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -1201,7 +1201,7 @@ class Trainer(BaseTrainer):
         return self.distributed.local_rank()
 
     def barrier(self):
-        self.distributed.allreduce(torch.as_tensor([0], dtype=torch.int))
+        self.distributed.barrier()
 
     def callback(self, fn, coordinator_only=True):
         if not coordinator_only or self.is_coordinator():


### PR DESCRIPTION
Previous implementation causes `RuntimeError: Tensors must be CUDA and dense (type: RayTaskError(RuntimeError), retryable: true)`