### PR TITLE
int: Pin `sqlalchemy` to `1.x.x` versions

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -14,7 +14,9 @@ ConfigSpace
 
 # search_alg: ax
 ax-platform
-sqlalchemy
+
+# Pinning because aimstack does not support 2.x.x - https://github.com/aimhubio/aim/issues/2514
+sqlalchemy<2
 
 # search_alg: bayesopt
 bayesian-optimization


### PR DESCRIPTION
Was experimenting with my ludwig installation, and I came across this error while trying to run a basic test:
```
Created a temporary directory at /tmp/tmphl05r644
Writing /tmp/tmphl05r644/_remote_module_non_scriptable.py
[2023-08-02 23:23:56,329] [INFO] [real_accelerator.py:133:get_accelerator] Setting ds_accelerator to cuda (auto detect)
ImportError while loading conftest '/home/ksbrar/work/ludwig-2/tests/conftest.py'.
tests/conftest.py:35: in <module>
    from ludwig.hyperopt.run import hyperopt
ludwig/hyperopt/run.py:11: in <module>
    from ludwig.api import LudwigModel
ludwig/api.py:40: in <module>
    from ludwig.backend import Backend, initialize_backend, provision_preprocessing_workers
ludwig/backend/__init__.py:22: in <module>
    from ludwig.backend.base import Backend, LocalBackend
ludwig/backend/base.py:32: in <module>
    from ludwig.data.cache.manager import CacheManager
ludwig/data/cache/manager.py:8: in <module>
    from ludwig.data.dataset.base import DatasetManager
ludwig/data/dataset/base.py:21: in <module>
    from ludwig.distributed import DistributedStrategy
ludwig/distributed/__init__.py:3: in <module>
    from ludwig.distributed.base import DistributedStrategy, LocalStrategy
ludwig/distributed/base.py:9: in <module>
    from ludwig.modules.optimization_modules import create_optimizer
ludwig/modules/optimization_modules.py:21: in <module>
    from ludwig.utils.torch_utils import LudwigModule
ludwig/utils/torch_utils.py:14: in <module>
    from ludwig.utils.strings_utils import SpecialSymbol
ludwig/utils/strings_utils.py:33: in <module>
    from ludwig.utils.tokenizers import get_tokenizer_from_registry
ludwig/utils/tokenizers.py:26: in <module>
    from ludwig.utils.hf_utils import load_pretrained_hf_tokenizer
ludwig/utils/hf_utils.py:7: in <module>
    from transformers import AutoConfig, AutoTokenizer, LlamaConfig, PreTrainedModel
../../.venvwrapper_virtualenvs/ludwig-2/lib/python3.8/site-packages/transformers/utils/import_utils.py:1089: in __getattr__
    module = self._get_module(self._class_to_module[name])
../../.venvwrapper_virtualenvs/ludwig-2/lib/python3.8/site-packages/transformers/utils/import_utils.py:1101: in _get_module
    raise RuntimeError(
E   RuntimeError: Failed to import transformers.modeling_utils because of the following error (look up to see its traceback):
E   Aim v3.17.5 does not support sqlalchemy v2.0.0. Please check the following issue for further updates: https://github.com/aimhubio/aim/issues/2514
```

It seems the aim package from aimstack only supports sqlalchemy 1.x.x, and there is an open issue in their repo to add support (https://github.com/aimhubio/aim/issues/2514)