### PR TITLE
Order prompt schema and add title

### DIFF
--- a/ludwig/schema/generation.py
+++ b/ludwig/schema/generation.py
@@ -16,6 +16,20 @@ class LLMGenerationConfig(schema_utils.BaseMarshmallowConfig):
 
     # Parameters that control the length of the output
 
+    max_new_tokens: Optional[int] = schema_utils.PositiveInteger(
+        default=20,
+        allow_none=True,
+        description="The maximum number of new tokens to generate, ignoring the number of tokens in the input prompt.",
+        parameter_metadata=LLM_METADATA["generation"]["max_new_tokens"],
+    )
+
+    min_new_tokens: Optional[int] = schema_utils.NonNegativeInteger(
+        default=None,
+        allow_none=True,
+        description="The minimum number of new tokens to generate, ignoring the number of tokens in the input prompt.",
+        parameter_metadata=LLM_METADATA["generation"]["min_new_tokens"],
+    )
+
     max_length: int = schema_utils.PositiveInteger(
         default=20,
         allow_none=True,
@@ -24,26 +38,12 @@ class LLMGenerationConfig(schema_utils.BaseMarshmallowConfig):
         parameter_metadata=LLM_METADATA["generation"]["max_length"],
     )
 
-    max_new_tokens: Optional[int] = schema_utils.PositiveInteger(
-        default=20,
-        allow_none=True,
-        description="The maximum number of new tokens to generate, ignoring the number of tokens in the input prompt.",
-        parameter_metadata=LLM_METADATA["generation"]["max_new_tokens"],
-    )
-
     min_length: int = schema_utils.NonNegativeInteger(
         default=0,
         allow_none=True,
         description="The minimum length of the sequence to be generated. Corresponds to the length of the "
         "input prompt + min_new_tokens. Its effect is overridden by min_new_tokens, if also set.",
         parameter_metadata=LLM_METADATA["generation"]["min_length"],
-    )
-
-    min_new_tokens: Optional[int] = schema_utils.NonNegativeInteger(
-        default=None,
-        allow_none=True,
-        description="The minimum number of new tokens to generate, ignoring the number of tokens in the input prompt.",
-        parameter_metadata=LLM_METADATA["generation"]["min_new_tokens"],
     )
 
     early_stopping: Optional[Union[bool, str]] = schema_utils.Boolean(

--- a/ludwig/schema/prompt.py
+++ b/ludwig/schema/prompt.py
@@ -67,15 +67,13 @@ class RetrievalConfigField(schema_utils.DictMarshmallowField):
         super().__init__(RetrievalConfig)
 
     def _jsonschema_type_mapping(self):
-        return schema_utils.unload_jsonschema_from_marshmallow_class(RetrievalConfig)
+        return schema_utils.unload_jsonschema_from_marshmallow_class(RetrievalConfig, title="Retrieval")
 
 
 @DeveloperAPI
 @ludwig_dataclass
 class PromptConfig(schema_utils.BaseMarshmallowConfig):
     """This Dataclass is a schema for the nested prompt config under preprocessing."""
-
-    retrieval: RetrievalConfig = RetrievalConfigField().get_default_field()
 
     task: str = schema_utils.String(
         default=None,
@@ -94,6 +92,8 @@ class PromptConfig(schema_utils.BaseMarshmallowConfig):
         ),
         parameter_metadata=LLM_METADATA["prompt"]["template"],
     )
+
+    retrieval: RetrievalConfig = RetrievalConfigField().get_default_field()
 
 
 @DeveloperAPI

--- a/ludwig/schema/utils.py
+++ b/ludwig/schema/utils.py
@@ -227,7 +227,7 @@ def assert_is_a_marshmallow_class(cls):
 
 
 @DeveloperAPI
-def unload_jsonschema_from_marshmallow_class(mclass, additional_properties: bool = True) -> TDict:
+def unload_jsonschema_from_marshmallow_class(mclass, additional_properties: bool = True, title: str = None) -> TDict:
     """Helper method to directly get a marshmallow class's JSON schema without extra wrapping props."""
     assert_is_a_marshmallow_class(mclass)
     schema = js(props_ordered=True).dump(mclass.Schema())["definitions"][mclass.__name__]
@@ -237,6 +237,8 @@ def unload_jsonschema_from_marshmallow_class(mclass, additional_properties: bool
         if "parameter_metadata" in prop_schema:
             prop_schema["parameter_metadata"] = copy.deepcopy(prop_schema["parameter_metadata"])
     schema["additionalProperties"] = additional_properties
+    if title is not None:
+        schema["title"] = title
     return schema
 
 


### PR DESCRIPTION
Reasoning for adding a title param to `unload_jsonschema_from_marshmallow_class`: Basically, in UI, when there is a nested JSON object - so think the Retrieval being a field under prompt - the schema processor looks to create a specific section for the nested object so that it can display all it's properties. Without a title however, it just displays a random UI divider bar which looks weird / doesn't make sense. particular line adds that title so it's clear that the user is adding in parameters for the retrieval section. Broadly speaking, the addition of a title param to this function allows us to add titles in for this reason in other parts of the schema when necessary.