### PR TITLE
Fix MNIST datasets img path column

### DIFF
--- a/ludwig/datasets/loaders/mnist.py
+++ b/ludwig/datasets/loaders/mnist.py
@@ -127,7 +127,7 @@ class MNISTLoader(DatasetLoader):
                 for file in os.listdir(img_dir):
                     if file.endswith(".png"):
                         labels.append(str(i))
-                        paths.append(os.path.join(label_dir, file))
+                        paths.append(os.path.join(img_dir, file))
                         splits.append(0 if name == "training" else 2)
             dataframes.append(pd.DataFrame({"image_path": paths, "label": labels, "split": splits}))
         return pd.concat(dataframes, ignore_index=True)


### PR DESCRIPTION
Use downloaded path instead of relative train/test path.

# Code Pull Requests

Current MNIST example fails due to reading wrong paths of images.
```
[Errno 2] No such file or directory: '/Users/chongxiaoc/git/ludwig/examples/mnist/training/0/16585.png'
/Users/chongxiaoc/git/ludwig/ludwig/utils/image_utils.py:138: UserWarning: Failed to read image from PNG file. Original exception: Bytes object is empty. This could be due to a failed load from storage.
  warnings.warn(f"Failed to read image from PNG file. Original exception: {e}")
/Users/chongxiaoc/git/ludwig/ludwig/utils/image_utils.py:149: UserWarning: Failed to read image from numpy file. Original exception: Cannot load file containing pickled data when allow_pickle=False
  warnings.warn(f"Failed to read image from numpy file. Original exception: {e}")
/Users/chongxiaoc/git/ludwig/ludwig/utils/image_utils.py:120: UserWarning: Unable to read image from bytes object.
  warnings.warn("Unable to read image from bytes object.")
```

This PR fixes the img_path column in the dataframe.