### PR TITLE
Ensure captum's halved batch size retry fn wrapper accepts the minimum batch size of 1.

### DIFF
--- a/ludwig/automl/auto_tune_config.py
+++ b/ludwig/automl/auto_tune_config.py
@@ -22,6 +22,7 @@ from ludwig.constants import (
     AUTOML_SMALLER_TEXT_LENGTH,
     AUTOML_TEXT_ENCODER_MAX_TOKEN_LEN,
     HYPEROPT,
+    MINIMUM_BATCH_SIZE,
     PREPROCESSING,
     SPACE,
     TEXT,
@@ -123,7 +124,7 @@ def compute_memory_usage(config_obj, training_set_metadata, model_category) -> i
     batch_size = config_obj.trainer.batch_size
     if batch_size == AUTO:
         # Smallest valid batch size that will allow training to complete
-        batch_size = 2
+        batch_size = MINIMUM_BATCH_SIZE
     memory_usage = model_size * (BYTES_PER_WEIGHT + BYTES_OPTIMIZER_PER_WEIGHT) * batch_size
     if model_category == TEXT:
         return _get_text_model_memory_usage(config_obj.to_dict(), training_set_metadata, memory_usage)

--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -195,6 +195,8 @@ BATCH_SIZE = "batch_size"
 EVAL_BATCH_SIZE = "eval_batch_size"
 DEFAULT_BATCH_SIZE = "auto"
 FALLBACK_BATCH_SIZE = 128
+# The smallest batch size that is supported on Ludwig.
+MINIMUM_BATCH_SIZE = 1
 # 2^40. Used for `max_batch_size` config param. Not a hard constraint for `batch_size` config param.
 MAX_POSSIBLE_BATCH_SIZE = 1099511627776
 # min batch size. Used as a floor for batch size tuning.

--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -22,6 +22,7 @@ from ludwig.constants import (
     DATE,
     IMAGE,
     INPUT_FEATURES,
+    MINIMUM_BATCH_SIZE,
     NAME,
     NUMBER,
     PREPROCESSING,
@@ -68,7 +69,7 @@ def retry_with_halved_batch_size(run_config: ExplanationRunConfig):
     def retry_with_halved_batch_size_fn(fn):
         def retry_with_halved_batch_size_wrapper(*args, **kwargs):
             latest_error = None
-            while run_config.batch_size >= 1:
+            while run_config.batch_size >= MINIMUM_BATCH_SIZE:
                 try:
                     return fn(*args, **kwargs)
                 except RuntimeError as e:

--- a/ludwig/explain/captum_ray.py
+++ b/ludwig/explain/captum_ray.py
@@ -15,7 +15,7 @@ from ludwig.explain.captum import (
     get_input_tensors,
     get_total_attribution,
     IntegratedGradientsExplainer,
-    retry_on_cuda_oom,
+    retry_with_halved_batch_size,
 )
 from ludwig.explain.explanation import ExplanationsResult
 from ludwig.features.feature_utils import LudwigFeatureDict
@@ -167,7 +167,7 @@ def get_input_tensors_task(
     model.model.unskip()
     model.model.to(get_torch_device())
     try:
-        get_total_attribution_with_retry = retry_on_cuda_oom(run_config)(get_input_tensors)
+        get_total_attribution_with_retry = retry_with_halved_batch_size(run_config)(get_input_tensors)
         return get_total_attribution_with_retry(model, df, run_config), run_config
     finally:
         model.model.cpu()
@@ -186,7 +186,7 @@ def get_total_attribution_task(
     model.model.unskip()
     model.model.to(get_torch_device())
     try:
-        get_total_attribution_with_retry = retry_on_cuda_oom(run_config)(get_total_attribution)
+        get_total_attribution_with_retry = retry_with_halved_batch_size(run_config)(get_total_attribution)
         return [
             get_total_attribution_with_retry(
                 model=model,

--- a/ludwig/schema/lr_scheduler.py
+++ b/ludwig/schema/lr_scheduler.py
@@ -47,8 +47,8 @@ class LRSchedulerConfig(schema_utils.BaseMarshmallowConfig, ABC):
     reduce_on_plateau: int = schema_utils.NonNegativeInteger(
         default=0,
         description=(
-            "How many times to reduce the learning rate when the algorithm hits a plateau (i.e. the performance on the"
-            "training set does not improve"
+            "How many times to reduce the learning rate when the algorithm hits a plateau (i.e. the performance on the "
+            "training set does not improve)"
         ),
         parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["reduce_on_plateau"],
     )

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Union
 
 from torch.utils.tensorboard import SummaryWriter
 
-from ludwig.constants import MODEL_LLM, TEST, TRAIN, TRAINING, VALIDATION
+from ludwig.constants import MINIMUM_BATCH_SIZE, MODEL_LLM, TEST, TRAIN, TRAINING, VALIDATION
 from ludwig.data.dataset.base import Dataset
 from ludwig.distributed.base import DistributedStrategy, LocalStrategy
 from ludwig.features.feature_utils import LudwigFeatureDict
@@ -198,7 +198,7 @@ class ZeroShotTrainer(BaseTrainer):
         max_trials: int = 10,
         halving_limit: int = 3,
     ) -> int:
-        return 1
+        return MINIMUM_BATCH_SIZE
 
     @property
     def validation_field(self):

--- a/tests/integration_tests/test_explain.py
+++ b/tests/integration_tests/test_explain.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 from ludwig.api import LudwigModel
-from ludwig.constants import BATCH_SIZE, BINARY, CATEGORY, MODEL_ECD, MODEL_GBM
+from ludwig.constants import BATCH_SIZE, BINARY, CATEGORY, MINIMUM_BATCH_SIZE, MODEL_ECD, MODEL_GBM
 from ludwig.explain.captum import IntegratedGradientsExplainer
 from ludwig.explain.explainer import Explainer
 from ludwig.explain.explanation import Explanation
@@ -111,7 +111,7 @@ def test_explainer_api_ray_minimum_batch_size(tmpdir, ray_cluster_2cpu):
         tmpdir,
         resources_per_task={"num_cpus": 1},
         num_workers=1,
-        batch_size=1,
+        batch_size=MINIMUM_BATCH_SIZE,
     )
 
 


### PR DESCRIPTION
Add a constant for `MINIMUM_BATCH_SIZE=1`, and use that as the basis for captum's batch size retry wrapper.