### PR TITLE
Set default global_max_sequence_length to 512 for LLMs

### DIFF
--- a/ludwig/schema/preprocessing.py
+++ b/ludwig/schema/preprocessing.py
@@ -39,11 +39,12 @@ class PreprocessingConfig(schema_utils.BaseMarshmallowConfig):
     )
 
     global_max_sequence_length: int = schema_utils.PositiveInteger(
-        default=None,
+        default=512,
         allow_none=True,
-        description="Specifically for LLMs. This is the maximum length of the input sequence going into the model's "
-        "forward pass during training. Sequences will be truncated to this length after merging inputs and targets. "
-        "If not set, the total length of the merged input and target token sequences will be used.",
+        description="Specifically for LLMs. Defaults to 512. This is the maximum length of the input sequence "
+        "going into the model's forward pass during training. Sequences will be truncated to this length after "
+        "merging inputs and targets. If set to None, the total length of the merged input and target token "
+        "sequences will be used.",
         parameter_metadata=PREPROCESSING_METADATA["global_max_sequence_length"],
     )
 

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -518,8 +518,9 @@ def test_global_max_sequence_length_for_llms():
     config_obj = ModelConfig.from_dict(config)
     model = LLM(config_obj)
 
-    # Default value is set based on model's context_len
-    assert model.global_max_sequence_length == 2048
+    # Default value is set based on model's context_len or global_max_sequence_length
+    # in preprocessing.
+    assert model.global_max_sequence_length == 512
 
     # Override to a larger value in the config
     config["preprocessing"] = {"global_max_sequence_length": 4096}


### PR DESCRIPTION
To prevent OOMs, and to ensure parity with huggingface's [SFTTrainer defaults](https://huggingface.co/docs/trl/v0.7.1/en/trainer#trl.SFTTrainer.max_seq_length), we set `global_max_sequence_length` to 512. This only affects LLMs.

For example:

```yaml
input_features:
  - name: instruction
    type: text
output_features:
  - name: output
    type: text
preprocessing:
   global_max_sequence_length: 512
```

will concat the all the input + output tokens (after stripping off the padding), then truncate to the first 512 tokens post-merge.