### PR TITLE
[LLM] Skip left padding removal when there is no left padding

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -115,7 +115,7 @@ class LLM(BaseModel):
             # HACK: Llama fast tokenizer takes about 2-4 minutes to load, so we disable it for now.
             use_fast = False
         self.tokenizer = AutoTokenizer.from_pretrained(self.config_obj.model_name, use_fast=use_fast)
-        set_pad_token()
+        set_pad_token(self.tokenizer)
 
         self.generation = GenerationConfig(**self.config_obj.generation.to_dict())
 

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -1,5 +1,21 @@
 import torch
-from transformers import PreTrainedTokenizer
+from transformers import GPT2Tokenizer, GPT2TokenizerFast, LlamaTokenizer, LlamaTokenizerFast, PreTrainedTokenizer
+
+
+def set_pad_token(tokenizer: PreTrainedTokenizer):
+    """Sets the pad token for the tokenizer if it is not already set."""
+    # Tokenizers might have the pad token id attribute since they tend to use the same base class, but
+    # it can be set to None so we check for this explicitly.
+    if hasattr(tokenizer, "pad_token_id") and tokenizer.pad_token_id is not None:
+        return
+
+    # HACK(Arnav): gpt, gpt2 and llama tokenizers had no pad tokens.
+    # These recommend using eos tokens instead
+    # https://github.com/huggingface/transformers/issues/2648#issuecomment-616177044
+    # https://github.com/huggingface/transformers/issues/2630#issuecomment-1290809338
+    if any(isinstance(tokenizer, t) for t in [GPT2Tokenizer, GPT2TokenizerFast, LlamaTokenizer, LlamaTokenizerFast]):
+        tokenizer.pad_token = tokenizer.eos_token
+        tokenizer.pad_token_id = tokenizer.eos_token_id
 
 
 def remove_left_padding(input_ids_sample: torch.Tensor, tokenizer: PreTrainedTokenizer):

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -1,0 +1,22 @@
+import torch
+from transformers import PreTrainedTokenizer
+
+
+def remove_left_padding(input_ids_sample: torch.Tensor, tokenizer: PreTrainedTokenizer):
+    """Removes left padding and other tokens until the first BOS token from the input_ids tensor."""
+    # Remove all PAD tokens
+    pad_idxs = torch.where(input_ids_sample == tokenizer.pad_token_id)[0]  # all PAD token locations
+    input_ids_no_padding = input_ids_sample
+    if len(pad_idxs) != 0:
+        pad_idx = pad_idxs[-1]  # get last PAD token location
+        input_ids_no_padding = input_ids_sample[pad_idx + 1 :]
+
+    # Start from the first BOS token
+    bos_idxs = torch.where(input_ids_no_padding == tokenizer.bos_token_id)[0]  # all BOS token locations
+    if len(bos_idxs) != 0:
+        bos_idx = bos_idxs[0]  # get first BOS token location
+    else:
+        bos_idx = 0
+
+    input_ids_no_bos = input_ids_no_padding[bos_idx:].unsqueeze(0)
+    return input_ids_no_bos

--- a/tests/ludwig/utils/test_llm_utils.py
+++ b/tests/ludwig/utils/test_llm_utils.py
@@ -1,0 +1,49 @@
+import pytest
+import torch
+from transformers import AutoTokenizer
+
+from ludwig.utils.llm_utils import remove_left_padding, set_pad_token
+
+# Pad token ID is 1 for OPT even though it uses the GPT2 tokenizer
+# BOS token ID is 2
+TEST_MODEL_NAME = "hf-internal-testing/tiny-random-OPTForCausalLM"
+
+
+@pytest.mark.llm
+def test_set_pad_token_doesnt_exist():
+    tokenizer = AutoTokenizer.from_pretrained("gpt2", use_fast=False)
+    assert tokenizer.pad_token_id is None
+
+    set_pad_token(tokenizer)
+    assert tokenizer.pad_token_id == 50256
+
+
+@pytest.mark.llm
+def test_set_pad_token_already_exists():
+    tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_NAME, use_fast=False)
+    assert tokenizer.pad_token_id == 1
+
+    set_pad_token(tokenizer)
+    assert tokenizer.pad_token_id == 1
+
+
+@pytest.mark.llm
+@pytest.mark.parametrize(
+    "input_ids, expected",
+    [
+        # No padding
+        (torch.tensor([5]), torch.tensor([5])),
+        (torch.tensor([5, 3]), torch.tensor([5, 3])),
+        # Padding
+        (torch.tensor([1, 5, 5, 3]), torch.tensor([5, 5, 3])),
+        # EOS token
+        (torch.tensor([2, 5, 5, 3]), torch.tensor([2, 5, 5, 3])),
+        # Padding + EOS token
+        (torch.tensor([1, 2, 5, 5, 3]), torch.tensor([2, 5, 5, 3])),
+    ],
+)
+def test_remove_left_padding(input_ids, expected):
+    tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_NAME, use_fast=False)
+    set_pad_token(tokenizer)
+
+    assert torch.equal(remove_left_padding(input_ids, tokenizer).squeeze(0), expected)


### PR DESCRIPTION
Fixes an issue with left padding removal when there is no padding in the input tensor. It previously assumed that would always happen, which was incorrect.