### PR TITLE
Temporarily switch to `eval` mode when using `batch_size: 1`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -151,15 +151,15 @@ jobs:
 
       - name: Unit Tests
         run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod" --junitxml pytest.xml tests/ludwig
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod and not llm" --junitxml pytest.xml tests/ludwig
 
       - name: Integration Tests
         run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=6000 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod" --junitxml pytest.xml tests/integration_tests
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=6000 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod and not llm" --junitxml pytest.xml tests/integration_tests
 
       - name: Regression Tests
         run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod or benchmark" --junitxml pytest.xml tests/regression_tests
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod or benchmark and not llm" --junitxml pytest.xml tests/regression_tests
 
       - name: Install Horovod if necessary
         if: matrix.test-markers == 'distributed'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -149,17 +149,17 @@ jobs:
           curl -L https://github.com/uber/neuropod/releases/download/v${{ env.NEUROPOD_VERISON }}/libneuropod-cpu-linux-v${{ env.NEUROPOD_VERISON }}-torchscript-${{ env.TORCHSCRIPT_VERISON }}-backend.tar.gz | sudo tar -xz -C "$NEUROPOD_BASE_DIR"
         shell: bash
 
-#      - name: Unit Tests
-#        run: |
-#          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod" --junitxml pytest.xml tests/ludwig
+      - name: Unit Tests
+        run: |
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod" --junitxml pytest.xml tests/ludwig
 
       - name: Integration Tests
         run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=6000 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod" --junitxml pytest.xml tests/integration_tests/test_experiment.py::test_tabnet_with_batch_size_1
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=6000 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod" --junitxml pytest.xml tests/integration_tests
 
-#      - name: Regression Tests
-#        run: |
-#          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod or benchmark" --junitxml pytest.xml tests/regression_tests
+      - name: Regression Tests
+        run: |
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod or benchmark" --junitxml pytest.xml tests/regression_tests
 
       - name: Install Horovod if necessary
         if: matrix.test-markers == 'distributed'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -149,17 +149,17 @@ jobs:
           curl -L https://github.com/uber/neuropod/releases/download/v${{ env.NEUROPOD_VERISON }}/libneuropod-cpu-linux-v${{ env.NEUROPOD_VERISON }}-torchscript-${{ env.TORCHSCRIPT_VERISON }}-backend.tar.gz | sudo tar -xz -C "$NEUROPOD_BASE_DIR"
         shell: bash
 
-      - name: Unit Tests
-        run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod and not llm" --junitxml pytest.xml tests/ludwig
+#      - name: Unit Tests
+#        run: |
+#          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod and not llm" --junitxml pytest.xml tests/ludwig
 
       - name: Integration Tests
         run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=6000 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod and not llm" --junitxml pytest.xml tests/integration_tests
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=6000 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod and not llm" --junitxml pytest.xml tests/integration_tests/test_experiment.py::test_tabnet_with_batch_size_1
 
-      - name: Regression Tests
-        run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod or benchmark and not llm" --junitxml pytest.xml tests/regression_tests
+#      - name: Regression Tests
+#        run: |
+#          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod or benchmark and not llm" --junitxml pytest.xml tests/regression_tests
 
       - name: Install Horovod if necessary
         if: matrix.test-markers == 'distributed'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -149,17 +149,17 @@ jobs:
           curl -L https://github.com/uber/neuropod/releases/download/v${{ env.NEUROPOD_VERISON }}/libneuropod-cpu-linux-v${{ env.NEUROPOD_VERISON }}-torchscript-${{ env.TORCHSCRIPT_VERISON }}-backend.tar.gz | sudo tar -xz -C "$NEUROPOD_BASE_DIR"
         shell: bash
 
-#      - name: Unit Tests
-#        run: |
-#          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod and not llm" --junitxml pytest.xml tests/ludwig
+      - name: Unit Tests
+        run: |
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod and not llm" --junitxml pytest.xml tests/ludwig
 
       - name: Integration Tests
         run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=6000 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod and not llm" --junitxml pytest.xml tests/integration_tests/test_experiment.py::test_tabnet_with_batch_size_1
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=6000 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod and not llm" --junitxml pytest.xml tests/integration_tests
 
-#      - name: Regression Tests
-#        run: |
-#          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod or benchmark and not llm" --junitxml pytest.xml tests/regression_tests
+      - name: Regression Tests
+        run: |
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod or benchmark and not llm" --junitxml pytest.xml tests/regression_tests
 
       - name: Install Horovod if necessary
         if: matrix.test-markers == 'distributed'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -217,8 +217,7 @@ jobs:
           python --version
           pip --version
           python -m pip install -U pip
-          pip install '.[full]'
-          pip install -r requirements_test.txt
+          pip install '.[test]'
           pip list
         shell: bash
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -149,17 +149,17 @@ jobs:
           curl -L https://github.com/uber/neuropod/releases/download/v${{ env.NEUROPOD_VERISON }}/libneuropod-cpu-linux-v${{ env.NEUROPOD_VERISON }}-torchscript-${{ env.TORCHSCRIPT_VERISON }}-backend.tar.gz | sudo tar -xz -C "$NEUROPOD_BASE_DIR"
         shell: bash
 
-      - name: Unit Tests
-        run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod" --junitxml pytest.xml tests/ludwig
+#      - name: Unit Tests
+#        run: |
+#          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod" --junitxml pytest.xml tests/ludwig
 
       - name: Integration Tests
         run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=6000 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod" --junitxml pytest.xml tests/integration_tests
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=6000 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod" --junitxml pytest.xml tests/integration_tests/test_experiment.py::test_tabnet_with_batch_size_1
 
-      - name: Regression Tests
-        run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod or benchmark" --junitxml pytest.xml tests/regression_tests
+#      - name: Regression Tests
+#        run: |
+#          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod or benchmark" --junitxml pytest.xml tests/regression_tests
 
       - name: Install Horovod if necessary
         if: matrix.test-markers == 'distributed'
@@ -217,7 +217,7 @@ jobs:
           python --version
           pip --version
           python -m pip install -U pip
-          pip install -r requirements.txt
+          pip install '.[full]'
           pip install -r requirements_test.txt
           pip list
         shell: bash

--- a/ludwig/distributed/ddp.py
+++ b/ludwig/distributed/ddp.py
@@ -37,9 +37,7 @@ class DDPStrategy(DistributedStrategy):
         trainer_config: "ECDTrainerConfig",
         base_learning_rate: float,
     ) -> Tuple[nn.Module, Optimizer]:
-        return DDP(model, find_unused_parameters=True), create_optimizer(
-            model, trainer_config.optimizer, base_learning_rate
-        )
+        return DDP(model), create_optimizer(model, trainer_config.optimizer, base_learning_rate)
 
     def size(self) -> int:
         return dist.get_world_size()

--- a/ludwig/distributed/ddp.py
+++ b/ludwig/distributed/ddp.py
@@ -37,7 +37,9 @@ class DDPStrategy(DistributedStrategy):
         trainer_config: "ECDTrainerConfig",
         base_learning_rate: float,
     ) -> Tuple[nn.Module, Optimizer]:
-        return DDP(model), create_optimizer(model, trainer_config.optimizer, base_learning_rate)
+        return DDP(model, find_unused_parameters=True), create_optimizer(
+            model, trainer_config.optimizer, base_learning_rate
+        )
 
     def size(self) -> int:
         return dist.get_world_size()

--- a/ludwig/modules/normalization_modules.py
+++ b/ludwig/modules/normalization_modules.py
@@ -44,7 +44,7 @@ class GhostBatchNormalization(LudwigModule):
                 splits_with_bn = [self.bn(x) if x.shape[0] >= 1 else x for x in splits]
                 self.bn.train()
             else:
-                splits_with_bn = [self.bn(x) if x.shape[0] >= 1 else x for x in splits]
+                splits_with_bn = [self.bn(x) if x.shape[0] > 1 else x for x in splits]
 
             return torch.cat(splits_with_bn, 0)
 

--- a/ludwig/modules/normalization_modules.py
+++ b/ludwig/modules/normalization_modules.py
@@ -25,20 +25,27 @@ class GhostBatchNormalization(LudwigModule):
 
         if self.training and self.virtual_batch_size:
             splits = inputs.chunk(int(np.ceil(batch_size / self.virtual_batch_size)), 0)
-            if batch_size == 1:
-                logger.warning(
-                    "Batch size is 1, but batch normalization requires batch size >= 2. Skipping batch normalization."
-                    "Make sure to set `batch_size` to a value greater than 1."
-                )
-                # Skip batch normalization if the batch size is 1.
-                return torch.cat(splits, 0)
+
             if batch_size % self.virtual_batch_size == 1:
                 # Skip batch normalization for the last chunk if it is size 1.
                 logger.warning(
                     f"Virtual batch size `{self.virtual_batch_size}` is not a factor of the batch size `{batch_size}`, "
                     "resulting in a chunk of size 1. Skipping batch normalization for the last chunk of size 1."
                 )
-            splits_with_bn = [self.bn(x) if x.shape[0] > 1 else x for x in splits]
+
+            if batch_size == 1:
+                logger.warning(
+                    "Batch size is 1, but batch normalization requires batch size >= 2. Skipping batch normalization."
+                    "Make sure to set `batch_size` to a value greater than 1."
+                )
+                # We temporarily set the batch_norm module to eval mode as we can't compute the running statistics
+                # when the batch size is 1.
+                self.bn.eval()
+                splits_with_bn = [self.bn(x) if x.shape[0] >= 1 else x for x in splits]
+                self.bn.train()
+            else:
+                splits_with_bn = [self.bn(x) if x.shape[0] >= 1 else x for x in splits]
+
             return torch.cat(splits_with_bn, 0)
 
         if batch_size != 1 or not self.training:

--- a/ludwig/modules/tabnet_modules.py
+++ b/ludwig/modules/tabnet_modules.py
@@ -111,6 +111,12 @@ class TabNet(LudwigModule):
         if batch_size != 1 or not self.training:
             # Skip batch normalization training if the batch size is 1.
             features = self.batch_norm(features)  # [b_s, i_s]
+        elif batch_size == 1:
+            # We temporarily set the batch_norm module to eval mode as we can't compute the running statistics
+            # when the batch size is 1.
+            self.batch_norm.eval()
+            features = self.batch_norm(features)  # [b_s, i_s]
+            self.batch_norm.train()
         masked_features = features
 
         x = self.feature_transforms[0](masked_features)  # [b_s, s + o_s]

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -848,6 +848,31 @@ def test_experiment_model_resume_before_1st_epoch_distributed(tmpdir, ray_cluste
         )
 
 
+@pytest.mark.distributed
+def test_tabnet_with_batch_size_1(tmpdir):
+    input_features = [number_feature()]
+    output_features = [category_feature(output_feature=True)]
+    training_set = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"))
+
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        "combiner": {"type": "tabnet"},
+        TRAINER: {"train_steps": 1, BATCH_SIZE: 1},
+        "backend": {"type": "ray"},
+    }
+    model = LudwigModel(config=config, logging_level=logging.INFO)
+    model.train(
+        dataset=training_set,
+        skip_save_training_description=True,
+        skip_save_training_statistics=True,
+        skip_save_model=True,
+        skip_save_progress=True,
+        skip_save_log=True,
+        skip_save_processed_input=True,
+    )
+
+
 def test_experiment_various_feature_types(csv_filename):
     input_features = [binary_feature(), bag_feature()]
     output_features = [set_feature(decoder={"max_len": 3, "vocab_size": 5})]

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -849,7 +849,7 @@ def test_experiment_model_resume_before_1st_epoch_distributed(tmpdir, ray_cluste
 
 
 @pytest.mark.distributed
-def test_tabnet_with_batch_size_1(tmpdir, ray_cluster_5cpu):
+def test_tabnet_with_batch_size_1(tmpdir, ray_cluster_4cpu):
     input_features = [number_feature()]
     output_features = [category_feature(output_feature=True)]
     training_set = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"))

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -859,7 +859,7 @@ def test_tabnet_with_batch_size_1(tmpdir, ray_cluster_4cpu):
         "output_features": output_features,
         "combiner": {"type": "tabnet"},
         TRAINER: {"train_steps": 1, BATCH_SIZE: 1},
-        "backend": {"type": "ray"},
+        "backend": {"type": "ray", "trainer": {"strategy": "ddp", "num_workers": 2}},
     }
     model = LudwigModel(config=config, logging_level=logging.INFO)
     model.train(

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -849,7 +849,7 @@ def test_experiment_model_resume_before_1st_epoch_distributed(tmpdir, ray_cluste
 
 
 @pytest.mark.distributed
-def test_tabnet_with_batch_size_1(tmpdir):
+def test_tabnet_with_batch_size_1(tmpdir, ray_cluster_5cpu):
     input_features = [number_feature()]
     output_features = [category_feature(output_feature=True)]
     training_set = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"))

--- a/tests/ludwig/modules/test_tabnet_modules.py
+++ b/tests/ludwig/modules/test_tabnet_modules.py
@@ -181,7 +181,7 @@ def test_tabnet(
 
     if batch_size == 1:
         # for single record batches, batchnorm layer is bypassed, only a subset of parameters are updated
-        assert upc == 15, (
+        assert upc == 17, (
             f"Updated parameter count not expected value. Parameters not updated: {not_updated}"
             f"\nModule structure:\n{tabnet}"
         )


### PR DESCRIPTION
fixes the following error
```
RuntimeError: Expected to have finished reduction in the prior iteration before starting a new one. This error indicates that your module has parameters that were not used in producing loss. You can enable unused parameter detection by passing the keyword argument `find_unused_parameters=True` to `torch.nn.parallel.DistributedDataParallel`, and by 
making sure all `forward` function outputs participate in calculating loss. 
If you already have done the above, then the distributed data parallel module wasn't able to locate the output tensors in the return value of your module's `forward` function. Please include the loss function and the structure of the return value of `forward` of your module when reporting this issue (e.g. list, dict, iterable).
Parameter indices which did not receive grad for rank 0: 48 49 51 52 54 55 57 58 60 61 62 63 64 65 67 68 70 71 72 73 74 75 77 78 80 81 82 83 84 85 87 88 90 91 93 94 96 97 99 100
 In addition, you can set the environment variable TORCH_DISTRIBUTED_DEBUG to either INFO or DETAIL to print out information about which particular parameters did not receive gradient on this rank as part of this error
```
The affected parameters are batch norm parameters.