### PR TITLE
Adding --no-cache-dir to dockerfile pip install

### DIFF
--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -42,7 +42,7 @@ RUN pip install -U pip
 
 WORKDIR /ludwig
 
-RUN pip install torch==2.0.0 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu118
+RUN pip install --no-cache-dir torch==2.0.0 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu118
 
 COPY . .
 RUN pip install --no-cache-dir '.[full]' --extra-index-url https://download.pytorch.org/whl/cu118

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -29,7 +29,7 @@ RUN pip install -U pip
 
 WORKDIR /ludwig
 
-RUN pip install torch==2.0.0 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache-dir torch==2.0.0 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
 
 COPY . .
 RUN pip install --no-cache-dir '.[full]' --extra-index-url https://download.pytorch.org/whl/cpu

--- a/docker/ludwig/Dockerfile
+++ b/docker/ludwig/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install -U pip
 
 WORKDIR /ludwig
 
-RUN pip install torch==2.0.0 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache-dir torch==2.0.0 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
 
 COPY . .
 RUN pip install --no-cache-dir '.[full]'


### PR DESCRIPTION
# Code Pull Requests

Please provide the following:
- This adds the `--no-cache-dir` to pip installs within the Dockerfile. Without doing this, the pip cache adds around 2.5 GB uncompressed to the resulting containers. 

