### PR TITLE
[bug] Support preprocessing `datetime.date` date features

### DIFF
--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 import logging
-from datetime import datetime
+from datetime import date, datetime
 from typing import Dict, List
 
 import numpy as np
@@ -66,6 +66,8 @@ class DateFeatureMixin(BaseFeatureMixin):
         try:
             if isinstance(date_value, datetime):
                 datetime_obj = date_value
+            elif isinstance(date_value, date):
+                datetime_obj = datetime.combine(date=date_value, time=datetime.min.time())
             elif isinstance(date_value, str) and datetime_format is not None:
                 try:
                     datetime_obj = datetime.strptime(date_value, datetime_format)

--- a/tests/ludwig/features/test_date_feature.py
+++ b/tests/ludwig/features/test_date_feature.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, List
 
 import pytest
@@ -157,3 +157,26 @@ def test_date_to_list__UsesFillValueOnInvalidDate():
         0,
         0,
     ]
+
+
+@pytest.fixture(scope="module")
+def date_obj():
+    return date.fromisoformat("2022-06-25")
+
+
+@pytest.fixture(scope="module")
+def date_obj_vec():
+    return create_vector_from_datetime_obj(datetime.fromisoformat("2022-06-25"))
+
+
+def test_date_object_to_list(date_obj, date_obj_vec, fill_value):
+    """Test support for datetime.date object conversion.
+
+    Args:
+        date_obj: Date object to convert into a vector
+        date_obj_vector: Expected vector version of `date_obj`
+    """
+    computed_date_vec = date_feature.DateInputFeature.date_to_list(
+        date_obj, None, preprocessing_parameters={MISSING_VALUE_STRATEGY: FILL_WITH_CONST, "fill_value": fill_value}
+    )
+    assert computed_date_vec == date_obj_vec


### PR DESCRIPTION
Currently, date feature preprocessing supports `datetime.datetime` objects, ISO time strings, custom time strings, and int/float timestamps. `datetime.date` objects, however, are considered invalid and replaced with the fill value despite being valid date features. This update

 - adds support for `datetime.date` objects to `DateFeatureMixin.date_to_list`
 - adds a test for `datetime.date` support