### PR TITLE
Pin Transformers to 4.31.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
+# TODO(Arnav): Lift transformers package restriction once 4.32.2 is released.
+# Issue: https://github.com/ludwig-ai/ludwig/issues/3571
 transformers>=4.31.0,<4.32.0
 tokenizers>=0.13.3
 spacy>=2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
-transformers<4.32.0
+transformers>=4.31.0,<4.32.0
 tokenizers>=0.13.3
 spacy>=2.3
 PyYAML>=3.12,<6.0.1,!=5.4.* #Exlude PyYAML 5.4.* due to incompatibility with awscli

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
-transformers>=4.31.0
+transformers<4.32.0
 tokenizers>=0.13.3
 spacy>=2.3
 PyYAML>=3.12,<6.0.1,!=5.4.* #Exlude PyYAML 5.4.* due to incompatibility with awscli


### PR DESCRIPTION
It seems like the latest `transformers` package has a bug. This can be fixed by either using `transformers` master, or downgrading to `4.31.0` which is stable and works correctly. 

This is the error we run into with 4.32.1:
```
site-packages/ludwig/api.py:1510), in LudwigModel.preprocess(self, dataset, training_set, validation_set, test_set, training_set_metadata, data_format, skip_save_processed_input, random_seed, **kwargs)
   1508     return PreprocessedDataset(proc_training_set, proc_validation_set, proc_test_set, training_set_metadata)
   1509 except Exception as e:
-> 1510     raise RuntimeError(f"Caught exception during model preprocessing: {str(e)}") from e
   1511 finally:
   1512     for callback in self.callbacks:
RuntimeError: Caught exception during model preprocessing: local variable 'tokens' referenced before assignment
```

Closes: #3568 