### PR TITLE
fix: Move target tensor to model output device in `check_module_parameters_updated`

### DIFF
--- a/tests/integration_tests/parameter_update_utils.py
+++ b/tests/integration_tests/parameter_update_utils.py
@@ -46,6 +46,7 @@ def check_module_parameters_updated(
     module.train(True)
 
     target_tensor = module_target
+    target_tensor = target_tensor.to(device=module.device)
 
     trainable_parameter_list = []
     frozen_parameter_list = []

--- a/tests/integration_tests/parameter_update_utils.py
+++ b/tests/integration_tests/parameter_update_utils.py
@@ -46,7 +46,6 @@ def check_module_parameters_updated(
     module.train(True)
 
     target_tensor = module_target
-    target_tensor = target_tensor.to(device=module.device)
 
     trainable_parameter_list = []
     frozen_parameter_list = []
@@ -70,15 +69,20 @@ def check_module_parameters_updated(
             # do update of model parameters
             optimizer.zero_grad()
             if isinstance(module_output, torch.Tensor):
+                module_target = module_target.to(device=module_output.device)
                 loss = loss_function(module_output, target_tensor)
             elif isinstance(module_output, dict):
                 if "logits" in module_output:
+                    module_target = module_target.to(device=module_output["logits"].device)
                     loss = loss_function(module_output["logits"], target_tensor)
                 elif ENCODER_OUTPUT in module_output:
+                    module_target = module_target.to(device=module_output[ENCODER_OUTPUT].device)
                     loss = loss_function(module_output[ENCODER_OUTPUT], target_tensor)
                 elif "combiner_output" in module_output:
+                    module_target = module_target.to(device=module_output["combiner_output"].device)
                     loss = loss_function(module_output["combiner_output"], target_tensor)
             elif isinstance(module_output, (list, tuple)):
+                module_target = module_target.to(device=module_output[0].device)
                 loss = loss_function(module_output[0], target_tensor)
             else:
                 raise ValueError(f"Unexpected output type.  Module type found is {type(module_output)}")


### PR DESCRIPTION
Running any test that calls `tests.integration_tests.parameter_update_utils.check_module_parameters_updated` in an environment with a GPU leads to a device mismatch error, with the model on GPU and the target tensor on CPU. This fixes the device mismatch by putting the target tensor on the model device in this function.