### PR TITLE
add missing ptitprince depedency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ gpustat
 rich~=12.4.4
 packaging
 retry
+ptitprince==0.2.6
 
 # required for TransfoXLTokenizer when using transformer_xl
 sacremoses


### PR DESCRIPTION
# Description

The `ptitprince` is missing from `requirements.txt` and thus some cli commands throw an error

# Changes

- Add missing `ptitprince` to  `requirements.txt` 

# POC

## Pre-commit check passes
![image](https://github.com/ludwig-ai/ludwig/assets/459925/deb7b289-71d6-44bc-8520-3fbe0d517099)


## Before Chage
![image](https://github.com/ludwig-ai/ludwig/assets/459925/4ade082a-17fd-4520-83e3-c968ef1d80dd)

## After Change

![image](https://github.com/ludwig-ai/ludwig/assets/459925/b35c9807-7033-4f3a-a418-7cf1414d7754)
