### PR TITLE
Add model name param metadata

### DIFF
--- a/ludwig/schema/metadata/configs/llm.yaml
+++ b/ludwig/schema/metadata/configs/llm.yaml
@@ -1,3 +1,6 @@
+model_name:
+    ui_display_name: Model Name
+    expected_impact: 3
 generation:
   temperature:
     ui_display_name: Temperature

--- a/ludwig/schema/model_types/llm.py
+++ b/ludwig/schema/model_types/llm.py
@@ -19,6 +19,7 @@ from ludwig.schema.preprocessing import PreprocessingConfig, PreprocessingField
 from ludwig.schema.prompt import PromptConfig, PromptConfigField
 from ludwig.schema.trainer import LLMTrainerConfig, LLMTrainerDataclassField
 from ludwig.schema.utils import ludwig_dataclass
+from ludwig.schema.metadata import LLM_METADATA
 
 
 @DeveloperAPI
@@ -48,6 +49,7 @@ class LLMModelConfig(ModelConfig):
             "model name or a path to a local directory containing a valid "
             "HuggingFace model."
         ),
+        parameter_metadata=LLM_METADATA["model_name"],
     )
 
     input_features: FeatureCollection[BaseInputFeatureConfig] = LLMInputFeatureSelection().get_list_field()

--- a/ludwig/schema/model_types/llm.py
+++ b/ludwig/schema/model_types/llm.py
@@ -14,12 +14,12 @@ from ludwig.schema.features.base import (
 )
 from ludwig.schema.generation import LLMGenerationConfig, LLMGenerationConfigField
 from ludwig.schema.hyperopt import HyperoptConfig, HyperoptField
+from ludwig.schema.metadata import LLM_METADATA
 from ludwig.schema.model_types.base import ModelConfig, register_model_type
 from ludwig.schema.preprocessing import PreprocessingConfig, PreprocessingField
 from ludwig.schema.prompt import PromptConfig, PromptConfigField
 from ludwig.schema.trainer import LLMTrainerConfig, LLMTrainerDataclassField
 from ludwig.schema.utils import ludwig_dataclass
-from ludwig.schema.metadata import LLM_METADATA
 
 
 @DeveloperAPI


### PR DESCRIPTION
Param filtering was broken, I fixed but then realized model name doesn't have an expected impact so it gets filtered out. This adds it in so it doesn't.