### PR TITLE
Add use_pretrained attribute for AutoTransformers

### DIFF
--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -3092,6 +3092,13 @@ class AutoTransformerConfig(HFEncoderConfig):
         description=ENCODER_METADATA["AutoTransformer"]["type"].long_description,
     )
 
+    use_pretrained: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether to use the pretrained weights for the model. If false, the model will train from "
+        "scratch which is very computationally expensive.",
+        parameter_metadata=ENCODER_METADATA["AutoTransformer"]["use_pretrained"],
+    )
+
     pretrained_model_name_or_path: str = schema_utils.String(
         default=None,
         allow_none=True,

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -3092,12 +3092,9 @@ class AutoTransformerConfig(HFEncoderConfig):
         description=ENCODER_METADATA["AutoTransformer"]["type"].long_description,
     )
 
-    use_pretrained: bool = schema_utils.Boolean(
-        default=True,
-        description="Whether to use the pretrained weights for the model. If false, the model will train from "
-        "scratch which is very computationally expensive.",
-        parameter_metadata=ENCODER_METADATA["AutoTransformer"]["use_pretrained"],
-    )
+    # Always set this to True since we always want to use the pretrained weights
+    # We don't currently support training from scratch for AutoTransformers
+    use_pretrained: bool = True
 
     pretrained_model_name_or_path: str = schema_utils.String(
         default=None,

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -2574,7 +2574,7 @@ class FlauBERTConfig(HFEncoderConfig):
     )
 
     use_pretrained: bool = schema_utils.Boolean(
-        default=False,
+        default=True,
         description="Whether to use the pretrained weights for the model. If false, the model will train from "
         "scratch which is very computationally expensive.",
         parameter_metadata=ENCODER_METADATA["FlauBERT"]["use_pretrained"],
@@ -3081,6 +3081,11 @@ class AutoTransformerConfig(HFEncoderConfig):
         if self.pretrained_model_name_or_path is None:
             raise ConfigValidationError(
                 "`pretrained_model_name_or_path` must be specified for encoder: `auto_transformer`."
+            )
+
+        if not self.use_pretrained:
+            raise ConfigValidationError(
+                "Training `auto_transformer` from scratch is not supported. Set `use_pretrained` to `True`."
             )
 
     @staticmethod

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -3083,23 +3083,20 @@ class AutoTransformerConfig(HFEncoderConfig):
                 "`pretrained_model_name_or_path` must be specified for encoder: `auto_transformer`."
             )
 
-        if not self.use_pretrained:
-            raise ConfigValidationError(
-                "Training `auto_transformer` from scratch is not supported. Set `use_pretrained` to `True`."
-            )
-
     @staticmethod
     def module_name():
         return "AutoTransformer"
+
+    @property
+    def use_pretrained(self) -> bool:
+        # Always set this to True since we always want to use the pretrained weights
+        # We don't currently support training from scratch for AutoTransformers
+        return True
 
     type: str = schema_utils.ProtectedString(
         "auto_transformer",
         description=ENCODER_METADATA["AutoTransformer"]["type"].long_description,
     )
-
-    # Always set this to True since we always want to use the pretrained weights
-    # We don't currently support training from scratch for AutoTransformers
-    use_pretrained: bool = True
 
     pretrained_model_name_or_path: str = schema_utils.String(
         default=None,

--- a/ludwig/schema/metadata/configs/encoders.yaml
+++ b/ludwig/schema/metadata/configs/encoders.yaml
@@ -412,26 +412,6 @@ AutoTransformer:
     trainable:
         expected_impact: 3
         ui_display_name: null
-    use_pretrained:
-        default_value_reasoning:
-            By default, the model is initialized as a pretrained
-            model.
-        description_implications:
-            Pretrained models have typically already learned
-            features that are difficult to learn from scratch. They are particularly
-            beneficial when training on small amounts of data.
-        expected_impact: 3
-        literature_references:
-            - https://machinelearningmastery.com/transfer-learning-for-deep-learning/
-        related_parameters:
-            - trainable, pretrained_model_name, pretrained_model_name_or_path, pretrained_kwargs
-        suggested_values:
-            - false
-        suggested_values_reasoning:
-            If you have a large amount of data and/or you
-            have data that differs from the typical distribution, then it might be
-            worth training the model from scratch.
-        ui_display_name: Use Pretrained
     vocab:
         default_value_reasoning:
             Computed and passed along internally according to

--- a/ludwig/schema/metadata/configs/encoders.yaml
+++ b/ludwig/schema/metadata/configs/encoders.yaml
@@ -412,6 +412,26 @@ AutoTransformer:
     trainable:
         expected_impact: 3
         ui_display_name: null
+    use_pretrained:
+        default_value_reasoning:
+            By default, the model is initialized as a pretrained
+            model.
+        description_implications:
+            Pretrained models have typically already learned
+            features that are difficult to learn from scratch. They are particularly
+            beneficial when training on small amounts of data.
+        expected_impact: 3
+        literature_references:
+            - https://machinelearningmastery.com/transfer-learning-for-deep-learning/
+        related_parameters:
+            - trainable, pretrained_model_name, pretrained_model_name_or_path, pretrained_kwargs
+        suggested_values:
+            - false
+        suggested_values_reasoning:
+            If you have a large amount of data and/or you
+            have data that differs from the typical distribution, then it might be
+            worth training the model from scratch.
+        ui_display_name: Use Pretrained
     vocab:
         default_value_reasoning:
             Computed and passed along internally according to

--- a/tests/ludwig/encoders/test_text_encoders.py
+++ b/tests/ludwig/encoders/test_text_encoders.py
@@ -210,7 +210,6 @@ def test_hf_ludwig_model_auto_transformers(tmpdir, csv_filename, pretrained_mode
                 "min_len": 1,
                 "type": "auto_transformer",
                 "pretrained_model_name_or_path": pretrained_model_name_or_path,
-                "use_pretrained": True,
             },
         )
     ]


### PR DESCRIPTION
Fixes the following error:

```
'AutoTransformerConfig' object has no attribute 'use_pretrained'
```

when trying to train an custom transformer model from HF using a config that looks like this:

```
encoder:
      type: auto_transformer
      trainable: false
      pretrained_model_name_or_path: huggyllama/llama-7b
    preprocessing:
      tokenizer: space_punct
      max_sequence_length: null
```
