### PR TITLE
[LLM] Fine-Tuning fixes: Correct inference mode, enable weight adjustment for adapters when fine-tuning for > 1 epoch, etc.

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -893,9 +893,7 @@ class LudwigModel:
             callbacks=self.callbacks + (callbacks or []),
         )
 
-        # HACK(Arnav): To use the correct code path for inferennce for LLMs, we need to set the
-        # model's config_object adapter to None. This works because the model is already loaded with the
-        # adapter at this point and it overrides the finetuning related forwad pass.
+        # HACK(Arnav): Set the model to inference mode if we are using an adapter
         if self.config_obj.model_type == MODEL_LLM and self.model.config_obj.adapter:
             self.model.model.peft_config["default"].inference_mode = True
 
@@ -932,8 +930,8 @@ class LudwigModel:
 
                     logger.info(f"Saved to: {output_directory}")
 
-            # HACK(Arnav): Reset the model's adapter in the config object to the original value after inference is done.
-            if self.config_obj.model_type == MODEL_LLM:
+            # HACK(Arnav): Change back to training mode if we are using an adapter
+            if self.config_obj.model_type == MODEL_LLM and self.model.config_obj.adapter:
                 self.model.model.peft_config["default"].inference_mode = False
 
             return converted_postproc_predictions, output_directory

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -108,6 +108,8 @@ class LLM(BaseModel):
             peft_config = self.config_obj.adapter.to_config(
                 task_type="CAUSAL_LM", tokenizer_name_or_path=self.model_name
             )
+            # Incase inference_mode is True, set it to False
+            peft_config.inference_mode = False
             self.model = get_peft_model(self.model, peft_config)
 
             logger.info("==================================================")
@@ -412,6 +414,7 @@ class LLM(BaseModel):
 
             # Do this since we want to train the PEFT adapter and model. During inference,
             # we will explicitly override this to True.
+            # Note: default is the name of the adapter (always the case)
             self.model.peft_config["default"].inference_mode = False
 
     def get_args(self):

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -406,9 +406,13 @@ class LLM(BaseModel):
 
             weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
             config = PeftConfig.from_pretrained(weights_save_path)
-            config.inference_mode = False
+
             self.model = AutoModelForCausalLM.from_pretrained(config.base_model_name_or_path)
             self.model = PeftModel.from_pretrained(self.model, weights_save_path)
+
+            # Do this since we want to train the PEFT adapter and model. During inference,
+            # we will explicitly override this to True.
+            self.model.peft_config["default"].inference_mode = False
 
     def get_args(self):
         """Returns init arguments for constructing this model."""

--- a/requirements_llm.txt
+++ b/requirements_llm.txt
@@ -1,6 +1,7 @@
 sentence-transformers
 faiss-cpu
 
+tokenizers>=0.13.3
 accelerate
 loralib
 bitsandbytes


### PR DESCRIPTION
This PR makes a few updates:

1. Fixes/Pins missing dependency for `tokenizers`, and sets it to a minimum version of `0.13.3` for LlamaTokenizer support
2. During adapter initialization, we explicitly set the PEFT inference mode to False to make the PEFT adapter weights trainable.
3. On LLM model load, we were setting the config's inference mode to False to make the weights trainable after each epoch, but the config wasn't being used. This meant that the weights were trainable for the first epoch, but not for any subsequent epoch. The new fix always sets this to False for the loaded model so that the weights are trainable beyond the first epoch.
4. During prediction, we dynamically set inference_mode for LLM model types when using adapters. It gets set to True since we're doing inference. Peft makes optimizations, which are useful since they speed up batch prediction.
5. Fixes an issue during `model.predict()` where the trained LLM goes through the forward pass of the "fine-tuning" route as opposed to the forward pass for "generation", which is what we should be doing. When it goes through the code path for fine-tuning, it ends up producing non-sensical outputs since the call to the model returns logits as opposed to the output token IDs. To make this fix, we hotswap the adapter in the config object to None, and then set it back in the config object post `model.predict()` incase a user decides to now go back to `model.train()`. This fix is a bit hacky, but it is the fastest solution I could think of to fix this.