### PR TITLE
Fix tokenizer pad and eos token assumption for HF tokenizers

### DIFF
--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -28,6 +28,7 @@ from ludwig.constants import PADDING_SYMBOL, START_SYMBOL, STOP_SYMBOL, UNKNOWN_
 from ludwig.data.dataframe.base import DataFrameEngine
 from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.utils.fs_utils import open_file
+from ludwig.utils.logging_utils import log_once
 from ludwig.utils.math_utils import int_type
 from ludwig.utils.tokenizers import get_tokenizer_from_registry
 from ludwig.utils.types import Series
@@ -506,7 +507,14 @@ def build_sequence_matrix(
 
     # Set padding token id based on tokenizer_type. Huggingface tokenizers typically have a pad_token_id attribute.
     if tokenizer_type == "hf_tokenizer":
-        pad_token_id = tokenizer.tokenizer.pad_token_id
+        if hasattr(tokenizer.tokenizer, "pad_token_id") and tokenizer.tokenizer.pad_token_id is not None:
+            pad_token_id = tokenizer.tokenizer.pad_token_id
+        elif hasattr(tokenizer.tokenizer, "eos_token_id") and tokenizer.tokenizer.eos_token_id is not None:
+            pad_token_id = tokenizer.tokenizer.eos_token_id
+        else:
+            # This happens for torchtext tokenizers like BERTTokenizer. We set pad token to 0.
+            log_once("Could not find pad_token_id or eos_token_id. Setting pad_token_id to 0.")
+            pad_token_id = 0
     else:
         pad_token_id = inverse_vocabulary[padding_symbol]
 

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -507,9 +507,9 @@ def build_sequence_matrix(
 
     # Set padding token id based on tokenizer_type. Huggingface tokenizers typically have a pad_token_id attribute.
     if tokenizer_type == "hf_tokenizer":
-        if hasattr(tokenizer.tokenizer, "pad_token_id"):
+        if hasattr(tokenizer.tokenizer, "pad_token_id") and tokenizer.tokenizer.pad_token_id:
             pad_token_id = tokenizer.tokenizer.pad_token_id
-        elif hasattr(tokenizer.tokenizer, "eos_token_id"):
+        elif hasattr(tokenizer.tokenizer, "eos_token_id") and tokenizer.tokenizer.eos_token_id:
             pad_token_id = tokenizer.tokenizer.eos_token_id
         # Some tokenizers may not have pad_token_id set or eos_token_id. In this case, we use 0 as the padding token id.
         else:

--- a/ludwig/utils/strings_utils.py
+++ b/ludwig/utils/strings_utils.py
@@ -28,7 +28,6 @@ from ludwig.constants import PADDING_SYMBOL, START_SYMBOL, STOP_SYMBOL, UNKNOWN_
 from ludwig.data.dataframe.base import DataFrameEngine
 from ludwig.data.dataframe.pandas import PANDAS
 from ludwig.utils.fs_utils import open_file
-from ludwig.utils.logging_utils import log_once
 from ludwig.utils.math_utils import int_type
 from ludwig.utils.tokenizers import get_tokenizer_from_registry
 from ludwig.utils.types import Series
@@ -507,14 +506,7 @@ def build_sequence_matrix(
 
     # Set padding token id based on tokenizer_type. Huggingface tokenizers typically have a pad_token_id attribute.
     if tokenizer_type == "hf_tokenizer":
-        if hasattr(tokenizer.tokenizer, "pad_token_id") and tokenizer.tokenizer.pad_token_id:
-            pad_token_id = tokenizer.tokenizer.pad_token_id
-        elif hasattr(tokenizer.tokenizer, "eos_token_id") and tokenizer.tokenizer.eos_token_id:
-            pad_token_id = tokenizer.tokenizer.eos_token_id
-        # Some tokenizers may not have pad_token_id set or eos_token_id. In this case, we use 0 as the padding token id.
-        else:
-            log_once("No padding token id or eos token id found in tokenizer. Using 0 as padding token id.")
-            pad_token_id = 0
+        pad_token_id = tokenizer.tokenizer.pad_token_id
     else:
         pad_token_id = inverse_vocabulary[padding_symbol]
 


### PR DESCRIPTION
It seems like tokenizers may have the attribute, yet not have a value set for that attribute. We make these assumptions in the HFTokenizer class. This PR tests for those assumptions and adds falling back to pad token id = 0