### PR TITLE
Support combining multiple columns into a single text feature

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1231,7 +1231,7 @@ def build_dataset(
     # update input features with prompt configs during preprocessing (as opposed to during the model forward pass)
     # so that we can compute metadata and build the dataset correctly.
     logger.debug("handle text features with prompt parameters")
-    dataset_cols = handle_features_with_prompt_config(
+    synthesized_dataset_cols = handle_features_with_prompt_config(
         config, dataset_df, features, split_col=split_col, backend=backend
     )
 
@@ -1243,8 +1243,12 @@ def build_dataset(
             feature_configs.append(feature)
             feature_hashes.add(feature[PROC_COLUMN])
 
+    dataset_cols = {}
     for feature_config in feature_configs:
-        dataset_cols[feature_config[COLUMN]] = dataset_df[feature_config[COLUMN]]
+        col_name = feature_config[COLUMN]
+        dataset_cols[col_name] = (
+            synthesized_dataset_cols[col_name] if col_name in synthesized_dataset_cols else dataset_df[col_name]
+        )
 
     logger.debug("build preprocessing parameters")
     feature_name_to_preprocessing_parameters = build_preprocessing_parameters(

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -49,6 +49,7 @@ from ludwig.constants import (
     SPLIT,
     SRC,
     TEST,
+    TEXT,
     TRAINING,
     TYPE,
     VALIDATION,
@@ -1217,18 +1218,6 @@ def build_dataset(
         raise ValueError(f"Invalid mode {mode}")
     global_preprocessing_parameters = merge_dict(default_preprocessing_parameters, global_preprocessing_parameters)
 
-    # Get all the unique preprocessing features to compute
-    feature_configs = []
-    feature_hashes = set()
-    for feature in features:
-        if feature[PROC_COLUMN] not in feature_hashes:
-            feature_configs.append(feature)
-            feature_hashes.add(feature[PROC_COLUMN])
-
-    dataset_cols = {}
-    for feature_config in feature_configs:
-        dataset_cols[feature_config[COLUMN]] = dataset_df[feature_config[COLUMN]]
-
     split_col = None
     if global_preprocessing_parameters["split"]["type"] == "fixed":
         if global_preprocessing_parameters["split"]["column"] in dataset_df.columns:
@@ -1238,6 +1227,24 @@ def build_dataset(
                 f"Specified split column {global_preprocessing_parameters['split']['column']} for fixed "
                 f"split strategy was not found in dataset."
             )
+
+    # update input features with prompt configs during preprocessing (as opposed to during the model forward pass)
+    # so that we can compute metadata and build the dataset correctly.
+    logger.debug("handle text features with prompt parameters")
+    dataset_cols = handle_features_with_prompt_config(
+        config, dataset_df, features, split_col=split_col, backend=backend
+    )
+
+    # Get all the unique preprocessing features to compute
+    feature_configs = []
+    feature_hashes = set()
+    for feature in features:
+        if feature[PROC_COLUMN] not in feature_hashes:
+            feature_configs.append(feature)
+            feature_hashes.add(feature[PROC_COLUMN])
+
+    for feature_config in feature_configs:
+        dataset_cols[feature_config[COLUMN]] = dataset_df[feature_config[COLUMN]]
 
     logger.debug("build preprocessing parameters")
     feature_name_to_preprocessing_parameters = build_preprocessing_parameters(
@@ -1259,11 +1266,6 @@ def build_dataset(
     for feature_config in feature_configs:
         preprocessing_parameters = feature_name_to_preprocessing_parameters[feature_config[NAME]]
         handle_missing_values(dataset_cols, feature_config, preprocessing_parameters, backend)
-
-    # update input features with prompt configs during preprocessing (as opposed to during the model forward pass)
-    # so that we can compute metadata and build the dataset correctly.
-    logger.debug("handle text features with prompt parameters")
-    handle_features_with_prompt_config(config, dataset_cols, features, split_col=split_col, backend=backend)
 
     # Happens after missing values are handled to avoid NaN casting issues.
     logger.debug("cast columns")
@@ -1733,24 +1735,26 @@ def _handle_missing_values(
 
 def handle_features_with_prompt_config(
     config: ModelConfigDict,
-    dataset_cols: Dict[str, Series],
+    dataset_df: DataFrame,
     features: List[FeatureConfigDict],
     backend: Backend,
     split_col: Optional[Series] = None,
-):
+) -> Dict[str, Series]:
     """Updates (in-place) dataset columns with prompt configurations containing a non-None task parameter.
 
     Dataset columns that are updated here are enriched to have prompts as specified by the prompt configuration.
 
     Args:
         config: Model configuration.
-        dataset_cols (Dict[str, Series]): Dataset columns.
-        feature_name_to_preprocessing_parameters (Dict[str, PreprocessingConfigDict]): Mapping from feature name to
-            preprocessing parameters.
+        dataset_df (DataFrame): Input dataset.
         features (List[FeatureConfigDict]): List of feature configurations.
         df_engine (DataFrameEngine): Dataframe engine.
         split_col (Optional[Series], optional): Split column. Defaults to None.
+
+    Returns:
+        Dict[str, Series]: Modified dataset columns.
     """
+    dataset_cols = {}
     input_features, output_features = get_input_and_output_features(features)
     for input_feature_config in input_features:
         prompt_config = _get_prompt_config(config, input_feature_config)
@@ -1762,8 +1766,12 @@ def handle_features_with_prompt_config(
             # Ensure that the output features are in the dataset columns saved as part of the index
             # so that they can be retrieved later at lookup time.
             output_feature_col_names = [output_feature_config[COLUMN] for output_feature_config in output_features]
-            input_and_output_col_names = [input_col_name] + output_feature_col_names
-            input_and_output_cols = {k: v for k, v in dataset_cols.items() if k in input_and_output_col_names}
+            input_and_output_col_names = set([input_col_name] + output_feature_col_names)
+            input_and_output_cols = {
+                feature[NAME]: dataset_df[feature[COLUMN]]
+                for feature in features
+                if feature[NAME] in input_and_output_col_names
+            }
             retrieval_model, index_name = index_column(
                 prompt_config["retrieval"],
                 col_name=input_col_name,
@@ -1783,7 +1791,7 @@ def handle_features_with_prompt_config(
 
         dataset_cols[input_col_name] = format_input_with_prompt(
             input_col_name,
-            dataset_cols[input_col_name],
+            dataset_df,
             backend,
             prompt_config["task"],
             retrieval_model=retrieval_model,
@@ -1791,16 +1799,26 @@ def handle_features_with_prompt_config(
             template=prompt_config["template"],
         )
 
+    return dataset_cols
+
 
 def _get_prompt_config(config: ModelConfigDict, input_feature_config: Dict) -> Dict:
-    if "prompt" in config and config["prompt"]["task"] is not None:
-        return config["prompt"]
+    if input_feature_config[TYPE] != TEXT:
+        # Prompt config is only applied to text features
+        return None
 
     preprocessing = input_feature_config["preprocessing"]
-    if "prompt" in preprocessing and preprocessing["prompt"]["task"] is not None:
+    if _has_prompt_section(preprocessing):
         return preprocessing["prompt"]
 
+    if _has_prompt_section(config):
+        return config["prompt"]
+
     return None
+
+
+def _has_prompt_section(config: Dict) -> bool:
+    return "prompt" in config and (config["prompt"]["template"] is not None or config["prompt"]["task"] is not None)
 
 
 def load_hdf5(hdf5_file_path, preprocessing_params, backend, split_data=True, shuffle_training=False):

--- a/ludwig/data/prompt.py
+++ b/ludwig/data/prompt.py
@@ -230,6 +230,9 @@ def _get_template_fields(template: str) -> Tuple[Set[str], Dict[str, Type]]:
 
 
 def _get_dtype(format_spec: str) -> Type:
+    # We need to prepare data in the row for different formatting options.
+    # If you have a number like 0.1234 in the DF and you want to format it like {number:.2f} it will fail if the
+    # number is represented as a string in the DF. So we need to cast it to a float before formatting.
     if not format_spec:
         return str
     if "f" in format_spec:

--- a/ludwig/data/prompt.py
+++ b/ludwig/data/prompt.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import string
-from typing import Any, Dict, List, Optional, Set, Tuple, TYPE_CHECKING, Type
+from typing import Any, Dict, List, Optional, Set, Tuple, Type, TYPE_CHECKING
 
 import pandas as pd
 

--- a/ludwig/schema/prompt.py
+++ b/ludwig/schema/prompt.py
@@ -75,10 +75,6 @@ class RetrievalConfigField(schema_utils.DictMarshmallowField):
 class PromptConfig(schema_utils.BaseMarshmallowConfig):
     """This Dataclass is a schema for the nested prompt config under preprocessing."""
 
-    def __post_init__(self):
-        if self.template is None and self.task is None:
-            raise ConfigValidationError("Either `template` or `task` must be set.")
-
     template: str = schema_utils.String(
         default=None,
         allow_none=True,

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -941,19 +941,19 @@ def test_handle_features_with_prompt_config_multi_col(backend, ray_cluster_2cpu)
             {
                 "instruction": "Name this province",
                 "country": "Canada",
-                "year": "1871",
+                "year": 1871,
                 "answer": "British Columbia",
             },
             {
                 "instruction": "Name this city",
                 "country": "France",
-                "year": "1789",
+                "year": 1789,
                 "answer": "Paris",
             },
             {
                 "instruction": "Name this country",
                 "country": "UK",
-                "year": "1057",
+                "year": 1057,
                 "answer": "Wales",
             },
         ]
@@ -965,7 +965,7 @@ def test_handle_features_with_prompt_config_multi_col(backend, ray_cluster_2cpu)
         "input_features": [text_feature(name="question", encoder={"type": "passthrough"})],
         "output_features": [text_feature(name="answer")],
         "prompt": {
-            "template": "You are a helpful chatbot. USER: {instruction}: {country}, {year} ASSISTANT:",
+            "template": "You are a helpful chatbot. USER: {instruction}: {country}, {year:.2f} ASSISTANT:",
         },
     }
     config = ModelConfig.from_dict(config).to_dict()
@@ -991,6 +991,6 @@ def test_handle_features_with_prompt_config_multi_col(backend, ray_cluster_2cpu)
 
     col = backend.df_engine.compute(dataset_cols["question"])
     assert len(col) == 3
-    assert col[0].startswith("You are a helpful chatbot. USER: Name this province: Canada, 1871 ASSISTANT:")
-    assert col[1].startswith("You are a helpful chatbot. USER: Name this city: France, 1789 ASSISTANT:")
-    assert col[2].startswith("You are a helpful chatbot. USER: Name this country: UK, 1057 ASSISTANT:")
+    assert col[0].startswith("You are a helpful chatbot. USER: Name this province: Canada, 1871.00 ASSISTANT:")
+    assert col[1].startswith("You are a helpful chatbot. USER: Name this city: France, 1789.00 ASSISTANT:")
+    assert col[2].startswith("You are a helpful chatbot. USER: Name this country: UK, 1057.00 ASSISTANT:")

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 import logging
 import os
 import random
@@ -870,6 +871,8 @@ input:"""
 )
 def test_prompt_template(input_features, expected, model_type, backend, tmpdir, ray_cluster_2cpu):
     """Tests that prompt template is correctly applied to inputs."""
+    input_features = copy.deepcopy(input_features)
+
     output_features = [category_feature()]
     data_csv = generate_data(input_features, output_features, os.path.join(tmpdir, "dataset.csv"), num_examples=25)
 

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -963,6 +963,7 @@ def test_handle_features_with_prompt_config_multi_col(backend):  # , ray_cluster
         },
     }
     config = ModelConfig.from_dict(config).to_dict()
+    print(config["prompt"])
 
     if backend == "ray":
         import dask.dataframe as dd

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -929,7 +929,7 @@ def test_handle_features_with_few_shot_prompt_config(backend, retrieval_kwargs, 
 
 @pytest.mark.llm
 @pytest.mark.parametrize("backend", ["local", "ray"])
-def test_handle_features_with_prompt_config_multi_col(backend):  # , ray_cluster_2cpu):
+def test_handle_features_with_prompt_config_multi_col(backend, ray_cluster_2cpu):
     df = pd.DataFrame(
         [
             {
@@ -982,8 +982,10 @@ def test_handle_features_with_prompt_config_multi_col(backend):  # , ray_cluster
     )
 
     assert len(dataset_cols) == 1
-    assert "instruction" in dataset_cols
+    assert "question" in dataset_cols
 
-    # Inspect the generated prompts
-    for prompt in dataset_cols["instruction"]:
-        print(prompt)
+    col = backend.df_engine.compute(dataset_cols["question"])
+    assert len(col) == 3
+    assert col[0].startswith("You are a helpful chatbot. USER: Name this province: Canada, 1871 ASSISTANT:")
+    assert col[1].startswith("You are a helpful chatbot. USER: Name this city: France, 1789 ASSISTANT:")
+    assert col[2].startswith("You are a helpful chatbot. USER: Name this country: UK, 1057 ASSISTANT:")


### PR DESCRIPTION
For LLMs and other text models, it's common to treat multiple inputs as a single string of text to feed into the model as input, rather than construct separate "towers" for each feature. This PR provides a standard way to do this via the `prompt` config.

For ECD:

```
input_features:
    - name: context
      type: text
      preprocessing:
          prompt:
            template: The {color} {animal} jumped over the {size} {object}
```

For LLM:

```
model_type: llm
prompt:
    template: The {color} {animal} jumped over the {size} {object}
input_features:
    - name: context
      type: text
```

Here, it is not required that `context` be a valid column of the input dataset, as it will be generated from the `prompt`. However, each of `color`, `animal`, `size`, and `object` are assumed to be columns of the input dataset.