### PR TITLE
Add mechanic to override default values for generation during model.predict()

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -831,6 +831,7 @@ class LudwigModel:
         data_format: str = None,
         split: str = FULL,
         batch_size: int = 128,
+        generation_config: Optional[Dict] = None,
         skip_save_unprocessed_output: bool = True,
         skip_save_predictions: bool = True,
         output_directory: str = "results",
@@ -840,45 +841,41 @@ class LudwigModel:
     ) -> Tuple[Union[dict, pd.DataFrame], str]:
         """Using a trained model, make predictions from the provided dataset.
 
-        # Inputs
-        :param dataset: (Union[str, dict, pandas.DataFrame]) source containing
-            the entire dataset to be evaluated.
-        :param data_format: (str, default: `None`) format to interpret data
-            sources. Will be inferred automatically if not specified.  Valid
-            formats are `'auto'`, `'csv'`, `'df'`, `'dict'`, `'excel'`, `'feather'`,
-            `'fwf'`, `'hdf5'` (cache file produced during previous training),
-            `'html'` (file containing a single HTML `<table>`), `'json'`, `'jsonl'`,
-            `'parquet'`, `'pickle'` (pickled Pandas DataFrame), `'sas'`, `'spss'`,
-            `'stata'`, `'tsv'`.
-        :param: split: (str, default= `'full'`): if the input dataset contains
-            a split column, this parameter indicates which split of the data
-            to use. Possible values are `'full'`, `'training'`, `'validation'`, `'test'`.
-        :param batch_size: (int, default: 128) size of batch to use when making
-            predictions.
-        :param skip_save_unprocessed_output: (bool, default: `True`) if this
-            parameter is `False`, predictions and their probabilities are saved
-            in both raw unprocessed numpy files containing tensors and as
-            postprocessed CSV files (one for each output feature).
-            If this parameter is `True`, only the CSV ones are saved and the
-            numpy ones are skipped.
-        :param skip_save_predictions: (bool, default: `True`) skips saving
-            test predictions CSV files.
-        :param output_directory: (str, default: `'results'`) the directory that
-            will contain the training statistics, TensorBoard logs, the saved
-            model and the training progress files.
-        :param return_type: (Union[str, dict, pandas.DataFrame], default: pd.DataFrame)
-            indicates the format of the returned predictions.
-        :param callbacks: (Optional[List[Callback]], default: None)
-            optional list of callbacks to use during this predict operation. Any callbacks
-            already registered to the model will be preserved.
+        Args:
+            dataset: (Union[str, dict, pandas.DataFrame]): source containing the entire dataset to be evaluated.
+            data_format: (str, default: `None`) format to interpret data sources. Will be inferred automatically if not
+                specified.  Valid formats are `'auto'`, `'csv'`, `'df'`, `'dict'`, `'excel'`, `'feather'`, `'fwf'`,
+                `'hdf5'` (cache file produced during previous training), `'html'` (file containing a single HTML
+                `<table>`), `'json'`, `'jsonl'`, `'parquet'`, `'pickle'` (pickled Pandas DataFrame), `'sas'`, `'spss'`,
+                `'stata'`, `'tsv'`.
+            split: (str, default= `'full'`):  if the input dataset contains a split column, this parameter indicates
+                which split of the data to use. Possible values are `'full'`, `'training'`, `'validation'`, `'test'`.
+            batch_size: (int, default: 128) size of batch to use when making predictions.
+            generation_config: Dict, default: `None`) config for the generation of the predictions. If `None`, the
+                config that was used during model training is used.
+            skip_save_unprocessed_output: (bool, default: `True`) if this parameter is `False`, predictions and their
+                probabilities are saved in both raw unprocessed numpy files containing tensors and as postprocessed CSV
+                files (one for each output feature). If this parameter is `True`, only the CSV ones are saved and the
+                numpy ones are skipped.
+            skip_save_predictions: (bool, default: `True`) skips saving test predictions CSV files.
+            output_directory: (str, default: `'results'`) the directory that will contain the training statistics,
+                TensorBoard logs, the saved model and the training progress files.
+            return_type: (Union[str, dict, pandas.DataFrame], default: pd.DataFrame) indicates the format of the
+                returned predictions.
+            callbacks: (Optional[List[Callback]], default: None) optional list of callbacks to use during this predict
+                operation. Any callbacks already registered to the model will be preserved.
 
-        # Return
-
-        :return: (Tuple[Union[dict, pd.DataFrame], str]) `(predictions, output_directory)`
-            `predictions` predictions from the provided dataset,
-            `output_directory` filepath string to where data was stored.
+        Returns:
+            `(predictions, output_directory)`: (Tuple[Union[dict, pd.DataFrame], str])
+                `predictions` predictions from the provided dataset,
+                `output_directory` filepath string to where data was stored.
         """
         self._check_initialization()
+
+        # Set the generation config if it exists.
+        # model.reset_generation_config() is called after batch prediction.
+        if generation_config is not None:
+            self.model.set_generation_config(generation_config)
 
         # preprocessing
         logger.debug("Preprocessing")
@@ -898,6 +895,10 @@ class LudwigModel:
             predictions = predictor.batch_predict(
                 dataset,
             )
+
+            # If there was a generation config, reset it.
+            if generation_config is not None:
+                self.model.reset_generation_config()
 
             if self.backend.is_coordinator():
                 # if we are skipping all saving,

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -872,11 +872,6 @@ class LudwigModel:
         """
         self._check_initialization()
 
-        # Set the generation config if it exists.
-        # model.reset_generation_config() is called after batch prediction.
-        if generation_config is not None:
-            self.model.set_generation_config(generation_config)
-
         # preprocessing
         logger.debug("Preprocessing")
         dataset, _ = preprocess_for_prediction(  # TODO (Connor): Refactor to use self.config_obj
@@ -890,13 +885,18 @@ class LudwigModel:
             callbacks=self.callbacks + (callbacks or []),
         )
 
+        # Set the generation config if it exists.
+        # model.reset_generation_config() is called after batch prediction.
+        if generation_config is not None:
+            self.model.set_generation_config(generation_config)
+
         logger.debug("Predicting")
         with self.backend.create_predictor(self.model, batch_size=batch_size) as predictor:
             predictions = predictor.batch_predict(
                 dataset,
             )
 
-            # If there was a generation config, reset it.
+            # If there was a generation config set prior to batch prediction, reset it.
             if generation_config is not None:
                 self.model.reset_generation_config()
 


### PR DESCRIPTION
Sample code:

```python
model = LudwigModel(config=config, logging_level=logging.INFO)
results = model.train(training_set=dataset)
model.predict(dataset=dataset[:1], generation_config={"max_new_tokens": 513})
```

I've added additional logging statements to make it easier for testers/users to verify behavior.