### PR TITLE
Fixed DDP checkpointing to save to local disk on each node

### DIFF
--- a/examples/llm_finetuning/train_imdb_ray.py
+++ b/examples/llm_finetuning/train_imdb_ray.py
@@ -4,10 +4,6 @@ import os
 import yaml
 
 from ludwig.api import LudwigModel
-from ludwig.datasets import imdb
-
-# Download and prepare the dataset
-dataset = imdb.load()
 
 config = yaml.safe_load(
     """
@@ -51,7 +47,7 @@ model = LudwigModel(config=config, logging_level=logging.INFO)
     preprocessed_data,  # tuple Ludwig Dataset objects of pre-processed training data
     output_directory,  # location of training results stored on disk
 ) = model.train(
-    dataset=dataset,
+    dataset="ludwig://imdb",
     experiment_name="imdb_sentiment",
     model_name="bloom3b",
 )

--- a/ludwig/distributed/base.py
+++ b/ludwig/distributed/base.py
@@ -181,9 +181,9 @@ class DistributedStrategy(ABC):
         optimizer: Optional[Optimizer] = None,
         scheduler: Optional["LRScheduler"] = None,
     ) -> "Checkpoint":
-        from ludwig.utils.checkpoint_utils import CoordinatorCheckpoint
+        from ludwig.utils.checkpoint_utils import MultiNodeCheckpoint
 
-        return CoordinatorCheckpoint(self, model, optimizer, scheduler)
+        return MultiNodeCheckpoint(self, model, optimizer, scheduler)
 
 
 class LocalStrategy(DistributedStrategy):

--- a/ludwig/distributed/ddp.py
+++ b/ludwig/distributed/ddp.py
@@ -124,9 +124,9 @@ class DDPStrategy(DistributedStrategy):
         optimizer: Optional[Optimizer] = None,
         scheduler: Optional["LRScheduler"] = None,
     ) -> "Checkpoint":
-        from ludwig.utils.checkpoint_utils import CoordinatorCheckpoint
+        from ludwig.utils.checkpoint_utils import MultiNodeCheckpoint
 
-        return CoordinatorCheckpoint(self, model, optimizer, scheduler)
+        return MultiNodeCheckpoint(self, model, optimizer, scheduler)
 
 
 def local_rank_and_size() -> Tuple[int, int]:


### PR DESCRIPTION
When loading the checkpoint, we assume it exists on each node, so we should make sure we save on each node.

This assumes we're not using a global filesystem like NFS. We could consider ways of checking this (like try writing files to the directory from each node and see if nodes can read each-other's files), but for now this should suffice for most use cases.