### PR TITLE
fix: Install html5lib and test html reads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ openpyxl>=3.0.7     # excel
 pyxlsb>=1.0.8       # excel
 pyarrow             # parquet
 lxml                # html
+html5lib            # html


### PR DESCRIPTION
The HTML reader was broken due to a missing `html5lib` import. Our reader uses `pandas.read_html`, which calls `lxml` to parse HTML, which in turn calls `html5lib` to parse it. That library is not an explicit dependency for `lxml`, so it need to be installed separately. This PR adds `html5lib` to `requirements.txt` and adds a small test for `read_html`.