### PR TITLE
typo in parameter of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ trainer:
   batch_size: 64
   optimizer:
     type: adamw
-    beat1: 0.9
+    bata1: 0.9
   learning_rate: 0.001
 
 backend:


### PR DESCRIPTION
corrected beat1 to beta1 in parameters of the trainer type : adamw 
in line 224 
in readme.md