### PR TITLE
Daft reads PR for 0.1

### DIFF
--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -57,7 +57,7 @@ from ludwig.schema.trainer import ECDTrainerConfig
 from ludwig.trainers.registry import ray_trainers_registry, register_ray_trainer
 from ludwig.trainers.trainer import BaseTrainer, RemoteTrainer, Trainer
 from ludwig.types import HyperoptConfigDict, ModelConfigDict, TrainerConfigDict, TrainingSetMetadataDict
-from ludwig.utils.dataframe_utils import is_dask_series_or_df, set_index_name
+from ludwig.utils.dataframe_utils import set_index_name
 from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.system_utils import Resources
 from ludwig.utils.torch_utils import get_torch_device, initialize_pytorch

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -890,7 +890,8 @@ class RayBackend(RemoteTrainingMixin, Backend):
             # Set the runner for executing Daft dataframes to a Ray cluster
             # Prevent re-initialization errors if the runner is already set
             # This can happen if there are 2 or more audio/image columns
-            daft.context.set_runner_ray(address=ray.util.get_node_ip_address(), noop_if_initialized=True)
+            assert ray.is_initialized(), "Ray should be initialized by Ludwig already at application start"
+            daft.context.set_runner_ray(address="auto", noop_if_initialized=True)
 
             # Create 1 partition for each available CPU in the Ray cluster
             # Fall back to distributing this over 1 GPU if no CPUs are available

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -910,9 +910,9 @@ class RayBackend(RemoteTrainingMixin, Backend):
                 if map_fn is not None:
                     df = df.with_column(column.name, df[column.name].apply(map_fn, return_dtype=daft.DataType.python()))
 
-            # Executes and convert Daft Dataframe to Dask DataFrame - note that this preserves partitioning
-            df = df.to_dask_dataframe()
-            df = self.df_engine.persist(df)
+                # Executes and convert Daft Dataframe to Dask DataFrame - note that this preserves partitioning
+                df = df.to_dask_dataframe()
+                df = self.df_engine.persist(df)
         else:
             # Assume the path has already been read in, so just convert directly to a dataset
             # Name the column "value" to match the behavior of the above

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -913,7 +913,7 @@ class RayBackend(RemoteTrainingMixin, Backend):
                 df = df.into_partitions(num_downloading_partitions)
                 # Download binary files in parallel
                 # Use 16 worker threads to maximize image read throughput over each partition
-                df = df.with_column(column.name, df[column.name].url.download(max_worker_threads=16))
+                df = df.with_column(column.name, df[column.name].url.download(max_worker_threads=16, on_error="null"))
                 # Revert back to the original number of partitions in this column
                 df = df.into_partitions(n_col_partitions)
 


### PR DESCRIPTION
# Summary

This PR is contributed by developers of www.getdaft.io and increases performance of a preprocessing pipeline on the melbourne airbnb dataset by a factor of 2x in many cases.

## Benchmarking

In the local single-partition Ray cluster setup: Daft is a 50% speedup over the existing Ludwig code for URL downloading, and an overall 40% speedup for all of preprocessing.

In the distributed multi-partition Ray cluster setup: Daft is a 50% speedup over the existing Ludwig code for URL downloading, and an overall 40% speedup for all of preprocessing.

See [benchmarking doc](https://docs.google.com/document/d/1gu2Zi75v0SVVIVm8lqU8rLH9GZ9Mx4kCeyTLgMZrXsk/edit?usp=sharing) for more details.

## Changes made

### Bug Fixes

**Fix daft.context.set_runner_ray**:

`daft.context.set_runner_ray(ray.util.get_node_ip_address(), ...)` is fixed to `daft.context.set_runner_ray(address="auto", ...)`: the old code breaks in a distributed setting when the head node is **not** the current node. Instead, we added an assert before setting the runner, since Ludwig should already have initialized the Ray cluster correctly for Daft to detect and latch onto.

**Remove repartitioning logic**:

Removed `.into_partitions()` logic for coercing into `num_downloading_partitions` and then back into the original `n_col_partitions`. This logic is problematic in a distributed multi-partition scenario, since Ludwig doesn't just have strong assumptions about the **number of partitions**, but also the specific "divisions" or **cardinality of partitions** which Daft cannot make any guarantees over since it does not have this information. This leads to egregious failures downstream in the outer-join step of preprocessing, which assumes that the preprocessed feature partitions can simply be "zipped" with the existing partitions.

Instead, the new code maintains the partitioning scheme of the input Dask Series in Daft. This is the only way for Daft to be compatible with the existing partitioning and to be easily "zipped" back with the rest of the dataset.

### Performance

**Use Daft-Dask integrations**:

Makes use of the new `to_dask_dataframe` and `from_dask_dataframe` APIs. Note that these APIs maintain the same partitioning as defined by Dask.

Note that Daft has no concept of "indices" which Pandas and Dask do. Hence, we need to extract that as an "idx" tag-along column, which the existing code already seems to use after preprocessing during the cast back to Dask (`df.set_index("idx", drop=True)`)

**Fuse map_fn**:

As an optimization, the `map_fn` call is also inlined into the Daft dataframe. This lets us "fuse" the operation with the URL download and helps a lot with memory pressure (since this `map_fn` call typically resizes/crops the data to a smaller size and doing this results in not having to materialize the intermediate downloaded `bytes` partition, and only materializing the smaller resized/cropped partitions).

### Compatibility

**.url.download() error behavior:**

The default behavior of `.url.download()` was changed in Daft in the 0.1.1 pre-release to throw an error instead of returning null and logging the error. To have the old behavior instead a keyword arg was added: `on_error="null"`.
