### PR TITLE
Add new sythesized `response` column for text output features during postprocessing

### DIFF
--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -322,7 +322,6 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
         result,
         metadata,
     ):
-        breakpoint()
         # todo: refactor to reuse SequenceOutputFeature.postprocess_predictions
         predictions_col = f"{self.feature_name}_{PREDICTIONS}"
 
@@ -335,7 +334,6 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
             )
 
         if predictions_col in result:
-
             token_col = result[predictions_col]
 
             def idx2str(pred):
@@ -353,10 +351,12 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
             def idx2response(pred):
                 if tokenizer is None:
                     # This works because we treat each word as a token.
-                    return " ".join([
-                        metadata["idx2str"][token] if token < len(metadata["idx2str"]) else UNKNOWN_SYMBOL
-                        for token in pred
-                    ])
+                    return " ".join(
+                        [
+                            metadata["idx2str"][token] if token < len(metadata["idx2str"]) else UNKNOWN_SYMBOL
+                            for token in pred
+                        ]
+                    )
                 return tokenizer.tokenizer.batch_decode([pred], skip_special_tokens=True)
 
             result[f"{self.feature_name}_response"] = token_col.map(idx2response)

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -1167,3 +1167,27 @@ combiner:
     model = LudwigModel(config, logging_level=logging.INFO)
 
     model.train(dataset=df, output_directory=tmpdir)
+
+
+def test_text_output_feature_cols(tmpdir, csv_filename):
+    """Test ensures that there are 4 output columns when model.predict() is called for text output features."""
+    input_features = [text_feature(encoder={"type": "parallel_cnn"})]
+    output_features = [text_feature(output_feature=True)]
+
+    # Generate test data
+    rel_path = generate_data(input_features, output_features, os.path.join(tmpdir, csv_filename))
+
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        "trainer": {"train_steps": 2, "batch_size": 5},
+    }
+
+    model = LudwigModel(config, logging_level=logging.INFO)
+    model.train(dataset=rel_path, output_directory=tmpdir)
+    predict_output = model.predict(dataset=rel_path)[0]
+
+    assert len(predict_output.columns) == 4
+
+    predict_df_headers = {col_name.split("_")[2] for col_name in list(predict_output.columns)}
+    assert predict_df_headers == {"predictions", "probability", "probabilities", "response"}

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -129,10 +129,12 @@ def test_llm_text_to_text(tmpdir, backend, ray_cluster_4cpu):
     assert "Answer_predictions" in preds
     assert "Answer_probabilities" in preds
     assert "Answer_probability" in preds
+    assert "Answer_response" in preds
 
     assert preds["Answer_predictions"]
     assert preds["Answer_probabilities"]
     assert preds["Answer_probability"]
+    assert preds["Answer_response"]
 
 
 @pytest.mark.llm


### PR DESCRIPTION
This PR enables adds a new output column when calling `model.predict()` for text output features called `response`. It is the synthesized string representation of each of the tokens in the `predictions` column.

For non HF pretrained models, it simply concatenates with white spaces since the underlying vocabulary created is a per-word vocab, while for HF models with tokenizers, it does proper batch decoding to create the right output string.

The new output from the text features will have:

```
<feature_name>_predictions
<feature_name>_probabilities
<feature_name>_probability
<feature_name>_response
```