### PR TITLE
Fix Missing Param Metadata

### DIFF
--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -241,7 +241,11 @@ def unload_jsonschema_from_marshmallow_class(mclass, additional_properties: bool
 
 
 @DeveloperAPI
-def InitializerOptions(default: str = "xavier_uniform", description="", parameter_metadata: ParameterMetadata = None):
+def InitializerOptions(
+        default: str = "xavier_uniform",
+        description="",
+        parameter_metadata: ParameterMetadata = ParameterMetadata()
+):
     """Utility wrapper that returns a `StringOptions` field with keys from `initializer_registry`."""
     return StringOptions(
         list(initializer_registry.keys()),
@@ -254,7 +258,7 @@ def InitializerOptions(default: str = "xavier_uniform", description="", paramete
 
 @DeveloperAPI
 def ActivationOptions(
-    default: Union[str, None] = "relu", description=None, parameter_metadata: ParameterMetadata = None
+    default: Union[str, None] = "relu", description=None, parameter_metadata: ParameterMetadata = ParameterMetadata()
 ):
     """Utility wrapper that returns a `StringOptions` field with keys from `activations` registry."""
     description = description or "Default activation function applied to the output of the fully connected layers."
@@ -269,7 +273,7 @@ def ActivationOptions(
 
 
 @DeveloperAPI
-def ReductionOptions(default: Union[None, str] = None, description="", parameter_metadata: ParameterMetadata = None):
+def ReductionOptions(default: Union[None, str] = None, description="", parameter_metadata: ParameterMetadata = ParameterMetadata()):
     """Utility wrapper that returns a `StringOptions` field with keys from `reduce_mode_registry`."""
     return StringOptions(
         list(reduce_mode_registry.keys()),
@@ -285,7 +289,7 @@ def RegularizerOptions(
     default: Union[None, str],
     allow_none: bool = False,
     description="",
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     """Utility wrapper that returns a `StringOptions` field with prefilled regularizer options."""
     return StringOptions(
@@ -303,7 +307,7 @@ def String(
     default: Union[None, str],
     allow_none: bool = False,
     pattern: str = None,
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     if not allow_none and not isinstance(default, str):
         raise ValidationError(f"Provided default `{default}` should be a string!")
@@ -337,7 +341,7 @@ def StringOptions(
     default: Union[None, str],
     allow_none: bool = False,
     description: str = "",
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     """Returns a dataclass field with marshmallow metadata that enforces string inputs must be one of `options`.
 
@@ -367,7 +371,7 @@ def StringOptions(
                 dump_default=default,
                 metadata={
                     "description": description,
-                    "parameter_metadata": convert_metadata_to_json(parameter_metadata) if parameter_metadata else None,
+                    "parameter_metadata": convert_metadata_to_json(parameter_metadata)
                 },
             )
         },
@@ -379,7 +383,7 @@ def StringOptions(
 def ProtectedString(
     pstring: str,
     description: str = "",
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     """Alias for a `StringOptions` field with only one option.
 
@@ -400,7 +404,7 @@ def IntegerOptions(
     default: Union[None, int],
     allow_none: bool = False,
     description: str = "",
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     """Returns a dataclass field with marshmallow metadata that enforces integer inputs must be one of `options`.
 
@@ -436,7 +440,7 @@ def IntegerOptions(
 
 
 @DeveloperAPI
-def Boolean(default: bool, description: str = "", parameter_metadata: ParameterMetadata = None):
+def Boolean(default: bool, description: str = "", parameter_metadata: ParameterMetadata = ParameterMetadata()):
     if default is not None:
         try:
             assert isinstance(default, bool)
@@ -463,7 +467,7 @@ def Boolean(default: bool, description: str = "", parameter_metadata: ParameterM
 
 
 @DeveloperAPI
-def Integer(default: Union[None, int], allow_none=False, description="", parameter_metadata: ParameterMetadata = None):
+def Integer(default: Union[None, int], allow_none=False, description="", parameter_metadata: ParameterMetadata = ParameterMetadata()):
     """Returns a dataclass field with marshmallow metadata strictly enforcing (non-float) inputs."""
     if default is not None:
         try:
@@ -489,7 +493,7 @@ def Integer(default: Union[None, int], allow_none=False, description="", paramet
 
 @DeveloperAPI
 def PositiveInteger(
-    description: str, default: Union[None, int], allow_none: bool = False, parameter_metadata: ParameterMetadata = None
+    description: str, default: Union[None, int], allow_none: bool = False, parameter_metadata: ParameterMetadata = ParameterMetadata()
 ):
     """Returns a dataclass field with marshmallow metadata strictly enforcing (non-float) inputs must be
     positive."""
@@ -524,7 +528,7 @@ def NonNegativeInteger(
     description: str,
     default: Union[None, int],
     allow_none: bool = False,
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     """Returns a dataclass field with marshmallow metadata strictly enforcing (non-float) inputs must be
     nonnegative."""
@@ -559,7 +563,7 @@ def IntegerRange(
     description: str,
     default: Union[None, int],
     allow_none: bool = False,
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
     min: int = None,
     max: int = None,
     min_inclusive: bool = True,
@@ -599,7 +603,7 @@ def NonNegativeFloat(
     allow_none: bool = False,
     description: str = "",
     max: Optional[float] = None,
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     """Returns a dataclass field with marshmallow metadata enforcing numeric inputs must be nonnegative."""
     val = validate.Range(min=0.0, max=max)
@@ -632,7 +636,7 @@ def FloatRange(
     default: Union[None, float],
     allow_none: bool = False,
     description: str = "",
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
     min: int = None,
     max: int = None,
     min_inclusive: bool = True,
@@ -670,7 +674,7 @@ def Dict(
     default: Union[None, TDict] = None,
     allow_none: bool = True,
     description: str = "",
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     """Returns a dataclass field with marshmallow metadata enforcing input must be a dict."""
     allow_none = allow_none or default is None
@@ -709,7 +713,7 @@ def List(
     default: Union[None, TList[Any]] = None,
     allow_none: bool = True,
     description: str = "",
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     """Returns a dataclass field with marshmallow metadata enforcing input must be a list.
 
@@ -767,7 +771,7 @@ def DictList(
     default: Union[None, TList[TDict]] = None,
     allow_none: bool = True,
     description: str = "",
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     """Returns a dataclass field with marshmallow metadata enforcing input must be a list of dicts."""
     if default is not None:
@@ -800,7 +804,7 @@ def DictList(
 
 
 @DeveloperAPI
-def Embed(description: str = "", parameter_metadata: ParameterMetadata = None):
+def Embed(description: str = "", parameter_metadata: ParameterMetadata = ParameterMetadata()):
     """Returns a dataclass field with marshmallow metadata enforcing valid values for embedding input feature
     names.
 
@@ -859,7 +863,7 @@ def Embed(description: str = "", parameter_metadata: ParameterMetadata = None):
 
 @DeveloperAPI
 def InitializerOrDict(
-    default: str = "xavier_uniform", description: str = "", parameter_metadata: ParameterMetadata = None
+    default: str = "xavier_uniform", description: str = "", parameter_metadata: ParameterMetadata = ParameterMetadata()
 ):
     """Returns a dataclass field with marshmallow metadata allowing customizable initializers.
 
@@ -942,7 +946,7 @@ def FloatRangeTupleDataclassField(
     min: Union[int, None] = 0,
     max: Union[int, None] = 1,
     description: str = "",
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     """Returns a dataclass field with marshmallow metadata enforcing a `N`-dim.
 
@@ -1025,7 +1029,7 @@ def OneOfOptionsField(
     description: str,
     field_options: TList,
     allow_none: bool = False,
-    parameter_metadata: ParameterMetadata = None,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     """Returns a dataclass field that is a combination of the other fields defined in `ludwig.schema.utils`.
 
@@ -1159,7 +1163,7 @@ class TypeSelection(fields.Field):
         default_value: Optional[str] = None,
         key: str = "type",
         description: str = "",
-        parameter_metadata: ParameterMetadata = None,
+        parameter_metadata: ParameterMetadata = ParameterMetadata(),
         allow_str_value: bool = False,
         allow_none: bool = False,
     ):

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -242,9 +242,7 @@ def unload_jsonschema_from_marshmallow_class(mclass, additional_properties: bool
 
 @DeveloperAPI
 def InitializerOptions(
-        default: str = "xavier_uniform",
-        description="",
-        parameter_metadata: ParameterMetadata = ParameterMetadata()
+    default: str = "xavier_uniform", description="", parameter_metadata: ParameterMetadata = ParameterMetadata()
 ):
     """Utility wrapper that returns a `StringOptions` field with keys from `initializer_registry`."""
     return StringOptions(
@@ -273,7 +271,9 @@ def ActivationOptions(
 
 
 @DeveloperAPI
-def ReductionOptions(default: Union[None, str] = None, description="", parameter_metadata: ParameterMetadata = ParameterMetadata()):
+def ReductionOptions(
+    default: Union[None, str] = None, description="", parameter_metadata: ParameterMetadata = ParameterMetadata()
+):
     """Utility wrapper that returns a `StringOptions` field with keys from `reduce_mode_registry`."""
     return StringOptions(
         list(reduce_mode_registry.keys()),
@@ -371,7 +371,7 @@ def StringOptions(
                 dump_default=default,
                 metadata={
                     "description": description,
-                    "parameter_metadata": convert_metadata_to_json(parameter_metadata)
+                    "parameter_metadata": convert_metadata_to_json(parameter_metadata),
                 },
             )
         },
@@ -467,7 +467,12 @@ def Boolean(default: bool, description: str = "", parameter_metadata: ParameterM
 
 
 @DeveloperAPI
-def Integer(default: Union[None, int], allow_none=False, description="", parameter_metadata: ParameterMetadata = ParameterMetadata()):
+def Integer(
+    default: Union[None, int],
+    allow_none=False,
+    description="",
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
+):
     """Returns a dataclass field with marshmallow metadata strictly enforcing (non-float) inputs."""
     if default is not None:
         try:
@@ -493,7 +498,10 @@ def Integer(default: Union[None, int], allow_none=False, description="", paramet
 
 @DeveloperAPI
 def PositiveInteger(
-    description: str, default: Union[None, int], allow_none: bool = False, parameter_metadata: ParameterMetadata = ParameterMetadata()
+    description: str,
+    default: Union[None, int],
+    allow_none: bool = False,
+    parameter_metadata: ParameterMetadata = ParameterMetadata(),
 ):
     """Returns a dataclass field with marshmallow metadata strictly enforcing (non-float) inputs must be
     positive."""

--- a/tests/ludwig/config_validation/test_validate_config_misc.py
+++ b/tests/ludwig/config_validation/test_validate_config_misc.py
@@ -26,6 +26,9 @@ from ludwig.schema.combiners.utils import get_combiner_jsonschema
 from ludwig.schema.defaults.ecd import ECDDefaultsConfig
 from ludwig.schema.defaults.gbm import GBMDefaultsConfig
 from ludwig.schema.encoders.text.peft import LoraConfig
+from ludwig.schema import utils as schema_utils
+from ludwig.schema.utils import ludwig_dataclass
+from ludwig.schema.utils import unload_jsonschema_from_marshmallow_class
 from ludwig.schema.features.preprocessing.audio import AudioPreprocessingConfig
 from ludwig.schema.features.preprocessing.bag import BagPreprocessingConfig
 from ludwig.schema.features.preprocessing.binary import BinaryPreprocessingConfig
@@ -450,3 +453,18 @@ def test_text_encoder_adapter(encoder_config, expected_adapter):
     config_obj = ModelConfig.from_dict(config)
 
     assert config_obj.input_features[0].encoder.adapter == expected_adapter
+
+
+def test_default_param_metadata():
+    @ludwig_dataclass
+    class TestClass:
+
+        test_schema_entry: str = schema_utils.StringOptions(
+            options=["test"],
+            default="test",
+            description="",
+        )
+
+    test_class = unload_jsonschema_from_marshmallow_class(TestClass)
+
+    assert test_class["properties"]["test_schema_entry"]["parameter_metadata"] is not None

--- a/tests/ludwig/config_validation/test_validate_config_misc.py
+++ b/tests/ludwig/config_validation/test_validate_config_misc.py
@@ -22,13 +22,11 @@ from ludwig.constants import (
 )
 from ludwig.error import ConfigValidationError
 from ludwig.features.feature_registries import get_output_type_registry
+from ludwig.schema import utils as schema_utils
 from ludwig.schema.combiners.utils import get_combiner_jsonschema
 from ludwig.schema.defaults.ecd import ECDDefaultsConfig
 from ludwig.schema.defaults.gbm import GBMDefaultsConfig
 from ludwig.schema.encoders.text.peft import LoraConfig
-from ludwig.schema import utils as schema_utils
-from ludwig.schema.utils import ludwig_dataclass
-from ludwig.schema.utils import unload_jsonschema_from_marshmallow_class
 from ludwig.schema.features.preprocessing.audio import AudioPreprocessingConfig
 from ludwig.schema.features.preprocessing.bag import BagPreprocessingConfig
 from ludwig.schema.features.preprocessing.binary import BinaryPreprocessingConfig
@@ -44,6 +42,7 @@ from ludwig.schema.features.preprocessing.timeseries import TimeseriesPreprocess
 from ludwig.schema.features.preprocessing.vector import VectorPreprocessingConfig
 from ludwig.schema.features.utils import get_input_feature_jsonschema, get_output_feature_jsonschema
 from ludwig.schema.model_types.base import ModelConfig
+from ludwig.schema.utils import ludwig_dataclass, unload_jsonschema_from_marshmallow_class
 from tests.integration_tests.utils import (
     audio_feature,
     bag_feature,
@@ -458,7 +457,6 @@ def test_text_encoder_adapter(encoder_config, expected_adapter):
 def test_default_param_metadata():
     @ludwig_dataclass
     class TestClass:
-
         test_schema_entry: str = schema_utils.StringOptions(
             options=["test"],
             default="test",


### PR DESCRIPTION
What was going wrong here is that the default for param metadata was `None` which would directly get put into the schema, so unless you explicitly defined param metadata, it would come without param metadata and cause issues downstream. This basically sets the default param metadata value to an empty parameter metadata entry with all the default values for that data class.