### PR TITLE
Fix pad + bos token issues for all models

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -553,6 +553,13 @@ class LLM(BaseModel):
             _predictions = predictions
 
             of_train_loss = of_obj.train_loss(_targets[of_name], _predictions, of_name)
+            if torch.isnan(of_train_loss).item():
+                logger.warning(
+                    "Training loss for current batch was NaN. This is likely because of exploding gradients. "
+                    "You may need to decrease your learning rate, change gradient clipping parameters, or try use non "
+                    "quantized training."
+                )
+
             train_loss += of_obj.loss.weight * of_train_loss
             of_train_losses[of_name] = of_train_loss
 

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -24,7 +24,7 @@ from ludwig.utils.llm_utils import (
     generate_merged_ids,
     pad_target_tensor_for_fine_tuning,
     realign_target_and_prediction_tensors_for_inference,
-    remove_left_padding,
+    remove_left_padding_and_bos_token,
     set_pad_token,
 )
 from ludwig.utils.logging_utils import log_once
@@ -395,7 +395,7 @@ class LLM(BaseModel):
             input_lengths = []
             sequences_list = []
             for input_ids_sample in input_ids:
-                input_ids_sample_no_padding = remove_left_padding(input_ids_sample, self.tokenizer)
+                input_ids_sample_no_padding = remove_left_padding_and_bos_token(input_ids_sample, self.tokenizer)
                 logger.info(
                     "Decoded text inputs for the first example in batch: "
                     f"{self.tokenizer.decode(input_ids_sample_no_padding[0], skip_special_tokens=True)}"
@@ -666,7 +666,7 @@ class LLM(BaseModel):
 
         pad_token_tensor = torch.tensor([self.tokenizer.pad_token_id])
         for target in targets[of_name]:
-            target = remove_left_padding(target, self.tokenizer)[0]
+            target = remove_left_padding_and_bos_token(target, self.tokenizer)[0]
             target = torch.cat([target, pad_token_tensor.to(device=target.device)], dim=-1).unsqueeze(0)
             targets_without_padding.append(target)
             lengths.append(target.shape[1])

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -101,14 +101,6 @@ def load_pretrained_from_config(
     logger.info("Loading large language model...")
     pretrained_model_name_or_path = weights_save_path or config_obj.base_model
     model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path, **load_kwargs)
-
-    # HACK(Arnav): The original Llama and Llama-2 models use pad_id = -1 which means that there is no padding token.
-    # During preprocessing, we add a padding token using tokenizer.add_special_tokens({"pad_token":"<pad>"}). To make
-    # sure this is reflected properly, we need to resize the model's token embeddings to include the new padding token.
-    if isinstance(model.config, LlamaConfig):
-        # Ensures that encoding the padding token will output zeros.
-        model.get_input_embeddings().padding_idx = tokenizer.pad_token_id
-
     return model
 
 

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -281,14 +281,15 @@ def generate_merged_ids(
     merged_input_and_targets = []
     lengths = []
 
-    pad_tensor = torch.tensor([tokenizer.pad_token_id]).to(target_ids[0].device)
+    # pad_tensor = torch.tensor([tokenizer.pad_token_id]).to(target_ids[0].device)
+    eos_tensor = torch.tensor([tokenizer.eos_token_id]).to(target_ids[0].device)
 
     # Merge input_ids and target_ids by concatenating them together.
     # We remove the left padding from both input_ids and target_ids before concatenating them.
     for input_id_sample, target_id_sample in zip(input_ids, target_ids):
         input_id_sample_no_padding = remove_left_padding_and_bos_token(input_id_sample, tokenizer)[0]
         target_id_sample_no_padding = remove_left_padding_and_bos_token(target_id_sample, tokenizer)[0]
-        target_id_sample_no_padding = torch.cat((target_id_sample_no_padding, pad_tensor), dim=-1)
+        target_id_sample_no_padding = torch.cat((target_id_sample_no_padding, eos_tensor), dim=-1)
 
         merged_sample_ids = torch.cat((input_id_sample_no_padding, target_id_sample_no_padding), dim=-1)
         # If the merged tensor is longer than the maximum sequence length, we truncate it.

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -33,15 +33,13 @@ def set_pad_token(tokenizer: PreTrainedTokenizer):
         return
 
     # HACK(Arnav): LlamaTokenizer has no pad token. Recommendation is to use a custom pad token
-    # instead. https://huggingface.co/docs/transformers/model_doc/llama2
-    # The original model uses pad_id = -1 which means that there is not padding token. We can’t have the
-    # same logic, make sure to add a padding token using tokenizer.add_special_tokens({"pad_token":"<pad>"})
-    # and resize the token embedding accordingly.
+    # instead. https://huggingface.co/docs/transformers/model_doc/llama2 but this is very hard to implement
+    # with embedding resizing. The other suggested approach is to set this to unk token. That is what
+    # is implemented here.
     if any(isinstance(tokenizer, t) for t in [LlamaTokenizer, LlamaTokenizerFast]):
-        # This adds <pad> as a new token in the vocabulary and sets the pad_token_id to the new token's id,
-        # which is the last token in the vocabulary (new). For both tokenizer variants, this adds <pad> as the
-        # 32001th token with token ID 32000.
-        tokenizer.add_special_tokens({"pad_token": "<pad>"})
+        tokenizer.pad_token = tokenizer.unk_token
+        tokenizer.pad_token_id = tokenizer.unk_token_id
+        return
 
 
 def has_padding_token(input_tensor: torch.Tensor, tokenizer: PreTrainedTokenizer):

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -281,15 +281,16 @@ def generate_merged_ids(
     merged_input_and_targets = []
     lengths = []
 
-    # pad_tensor = torch.tensor([tokenizer.pad_token_id]).to(target_ids[0].device)
+    pad_tensor = torch.tensor([tokenizer.pad_token_id]).to(target_ids[0].device)
     eos_tensor = torch.tensor([tokenizer.eos_token_id]).to(target_ids[0].device)
 
     # Merge input_ids and target_ids by concatenating them together.
     # We remove the left padding from both input_ids and target_ids before concatenating them.
     for input_id_sample, target_id_sample in zip(input_ids, target_ids):
         input_id_sample_no_padding = remove_left_padding_and_bos_token(input_id_sample, tokenizer)[0]
+
         target_id_sample_no_padding = remove_left_padding_and_bos_token(target_id_sample, tokenizer)[0]
-        target_id_sample_no_padding = torch.cat((target_id_sample_no_padding, eos_tensor), dim=-1)
+        target_id_sample_no_padding = torch.cat((target_id_sample_no_padding, pad_tensor, eos_tensor), dim=-1)
 
         merged_sample_ids = torch.cat((input_id_sample_no_padding, target_id_sample_no_padding), dim=-1)
         print(merged_sample_ids)

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -282,7 +282,6 @@ def generate_merged_ids(
     lengths = []
 
     pad_tensor = torch.tensor([tokenizer.pad_token_id]).to(target_ids[0].device)
-    eos_tensor = torch.tensor([tokenizer.eos_token_id]).to(target_ids[0].device)
 
     # Merge input_ids and target_ids by concatenating them together.
     # We remove the left padding from both input_ids and target_ids before concatenating them.
@@ -290,10 +289,9 @@ def generate_merged_ids(
         input_id_sample_no_padding = remove_left_padding_and_bos_token(input_id_sample, tokenizer)[0]
 
         target_id_sample_no_padding = remove_left_padding_and_bos_token(target_id_sample, tokenizer)[0]
-        target_id_sample_no_padding = torch.cat((target_id_sample_no_padding, pad_tensor, eos_tensor), dim=-1)
+        target_id_sample_no_padding = torch.cat((target_id_sample_no_padding, pad_tensor), dim=-1)
 
         merged_sample_ids = torch.cat((input_id_sample_no_padding, target_id_sample_no_padding), dim=-1)
-        print(merged_sample_ids)
 
         # If the merged tensor is longer than the maximum sequence length, we truncate it.
         if max_sequence_length and merged_sample_ids.shape[0] > max_sequence_length:

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -292,6 +292,8 @@ def generate_merged_ids(
         target_id_sample_no_padding = torch.cat((target_id_sample_no_padding, eos_tensor), dim=-1)
 
         merged_sample_ids = torch.cat((input_id_sample_no_padding, target_id_sample_no_padding), dim=-1)
+        print(merged_sample_ids)
+
         # If the merged tensor is longer than the maximum sequence length, we truncate it.
         if max_sequence_length and merged_sample_ids.shape[0] > max_sequence_length:
             merged_sample_ids = merged_sample_ids[:max_sequence_length]

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -827,15 +827,13 @@ class HFTokenizer(BaseTokenizer):
                 self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
 
         # HACK(Arnav): LlamaTokenizer has no pad token. Recommendation is to use a custom pad token
-        # instead. https://huggingface.co/docs/transformers/model_doc/llama2
-        # The original model uses pad_id = -1 which means that there is not padding token. We can’t have the
-        # same logic, make sure to add a padding token using tokenizer.add_special_tokens({"pad_token":"<pad>"})
-        # and resize the token embedding accordingly.
+        # instead. https://huggingface.co/docs/transformers/model_doc/llama2 but this is very hard to implement
+        # with embedding resizing. The other suggested approach is to set this to unk token. That is what
+        # is implemented here.
         if any(isinstance(self.tokenizer, t) for t in [LlamaTokenizer, LlamaTokenizerFast]):
-            # This adds <pad> as a new token in the vocabulary and sets the pad_token_id to the new token's id,
-            # which is the last token in the vocabulary (new). For both tokenizer variants, this adds <pad> as the
-            # 32001th token with token ID 32000.
-            self.tokenizer.add_special_tokens({"pad_token": "<pad>"})
+            self.tokenizer.pad_token = self.tokenizer.unk_token
+            self.tokenizer.pad_token_id = self.tokenizer.unk_token_id
+            return
 
         # Incase any HF tokenizer does not have pad token ID, just default to using 0
         # as the pad_token_id.

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -820,14 +820,22 @@ class HFTokenizer(BaseTokenizer):
         # HACK(geoffrey): gpt2 has no pad token. Recommendation is to use eos token instead.
         # https://github.com/huggingface/transformers/issues/2630#issuecomment-1290809338
         # https://github.com/huggingface/transformers/issues/2648#issuecomment-616177044
-        if any(
-            isinstance(self.tokenizer, t)
-            for t in [GPT2Tokenizer, GPT2TokenizerFast, LlamaTokenizer, LlamaTokenizerFast]
-        ):
+        if any(isinstance(self.tokenizer, t) for t in [GPT2Tokenizer, GPT2TokenizerFast]):
             if hasattr(self.tokenizer, "eos_token") and self.tokenizer.eos_token is not None:
                 logger.warning("No padding token id found. Using eos_token as pad_token.")
                 self.tokenizer.pad_token = self.tokenizer.eos_token
                 self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+
+        # HACK(Arnav): LlamaTokenizer has no pad token. Recommendation is to use a custom pad token
+        # instead. https://huggingface.co/docs/transformers/model_doc/llama2
+        # The original model uses pad_id = -1 which means that there is not padding token. We can’t have the
+        # same logic, make sure to add a padding token using tokenizer.add_special_tokens({"pad_token":"<pad>"})
+        # and resize the token embedding accordingly.
+        if any(isinstance(self.tokenizer, t) for t in [LlamaTokenizer, LlamaTokenizerFast]):
+            # This adds <pad> as a new token in the vocabulary and sets the pad_token_id to the new token's id,
+            # which is the last token in the vocabulary (new). For both tokenizer variants, this adds <pad> as the
+            # 32001th token with token ID 32000.
+            self.tokenizer.add_special_tokens({"pad_token": "<pad>"})
 
         # Incase any HF tokenizer does not have pad token ID, just default to using 0
         # as the pad_token_id.

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -323,7 +323,7 @@ def test_llm_few_shot_classification(tmpdir, backend, csv_filename, ray_cluster_
 @pytest.mark.parametrize(
     "finetune_strategy,adapter_args,quantization",
     [
-        (None, {}, None),
+        # (None, {}, None),
         # (
         #     "prompt_tuning",
         #     {
@@ -343,26 +343,26 @@ def test_llm_few_shot_classification(tmpdir, backend, csv_filename, ray_cluster_
         # ("p_tuning", {"num_virtual_tokens": 8, "encoder_reparameterization_type": "MLP"}),
         # ("p_tuning", {"num_virtual_tokens": 8, "encoder_reparameterization_type": "LSTM"}),
         ("lora", {}, None),
-        ("lora", {}, {"bits": 4}),  # qlora
+        # ("lora", {}, {"bits": 4}),  # qlora
         # ("adalora", {}),
-        ("adaption_prompt", {"adapter_len": 6, "adapter_layers": 1}, None),
+        # ("adaption_prompt", {"adapter_len": 6, "adapter_layers": 1}, None),
     ],
     ids=[
-        "none",
+        # "none",
         # "prompt_tuning_init_random",
         # "prompt_tuning_init_text",
         # "prefix_tuning",
         # "p_tuning_mlp_reparameterization",
         # "p_tuning_lstm_reparameterization",
         "lora",
-        "qlora",
+        # "qlora",
         # "adalora",
-        "adaption_prompt",
+        # "adaption_prompt",
     ],
 )
 def test_llm_finetuning_strategies(tmpdir, csv_filename, backend, finetune_strategy, adapter_args, quantization):
-    if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
-        pytest.skip("Skip: quantization requires GPU and none are available.")
+    # if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
+    #     pytest.skip("Skip: quantization requires GPU and none are available.")
 
     input_features = [text_feature(name="input", encoder={"type": "passthrough"})]
     output_features = [text_feature(name="output")]
@@ -384,7 +384,7 @@ def test_llm_finetuning_strategies(tmpdir, csv_filename, backend, finetune_strat
         OUTPUT_FEATURES: output_features,
         TRAINER: {
             TYPE: "finetune",
-            BATCH_SIZE: 8,
+            BATCH_SIZE: 1,
             EPOCHS: 2,
         },
         BACKEND: backend,

--- a/tests/ludwig/utils/test_llm_utils.py
+++ b/tests/ludwig/utils/test_llm_utils.py
@@ -11,7 +11,7 @@ from ludwig.utils.llm_utils import (
     has_padding_token,
     pad_target_tensor_for_fine_tuning,
     realign_target_and_prediction_tensors_for_inference,
-    remove_left_padding,
+    remove_left_padding_and_bos_token,
     set_pad_token,
 )
 
@@ -84,13 +84,13 @@ def test_has_padding_token_without_padding_tokens(tokenizer):
         # Padding
         (torch.tensor([1, 5, 5, 3]), torch.tensor([5, 5, 3])),
         # EOS token
-        (torch.tensor([2, 5, 5, 3]), torch.tensor([2, 5, 5, 3])),
+        (torch.tensor([2, 5, 5, 3]), torch.tensor([5, 5, 3])),
         # Padding + EOS token
-        (torch.tensor([1, 2, 5, 5, 3]), torch.tensor([2, 5, 5, 3])),
+        (torch.tensor([1, 2, 5, 5, 3]), torch.tensor([5, 5, 3])),
     ],
 )
-def test_remove_left_padding(input_ids, expected, tokenizer):
-    assert torch.equal(remove_left_padding(input_ids, tokenizer).squeeze(0), expected)
+def test_remove_left_padding_and_bos_token(input_ids, expected, tokenizer):
+    assert torch.equal(remove_left_padding_and_bos_token(input_ids, tokenizer).squeeze(0), expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This fixes some very minor (but potentially serious) bugs in LLM fine-tuning, specifically for Llama-based models. This can cause less accurate text generation outputs during fine-tuning, and may potentially lead to NaN loss during fine-tuning (although there are fairly low chances of this happening since we have already seen good post-finetuning results).

##  Issue 1:
When removing padding tokens from the input and target tensors, we left the BOS token in for both the input and target tensors. This led to the curios case of the merged_tensor looking like `[bos_token, input_tokens, bos_token, target_tokens, pad_token]`. It turns out that this in fact incorrect, and we should remove it from both the input and target tensors before merging them together to instead be represented as `[input_tokens, target_tokens, pad_token]`. This PR fixes this.

##  Issue 2:
2. Llama-based tokenizers don't have padding tokens set by default. Traditionally, the approach has been to set the pad token to the EOS token, and this is what 90% of notebooks do online. However, what they never mention is that this only makes sense when the default padding side is right padding. This makes sense, because you end up with a sequence that is your input tokens + target tokens + EOS token. However, when you do left padding, this is actually causes an issue. Your sequence begins with EOS tokens (since it is what is used as padding), followed by a BOS token, followed by your input tokens + target tokens, and then an EOS token at the very end (which substitutes a final padding token). Effectively, this is going to teach your model not to generate anything, or rather, generate incorrectly because it just sees EOS tokens at the beginning of the sequence. This is not what we want. 

To fix this, there are two recommended approaches:

### Approach 1
Add a special token called "<pad>" to the tokenizer's vocabulary and preprocess the data. Then, when loading in the Llama based model, update the `embed_tokens` layer to use the right padding token/resize the embedding layer. See https://huggingface.co/docs/transformers/model_doc/llama2

> The original model uses pad_id = -1 which means that there is not padding token. We can’t have the same logic, make sure to add a padding token using tokenizer.add_special_tokens({"pad_token":"<pad>"}) and resize the token embedding accordingly. You should also set the model.config.pad_token_id. The embed_tokens layer of the model is initialized withself.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.config.padding_idx), which makes sure that encoding the padding token will output zeros, so passing it when initializing is recommended.

This is actually non-trivial to do unless you're training the model from scratch. The reason is that the new token gets assigned a value of len(vocab) + 1, but the embedding layer has a shape of (vocab, hidden_size) with padding_idx set in advance to the last token in the vocab. Here are some issues I ran into:

- The default embedding layer uses (embed_tokens): Embedding(32000, 4096, padding_idx=31999) 31999 as the padding_idx. By doing the tokenizer.add_special_tokens({"pad_token": "<pad>"}) as HF suggests, it actually increases the vocab_size by 1 and sets the padding token ID to 32000, which is 1 more than the size of the embedding layer (32000).
- If you try and get the config using AutoConfig, then update the config (padding_token_id or vocab_size or both) and initialize the model using that, you run into the following error: `AssertionError: Padding_idx must be within num_embeddings`. That makes sense. Also, if we do it this way, we lose all of the other model_load_kwargs way of initializing the model which is not at all good.
- If you try and do it after initialization through something like `model.get_input_embeddings().padding_idx = tokenizer.pad_token_id`, it causes the same error but at `RunTime: AssertionError: Padding_idx must be within num_embeddings`.
- The final thing one could do is actually create a fresh `torch.nn.embeddings` layer `torch.nn.Embedding(32001, 4096, padding_idx=32000)` overwriting the existing layer, but then you lose the pre-trained weights which I'm absolutely not in favor of doing.

### Approach 2
Set the pad token to the UNK token since it's hardly used during pretraining, which means it will be treated in a similar fashion to what a real pad token would do. Here's an example of a notebook that does this exact thing for Llama-2-finetuning when the padding side is left: https://github.com/run-llama/modal_finetune_sql/blob/main/src/finetune_sql.py. This is the approach I've implemented.

Finally, I added a test to check a majority of the LLM util functions in sequence to imitate their calling pattern in the LLM model's forward pass. This is good for us to have both from an understanding perspective, but also to confirm that things are happening exactly as expected.

## Comparing Quality Before And After

I fine-tuned Llama-2-7b using the Code Alpaca dataset on 100 rows of data for 5 epochs.

Here are the results before this change:

```
Instruction: Create an array of length 5 which contains all even numbers between 1 and 10.
Input: 
Generated Output: sierp = [2, 4, 6, 8, 10]



Instruction: Create an array of length 15 containing numbers divisible by 3 up to 45.
Input: 
Generated Output: sierp = [3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45]



Instruction: Create a nested loop to print every combination of numbers between 0-9
Input: 
Generated Output: sierpana = [0,1,2,3,4,5,6,7,8,9]
for i in range(10):
    for j in range(10):
        print(augustana[i], augustana[j])



Instruction: Generate a function that computes the sum of the numbers in a given list
Input: 
Generated Output: sierp = [1, 2, 3, 4, 5]
sum = 0
for i in sierp:
    sum += i
return sum



Instruction: Create a class to store student names, ages and grades.
Input: 
Generated Output: sierpana.py

class student:
    def __init__(self, name, age, grade):
        self.name = name
        self.age = age
        self.grade = grade

    def __str__(self):
        return f"{self.name} is {self.age} years old and has a grade of {self.grade}."



Instruction: Print out the values in the following dictionary.
Input: my_dict = {
  'name': 'John Doe',
  'age': 32,
  'city': 'New York'
}
Generated Output: sierp_dict = {
  'name': 'john doe',
  'age': 32,
  'city': 'new york'
}
for key, value in my_dict.items():
    print(key, ":", value)
```

Here are the results using this branch:
```
Instruction: Create an array of length 5 which contains all even numbers between 1 and 10.
Input: 
Generated Output: arr = [2, 4, 6, 8, 10]

def create_array_of_length_5_which_contains_all_even_numbers_between_1_and_10():
    arr = [2, 4, 6, 8, 10]
    return arr

arr = create_array_of_length_5_which_contains_all_even_numbers_between_1_and_10()
print(arr)


Instruction: Create an array of length 15 containing numbers divisible by 3 up to 45.
Input: 
Generated Output: arr = [3,6,9,12,15,18,21,24,27,30,33,36,40,45]ITableView(arr)

def array_of_length_15_containing_numbers_divisible_by_3_up_to_45():
    arr = [3,6,9,12,15,18,21,24,27,30,33,36,40,45]
    print(arr)

array_of_length_15_containing_numbers_divisible_by_3_up_to_45()


Instruction: Create a nested loop to print every combination of numbers between 0-9
Input: 
Generated Output: for (int i = 0; i < 10; i++) {
    for (int j = 0; j < 10; j++) {
        std::cout << i << " " << j << " ";
    }
    std::cout << std::endl;
}

Instruction: Generate a function that computes the sum of the numbers in a given list
Input: 
Generated Output: def sum_of_numbers_in_list(numbers):
    total = 0
    for number in numbers:
        total += number
    return total

sum_of_numbers_in_list([1, 2, 3, 4, 5])
# output: 15


Instruction: Create a class to store student names, ages and grades.
Input: 
Generated Output: 
class student:
    def __init__(self, name, age, grade):
        self.name = name
        self.age = age
        self.grade = grade

    def __str__(self):
        return f"{self.name} is {self.age} years old and has a grade of {self.grade}."

Instruction: Print out the values in the following dictionary.
Input: my_dict = {
  'name': 'John Doe',
  'age': 32,
  'city': 'New York'
}
Generated Output: print(my_dict)
name: john doe
age: 32
city: new york
```

In my opinion, the latter results are objectively much better when training for the same duration on the exact same dataset. One clear observation is that because the last token is now a PAD token instead of a EOS token, the model tends to overgenerate a little bit. I wonder if we should just set the last token to a EOS token instead of a PAD token (PAD token is what is recommended by PEFT for CausalLM fine-tuning).