### PR TITLE
Remove `tables` requirement as it causes issues installing ludwig in linux env.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ PyYAML>=3.12
 absl-py
 kaggle
 requests
-tables
 fsspec[http]
 dataclasses-json
 jsonschema>=4.5.0,<4.7

--- a/requirements_distributed.txt
+++ b/requirements_distributed.txt
@@ -3,7 +3,7 @@ dask[dataframe]<2023.4.0
 pyarrow
 
 # requirements for ray
-ray[default,data,serve,tune]>=2.2.0
+ray[default,data,serve,tune]>=2.2.0,<2.5
 tensorboardX<2.3
 GPUtil
 tblib


### PR DESCRIPTION
`tables`, afaict, isn't used anywhere directly in ludwig code.

```
python3 -m venv env
source env/bin/activate
pip install ludwig
```

Installation errors out:
```
...

Collecting tables
  Using cached tables-3.8.0.tar.gz (8.0 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [11 lines of output]
      <string>:19: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
      ld: library not found for -lhdf5
      clang: error: linker command failed with exit code 1 (use -v to see invocation)
      cpuinfo failed, assuming no CPU features: 'flags'
      * Using Python 3.11.3 (main, Apr  7 2023, 21:05:46) [Clang 14.0.0 (clang-1400.0.29.202)]
      * Found cython 3.0.0
      * USE_PKGCONFIG: True
      .. ERROR:: Could not find a local HDF5 installation.
         You may need to explicitly state where your local HDF5 headers and
         library can be found by setting the ``HDF5_DIR`` environment
         variable or by using the ``--hdf5`` command-line option.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```