### PR TITLE
[LLM] Add Prefix Tuning, PTuning, Lora, Adalora and Adaption Prompt fine-tuning strategies

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -221,9 +221,9 @@ jobs:
           # remove torch and ray from the dependencies so we can add them depending on the matrix args for the job.
           cat requirements.txt | sed '/^torch[>=<\b]/d' | sed '/^torchtext/d' | sed '/^torchvision/d' | sed '/^torchaudio/d' > requirements-temp && mv requirements-temp requirements.txt
           cat requirements_distributed.txt | sed '/^ray[\[]/d'
-          pip install torch==2.0.0 torchtext torchvision torchaudio
+          pip install torch==2.0.0 torchtext
           pip install ray==2.3.0
-          pip install '.[test]'
+          pip install '.'
           pip list
         shell: bash
 

--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -522,6 +522,9 @@ def check_llm_prompt_tuning_adapter(config: "ModelConfig"):  # noqa: F821
     if config.model_type != MODEL_LLM:
         return
 
+    if not config.adapter:
+        return
+
     if config.adapter.type != "prompt_tuning":
         return
 
@@ -535,6 +538,9 @@ def check_llm_prompt_tuning_adapter(config: "ModelConfig"):  # noqa: F821
 def check_llm_finetuning_num_virtual_tokens_set(config: "ModelConfig"):
     """Checks that the num_virtual_tokens is set to a value greater than 0 when finetuning is enabled."""
     if config.model_type != MODEL_LLM:
+        return
+
+    if not config.adapter:
         return
 
     # num_virtual_tokens is only required by these 3 adapter types
@@ -557,6 +563,9 @@ def check_llm_finetuning_adalora_config(config: "ModelConfig"):
     neither is true, AdaloraModel will run into issues downstream.
     """
     if config.model_type != MODEL_LLM:
+        return
+
+    if not config.adapter:
         return
 
     if config.adapter.type != "adalora":
@@ -584,6 +593,9 @@ def check_llm_finetuning_adaption_prompt_parameters(config: "ModelConfig"):
     Adaption prompt is only supported for Llama models.
     """
     if config.model_type != MODEL_LLM:
+        return
+
+    if not config.adapter:
         return
 
     if config.adapter.type != "adaption_prompt":

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -58,12 +58,13 @@ class LLM(BaseModel):
 
             # Deepcopy and remove type manually since it is not a valid argument for the adapter config
             adapter_config = copy.deepcopy(self.config_obj.adapter.to_dict())
-            adapter_config.pop("type", None)
+            adapter_type = adapter_config.pop("type", None)
 
             self.model = get_peft_model(self.model, get_peft_config(adapter_config))
 
             logger.info("==================================================")
             logger.info("Trainable Parameter Summary For Fine-Tuning:")
+            logger.info(f"Fine-tuning with adapter: {adapter_type}")
             self.model.print_trainable_parameters()
             logger.info("==================================================")
 

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -53,8 +53,9 @@ class LLM(BaseModel):
         if self.config_obj.adapter:
             from peft import get_peft_config, get_peft_model
 
-            # Set tokenizer_name_or_path to the model name since it is required by all PEFT adapter config
-            self.config_obj.adapter.tokenizer_name_or_path = self.model_name
+            # Set tokenizer_name_or_path to the model name since it is required by some adapter configs
+            if self.config_obj.adapter.type not in {"lora", "adalora", "adaption_prompt"}:
+                self.config_obj.adapter.tokenizer_name_or_path = self.model_name
 
             # Deepcopy and remove type manually since it is not a valid argument for the adapter config
             adapter_config = copy.deepcopy(self.config_obj.adapter.to_dict())

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -53,8 +53,8 @@ class LLM(BaseModel):
         if self.config_obj.adapter:
             from peft import get_peft_config, get_peft_model
 
-            # Set tokenizer_name_or_path to the model name since it is required by some adapter configs
-            if self.config_obj.adapter.type not in {"lora", "adalora", "adaption_prompt"}:
+            # Set tokenizer_name_or_path to the model name only for prompt_tuning strategy
+            if self.config_obj.adapter.type == "prompt_tuning":
                 self.config_obj.adapter.tokenizer_name_or_path = self.model_name
 
             # Deepcopy and remove type manually since it is not a valid argument for the adapter config

--- a/ludwig/schema/adapter.py
+++ b/ludwig/schema/adapter.py
@@ -324,6 +324,39 @@ class AdaLoRAAdapterConfig(LoRAAdapterConfig):
 
 
 @DeveloperAPI
+@register_adapter("adaption_prompt")
+@schema_utils.ludwig_dataclass
+class AdaptionPromptAdapterConfig(BasePeftConfig):
+    """Adapted from https://github.com/huggingface/peft/blob/main/src/peft/tuners/adaption_prompt.py."""
+
+    # Explicitly set type property in the config because it is needed when we
+    # load a saved PEFT model back into Ludwig.
+    type: str = schema_utils.ProtectedString("adaption_prompt")
+
+    peft_type: str = schema_utils.ProtectedString("ADAPTION_PROMPT")
+
+    # TODO(Arnav): Extended to support regex expression of the module names to replace.
+    target_modules: List[str] = schema_utils.List(
+        list_type=str,
+        default=None,
+        allow_none=True,
+        description="Name of the attention submodules to insert adaption prompts into.",
+    )
+
+    adapter_length: int = schema_utils.Integer(
+        default=None,
+        allow_none=True,
+        description="Number of adapter tokens to insert.",
+    )
+
+    adapter_layers: int = schema_utils.Integer(
+        default=None,
+        allow_none=True,
+        description="Number of adapter layers to insert (from the top).",
+    )
+
+
+@DeveloperAPI
 def get_adapter_conds():
     """Returns a JSON schema of conditionals to validate against adapter types."""
     conds = []

--- a/ludwig/schema/adapter.py
+++ b/ludwig/schema/adapter.py
@@ -344,15 +344,17 @@ class AdaptionPromptAdapterConfig(BasePeftConfig):
         description="Name of the attention submodules to insert adaption prompts into.",
     )
 
-    adapter_length: int = schema_utils.Integer(
+    adapter_len: int = schema_utils.Integer(
         default=None,
-        allow_none=True,
+        allow_none=False,
         description="Number of adapter tokens to insert.",
     )
 
+    # Set default to 1 even though the original PEFT dataclass sets this to None
+    # Otherwise, this runs into issues when initializating the AdaptionPromptModel
     adapter_layers: int = schema_utils.Integer(
         default=None,
-        allow_none=True,
+        allow_none=False,
         description="Number of adapter layers to insert (from the top).",
     )
 

--- a/ludwig/schema/adapter.py
+++ b/ludwig/schema/adapter.py
@@ -41,7 +41,6 @@ class BasePeftConfig(schema_utils.BaseMarshmallowConfig, ABC):
 
     inference_mode: bool = schema_utils.Boolean(
         default=False,
-        allow_none=True,
         description="Whether to use the model in inference mode. In inference mode, the model will not be trained.",
     )
 
@@ -131,7 +130,6 @@ class PrefixTuningAdapterconfig(BasePromptLearningConfig):
 
     prefix_projection: bool = schema_utils.Boolean(
         default=False,
-        allow_none=True,
         description="Whether to use a projection layer in the prompt encoder to project the prefix tokens",
     )
 
@@ -216,7 +214,6 @@ class LoRAAdapterConfig(BasePeftConfig):
 
     fan_in_fan_out: bool = schema_utils.Boolean(
         default=False,
-        allow_none=True,
         description="Whether to use fan-in/fan-out initialization for LoRA attention."
         "Set this to True if the layer to replace stores weight like (fan_in, fan_out)",
     )
@@ -239,7 +236,6 @@ class LoRAAdapterConfig(BasePeftConfig):
 
     init_lora_weights: bool = schema_utils.Boolean(
         default=True,
-        allow_none=True,
         description="Whether to initialize LoRA weights with the original weights of the layer to replace.",
     )
 

--- a/ludwig/schema/adapter.py
+++ b/ludwig/schema/adapter.py
@@ -199,14 +199,18 @@ class LoRAAdapterConfig(BasePeftConfig):
         description="List of module names to replace with LoRA attention.",
     )
 
+    # Set default to 16 even thought the original PEFT dataclass sets this to None
+    # Otherwise, this runs into issues when initialization the LoraModel
     lora_alpha: int = schema_utils.Integer(
-        default=None,
+        default=16,
         allow_none=True,
         description="LoRA alpha parameter",
     )
 
+    # Set default to 0.05 even though the original PEFT dataclass sets this to None
+    # Otherwise, this runs into issues when initializating the LoraModel
     lora_dropout: float = schema_utils.FloatRange(
-        default=None,
+        default=0.05,
         min=0.0,
         max=1.0,
         allow_none=True,

--- a/ludwig/schema/adapter.py
+++ b/ludwig/schema/adapter.py
@@ -12,7 +12,7 @@ _adapter_registry = Registry()
 def register_adapter(name: str):
     """Registers an adapter config class with the adapter config registry."""
 
-    def wrap(adapter_config: BaseAdapterConfig):
+    def wrap(adapter_config: BasePeftAdapterConfig):
         _adapter_registry[name] = adapter_config
         return adapter_config
 
@@ -27,24 +27,13 @@ def get_adapter_cls(name: str):
 
 @DeveloperAPI
 @schema_utils.ludwig_dataclass
-class BaseAdapterConfig(schema_utils.BaseMarshmallowConfig, ABC):
-    """Base class for adapter configs.
+class BasePeftAdapterConfig(schema_utils.BaseMarshmallowConfig, ABC):
+    """Config for prompt learning adapters.
 
     Not meant to be used directly.
     """
 
     task_type: str = schema_utils.ProtectedString("CAUSAL_LM")
-
-
-@DeveloperAPI
-@register_adapter("prompt_tuning")
-@schema_utils.ludwig_dataclass
-class PromptTuningAdapterConfig(BaseAdapterConfig):
-    # Explicitly set type property in the config because it is needed when we
-    # load a saved PEFT model back into Ludwig.
-    type: str = schema_utils.ProtectedString("prompt_tuning")
-
-    peft_type: str = schema_utils.ProtectedString("PROMPT_TUNING")
 
     num_virtual_tokens: Optional[int] = schema_utils.Integer(
         default=None,
@@ -77,6 +66,17 @@ class PromptTuningAdapterConfig(BaseAdapterConfig):
         description="The number of layers in the base transformer model.",
     )
 
+
+@DeveloperAPI
+@register_adapter("prompt_tuning")
+@schema_utils.ludwig_dataclass
+class PromptTuningAdapterConfig(BasePeftAdapterConfig):
+    # Explicitly set type property in the config because it is needed when we
+    # load a saved PEFT model back into Ludwig.
+    type: str = schema_utils.ProtectedString("prompt_tuning")
+
+    peft_type: str = schema_utils.ProtectedString("PROMPT_TUNING")
+
     # TODO(Arnav): Refactor to allow both RANDOM and TEXT strategies
     prompt_tuning_init: str = schema_utils.ProtectedString(
         "TEXT", description="The type of initialization to use for the prompt embedding. "
@@ -86,6 +86,84 @@ class PromptTuningAdapterConfig(BaseAdapterConfig):
         default="",
         allow_none=False,
         description="The text to use to initialize the prompt embedding.",
+    )
+
+
+@DeveloperAPI
+@register_adapter("prefix_tuning")
+@schema_utils.ludwig_dataclass
+class PrefixTuningAdapterconfig(BasePeftAdapterConfig):
+    # Explicitly set type property in the config because it is needed when we
+    # load a saved PEFT model back into Ludwig.
+    type: str = schema_utils.ProtectedString("prefix_tuning")
+
+    peft_type: str = schema_utils.ProtectedString("PREFIX_TUNING")
+
+    encoder_hidden_size: int = schema_utils.Integer(
+        default=None,
+        allow_none=True,
+        description="The hidden embedding dimension of the prompt encoder.",
+    )
+
+    prefix_projection: bool = schema_utils.Boolean(
+        default=False,
+        allow_none=True,
+        description="Whether to use a projection layer in the prompt encoder to project the prefix tokens",
+    )
+
+
+@DeveloperAPI
+@register_adapter("p_tuning")
+@schema_utils.ludwig_dataclass
+class PTuningAdapterConfig(BasePeftAdapterConfig):
+    # Explicitly set type property in the config because it is needed when we
+    # load a saved PEFT model back into Ludwig.
+    type: str = schema_utils.ProtectedString("p_tuning")
+
+    peft_type: str = schema_utils.ProtectedString("P_TUNING")
+
+    encoder_reparameterization_type: str = schema_utils.StringOptions(
+        ["MLP", "LSTM"],
+        default="MLP",
+        allow_none=True,
+        description="The type of reparameterization to use for the prompt encoder.",
+    )
+
+    encoder_hidden_size: int = schema_utils.Integer(
+        default=None,
+        allow_none=True,
+        description="The hidden embedding dimension of the prompt encoder.",
+    )
+
+    encoder_num_layers: int = schema_utils.Integer(
+        default=2,
+        allow_none=True,
+        description="The number of layers in the prompt encoder.",
+    )
+
+    encoder_dropout: float = schema_utils.FloatRange(
+        default=0.0,
+        min=0.0,
+        max=1.0,
+        allow_none=True,
+        description="The dropout probability for the prompt encoder.",
+    )
+
+
+@DeveloperAPI
+@register_adapter("lora")
+@schema_utils.ludwig_dataclass
+class LoRAAdapterConfig(BasePeftAdapterConfig):
+    # Explicitly set type property in the config because it is needed when we
+    # load a saved PEFT model back into Ludwig.
+    type: str = schema_utils.ProtectedString("lora")
+
+    peft_type: str = schema_utils.ProtectedString("LORA")
+
+    r: int = schema_utils.Integer(
+        default=8,
+        allow_none=True,
+        description="LoRA attention dimension",
     )
 
 

--- a/ludwig/schema/adapter.py
+++ b/ludwig/schema/adapter.py
@@ -53,9 +53,9 @@ class BasePromptLearningConfig(BasePeftConfig):
     Adapted from https://github.com/huggingface/peft/blob/main/src/peft/utils/config.py (PromptLearningConfig)
     """
 
-    num_virtual_tokens: Optional[int] = schema_utils.Integer(
+    num_virtual_tokens: int = schema_utils.Integer(
         default=None,
-        allow_none=True,
+        allow_none=False,
         description="Number of virtual tokens to add to the prompt. Virtual tokens are used to control the behavior of "
         " the model during inference. ",
     )
@@ -97,9 +97,10 @@ class PromptTuningAdapterConfig(BasePromptLearningConfig):
 
     peft_type: str = schema_utils.ProtectedString("PROMPT_TUNING")
 
-    # TODO(Arnav): Refactor to allow both RANDOM and TEXT strategies
-    prompt_tuning_init: str = schema_utils.ProtectedString(
-        "TEXT",
+    prompt_tuning_init: str = schema_utils.StringOptions(
+        ["RANDOM", "TEXT"],
+        default="RANDOM",
+        allow_none=True,
         description="The type of initialization to use for the prompt embedding. ",
     )
 
@@ -122,7 +123,7 @@ class PrefixTuningAdapterconfig(BasePromptLearningConfig):
 
     peft_type: str = schema_utils.ProtectedString("PREFIX_TUNING")
 
-    encoder_hidden_size: int = schema_utils.Integer(
+    encoder_hidden_size: Optional[int] = schema_utils.Integer(
         default=None,
         allow_none=True,
         description="The hidden embedding dimension of the prompt encoder.",
@@ -151,19 +152,19 @@ class PTuningAdapterConfig(BasePromptLearningConfig):
         description="The type of reparameterization to use for the prompt encoder.",
     )
 
-    encoder_hidden_size: int = schema_utils.Integer(
+    encoder_hidden_size: Optional[int] = schema_utils.Integer(
         default=None,
         allow_none=True,
         description="The hidden embedding dimension of the prompt encoder.",
     )
 
-    encoder_num_layers: int = schema_utils.Integer(
+    encoder_num_layers: Optional[int] = schema_utils.Integer(
         default=2,
         allow_none=True,
         description="The number of layers in the prompt encoder.",
     )
 
-    encoder_dropout: float = schema_utils.FloatRange(
+    encoder_dropout: Optional[float] = schema_utils.FloatRange(
         default=0.0,
         min=0.0,
         max=1.0,

--- a/ludwig/schema/adapter.py
+++ b/ludwig/schema/adapter.py
@@ -245,6 +245,85 @@ class LoRAAdapterConfig(BasePeftConfig):
 
 
 @DeveloperAPI
+@register_adapter("adalora")
+@schema_utils.ludwig_dataclass
+class AdaLoRAAdapterConfig(LoRAAdapterConfig):
+    """Adapted from https://github.com/huggingface/peft/blob/main/src/peft/tuners/adalora.py."""
+
+    # Explicitly set type property in the config because it is needed when we
+    # load a saved PEFT model back into Ludwig.
+    type: str = schema_utils.ProtectedString("adalora")
+
+    peft_type: str = schema_utils.ProtectedString("ADALORA")
+
+    target_r: int = schema_utils.Integer(
+        default=8,
+        allow_none=True,
+        description="Target Lora Matrix Dimension. The target average rank of incremental matrix.",
+    )
+
+    init_r: int = schema_utils.Integer(
+        default=12,
+        allow_none=True,
+        description="Initial Lora Matrix Dimension. The initial rank for each incremental matrix.",
+    )
+
+    tinit: int = schema_utils.Integer(
+        default=0,
+        allow_none=True,
+        description="The steps of initial fine-tuning warmup.",
+    )
+
+    tfinal: int = schema_utils.Integer(
+        default=0,
+        allow_none=True,
+        description="The steps of final fine-tuning warmup.",
+    )
+
+    deltaT: int = schema_utils.Integer(
+        default=1,
+        allow_none=True,
+        description="The time internval between two budget allocations. The step interval of rank allocation.",
+    )
+
+    beta1: float = schema_utils.FloatRange(
+        default=0.85,
+        min=0.0,
+        max=1.0,
+        allow_none=True,
+        description="The hyperparameter of EMA for sensitivity smoothing.",
+    )
+
+    beta2: float = schema_utils.FloatRange(
+        default=0.85,
+        min=0.0,
+        max=1.0,
+        allow_none=True,
+        description=" The hyperparameter of EMA for undertainty quantification.",
+    )
+
+    orth_reg_weight: float = schema_utils.FloatRange(
+        default=0.5,
+        min=0.0,
+        max=1.0,
+        allow_none=True,
+        description="The coefficient of orthogonality regularization.",
+    )
+
+    total_step: Optional[int] = schema_utils.Integer(
+        default=None,
+        allow_none=True,
+        description="The total training steps that should be specified before training.",
+    )
+
+    rank_pattern: Optional[dict] = schema_utils.Dict(
+        default=None,
+        allow_none=True,
+        description="The allocated rank for each weight matrix by RankAllocator.",
+    )
+
+
+@DeveloperAPI
 def get_adapter_conds():
     """Returns a JSON schema of conditionals to validate against adapter types."""
     conds = []

--- a/ludwig/schema/model_types/llm.py
+++ b/ludwig/schema/model_types/llm.py
@@ -1,8 +1,8 @@
-from typing import Optional
+from typing import Optional, Union
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.schema import utils as schema_utils
-from ludwig.schema.adapter import AdapterDataclassField, BasePeftAdapterConfig
+from ludwig.schema.adapter import AdapterDataclassField, BasePeftConfig, BasePromptLearningConfig
 from ludwig.schema.defaults.llm import LLMDefaultsConfig, LLMDefaultsField
 from ludwig.schema.features.base import (
     BaseInputFeatureConfig,
@@ -46,7 +46,6 @@ class LLMModelConfig(ModelConfig):
     defaults: Optional[LLMDefaultsConfig] = LLMDefaultsField().get_default_field()
     hyperopt: Optional[HyperoptConfig] = HyperoptField().get_default_field()
 
-    # trainer: LLMTrainerConfig = LLMTrainerField().get_default_field()
     trainer: LLMTrainerConfig = LLMTrainerDataclassField(
         default="zeroshot",
         description="The trainer to use for the model",
@@ -54,7 +53,7 @@ class LLMModelConfig(ModelConfig):
 
     generation: LLMGenerationConfig = LLMGenerationConfigField().get_default_field()
 
-    adapter: BasePeftAdapterConfig = AdapterDataclassField(
+    adapter: Union[BasePeftConfig, BasePromptLearningConfig] = AdapterDataclassField(
         default=None,
         description="The adapter to use for the model. This is used for PEFT based fine-tuning",
     )

--- a/ludwig/schema/model_types/llm.py
+++ b/ludwig/schema/model_types/llm.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.schema import utils as schema_utils
-from ludwig.schema.adapter import AdapterDataclassField, BaseAdapterConfig
+from ludwig.schema.adapter import AdapterDataclassField, BasePeftAdapterConfig
 from ludwig.schema.defaults.llm import LLMDefaultsConfig, LLMDefaultsField
 from ludwig.schema.features.base import (
     BaseInputFeatureConfig,
@@ -54,7 +54,7 @@ class LLMModelConfig(ModelConfig):
 
     generation: LLMGenerationConfig = LLMGenerationConfigField().get_default_field()
 
-    adapter: BaseAdapterConfig = AdapterDataclassField(
+    adapter: BasePeftAdapterConfig = AdapterDataclassField(
         default=None,
         description="The adapter to use for the model. This is used for PEFT based fine-tuning",
     )

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -42,13 +42,11 @@ RAY_BACKEND = {
 
 @pytest.fixture(scope="module")
 def local_backend():
-    os.environ["TOKENIZERS_PARALLELISM"] = "false"  # Disable warning message
     return LOCAL_BACKEND
 
 
 @pytest.fixture(scope="module")
 def ray_backend():
-    os.environ["TOKENIZERS_PARALLELISM"] = "false"  # Disable warning message
     return RAY_BACKEND
 
 

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -312,6 +312,7 @@ def test_llm_prompt_tuning(tmpdir, backend, ray_cluster_4cpu):
         OUTPUT_FEATURES: output_features,
         TRAINER: {
             TYPE: "finetune",
+            "epochs": 10,
         },
     }
 

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -318,7 +318,7 @@ def test_llm_few_shot_classification(tmpdir, backend, csv_filename, ray_cluster_
         ("p_tuning", {"num_virtual_tokens": 8, "encoder_reparameterization_type": "LSTM"}),
         ("lora", {}),
         # ("adalora", {}),
-        ("adaption_prompt", {"adapter_len": 8, "adapter_layers": 1}),
+        ("adaption_prompt", {"adapter_len": 6, "adapter_layers": 1}),
     ],
     ids=[
         # "no_finetune_adapter",


### PR DESCRIPTION
This PR adds support for parameter efficient fine-tuning strategies like Prefix Tuning, PTuning, LoRA, AdaLoRA and Adaption Prompt. 

To use them in Ludwig with the LLM model types, you need to specify the strategy name in the adapter config:

- Prompt Tuning: `prompt_tuning`
- Prefix Tuning: `prefix_tuning`
- P-Tuning: `p_tuning`
- LoRA: `lora`
- AdaLoRA: `adalora`
- Adaption Prompt: `adaption_prompt`

Here's an example config.

```yaml
model_type: llm
model_name: facebook/opt-66b
adapter:
    type: lora
```

Things to note:
1. `Prompt Tuning`, `Prefix Tuning` and `PTuning` require the `num_virtual_tokens` parameter to be set to a non-zero value
2. `Lora` is only supported for the following model types: `t5`, `mt5`, `bart`, `opt`, `roberta` and `deberta-v2`
3. `Adaption Prompt` is only supported for Llama model types and requires `adapter_len` and `adapter_layers` parameters to be set