### PR TITLE
Add low cpu mem support for LLM instantiation

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -90,8 +90,12 @@ class LLM(BaseModel):
 
         self.model_name = self.config_obj.base_model
 
-        logger.info("Loading large language model...")
-        self.model = AutoModelForCausalLM.from_pretrained(self.config_obj.base_model)
+        logger.info(f"Loading large language model {self.config_obj.base_model} ...")
+        self.model = AutoModelForCausalLM.from_pretrained(
+            self.config_obj.base_model,
+            torch_dtype=torch.float16,
+            low_cpu_mem_usage=True,
+        )
         self.curr_device = torch.device("cpu")  # model initially loaded onto cpu
         logger.info("Done.")
 


### PR DESCRIPTION
Reduces memory overhead when LLMs are loaded onto CPU memory but enabling `low_cpu_mem_usage` that loads the model using ~1x model size CPU memory. See https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.from_pretrained for more info.

This also enables half-precision loading by default, which seems like a reasonable thing to do. It uses float16 since that always works, unlike bf16 which has hardware restrictions. 

