### PR TITLE
[LLM] Ensure prompt is only supported for LLM text input features

### DIFF
--- a/ludwig/schema/features/preprocessing/text.py
+++ b/ludwig/schema/features/preprocessing/text.py
@@ -17,8 +17,6 @@ from ludwig.utils.tokenizers import tokenizer_registry
 class TextPreprocessingConfig(BasePreprocessingConfig):
     """TextPreprocessingConfig is a dataclass that configures the parameters used for a text input feature."""
 
-    prompt: PromptConfig = PromptConfigField().get_default_field()
-
     pretrained_model_name_or_path: str = schema_utils.String(
         default=None,
         allow_none=True,
@@ -202,3 +200,10 @@ class TextOutputPreprocessingConfig(TextPreprocessingConfig):
         description="The size of the ngram when using the `ngram` tokenizer (e.g, 2 = bigram, 3 = trigram, etc.).",
         parameter_metadata=FEATURE_METADATA[TEXT][PREPROCESSING]["ngram_size"],
     )
+
+
+@DeveloperAPI
+@register_preprocessor("text_llm")
+@ludwig_dataclass
+class LLMTextPreprocessingConfig(TextPreprocessingConfig):
+    prompt: PromptConfig = PromptConfigField().get_default_field()

--- a/ludwig/schema/features/text_feature.py
+++ b/ludwig/schema/features/text_feature.py
@@ -73,6 +73,8 @@ class GBMTextInputFeatureConfig(TextInputFeatureConfig):
 @llm_input_config_registry.register(TEXT)
 @ludwig_dataclass
 class LLMTextInputFeatureConfig(TextInputFeatureConfig):
+    preprocessing: BasePreprocessingConfig = PreprocessingDataclassField(feature_type="text_llm")
+
     encoder: BaseEncoderConfig = EncoderDataclassField(
         MODEL_LLM,
         feature_type=TEXT,


### PR DESCRIPTION
This ensures that

1. `prompt` is only an attribute for text input features for LLM models
2. `prompt` does not show up for text output features (LLM or otherwise)