### PR TITLE
Use TCP as an init method instead of ENV

### DIFF
--- a/ludwig/distributed/ddp.py
+++ b/ludwig/distributed/ddp.py
@@ -94,7 +94,7 @@ class DDPStrategy(DistributedStrategy):
     def get_ray_trainer_backend(cls, **kwargs) -> Optional[Any]:
         from ray.train.torch import TorchConfig
 
-        return TorchConfig()
+        return TorchConfig(init_method="tcp")
 
     @classmethod
     def get_trainer_cls(cls, backend_config: BackendConfig) -> Tuple[Type[DataParallelTrainer], Dict[str, Any]]:


### PR DESCRIPTION
This PR changes the torch process group init method to `tcp` instead of `env`. The default init method is `env` which relies on environment variables that have to be manually set (view different methods [here](https://pytorch.org/docs/stable/distributed.html#tcp-initialization)). I'm suspecting that this might have to do with `Connection reset by peer errors` we see in distributed environments.
In the `env` case, these environment variables are set by Ray on each worker [here](https://github.com/ray-project/ray/blob/f682777c8a657e36e13be63aca59a993e536c3fb/python/ray/train/torch/config.py#L177-L181).
Both the `tcp` and `env` methods eventually create a TCPStore [here](https://github.com/pytorch/pytorch/blob/main/torch/distributed/rendezvous.py). To minimize any flakiness associated with setting env variables across distributed workers, or of these env variables getting overridden by code or config files), this PR changes the init method to `tcp`.