### PR TITLE
Ensure user sets backend to local w/ quantization

### DIFF
--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -591,6 +591,8 @@ def _get_llm_model_config(model_name: str) -> AutoConfig:
 def check_llm_quantization_backend_incompatibility(config: "ModelConfig") -> None:  # noqa: F821
     """Checks that LLM model type with quantization uses the local backend."""
     if config.backend is None:
+        if config.model_type == MODEL_LLM and config.quantization:
+            raise ConfigValidationError("LLM with quantization requires the 'local' backend to be set in the config.")
         return
 
     backend_type = config.backend.get("type", "local")

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -444,6 +444,8 @@ output_features:
     type: text
 trainer:
   type: finetune
+backend:
+  type: local
 """
     )
 

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -421,7 +421,8 @@ backend:
     ModelConfig.from_dict(config)
 
     del config["backend"]
-    ModelConfig.from_dict(config)
+    with pytest.raises(ConfigValidationError):
+        ModelConfig.from_dict(config)
 
     del config["quantization"]
     config["backend"] = {"type": "ray"}

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -847,6 +847,7 @@ def test_llm_quantization_config(bits: Optional[int], expected_qconfig: Optional
         "quantization": {"bits": bits},
         INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
         OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
+        "backend": {"type": "local"},
     }
 
     if bits is None:


### PR DESCRIPTION
Previously: users could omit backend from their config when running LLM finetuning with quantization

Now: users are prompted to set backend to local explicitly when running LLM finetuning with quantization
