### PR TITLE
Remove tables for Ludwig 0.7.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ PyYAML>=3.12
 absl-py
 kaggle
 requests
-tables
 fsspec[http]
 dataclasses-json
 jsonschema>=4.5.0,<4.7


### PR DESCRIPTION
This dependency causes installation of ludwig v0.7.4 to fail.