### PR TITLE
[bug] Pin pydantic to < 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ torch>=1.13.0
 torchaudio
 torchtext
 torchvision
+pydantic<2.0
 transformers>=4.31.0
 tokenizers>=0.13.3
 spacy>=2.3


### PR DESCRIPTION
When installing Ludwig in a new env, `transformers` will raise the following error

```
RuntimeError: Failed to import transformers.modeling_utils because of the following error (look up to see its traceback):
If you use `@root_validator` with pre=False (the default) you MUST specify `skip_on_failure=True`. Note that `@root_validator` is deprecated and should be replaced with `@model_validator`.
```

`transformers` requires `pydantic` 1.x, however `pydantic` 2.x is being installed. More details can be found in [this issue](https://github.com/huggingface/transformers/pull/24596). This update pins `pydantic` to 1.x while `transformers` is being updated.