### PR TITLE
fix: sequence feature explain error

### DIFF
--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -26,6 +26,7 @@ from ludwig.constants import (
     NAME,
     NUMBER,
     PREPROCESSING,
+    SEQUENCE,
     SET,
     TEXT,
     UNKNOWN_SYMBOL,
@@ -42,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 # These types as provided as integer values and passed through an embedding layer that breaks integrated gradients.
 # As such, we need to take care to encode them before handing them to the explainer.
-EMBEDDED_TYPES = {TEXT, CATEGORY, SET, DATE}
+EMBEDDED_TYPES = {SEQUENCE, TEXT, CATEGORY, SET, DATE}
 
 
 @dataclass

--- a/tests/integration_tests/test_explain.py
+++ b/tests/integration_tests/test_explain.py
@@ -19,6 +19,7 @@ from tests.integration_tests.utils import (
     image_feature,
     LocalTestBackend,
     number_feature,
+    sequence_feature,
     set_feature,
     text_feature,
     timeseries_feature,
@@ -257,3 +258,20 @@ def test_explainer_api_text_outputs(tmpdir):
     run_test_explainer_api(
         IntegratedGradientsExplainer, MODEL_ECD, output_features, {}, tmpdir, input_features=input_features
     )
+
+
+@pytest.mark.parametrize(
+    "explainer_class,model_type",
+    [
+        pytest.param(IntegratedGradientsExplainer, MODEL_ECD, id="ecd_local"),
+        # pytest.param(RayIntegratedGradientsExplainer, MODEL_ECD, id="ecd_ray", marks=pytest.mark.distributed),
+    ],
+)
+@pytest.mark.parametrize(
+    "encoder_type", ["embed", "parallel_cnn", "stacked_cnn", "stacked_parallel_cnn", "rnn", "cnnrnn", "transformer"]
+)
+def test_explainer_sequence_feature(explainer_class, model_type, encoder_type, tmpdir):
+    input_features = [sequence_feature()]
+    input_features[0]["encoder"] = {"type": encoder_type}
+    output_features = [binary_feature()]
+    run_test_explainer_api(explainer_class, model_type, output_features, {}, tmpdir, input_features=input_features)

--- a/tests/integration_tests/test_explain.py
+++ b/tests/integration_tests/test_explain.py
@@ -264,7 +264,7 @@ def test_explainer_api_text_outputs(tmpdir):
     "explainer_class,model_type",
     [
         pytest.param(IntegratedGradientsExplainer, MODEL_ECD, id="ecd_local"),
-        # pytest.param(RayIntegratedGradientsExplainer, MODEL_ECD, id="ecd_ray", marks=pytest.mark.distributed),
+        pytest.param(RayIntegratedGradientsExplainer, MODEL_ECD, id="ecd_ray", marks=pytest.mark.distributed),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Sequence feature explanations always fail with the error

```
RuntimeError: One of the differentiated Tensors appears to not have been used in the graph. Set allow_unused=True if this is the desired behavior.
```

This happened because sequence features were not treated as embedded features, which led to the wrong encoder layer being passed into captum's `LayerIntegratedGradients`. This fix updates explanations to treat sequences as embedded features and adds explanation integration tests for all sequence encoders.