### PR TITLE
[Example] Fix llm_finetune example json part

### DIFF
--- a/examples/llm_finetuning/train_imdb_ray.py
+++ b/examples/llm_finetuning/train_imdb_ray.py
@@ -15,7 +15,8 @@ input_features:
       type: auto_transformer
       pretrained_model_name_or_path: bigscience/bloom-3b
       trainable: true
-      adapter: lora
+      adapter:
+        type: lora
 
 output_features:
   - name: sentiment


### PR DESCRIPTION
`llm_finetune` example is using out-dated json format.
This PR should fix it.

However, my testing env is using Ray 2.5 and still get failure in model training part.
