### PR TITLE
Ensure worker synchronization during resume

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,7 +60,7 @@ jobs:
         ports:
           - 9000:9000
 
-    timeout-minutes: 120
+    timeout-minutes: 135
     steps:
       - name: Setup ludwigai/ludwig-ray container for local testing with act.
         if: ${{ env.ACT }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Integration Tests
         run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod" --junitxml pytest.xml tests/integration_tests
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=6000 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod" --junitxml pytest.xml tests/integration_tests
 
       - name: Regression Tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ tags
 # examples
 examples/*/data/
 examples/*/visualizations/
+
+# benchmarking configs
+ludwig/benchmarking/configs/

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -448,6 +448,8 @@ class LudwigModel:
         if model_resume_path is not None:
             if path_exists(model_resume_path):
                 output_directory = model_resume_path
+                if self.backend.is_coordinator():
+                    logger.info(f"Model resume path '{model_resume_path}' exists, trying to resume training.")
             else:
                 if self.backend.is_coordinator():
                     logger.info(

--- a/ludwig/callbacks.py
+++ b/ludwig/callbacks.py
@@ -117,6 +117,9 @@ class Callback(ABC):
         """
         return False
 
+    def on_resume_training(self, is_coordinator: bool):
+        pass
+
     def on_train_init(
         self,
         base_config: ModelConfigDict,

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -605,12 +605,31 @@ class Trainer(BaseTrainer):
                 test_summary_writer = SummaryWriter(os.path.join(tensorboard_log_dir, TEST))
 
         # ================ Resume logic ================
-        if self.resume and self.resume_files_exist(training_progress_tracker_path, training_checkpoints_path):
-            logger.info("Resuming training from previous run.")
-            progress_tracker = self.resume_training_progress_tracker(training_progress_tracker_path)
-            self.resume_weights_and_optimizer(training_checkpoints_path, checkpoint)
+        self.callback(lambda c: c.on_resume_training(self.is_coordinator()))
+
+        should_resume = self.resume and self.resume_files_exist(
+            training_progress_tracker_path, training_checkpoints_path
+        )
+        # make sure all workers are on the same page about resuming.
+        should_resume = self.distributed.broadcast_object(should_resume, name="should_resume")
+
+        if should_resume:
+            try:
+                progress_tracker = self.resume_training_progress_tracker(training_progress_tracker_path)
+                self.resume_weights_and_optimizer(training_checkpoints_path, checkpoint)
+                logger.info("Resuming training from previous run.")
+            except Exception:
+                progress_tracker = get_new_progress_tracker(
+                    batch_size=self.batch_size,
+                    learning_rate=self.base_learning_rate,
+                    best_eval_metric_value=get_initial_validation_value(self.validation_metric),
+                    best_increase_batch_size_eval_metric=get_initial_validation_value(
+                        self.increase_batch_size_eval_metric
+                    ),
+                    output_features=output_features,
+                )
+                logger.info("Failed to resume training from previous run. Creating fresh model training run.")
         else:
-            logger.info("Creating fresh model training run.")
             progress_tracker = get_new_progress_tracker(
                 batch_size=self.batch_size,
                 learning_rate=self.base_learning_rate,
@@ -618,6 +637,7 @@ class Trainer(BaseTrainer):
                 best_increase_batch_size_eval_metric=get_initial_validation_value(self.increase_batch_size_eval_metric),
                 output_features=output_features,
             )
+            logger.info("Creating fresh model training run.")
 
         # Distributed: broadcast initial variable states from rank 0 to all other processes.
         # This is necessary to ensure consistent initialization of all workers when

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -619,6 +619,8 @@ class Trainer(BaseTrainer):
                 self.resume_weights_and_optimizer(training_checkpoints_path, checkpoint)
                 logger.info("Resuming training from previous run.")
             except Exception:
+                # This may happen if model training is interrupted after the progress tracker is initialized
+                # but before any real training progress is made.
                 progress_tracker = get_new_progress_tracker(
                     batch_size=self.batch_size,
                     learning_rate=self.base_learning_rate,

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -151,6 +151,8 @@ def upgrade_model_progress(model_progress: Dict) -> Dict:
         del ret["vali_metrics"]
 
     for metric_group in ("train_metrics", "test_metrics", "validation_metrics"):
+        if metric_group not in ret:
+            continue
         for tgt in ret[metric_group]:
             for metric in ret[metric_group][tgt]:
                 if len(ret[metric_group][tgt][metric]) == 0 or isinstance(

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -782,6 +782,7 @@ def test_experiment_model_resume_missing_file(tmpdir, missing_file):
     shutil.rmtree(output_dir, ignore_errors=True)
 
 
+@pytest.mark.distributed
 def test_experiment_model_resume_before_1st_epoch_distributed(tmpdir, ray_cluster_4cpu):
     # Single sequence input, single category output
     # Tests saving a model file, loading it to rerun training and predict

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -26,6 +26,7 @@ import yaml
 
 from ludwig.api import LudwigModel
 from ludwig.backend import LOCAL_BACKEND
+from ludwig.callbacks import Callback
 from ludwig.constants import BATCH_SIZE, COLUMN, ENCODER, H3, NAME, PREPROCESSING, TRAINER, TYPE
 from ludwig.data.concatenate_datasets import concatenate_df
 from ludwig.data.preprocessing import preprocess_for_training
@@ -779,6 +780,54 @@ def test_experiment_model_resume_missing_file(tmpdir, missing_file):
 
     predict_cli(os.path.join(output_dir, "model"), dataset=rel_path)
     shutil.rmtree(output_dir, ignore_errors=True)
+
+
+def test_experiment_model_resume_before_1st_epoch_distributed(tmpdir, ray_cluster_4cpu):
+    # Single sequence input, single category output
+    # Tests saving a model file, loading it to rerun training and predict
+    input_features = [number_feature()]
+    output_features = [category_feature(output_feature=True)]
+    # Generate test data
+    training_set = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"))
+
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        "combiner": {"type": "concat", "output_size": 8},
+        TRAINER: {"train_steps": 1, BATCH_SIZE: 128},
+        "backend": {"type": "ray", "trainer": {"strategy": "ddp", "num_workers": 2}},
+    }
+
+    class InducedFailureCallback(Callback):
+        """Class that defines the methods necessary to hook into process."""
+
+        def on_resume_training(self, is_coordinator):
+            if is_coordinator:
+                raise RuntimeError("Induced failure")
+
+    class NoFailureCallback(Callback):
+        """Class that defines the methods necessary to hook into process."""
+
+        def on_resume_training(self, is_coordinator):
+            pass
+
+    try:
+        # Define Ludwig model object that drive model training
+        model = LudwigModel(config=config, logging_level=logging.INFO, callbacks=[InducedFailureCallback()])
+        model.train(
+            dataset=training_set,
+            experiment_name="simple_experiment",
+            model_name="simple_model_incomplete",
+            skip_save_processed_input=True,
+            output_directory=os.path.join(tmpdir, "results1"),
+        )
+    except RuntimeError:
+        model = LudwigModel(config=config, logging_level=logging.INFO, callbacks=[NoFailureCallback()])
+        model.train(
+            dataset=training_set,
+            skip_save_processed_input=True,
+            model_resume_path=os.path.join(tmpdir, "results1"),
+        )
 
 
 def test_experiment_various_feature_types(csv_filename):


### PR DESCRIPTION
This PR ensures
- We're not accessing keys that don't exist in the progress tracker dictionary.
- All keys of the progress tracker dictionary are available for initialization.
- All workers are synced on whether to resume or create a new progress tracker (due to inconsistencies in the output of `resume_files_exist`)