### PR TITLE
Added LoRA tuner for HuggingFace text encoders

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,7 +60,7 @@ jobs:
         ports:
           - 9000:9000
 
-    timeout-minutes: 135
+    timeout-minutes: 150
     steps:
       - name: Setup ludwigai/ludwig-ray container for local testing with act.
         if: ${{ env.ACT }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Integration Tests
         run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=6000 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod and not llm" --junitxml pytest.xml tests/integration_tests
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=7200 pytest -v --timeout 300 --durations 100 -m "$MARKERS and not slow and not combinatorial and not horovod and not llm" --junitxml pytest.xml tests/integration_tests
 
       - name: Regression Tests
         run: |

--- a/examples/llm_finetuning/imdb_deepspeed_zero3.yaml
+++ b/examples/llm_finetuning/imdb_deepspeed_zero3.yaml
@@ -5,13 +5,14 @@ input_features:
       type: auto_transformer
       pretrained_model_name_or_path: bigscience/bloom-3b
       trainable: true
+      tuner: lora
 
 output_features:
   - name: sentiment
     type: category
 
 trainer:
-  batch_size: 1
+  batch_size: 8
   epochs: 3
   gradient_accumulation_steps: 8
 
@@ -22,3 +23,5 @@ backend:
     offload_optimizer:
       device: cpu
       pin_memory: true
+  fp16:
+    enabled: true

--- a/examples/llm_finetuning/imdb_deepspeed_zero3.yaml
+++ b/examples/llm_finetuning/imdb_deepspeed_zero3.yaml
@@ -12,7 +12,7 @@ output_features:
     type: category
 
 trainer:
-  batch_size: 8
+  batch_size: 4
   epochs: 3
   gradient_accumulation_steps: 8
 
@@ -23,5 +23,3 @@ backend:
     offload_optimizer:
       device: cpu
       pin_memory: true
-  fp16:
-    enabled: true

--- a/examples/llm_finetuning/imdb_deepspeed_zero3_ray.yaml
+++ b/examples/llm_finetuning/imdb_deepspeed_zero3_ray.yaml
@@ -12,7 +12,7 @@ output_features:
     type: category
 
 trainer:
-  batch_size: 8
+  batch_size: 4
   epochs: 3
   gradient_accumulation_steps: 8
 
@@ -27,5 +27,3 @@ backend:
         offload_optimizer:
           device: cpu
           pin_memory: true
-      fp16:
-        enabled: true

--- a/examples/llm_finetuning/imdb_deepspeed_zero3_ray.yaml
+++ b/examples/llm_finetuning/imdb_deepspeed_zero3_ray.yaml
@@ -5,13 +5,14 @@ input_features:
       type: auto_transformer
       pretrained_model_name_or_path: bigscience/bloom-3b
       trainable: true
+      tuner: lora
 
 output_features:
   - name: sentiment
     type: category
 
 trainer:
-  batch_size: 1
+  batch_size: 8
   epochs: 3
   gradient_accumulation_steps: 8
 
@@ -26,3 +27,5 @@ backend:
         offload_optimizer:
           device: cpu
           pin_memory: true
+      fp16:
+        enabled: true

--- a/examples/llm_finetuning/train_imdb_ray.py
+++ b/examples/llm_finetuning/train_imdb_ray.py
@@ -1,12 +1,9 @@
 import logging
 import os
-import shutil
 
 import yaml
 
 from ludwig.api import LudwigModel
-
-shutil.rmtree("./results", ignore_errors=True)
 
 config = yaml.safe_load(
     """
@@ -17,45 +14,31 @@ input_features:
     encoder:
       type: auto_transformer
       pretrained_model_name_or_path: bigscience/bloom-3b
-      # pretrained_model_name_or_path: bigscience/bloom-560m
-      # pretrained_model_name_or_path: bert-base-uncased
       trainable: true
       tuner: lora
-
-    # encoder:
-    #   type: bert
-    #   trainable: true
-    #   # tuner: lora
 
 output_features:
   - name: sentiment
     type: category
 
-preprocessing:
-  split:
-    type: random
-    probabilities: [0.99, 0.005, 0.005]
-
 trainer:
   batch_size: 8
-  # epochs: 3
-  train_steps: 3
+  epochs: 3
   gradient_accumulation_steps: 8
 
 backend:
   type: ray
-  cache_dir: /src/cache
   trainer:
     use_gpu: true
     strategy:
       type: deepspeed
-      fp16:
-        enabled: true
       zero_optimization:
         stage: 3
         offload_optimizer:
           device: cpu
           pin_memory: true
+      fp16:
+        enabled: true
 """
 )
 

--- a/examples/llm_finetuning/train_imdb_ray.py
+++ b/examples/llm_finetuning/train_imdb_ray.py
@@ -49,6 +49,8 @@ backend:
     use_gpu: true
     strategy:
       type: deepspeed
+      fp16:
+        enabled: true
       zero_optimization:
         stage: 3
         offload_optimizer:

--- a/examples/llm_finetuning/train_imdb_ray.py
+++ b/examples/llm_finetuning/train_imdb_ray.py
@@ -37,10 +37,10 @@ preprocessing:
     probabilities: [0.99, 0.005, 0.005]
 
 trainer:
-  batch_size: 4
+  batch_size: 8
   # epochs: 3
   train_steps: 3
-  gradient_accumulation_steps: 1
+  gradient_accumulation_steps: 8
 
 backend:
   type: ray

--- a/examples/llm_finetuning/train_imdb_ray.py
+++ b/examples/llm_finetuning/train_imdb_ray.py
@@ -10,22 +10,28 @@ config = yaml.safe_load(
 input_features:
   - name: review
     type: text
+    
     encoder:
       type: auto_transformer
       pretrained_model_name_or_path: bigscience/bloom-3b
       trainable: true
+
+    # encoder:
+    #   type: bert
+    #   trainable: true
 
 output_features:
   - name: sentiment
     type: category
 
 trainer:
-  batch_size: 1
+  batch_size: 4
   epochs: 3
   gradient_accumulation_steps: 8
 
 backend:
   type: ray
+  cache_dir: /src/cache
   trainer:
     use_gpu: true
     strategy:

--- a/examples/llm_finetuning/train_imdb_ray.py
+++ b/examples/llm_finetuning/train_imdb_ray.py
@@ -13,21 +13,31 @@ input_features:
 
     encoder:
       type: auto_transformer
-      pretrained_model_name_or_path: bigscience/bloom-3b
+      # pretrained_model_name_or_path: bigscience/bloom-3b
+      # pretrained_model_name_or_path: bigscience/bloom-560m
+      pretrained_model_name_or_path: bert-base-uncased
       trainable: true
+      tuner: lora
 
     # encoder:
     #   type: bert
     #   trainable: true
+    #   # tuner: lora
 
 output_features:
   - name: sentiment
     type: category
 
+preprocessing:
+  split:
+    type: random
+    probabilities: [0.99, 0.005, 0.005]
+
 trainer:
   batch_size: 4
-  epochs: 3
-  gradient_accumulation_steps: 8
+  # epochs: 3
+  train_steps: 3
+  gradient_accumulation_steps: 1
 
 backend:
   type: ray

--- a/examples/llm_finetuning/train_imdb_ray.py
+++ b/examples/llm_finetuning/train_imdb_ray.py
@@ -10,7 +10,7 @@ config = yaml.safe_load(
 input_features:
   - name: review
     type: text
-    
+
     encoder:
       type: auto_transformer
       pretrained_model_name_or_path: bigscience/bloom-3b

--- a/examples/llm_finetuning/train_imdb_ray.py
+++ b/examples/llm_finetuning/train_imdb_ray.py
@@ -1,9 +1,12 @@
 import logging
 import os
+import shutil
 
 import yaml
 
 from ludwig.api import LudwigModel
+
+shutil.rmtree("./results", ignore_errors=True)
 
 config = yaml.safe_load(
     """
@@ -13,9 +16,9 @@ input_features:
 
     encoder:
       type: auto_transformer
-      # pretrained_model_name_or_path: bigscience/bloom-3b
+      pretrained_model_name_or_path: bigscience/bloom-3b
       # pretrained_model_name_or_path: bigscience/bloom-560m
-      pretrained_model_name_or_path: bert-base-uncased
+      # pretrained_model_name_or_path: bert-base-uncased
       trainable: true
       tuner: lora
 

--- a/examples/llm_finetuning/train_imdb_ray.py
+++ b/examples/llm_finetuning/train_imdb_ray.py
@@ -22,7 +22,7 @@ output_features:
     type: category
 
 trainer:
-  batch_size: 8
+  batch_size: 4
   epochs: 3
   gradient_accumulation_steps: 8
 
@@ -37,8 +37,6 @@ backend:
         offload_optimizer:
           device: cpu
           pin_memory: true
-      fp16:
-        enabled: true
 """
 )
 

--- a/ludwig/backend/deepspeed.py
+++ b/ludwig/backend/deepspeed.py
@@ -15,14 +15,12 @@ class DeepSpeedBackend(DataParallelBackend):
         self,
         zero_optimization: Optional[Dict[str, Any]] = None,
         fp16: Optional[Dict[str, Any]] = None,
-        bf16: Optional[Dict[str, Any]] = None,
         compression_training: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
         self.zero_optimization = zero_optimization
         self.fp16 = fp16
-        self.bf16 = bf16
         self.compression_training = compression_training
 
     def initialize(self):
@@ -33,7 +31,6 @@ class DeepSpeedBackend(DataParallelBackend):
             self.BACKEND_TYPE,
             zero_optimization=self.zero_optimization,
             fp16=self.fp16,
-            bf16=self.bf16,
             compression_training=self.compression_training,
         )
 

--- a/ludwig/backend/deepspeed.py
+++ b/ludwig/backend/deepspeed.py
@@ -11,15 +11,31 @@ from ludwig.utils.batch_size_tuner import BatchSizeEvaluator
 class DeepSpeedBackend(DataParallelBackend):
     BACKEND_TYPE = "deepspeed"
 
-    def __init__(self, zero_optimization: Optional[Dict[str, Any]] = None, **kwargs):
+    def __init__(
+        self,
+        zero_optimization: Optional[Dict[str, Any]] = None,
+        fp16: Optional[Dict[str, Any]] = None,
+        bf16: Optional[Dict[str, Any]] = None,
+        compression_training: Optional[Dict[str, Any]] = None,
+        **kwargs
+    ):
         super().__init__(**kwargs)
         self.zero_optimization = zero_optimization
+        self.fp16 = fp16
+        self.bf16 = bf16
+        self.compression_training = compression_training
 
     def initialize(self):
         # Unlike when we use the Ray backend, we need to initialize the `torch.distributed` context so we can
         # broadcast, allgather, etc. before preparing the model within the trainer.
         deepspeed.init_distributed()
-        self._distributed = init_dist_strategy(self.BACKEND_TYPE, zero_optimization=self.zero_optimization)
+        self._distributed = init_dist_strategy(
+            self.BACKEND_TYPE,
+            zero_optimization=self.zero_optimization,
+            fp16=self.fp16,
+            bf16=self.bf16,
+            compression_training=self.compression_training,
+        )
 
     def supports_batch_size_tuning(self) -> bool:
         # TODO(travis): need to fix checkpoint saving/loading for DeepSpeed to enable tuning

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -490,8 +490,10 @@ class RayTrainerV2(BaseTrainer):
         results = ckpt.to_dict()["state_dict"]
 
         # load state dict back into the model
+        # use `strict=False` to account for PEFT training, where the saved state in the checkpoint
+        # might only contain the PEFT layers that were modified during training
         state_dict, *args = results
-        self.model.load_state_dict(state_dict)
+        self.model.load_state_dict(state_dict, strict=False)
         results = (self.model, *args)
 
         return results

--- a/ludwig/distributed/deepspeed.py
+++ b/ludwig/distributed/deepspeed.py
@@ -36,7 +36,14 @@ warnings.filterwarnings(
 
 
 class DeepSpeedStrategy(DDPStrategy):
-    def __init__(self, zero_optimization: Optional[Dict[str, Any]] = None, **kwargs):
+    def __init__(
+        self,
+        zero_optimization: Optional[Dict[str, Any]] = None,
+        fp16: Optional[Dict[str, Any]] = None,
+        bf16: Optional[Dict[str, Any]] = None,
+        compression_training: Optional[Dict[str, Any]] = None,
+        **kwargs
+    ):
         # If we're initializing from a `deepspeed` CLI command, deepspeed will have already been initialized, as
         # indicated by the presence of the LOCAL_RANK var. Otherwise, we're initializing from Ray / torchrun, and will
         # need to set this var ourselves, then init DeepSpeed here.
@@ -45,6 +52,9 @@ class DeepSpeedStrategy(DDPStrategy):
 
         super().__init__(**kwargs)
         self.zero_optimization = zero_optimization or DEFAULT_ZERO_OPTIMIZATION
+        self.fp16 = fp16
+        self.bf16 = bf16
+        self.compression_training = compression_training
 
         if init_deepspeed:
             os.environ["LOCAL_RANK"] = str(self.local_rank())
@@ -72,6 +82,9 @@ class DeepSpeedStrategy(DDPStrategy):
             },
             "optimizer": {"type": optimizer_cls.__name__, "params": optimizer_kwargs},
             "zero_optimization": self.zero_optimization,
+            "fp16": self.fp16,
+            "bf16": self.bf16,
+            "compression_training": self.compression_training,
             "gradient_clipping": trainer_config.gradient_clipping.clipglobalnorm,
             "train_micro_batch_size_per_gpu": batch_size,
             "gradient_accumulation_steps": trainer_config.gradient_accumulation_steps,

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -135,7 +135,6 @@ class HFTextEncoder(Encoder):
 
             peft_config = tuner.to_config()
             transformer = get_peft_model(transformer, peft_config)
-            print("!!! WRAPPED WITH LORA !!!", peft_config)
         return FreezeModule(transformer, frozen=not trainable)
 
     def get_embedding_layer(self) -> nn.Module:

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -19,8 +19,8 @@ from typing import Any, Callable, Dict, List, Optional, Type, TYPE_CHECKING, Typ
 
 import numpy as np
 import torch
-from torch import nn
 from peft import get_peft_model
+from torch import nn
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import TEXT

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Dict, List, Optional, Type, TYPE_CHECKING, Typ
 import numpy as np
 import torch
 from torch import nn
+from peft import LoraConfig, get_peft_model
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import TEXT
@@ -2212,6 +2213,9 @@ class AutoTransformerEncoder(HFTextEncoder):
         self._maybe_resize_token_embeddings(transformer, vocab_size)
 
         self.config = self._init_config(transformer, [], encoder_config)
+
+        peft_config = LoraConfig(inference_mode=False, r=8, lora_alpha=32, lora_dropout=0.1)
+        transformer = get_peft_model(transformer, peft_config)
 
         self.transformer = FreezeModule(transformer, frozen=not trainable)
         self.reduce_output = reduce_output

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -19,7 +19,6 @@ from typing import Any, Callable, Dict, List, Optional, Type, TYPE_CHECKING, Typ
 
 import numpy as np
 import torch
-from peft import get_peft_model
 from torch import nn
 
 from ludwig.api_annotations import DeveloperAPI
@@ -132,8 +131,11 @@ class HFTextEncoder(Encoder):
 
     def _wrap_transformer(self, transformer: nn.Module, tuner: Optional[BaseTunerConfig], trainable: bool):
         if tuner is not None:
+            from peft import get_peft_model
+
             peft_config = tuner.to_config()
             transformer = get_peft_model(transformer, peft_config)
+            print("!!! WRAPPED WITH LORA !!!", peft_config)
         return FreezeModule(transformer, frozen=not trainable)
 
     def get_embedding_layer(self) -> nn.Module:

--- a/ludwig/schema/encoders/text/peft.py
+++ b/ludwig/schema/encoders/text/peft.py
@@ -1,0 +1,123 @@
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Optional, Type
+from ludwig.api_annotations import DeveloperAPI
+
+from ludwig.schema import utils as schema_utils
+from ludwig.schema.metadata.parameter_metadata import ParameterMetadata
+from ludwig.schema.utils import ludwig_dataclass
+from ludwig.utils.registry import Registry
+
+if TYPE_CHECKING:
+    from peft import PeftConfig
+
+
+tuner_registry = Registry()
+
+
+@DeveloperAPI
+def register_tuner(name: str):
+    def wrap(config: BaseTunerConfig):
+        tuner_registry[name] = config
+        return config
+
+    return wrap
+
+
+@DeveloperAPI
+@ludwig_dataclass
+class BaseTunerConfig(schema_utils.BaseMarshmallowConfig, ABC):
+    type: str
+
+    @abstractmethod
+    def to_config(self) -> "PeftConfig":
+        pass
+
+
+@DeveloperAPI
+@register_tuner(name="lora")
+@ludwig_dataclass
+class LoraConfig(BaseTunerConfig):
+    type: str = schema_utils.ProtectedString("lora")
+
+    r: int = schema_utils.PositiveInteger(
+        default=8,
+        description="Lora attention dimension.",
+    )
+
+    alpha: int = schema_utils.PositiveInteger(
+        default=16,
+        description="The alpha parameter for Lora scaling.",
+    )
+
+    dropout: float = schema_utils.NonNegativeFloat(
+        default=0.05,
+        description="The dropout probability for Lora layers.",
+    )
+
+    bias: str = schema_utils.StringOptions(
+        options=["none", "all", "lora_only"],
+        default="none",
+        description="Bias type for Lora.",
+    )
+
+    def to_config(self) -> "PeftConfig":
+        from peft import LoraConfig as _LoraConfig
+
+        return _LoraConfig(
+            r=self.r,
+            lora_alpha=self.alpha,
+            lora_dropout=self.dropout,
+            bias=self.bias,
+        )
+
+
+@DeveloperAPI
+def get_tuner_conds():
+    conds = []
+    for tuner_type, tuner_cls in tuner_registry:
+        other_props = schema_utils.unload_jsonschema_from_marshmallow_class(tuner_cls)["properties"]
+        schema_utils.remove_duplicate_fields(other_props)
+        preproc_cond = schema_utils.create_cond(
+            {"type": tuner_type},
+            other_props,
+        )
+        conds.append(preproc_cond)
+    return conds
+
+
+@DeveloperAPI
+def TunerDataclassField(
+    default: Optional[str] = None, description: str = "", parameter_metadata: ParameterMetadata = None
+):
+    class TunerSelection(schema_utils.TypeSelection):
+        def __init__(self):
+            super().__init__(
+                registry=tuner_registry,
+                default_value=default,
+                description=description,
+                parameter_metadata=parameter_metadata,
+                allow_str_value=True,
+                allow_none=True,
+            )
+
+        def get_schema_from_registry(self, key: str) -> Type[schema_utils.BaseMarshmallowConfig]:
+            return tuner_registry[key]
+
+        def _jsonschema_type_mapping(self):
+            return {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": list(tuner_registry.keys()),
+                        "default": default,
+                        "description": "The type of PEFT tuner to use during fine-tuning",
+                    },
+                },
+                "title": "tuner_options",
+                "allOf": get_tuner_conds(),
+                "required": ["type"],
+                "description": description,
+            }
+
+    return TunerSelection().get_default_field()

--- a/ludwig/schema/encoders/text/peft.py
+++ b/ludwig/schema/encoders/text/peft.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Optional, Type
-from ludwig.api_annotations import DeveloperAPI
+from typing import Optional, Type, TYPE_CHECKING
 
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.metadata.parameter_metadata import ParameterMetadata
 from ludwig.schema.utils import ludwig_dataclass

--- a/ludwig/schema/encoders/text/peft.py
+++ b/ludwig/schema/encoders/text/peft.py
@@ -74,7 +74,7 @@ class LoraConfig(BaseTunerConfig):
 @DeveloperAPI
 def get_tuner_conds():
     conds = []
-    for tuner_type, tuner_cls in tuner_registry:
+    for tuner_type, tuner_cls in tuner_registry.items():
         other_props = schema_utils.unload_jsonschema_from_marshmallow_class(tuner_cls)["properties"]
         schema_utils.remove_duplicate_fields(other_props)
         preproc_cond = schema_utils.create_cond(

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -140,6 +140,8 @@ class ALBERTConfig(HFEncoderConfig):
         parameter_metadata=ENCODER_METADATA["ALBERT"]["trainable"],
     )
 
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
+
     reduce_output: str = schema_utils.String(
         default="cls_pooled",
         description="The method used to reduce a sequence of tensors down to a single tensor.",
@@ -339,6 +341,8 @@ class MT5Config(HFEncoderConfig):
         parameter_metadata=ENCODER_METADATA["MT5"]["trainable"],
     )
 
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
+
     reduce_output: str = schema_utils.String(
         default="sum",
         description="The method used to reduce a sequence of tensors down to a single tensor.",
@@ -535,6 +539,8 @@ class XLMRoBERTaConfig(HFEncoderConfig):
         parameter_metadata=ENCODER_METADATA["XLMRoBERTa"]["trainable"],
     )
 
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
+
     vocab: list = schema_utils.List(
         default=None,
         description="Vocabulary for the encoder",
@@ -639,6 +645,8 @@ class BERTConfig(HFEncoderConfig):
         description="Whether to finetune the model on your dataset.",
         parameter_metadata=ENCODER_METADATA["BERT"]["trainable"],
     )
+
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
 
     reduce_output: str = schema_utils.String(
         default="cls_pooled",
@@ -843,6 +851,8 @@ class XLMConfig(HFEncoderConfig):
         description="Whether to finetune the model on your dataset.",
         parameter_metadata=ENCODER_METADATA["XLM"]["trainable"],
     )
+
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
 
     reduce_output: str = schema_utils.String(
         default="sum",
@@ -1099,6 +1109,8 @@ class GPTConfig(HFEncoderConfig):
         parameter_metadata=ENCODER_METADATA["GPT"]["trainable"],
     )
 
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
+
     vocab: list = schema_utils.List(
         default=None,
         description="Vocabulary for the encoder",
@@ -1233,6 +1245,8 @@ class GPT2Config(HFEncoderConfig):
         description="Whether to finetune the model on your dataset.",
         parameter_metadata=ENCODER_METADATA["GPT2"]["trainable"],
     )
+
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
 
     vocab: list = schema_utils.List(
         default=None,
@@ -1395,6 +1409,8 @@ class RoBERTaConfig(HFEncoderConfig):
         parameter_metadata=ENCODER_METADATA["RoBERTa"]["trainable"],
     )
 
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
+
     vocab: list = schema_utils.List(
         default=None,
         description="Vocabulary for the encoder",
@@ -1486,6 +1502,8 @@ class TransformerXLConfig(HFEncoderConfig):
         description="Whether to finetune the model on your dataset.",
         parameter_metadata=ENCODER_METADATA["TransformerXL"]["trainable"],
     )
+
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
 
     vocab: list = schema_utils.List(
         default=None,
@@ -1715,6 +1733,8 @@ class XLNetConfig(HFEncoderConfig):
         description="Whether to finetune the model on your dataset.",
         parameter_metadata=ENCODER_METADATA["XLNet"]["trainable"],
     )
+
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
 
     vocab: list = schema_utils.List(
         default=None,
@@ -1957,6 +1977,8 @@ class DistilBERTConfig(HFEncoderConfig):
         parameter_metadata=ENCODER_METADATA["DistilBERT"]["trainable"],
     )
 
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
+
     vocab: list = schema_utils.List(
         default=None,
         description="Vocabulary for the encoder",
@@ -2114,6 +2136,8 @@ class CTRLConfig(HFEncoderConfig):
         parameter_metadata=ENCODER_METADATA["CTRL"]["trainable"],
     )
 
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
+
     vocab: list = schema_utils.List(
         default=None,
         description="Vocabulary for the encoder",
@@ -2256,6 +2280,8 @@ class CamemBERTConfig(HFEncoderConfig):
         description="Whether to finetune the model on your dataset.",
         parameter_metadata=ENCODER_METADATA["CamemBERT"]["trainable"],
     )
+
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
 
     vocab: list = schema_utils.List(
         default=None,
@@ -2430,6 +2456,8 @@ class T5Config(HFEncoderConfig):
         parameter_metadata=ENCODER_METADATA["T5"]["trainable"],
     )
 
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
+
     vocab: list = schema_utils.List(
         default=None,
         description="Vocabulary for the encoder",
@@ -2576,6 +2604,8 @@ class FlauBERTConfig(HFEncoderConfig):
         description="Whether to finetune the model on your dataset.",
         parameter_metadata=ENCODER_METADATA["FlauBERT"]["trainable"],
     )
+
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
 
     vocab: list = schema_utils.List(
         default=None,
@@ -2818,6 +2848,8 @@ class ELECTRAConfig(HFEncoderConfig):
         parameter_metadata=ENCODER_METADATA["ELECTRA"]["trainable"],
     )
 
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
+
     vocab: list = schema_utils.List(
         default=None,
         description="Vocabulary for the encoder",
@@ -3005,6 +3037,8 @@ class LongformerConfig(HFEncoderConfig):
         parameter_metadata=ENCODER_METADATA["Longformer"]["trainable"],
     )
 
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
+
     vocab: list = schema_utils.List(
         default=None,
         description="Vocabulary for the encoder",
@@ -3083,6 +3117,8 @@ class AutoTransformerConfig(HFEncoderConfig):
         description="Whether to finetune the model on your dataset.",
         parameter_metadata=ENCODER_METADATA["AutoTransformer"]["trainable"],
     )
+
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
 
     vocab: list = schema_utils.List(
         default=None,

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, TYPE_CHECKING, Union
+from typing import Callable, Dict, List, TYPE_CHECKING, Optional, Union
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import MODEL_ECD, MODEL_GBM, TEXT
@@ -6,6 +6,7 @@ from ludwig.error import ConfigValidationError
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.sequence_encoders import SequenceEncoderConfig
 from ludwig.schema.encoders.text.hf_model_params import DebertaModelParams
+from ludwig.schema.encoders.text.peft import BaseTunerConfig, TunerDataclassField
 from ludwig.schema.encoders.utils import register_encoder_config
 from ludwig.schema.metadata import ENCODER_METADATA
 from ludwig.schema.metadata.parameter_metadata import INTERNAL_ONLY, ParameterMetadata
@@ -59,6 +60,8 @@ class HFEncoderImplConfig(HFEncoderConfig):
         description="Whether to finetune the model on your dataset.",
         parameter_metadata=ENCODER_METADATA["HFEncoder"]["trainable"],
     )
+
+    tuner: Optional[BaseTunerConfig] = TunerDataclassField()
 
     pretrained_kwargs: dict = schema_utils.Dict(
         default=None,

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, TYPE_CHECKING, Optional, Union
+from typing import Callable, Dict, List, Optional, TYPE_CHECKING, Union
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import MODEL_ECD, MODEL_GBM, TEXT

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -1161,6 +1161,7 @@ class TypeSelection(fields.Field):
         description: str = "",
         parameter_metadata: ParameterMetadata = None,
         allow_str_value: bool = False,
+        allow_none: bool = False,
     ):
         self.registry = registry
         self.default_value = default_value
@@ -1178,7 +1179,7 @@ class TypeSelection(fields.Field):
             dump_default = cls.Schema().dump(default_obj)
 
         super().__init__(
-            allow_none=False,
+            allow_none=allow_none,
             dump_default=dump_default,
             load_default=load_default,
             metadata={"description": description, "parameter_metadata": convert_metadata_to_json(parameter_metadata)},

--- a/tests/integration_tests/test_cached_preprocessing.py
+++ b/tests/integration_tests/test_cached_preprocessing.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 
 import numpy as np
 import pytest
@@ -7,17 +6,7 @@ import pytest
 from ludwig.api import LudwigModel
 from ludwig.constants import MODEL_ECD, MODEL_GBM, PREPROCESSING, PROC_COLUMN, TRAINER
 from tests.integration_tests.test_gbm import category_feature
-from tests.integration_tests.utils import binary_feature, generate_data, number_feature, text_feature
-
-
-def run_test_suite(config, dataset, backend):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        model = LudwigModel(config, backend=backend)
-        _, _, output_dir = model.train(dataset=dataset, output_directory=tmpdir)
-
-        model_dir = os.path.join(output_dir, "model")
-        loaded_model = LudwigModel.load(model_dir, backend=backend)
-        loaded_model.predict(dataset=dataset)
+from tests.integration_tests.utils import binary_feature, generate_data, number_feature, run_test_suite, text_feature
 
 
 @pytest.mark.parametrize(

--- a/tests/integration_tests/test_peft.py
+++ b/tests/integration_tests/test_peft.py
@@ -1,0 +1,38 @@
+import os
+
+import pytest
+
+from ludwig.constants import TRAINER
+from tests.integration_tests.utils import binary_feature, generate_data, run_test_suite, text_feature
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param("local", id="local"),
+        pytest.param("ray", id="ray", marks=pytest.mark.distributed),
+    ],
+)
+def test_text_tuner_lora(tmpdir, backend, ray_cluster_2cpu):
+    input_features = [
+        text_feature(
+            encoder={
+                "type": "auto_transformer",
+                "pretrained_model_name_or_path": "hf-internal-testing/tiny-bert-for-token-classification",
+                "trainable": True,
+                "tuner": "lora",
+            },
+        ),
+    ]
+    output_features = [binary_feature()]
+
+    data_csv_path = os.path.join(tmpdir, "dataset.csv")
+    dataset = generate_data(input_features, output_features, data_csv_path)
+
+    config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 1}}
+    model = run_test_suite(config, dataset, backend)
+
+    state_dict = model.model.state_dict()
+
+    # check that at least one of the keys contains the word "lora_" denoting a lora parameter
+    assert any("lora_" in key for key in state_dict.keys())

--- a/tests/integration_tests/test_peft.py
+++ b/tests/integration_tests/test_peft.py
@@ -29,7 +29,12 @@ def test_text_tuner_lora(tmpdir, backend, ray_cluster_2cpu):
     data_csv_path = os.path.join(tmpdir, "dataset.csv")
     dataset = generate_data(input_features, output_features, data_csv_path)
 
-    config = {"input_features": input_features, "output_features": output_features, TRAINER: {"epochs": 1}}
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        "combiner": {"type": "concat", "output_size": 14},
+        TRAINER: {"epochs": 1},
+    }
     model = run_test_suite(config, dataset, backend)
 
     state_dict = model.model.state_dict()

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -1118,3 +1118,14 @@ def clear_huggingface_cache():
             os.unlink(os.path.join(root, f))
         for d in dirs:
             shutil.rmtree(os.path.join(root, d))
+
+
+def run_test_suite(config, dataset, backend):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = LudwigModel(config, backend=backend)
+        _, _, output_dir = model.train(dataset=dataset, output_directory=tmpdir)
+
+        model_dir = os.path.join(output_dir, "model")
+        loaded_model = LudwigModel.load(model_dir, backend=backend)
+        loaded_model.predict(dataset=dataset)
+        return loaded_model

--- a/tests/ludwig/config_validation/test_validate_config_misc.py
+++ b/tests/ludwig/config_validation/test_validate_config_misc.py
@@ -433,8 +433,12 @@ def test_deprecation_warning_raised_for_unknown_parameters():
         ({"type": "bert", "trainable": True, "tuner": "lora"}, LoraConfig()),
         ({"type": "bert", "trainable": True, "tuner": {"type": "lora"}}, LoraConfig()),
         (
-            {"type": "bert", "trainable": True, "tuner": {"type": "lora", "r": 16, "bias": "all"}},
-            LoraConfig(r=16, bias="all"),
+            {
+                "type": "bert",
+                "trainable": True,
+                "tuner": {"type": "lora", "r": 16, "alpha": 32, "dropout": 0.1, "bias_type": "all"},
+            },
+            LoraConfig(r=16, alpha=32, dropout=0.1, bias_type="all"),
         ),
     ],
 )

--- a/tests/ludwig/config_validation/test_validate_config_misc.py
+++ b/tests/ludwig/config_validation/test_validate_config_misc.py
@@ -25,6 +25,7 @@ from ludwig.features.feature_registries import get_output_type_registry
 from ludwig.schema.combiners.utils import get_combiner_jsonschema
 from ludwig.schema.defaults.ecd import ECDDefaultsConfig
 from ludwig.schema.defaults.gbm import GBMDefaultsConfig
+from ludwig.schema.encoders.text.peft import LoraConfig
 from ludwig.schema.features.preprocessing.audio import AudioPreprocessingConfig
 from ludwig.schema.features.preprocessing.bag import BagPreprocessingConfig
 from ludwig.schema.features.preprocessing.binary import BinaryPreprocessingConfig
@@ -422,3 +423,26 @@ def test_deprecation_warning_raised_for_unknown_parameters():
     }
     with pytest.warns(DeprecationWarning, match="not a valid parameter"):
         ModelConfig.from_dict(config)
+
+
+@pytest.mark.parametrize(
+    "encoder_config,expected_tuner",
+    [
+        ({"type": "bert", "trainable": True}, None),
+        ({"type": "bert", "trainable": True, "tuner": None}, None),
+        ({"type": "bert", "trainable": True, "tuner": "lora"}, LoraConfig()),
+        ({"type": "bert", "trainable": True, "tuner": {"type": "lora"}}, LoraConfig()),
+        (
+            {"type": "bert", "trainable": True, "tuner": {"type": "lora", "r": 16, "bias": "all"}},
+            LoraConfig(r=16, bias="all"),
+        ),
+    ],
+)
+def test_text_encoder_tuner(encoder_config, expected_tuner):
+    config = {
+        "input_features": [text_feature(encoder=encoder_config)],
+        "output_features": [category_feature(decoder={"type": "classifier", "vocab_size": 2}, reduce_input="sum")],
+    }
+    config_obj = ModelConfig.from_dict(config)
+
+    assert config_obj.input_features[0].encoder.tuner == expected_tuner


### PR DESCRIPTION
Using LoRA speeds up fine-tuning, allowing you to train with larger batch sizes and adjust fewer weights during training.

Usage:

```
encoder:
    type: bert
    trainable: true
    tuner: lora
```

You can also specify additional parameters:

```
encoder:
    type: bert
    trainable: true
    tuner:
        type: lora
        r: 16
        alpha: 32
        dropout: 0.1
        bias_type: all
```