### PR TITLE
[llm] Added support for bfloat16 with deepspeed

### DIFF
--- a/ludwig/backend/deepspeed.py
+++ b/ludwig/backend/deepspeed.py
@@ -15,12 +15,14 @@ class DeepSpeedBackend(DataParallelBackend):
         self,
         zero_optimization: Optional[Dict[str, Any]] = None,
         fp16: Optional[Dict[str, Any]] = None,
+        bf16: Optional[Dict[str, Any]] = None,
         compression_training: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
         self.zero_optimization = zero_optimization
         self.fp16 = fp16
+        self.bf16 = bf16
         self.compression_training = compression_training
 
     def initialize(self):
@@ -31,6 +33,7 @@ class DeepSpeedBackend(DataParallelBackend):
             self.BACKEND_TYPE,
             zero_optimization=self.zero_optimization,
             fp16=self.fp16,
+            bf16=self.bf16,
             compression_training=self.compression_training,
         )
 

--- a/ludwig/distributed/deepspeed.py
+++ b/ludwig/distributed/deepspeed.py
@@ -89,7 +89,6 @@ class DeepSpeedStrategy(DDPStrategy):
         }
 
         # DeepSpeed doesn't like passing these params as None values
-        # TODO(travis): bfloat16, which requires fixing numpy conversion on cpu
         if self.fp16 is not None:
             ds_config["fp16"] = self.fp16
         if self.bf16 is not None:

--- a/ludwig/distributed/deepspeed.py
+++ b/ludwig/distributed/deepspeed.py
@@ -40,6 +40,7 @@ class DeepSpeedStrategy(DDPStrategy):
         self,
         zero_optimization: Optional[Dict[str, Any]] = None,
         fp16: Optional[Dict[str, Any]] = None,
+        bf16: Optional[Dict[str, Any]] = None,
         compression_training: Optional[Dict[str, Any]] = None,
         **kwargs
     ):
@@ -52,6 +53,7 @@ class DeepSpeedStrategy(DDPStrategy):
         super().__init__(**kwargs)
         self.zero_optimization = zero_optimization or DEFAULT_ZERO_OPTIMIZATION
         self.fp16 = fp16
+        self.bf16 = bf16
         self.compression_training = compression_training
 
         if init_deepspeed:
@@ -90,6 +92,8 @@ class DeepSpeedStrategy(DDPStrategy):
         # TODO(travis): bfloat16, which requires fixing numpy conversion on cpu
         if self.fp16 is not None:
             ds_config["fp16"] = self.fp16
+        if self.bf16 is not None:
+            ds_config["bf16"] = self.bf16
         if self.compression_training is not None:
             ds_config["compression_training"] = self.compression_training
 

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -351,7 +351,7 @@ class Trainer(BaseTrainer):
         # all other losses
         for feature_name, loss in all_losses.items():
             loss_tag = f"{feature_name}/step_training_loss"
-            train_summary_writer.add_scalar(loss_tag, loss, global_step=step)
+            train_summary_writer.add_scalar(loss_tag, loss.detach().float(), global_step=step)
 
         if learning_rate:
             train_summary_writer.add_scalar("combined/step_learning_rate", learning_rate, global_step=step)
@@ -892,7 +892,7 @@ class Trainer(BaseTrainer):
             if self.is_coordinator() and not self.skip_save_log:
                 self.write_step_summary(
                     train_summary_writer=train_summary_writer,
-                    combined_loss=loss,
+                    combined_loss=loss.detach().float(),
                     all_losses=all_losses,
                     step=progress_tracker.steps,
                     learning_rate=progress_tracker.learning_rate,


### PR DESCRIPTION
Example:

```
strategy:
  type: deepspeed
  bf16:
    enabled: true
```