### PR TITLE
Initial implementation of DaftDataFrameEngine

### DIFF
--- a/ludwig/data/dataframe/daft.py
+++ b/ludwig/data/dataframe/daft.py
@@ -58,44 +58,34 @@ class DaftEngine(DataFrameEngine):
         )
 
     def map_objects(self, series, map_fn, meta=None):
-        # TODO(jay): Implement
-        pass
+        raise NotImplementedError("TODO: Needs implementation!")
 
     def map_partitions(self, series, map_fn, meta=None):
-        # TODO(jay): Implement
-        pass
+        raise NotImplementedError("TODO: Needs implementation!")
 
     def map_batches(self, series, map_fn, enable_tensor_extension_casting=True):
-        # TODO(jay): Implement
-        pass
+        raise NotImplementedError("TODO: Needs implementation!")
 
     def apply_objects(self, df, apply_fn, meta=None):
-        # TODO(jay): Implement
-        pass
+        raise NotImplementedError("TODO: Needs implementation!")
 
     def reduce_objects(self, series, reduce_fn):
-        # TODO(jay): Implement
-        pass
+        raise NotImplementedError("TODO: Needs implementation!")
 
     def split(self, df, probabilities):
-        # TODO(jay): Implement
-        pass
+        raise NotImplementedError("TODO: Needs implementation!")
 
     def remove_empty_partitions(self, df):
-        # TODO(jay): Implement
-        pass
+        raise NotImplementedError("TODO: Needs implementation!")
 
     def to_parquet(self, df, path, index=False):
-        # TODO(jay): Implement
-        pass
+        raise NotImplementedError("TODO: Needs implementation!")
 
     def write_predictions(self, df: daft.DataFrame, path: str):
-        # TODO(jay): Implement
-        pass
+        raise NotImplementedError("TODO: Needs implementation!")
 
     def read_predictions(self, path: str) -> daft.DataFrame:
-        # TODO(jay): Implement
-        pass
+        raise NotImplementedError("TODO: Needs implementation!")
 
     def to_ray_dataset(self, df: daft.DataFrame) -> Dataset:
         return df.to_ray_dataset()

--- a/ludwig/data/dataframe/daft.py
+++ b/ludwig/data/dataframe/daft.py
@@ -129,7 +129,10 @@ class DaftEngine(DataFrameEngine):
         )
 
     def reduce_objects(self, series, reduce_fn):
-        raise NotImplementedError("TODO: Needs implementation!")
+        raise NotImplementedError(
+            "Not implemented for DaftEngine - this is only used in audio_feature.py and is much better "
+            "expressed as a DataFrame aggregation using the provided dataframe APIs for mean/max/min/stddev etc"
+        )
 
     def split(self, df, probabilities):
         raise NotImplementedError("TODO: Needs implementation!")

--- a/ludwig/data/dataframe/daft.py
+++ b/ludwig/data/dataframe/daft.py
@@ -1,0 +1,133 @@
+import collections
+import logging
+from typing import Dict, List
+
+import daft
+import pandas as pd
+import ray
+from packaging import version
+from ray.data import Dataset
+
+from ludwig.api_annotations import DeveloperAPI
+from ludwig.data.dataframe.base import DataFrameEngine
+
+TMP_COLUMN = "__TMP_COLUMN__"
+
+# This is to be compatible with pyarrow.lib.schema
+PandasBlockSchema = collections.namedtuple("PandasBlockSchema", ["names", "types"])
+
+logger = logging.getLogger(__name__)
+
+
+_ray_230 = version.parse(ray.__version__) >= version.parse("2.3.0")
+
+
+@DeveloperAPI
+class DaftEngine(DataFrameEngine):
+    def __init__(self, parallelism: int | None):
+        self._parallelism = parallelism
+
+    def set_parallelism(self, parallelism):
+        raise NotImplementedError("Not implemented for DaftEngine - this does not appear to be called anywhere")
+
+    def df_like(self, df: daft.DataFrame, proc_cols: Dict[str, daft.Expression]) -> daft.DataFrame:
+        for col_name, expr in proc_cols.items():
+            df = df.with_column(col_name, expr)
+        return df
+
+    def parallelize(self, data: daft.DataFrame) -> daft.DataFrame:
+        if self._parallelism:
+            return data.into_partitions(self._parallelism)
+        return data
+
+    def persist(self, data: daft.DataFrame) -> daft.DataFrame:
+        # TODO(jay): Currently just a no-op. Let's see how far we can take it without persisting the dataframe at all
+        # It seems like the Dask implementation defaults to (and is likely always just) persist=True, but it is unclear
+        # why we need to persist.
+        return data
+
+    def concat(self, dfs: List[daft.DataFrame]) -> daft.DataFrame:
+        if len(dfs) == 0:
+            raise ValueError("Cannot concat a list of empty dataframes")
+        elif len(dfs) == 1:
+            return dfs[0]
+        else:
+            df = dfs[0]
+            for i in range(1, len(dfs)):
+                df = df.concat(dfs[i])
+            return df
+
+    def compute(self, data) -> pd.DataFrame:
+        return data.to_pandas()
+
+    def from_pandas(self, df):
+        parallelism = self._parallelism or 1
+        return daft.from_pydict({column: daft.Series.from_pandas(df[column]) for column in df.columns}).into_partitions(
+            parallelism
+        )
+
+    def map_objects(self, series, map_fn, meta=None):
+        # TODO(jay): Implement
+        pass
+
+    def map_partitions(self, series, map_fn, meta=None):
+        # TODO(jay): Implement
+        pass
+
+    def map_batches(self, series, map_fn, enable_tensor_extension_casting=True):
+        # TODO(jay): Implement
+        pass
+
+    def apply_objects(self, df, apply_fn, meta=None):
+        # TODO(jay): Implement
+        pass
+
+    def reduce_objects(self, series, reduce_fn):
+        # TODO(jay): Implement
+        pass
+
+    def split(self, df, probabilities):
+        # TODO(jay): Implement
+        pass
+
+    def remove_empty_partitions(self, df):
+        # TODO(jay): Implement
+        pass
+
+    def to_parquet(self, df, path, index=False):
+        # TODO(jay): Implement
+        pass
+
+    def write_predictions(self, df: daft.DataFrame, path: str):
+        # TODO(jay): Implement
+        pass
+
+    def read_predictions(self, path: str) -> daft.DataFrame:
+        # TODO(jay): Implement
+        pass
+
+    def to_ray_dataset(self, df: daft.DataFrame) -> Dataset:
+        return df.to_ray_dataset()
+
+    def from_ray_dataset(self, dataset: Dataset) -> daft.DataFrame:
+        return daft.from_ray_dataset(dataset)
+
+    def reset_index(self, df):
+        # Daft has no concept of indices so this is a no-op
+        return df
+
+    @property
+    def array_lib(self):
+        raise NotImplementedError("Daft has no array library - this does not seemt o be called from anywhere")
+
+    @property
+    def df_lib(self):
+        return daft
+
+    @property
+    def parallelism(self):
+        return self._parallelism
+
+    @property
+    def partitioned(self):
+        return True

--- a/ludwig/data/dataframe/daft.py
+++ b/ludwig/data/dataframe/daft.py
@@ -1,25 +1,14 @@
-import collections
 import logging
 from typing import Dict, List
 
 import daft
 import pandas as pd
-import ray
-from packaging import version
 from ray.data import Dataset
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.data.dataframe.base import DataFrameEngine
 
-TMP_COLUMN = "__TMP_COLUMN__"
-
-# This is to be compatible with pyarrow.lib.schema
-PandasBlockSchema = collections.namedtuple("PandasBlockSchema", ["names", "types"])
-
 logger = logging.getLogger(__name__)
-
-
-_ray_230 = version.parse(ray.__version__) >= version.parse("2.3.0")
 
 
 @DeveloperAPI
@@ -28,7 +17,9 @@ class DaftEngine(DataFrameEngine):
         self._parallelism = parallelism
 
     def set_parallelism(self, parallelism):
-        raise NotImplementedError("Not implemented for DaftEngine - this does not appear to be called anywhere")
+        raise NotImplementedError(
+            "Not implemented for DaftEngine - this does not appear to be called anywhere in Ludwig"
+        )
 
     def df_like(self, df: daft.DataFrame, proc_cols: Dict[str, daft.Expression]) -> daft.DataFrame:
         for col_name, expr in proc_cols.items():

--- a/ludwig/data/dataframe/daft.py
+++ b/ludwig/data/dataframe/daft.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List
+from typing import Callable, Dict, List
 
 import daft
 import pandas as pd
@@ -9,6 +9,39 @@ from ludwig.api_annotations import DeveloperAPI
 from ludwig.data.dataframe.base import DataFrameEngine
 
 logger = logging.getLogger(__name__)
+
+
+class DaftDataframeShim:
+    """Shim layer on top of a daft.Dataframe to make it behave like a Pandas Dataframe object."""
+
+    def __init__(self, df: daft.DataFrame):
+        self._df = df
+
+    @property
+    def inner(self) -> daft.DataFrame:
+        return self._df
+
+    def __setitem__(self, key: str, val: "DaftSeriesShim") -> None:
+        self._df = self._df.with_column(key, val.expr)
+
+    def __getitem__(self, key) -> "DaftSeriesShim":
+        return DaftSeriesShim(self, self.inner[key])
+
+
+class DaftSeriesShim:
+    """Shim layer on top of a daft.Expression to make it behave like a Pandas Series object."""
+
+    def __init__(self, src: DaftDataframeShim, expr: daft.Expression):
+        self._expr = expr
+        self._src = src
+
+    @property
+    def expr(self):
+        return self._expr
+
+    @property
+    def source_dataframe(self) -> daft.DataFrame:
+        return self._src.inner
 
 
 @DeveloperAPI
@@ -21,53 +54,79 @@ class DaftEngine(DataFrameEngine):
             "Not implemented for DaftEngine - this does not appear to be called anywhere in Ludwig"
         )
 
-    def df_like(self, df: daft.DataFrame, proc_cols: Dict[str, daft.Expression]) -> daft.DataFrame:
-        for col_name, expr in proc_cols.items():
-            df = df.with_column(col_name, expr)
-        return df
+    def df_like(self, df: DaftDataframeShim, proc_cols: Dict[str, DaftSeriesShim]) -> DaftDataframeShim:
+        df = df.inner
+        for col_name, series in proc_cols.items():
+            df = df.with_column(col_name, series.expr)
+        return DaftDataframeShim(df)
 
-    def parallelize(self, data: daft.DataFrame) -> daft.DataFrame:
+    def parallelize(self, data: DaftDataframeShim) -> DaftDataframeShim:
         if self._parallelism:
-            return data.into_partitions(self._parallelism)
+            return DaftDataframeShim(data.inner.into_partitions(self._parallelism))
         return data
 
-    def persist(self, data: daft.DataFrame) -> daft.DataFrame:
+    def persist(self, data: DaftDataframeShim) -> DaftDataframeShim:
         # TODO(jay): Currently just a no-op. Let's see how far we can take it without persisting the dataframe at all
         # It seems like the Dask implementation defaults to (and is likely always just) persist=True, but it is unclear
         # why we need to persist.
         return data
 
-    def concat(self, dfs: List[daft.DataFrame]) -> daft.DataFrame:
+    def concat(self, dfs: List[DaftDataframeShim]) -> DaftDataframeShim:
         if len(dfs) == 0:
             raise ValueError("Cannot concat a list of empty dataframes")
         elif len(dfs) == 1:
             return dfs[0]
         else:
-            df = dfs[0]
+            df = dfs[0].inner
             for i in range(1, len(dfs)):
-                df = df.concat(dfs[i])
-            return df
+                df = df.concat(dfs[i].inner)
+            return DaftDataframeShim(df)
 
-    def compute(self, data) -> pd.DataFrame:
-        return data.to_pandas()
+    def compute(self, data: DaftDataframeShim) -> pd.DataFrame:
+        return data.inner.to_pandas()
 
-    def from_pandas(self, df):
+    def from_pandas(self, df: pd.DataFrame) -> DaftDataframeShim:
         parallelism = self._parallelism or 1
-        return daft.from_pydict({column: daft.Series.from_pandas(df[column]) for column in df.columns}).into_partitions(
-            parallelism
+        return DaftDataframeShim(
+            daft.from_pydict({column: daft.Series.from_pandas(df[column]) for column in df.columns}).into_partitions(
+                parallelism
+            )
         )
 
-    def map_objects(self, series, map_fn, meta=None):
-        raise NotImplementedError("TODO: Needs implementation!")
+    def map_objects(self, series: DaftSeriesShim, map_fn: Callable[[object], object], meta=None) -> DaftSeriesShim:
+        # TODO(jay): If the user can supply the return dtype (e.g. daft.DataType.string()), this operation
+        # can be much more optimized in terms of memory usage
+        return DaftSeriesShim(series.source_dataframe, series.expr.apply(map_fn, return_dtype=daft.DataType.python()))
 
-    def map_partitions(self, series, map_fn, meta=None):
-        raise NotImplementedError("TODO: Needs implementation!")
+    def map_partitions(self, obj: DaftSeriesShim, map_fn: Callable[[pd.Series], pd.Series], meta=None):
+        if isinstance(obj, DaftDataframeShim):
+            raise NotImplementedError("map_partitions not implemented for Daft Dataframes, only on Daft Series")
+        elif isinstance(obj, DaftSeriesShim):
+            # TODO(jay): IMPLEMENT.
+            pass
+        else:
+            raise NotImplementedError(f"map_partitions not implemented for object of type: {type(obj)}")
 
-    def map_batches(self, series, map_fn, enable_tensor_extension_casting=True):
-        raise NotImplementedError("TODO: Needs implementation!")
+    def map_batches(
+        self,
+        obj: DaftDataframeShim,
+        map_fn: Callable[[pd.DataFrame], pd.DataFrame],
+        enable_tensor_extension_casting=True,
+    ):
+        if isinstance(obj, DaftDataframeShim):
+            # TODO(jay): IMPLEMENT.
+            pass
+        elif isinstance(obj, DaftSeriesShim):
+            # TODO(jay): It appears that even though this API is annotated as taking the Series as input, it is actually
+            # used on DataFrames, not Series. This branch should never be hit and is not used anywhere in Ludwig.
+            raise NotImplementedError("map_batches not implemented for Daft Series")
+        else:
+            raise NotImplementedError(f"map_batches not implemented for object of type: {type(obj)}")
 
     def apply_objects(self, df, apply_fn, meta=None):
-        raise NotImplementedError("TODO: Needs implementation!")
+        raise NotImplementedError(
+            "Not implemented for DaftEngine - this does not appear to be called anywhere in Ludwig"
+        )
 
     def reduce_objects(self, series, reduce_fn):
         raise NotImplementedError("TODO: Needs implementation!")
@@ -81,17 +140,17 @@ class DaftEngine(DataFrameEngine):
     def to_parquet(self, df, path, index=False):
         raise NotImplementedError("TODO: Needs implementation!")
 
-    def write_predictions(self, df: daft.DataFrame, path: str):
+    def write_predictions(self, df: DaftDataframeShim, path: str):
         raise NotImplementedError("TODO: Needs implementation!")
 
-    def read_predictions(self, path: str) -> daft.DataFrame:
+    def read_predictions(self, path: str) -> DaftDataframeShim:
         raise NotImplementedError("TODO: Needs implementation!")
 
-    def to_ray_dataset(self, df: daft.DataFrame) -> Dataset:
-        return df.to_ray_dataset()
+    def to_ray_dataset(self, df: DaftDataframeShim) -> Dataset:
+        return df.inner.to_ray_dataset()
 
-    def from_ray_dataset(self, dataset: Dataset) -> daft.DataFrame:
-        return daft.from_ray_dataset(dataset)
+    def from_ray_dataset(self, dataset: Dataset) -> DaftDataframeShim:
+        return DaftDataframeShim(daft.from_ray_dataset(dataset))
 
     def reset_index(self, df):
         # Daft has no concept of indices so this is a no-op
@@ -99,7 +158,9 @@ class DaftEngine(DataFrameEngine):
 
     @property
     def array_lib(self):
-        raise NotImplementedError("Daft has no array library - this does not seemt o be called from anywhere")
+        raise NotImplementedError(
+            "Not implemented for DaftEngine - this does not appear to be called anywhere in Ludwig"
+        )
 
     @property
     def df_lib(self):

--- a/ludwig/data/dataframe/daft.py
+++ b/ludwig/data/dataframe/daft.py
@@ -64,7 +64,7 @@ class LudwigDaftSeries:
     ```
     """
 
-    def __init__(self, expr: daft.Expression):
+    def __init__(self, expr: daft.expressions.Expression):
         self._expr = expr
 
     @property

--- a/tests/ludwig/data/dataframe/test_daft.py
+++ b/tests/ludwig/data/dataframe/test_daft.py
@@ -1,0 +1,32 @@
+import daft
+import numpy as np
+import pytest
+
+from ludwig.data.dataframe.daft import DaftEngine, LudwigDaftDataframe, LudwigDaftSeries
+
+
+@pytest.fixture(scope="function")
+def df() -> LudwigDaftDataframe:
+    data = {
+        "a": [i for i in range(10)],
+        "b": ["a" * i for i in range(10)],
+        "c": [np.zeros((i, i)) for i in range(1, 11)],
+    }
+    return LudwigDaftDataframe(daft.from_pydict(data))
+
+
+@pytest.fixture(scope="function", params=[1, 2])
+def engine(request) -> DaftEngine:
+    parallelism = request.param
+    return DaftEngine(parallelism=parallelism)
+
+
+def test_df_like(df: LudwigDaftDataframe, engine: DaftEngine):
+    s1 = LudwigDaftSeries(df["a"].expr * 2)
+    s2 = LudwigDaftSeries(df["b"].expr + "_suffix")
+    df = engine.df_like(df, {"foo": s1, "bar": s2})
+    pd_df = engine.compute(df)
+
+    assert list(pd_df.columns) == ["a", "b", "c", "foo", "bar"]
+    np.testing.assert_equal(np.array(pd_df["foo"]), np.array(pd_df["a"] * 2))
+    np.testing.assert_equal(np.array(pd_df["bar"]), np.array([item + "_suffix" for item in pd_df["b"]]))


### PR DESCRIPTION
# Code Pull Requests

This PR introduces the DaftDataFrameEngine, which is a DataFrameEngine implementation that is backed by [Daft](https://github.com/Eventual-Inc/Daft/tree/main/daft)

This has several advantages:

1. Daft is easy to use locally as well as remotely
2. Daft is fast and provides native kernels such as those for URLs, images and tensors
3. Daft runs natively on Ray
4. Daft has a simpler API than the current distributed dataframe abstraction (Dask) because it has no concept of indexing, which complicates many operations in Ludwig such as joins etc