### PR TITLE
Allow checkpoint download on non-coordinator process

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -1078,8 +1078,8 @@ class Trainer(BaseTrainer):
         training_progress_tracker_path: str,
         training_checkpoint_path: str,
     ) -> bool:
-        missing_files = []
         if self.is_coordinator():
+            missing_files = []
             # training_progress.json
             if not path_exists(training_progress_tracker_path):
                 missing_files.append(training_progress_tracker_path)
@@ -1087,10 +1087,11 @@ class Trainer(BaseTrainer):
             latest_ckpt = os.path.join(training_checkpoint_path, "latest.ckpt")
             if not path_exists(latest_ckpt):
                 missing_files.append(latest_ckpt)
-        if missing_files:
-            logger.warning(f"Could not find {missing_files} while trying to resume model training.")
-            return False
-        return True
+            if missing_files:
+                logger.warning(f"Could not find {missing_files} while trying to resume model training.")
+                return False
+            return True
+        return False
 
     def resume_training_progress_tracker(self, training_progress_tracker_path):
         progress_tracker_dict = None


### PR DESCRIPTION
Currently, if we're resuming model training from a checkpoint, we try to download artifacts from storage only on the coordinator process. DDP assumes all workers can read model params, so it's necessary to download in every worker process.