### PR TITLE
Exclude frozen weights from checkpoints and fix evaluation using quantized LLMs

### DIFF
--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -25,7 +25,7 @@ from ludwig.data.dataset.base import Dataset, DatasetManager
 from ludwig.data.sampler import DistributedSampler
 from ludwig.distributed import DistributedStrategy
 from ludwig.features.base_feature import BaseFeature
-from ludwig.utils.data_utils import DATA_TRAIN_HDF5_FP, save_hdf5
+from ludwig.utils.data_utils import DATA_TRAIN_HDF5_FP, load_hdf5, save_hdf5
 from ludwig.utils.dataframe_utils import from_numpy_dataset, to_numpy_dataset, to_scalar_df
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.fs_utils import download_h5
@@ -37,6 +37,9 @@ class PandasDataset(Dataset):
         self.features = features
         self.data_hdf5_fp = data_hdf5_fp
         self.size = len(dataset)
+
+        if isinstance(dataset, str):
+            dataset = load_hdf5(dataset)
         self.dataset = to_numpy_dataset(dataset)
 
     def to_df(self, features: Optional[Iterable[BaseFeature]] = None) -> DataFrame:

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -80,6 +80,10 @@ class PandasDataset(Dataset):
         return self.size
 
     @property
+    def processed_data_fp(self) -> Optional[str]:
+        return self.data_hdf5_fp
+
+    @property
     def in_memory_size_bytes(self):
         df = self.to_df()
         return df.memory_usage(deep=True).sum() if df is not None else 0

--- a/ludwig/distributed/deepspeed.py
+++ b/ludwig/distributed/deepspeed.py
@@ -210,6 +210,7 @@ class DeepSpeedCheckpoint(Checkpoint):
         if self.scheduler is not None:
             client_state["scheduler_state"] = self.scheduler.state_dict()
 
+        # TODO: set exclude_frozen_parameters=True to only save PEFT weights
         self.model.save_checkpoint(save_path, client_state=client_state)
 
     def get_state_for_inference(self, save_path: str, device: Optional[torch.device] = None) -> Mapping[str, Any]:

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -80,9 +80,7 @@ def load_pretrained_from_config(config_obj: LLMModelConfig, weights_save_path: O
 
     logger.info("Loading large language model...")
     pretrained_model_name_or_path = weights_save_path or config_obj.base_model
-    model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
-        pretrained_model_name_or_path, **load_kwargs
-    )
+    model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path, **load_kwargs)
     return model
 
 
@@ -379,9 +377,7 @@ class LLM(BaseModel):
                 # Wrap with flash attention backend for faster generation
                 with torch.backends.cuda.sdp_kernel(
                     enable_flash=True, enable_math=False, enable_mem_efficient=False
-                ) if (
-                    torch.cuda.is_available() and self.curr_device.type == "cuda"
-                ) else contextlib.nullcontext():
+                ) if (torch.cuda.is_available() and self.curr_device.type == "cuda") else contextlib.nullcontext():
                     # Generate text using the model
                     model_outputs = self.model.generate(
                         input_ids=input_ids_sample_no_padding,

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -823,7 +823,8 @@ class Trainer(BaseTrainer):
                     if self.distributed.is_model_parallel():
                         # Assume the full weights cannot fit in memory on GPU
                         self.model = self.model.cpu()
-                    self.model.load_state_dict(state_dict)
+                    _, unexpected_keys = self.model.load_state_dict(state_dict, strict=False)
+                    assert unexpected_keys == [], f"Unexpected keys found in state dict: {unexpected_keys}"
             elif return_state_dict:
                 state_dict = self.model.cpu().state_dict()
 


### PR DESCRIPTION
Saving all weights was slowing down training and bloating disk usage, since we only need to save weights trained as part of the PEFT adapter.

Previous implementation was reloading the model without quantization, leading to weights being placed on CPU and erroring during eval.