### PR TITLE
Add create_pr=True to `ludwig upload`.

### DIFF
--- a/ludwig/utils/upload_utils.py
+++ b/ludwig/utils/upload_utils.py
@@ -198,6 +198,7 @@ class HuggingFaceHub(BaseModelUpload):
             repo_type=repo_type,
             commit_message=commit_message,
             commit_description=commit_description,
+            create_pr=True,
         )
 
         if upload_path:


### PR DESCRIPTION
The command seems to fail for newly created model repositories.