### PR TITLE
Unpin deepspeed

### DIFF
--- a/requirements_distributed.txt
+++ b/requirements_distributed.txt
@@ -9,8 +9,7 @@ GPUtil
 tblib
 awscli
 
-# https://github.com/databrickslabs/dolly/issues/125
-deepspeed==0.9.2
+deepspeed
 
 # requirements for daft
 getdaft[ray]

--- a/requirements_distributed.txt
+++ b/requirements_distributed.txt
@@ -10,7 +10,7 @@ tblib
 awscli
 
 # https://github.com/databrickslabs/dolly/issues/125
-deepspeed<=0.9.2
+deepspeed==0.9.2
 
 # requirements for daft
 getdaft[ray]

--- a/requirements_distributed.txt
+++ b/requirements_distributed.txt
@@ -10,7 +10,7 @@ tblib
 awscli
 
 # https://github.com/databrickslabs/dolly/issues/125
-deepspeed<0.9
+deepspeed<=0.9.2
 
 # requirements for daft
 getdaft[ray]


### PR DESCRIPTION
Previously, we were defaulting to 0.8.3 which has a few bugs that are fixed in deepspeed 0.9.2. I'm temporarily pinning this version, and will test deepspeed 0.9.5 at a future point so we can unpin deepspeed. 