### PR TITLE
Fix: Device placement for metrics during evaluation

### DIFF
--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -116,6 +116,7 @@ class Predictor(BasePredictor):
         self.device = device
         self.dist_model = dist_model
         self.model = model
+        self.model.metrics_to_device(device)
 
         if remote:
             # Only return results from rank 0 to reduce network overhead


### PR DESCRIPTION
This fixes an issue where the metric functions are on the wrong device during evaluation, and ensures that metrics, metric functions and the model are all on the same device. 