### PR TITLE
Move loss metric to same device as inputs

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -467,7 +467,11 @@ class LLM(BaseModel):
                 continue
             of_obj.update_metrics(targets[of_name], predictions[of_name])
 
+        # HACK (Tim): get the device of the targets to transfer self.eval_loss_metric to the same device
+        target_device = list(targets.values())[0].device
+
         eval_loss, additional_losses = self.eval_loss(targets, predictions)
+        self.eval_loss_metric = self.eval_loss_metric.to(target_device)
         self.eval_loss_metric.update(eval_loss)
         self.eval_additional_losses_metrics.update(additional_losses)
 


### PR DESCRIPTION
Previously: evaluation loss metric could be on a different device than inputs

Now: evaluation loss metric moved to same device as inputs