### PR TITLE
WandB: Add metric logging support on eval end and epoch end

### DIFF
--- a/ludwig/contribs/wandb.py
+++ b/ludwig/contribs/wandb.py
@@ -55,16 +55,11 @@ class WandbCallback(Callback):
 
     def on_eval_end(self, trainer, progress_tracker, save_path):
         """Called from ludwig/models/model.py."""
-        # if wandb.run:
-        logger.info("wandb.on_eval_end() called...")
-        logger.info(f"Wandb.Run: {wandb.run}")
         for key, value in progress_tracker.log_metrics().items():
             wandb.log({key: value})
 
     def on_epoch_end(self, trainer, progress_tracker, save_path):
         """Called from ludwig/models/model.py."""
-        logger.info("wandb.on_epoch_end() called...")
-        logger.info(f"Wandb.Run: {wandb.run}")
         for key, value in progress_tracker.log_metrics().items():
             wandb.log({key: value})
 

--- a/ludwig/contribs/wandb.py
+++ b/ludwig/contribs/wandb.py
@@ -55,15 +55,18 @@ class WandbCallback(Callback):
 
     def on_eval_end(self, trainer, progress_tracker, save_path):
         """Called from ludwig/models/model.py."""
-        if wandb.run:
-            for key, value in progress_tracker.log_metrics().items():
-                wandb.log({key: value})
+        # if wandb.run:
+        logger.info("wandb.on_eval_end() called...")
+        logger.info(f"Wandb.Run: {wandb.run}")
+        for key, value in progress_tracker.log_metrics().items():
+            wandb.log({key: value})
 
     def on_epoch_end(self, trainer, progress_tracker, save_path):
         """Called from ludwig/models/model.py."""
-        if wandb.run:
-            for key, value in progress_tracker.log_metrics().items():
-                wandb.log({key: value})
+        logger.info("wandb.on_epoch_end() called...")
+        logger.info(f"Wandb.Run: {wandb.run}")
+        for key, value in progress_tracker.log_metrics().items():
+            wandb.log({key: value})
 
     def on_visualize_figure(self, fig):
         logger.info("wandb.on_visualize_figure() called...")

--- a/ludwig/contribs/wandb.py
+++ b/ludwig/contribs/wandb.py
@@ -52,6 +52,18 @@ class WandbCallback(Callback):
         del config["input_features"]
         del config["output_features"]
         wandb.config.update(config)
+    
+    def on_eval_end(self, trainer, progress_tracker, save_path):
+        """Called from ludwig/models/model.py."""
+        if wandb.run:
+            for key, value in progress_tracker.log_metrics().items():
+                wandb.log({key: value})
+                
+    def on_epoch_end(self, trainer, progress_tracker, save_path):
+        """Called from ludwig/models/model.py."""
+        if wandb.run:
+            for key, value in progress_tracker.log_metrics().items():
+                wandb.log({key: value})
 
     def on_visualize_figure(self, fig):
         logger.info("wandb.on_visualize_figure() called...")

--- a/ludwig/contribs/wandb.py
+++ b/ludwig/contribs/wandb.py
@@ -52,13 +52,13 @@ class WandbCallback(Callback):
         del config["input_features"]
         del config["output_features"]
         wandb.config.update(config)
-    
+
     def on_eval_end(self, trainer, progress_tracker, save_path):
         """Called from ludwig/models/model.py."""
         if wandb.run:
             for key, value in progress_tracker.log_metrics().items():
                 wandb.log({key: value})
-                
+
     def on_epoch_end(self, trainer, progress_tracker, save_path):
         """Called from ludwig/models/model.py."""
         if wandb.run:


### PR DESCRIPTION
Our current callback implementation only logs the dataset, but not any metrics. 

Confirmed that this branch works if you also downgrade `wandb` to `0.12.10`. We should spend time fixing our integration/making it compatible with the latest version of wandb, but for now, this fix should suffice. 

FYI, it's not clear what the issue is with the latest version (no code errors, just doesn't push metrics up to wandb). Here's the slack thread for context: https://ludwig-ai.slack.com/archives/C01PN6M2RSM/p1693941105546379