### PR TITLE
FIX: Failure in TabTransformer Combiner Unit test

### DIFF
--- a/tests/ludwig/combiners/test_combiners.py
+++ b/tests/ludwig/combiners/test_combiners.py
@@ -672,21 +672,17 @@ def test_tabtransformer_combiner_number_and_binary_with_category(
 @pytest.mark.parametrize(
     "feature_list",  # defines parameter for fixture features_to_test()
     [
-        # TODO: temporary fix for Iss#3591
-        # [
-        #     ("binary", [BATCH_SIZE, 1]),
-        # ],
         [
             ("binary", [BATCH_SIZE, 1]),
             ("binary", [BATCH_SIZE, 1]),
         ],
-        # TODO: temporary fix for Iss#3591
-        # [
-        #     ("number", [BATCH_SIZE, 1]),
-        # ],
         [
             ("number", [BATCH_SIZE, 1]),
             ("number", [BATCH_SIZE, 1]),
+        ],
+        [
+            ("number", [BATCH_SIZE, 1]),
+            ("binary", [BATCH_SIZE, 1]),
         ],
     ],
 )

--- a/tests/ludwig/combiners/test_combiners.py
+++ b/tests/ludwig/combiners/test_combiners.py
@@ -672,16 +672,18 @@ def test_tabtransformer_combiner_number_and_binary_with_category(
 @pytest.mark.parametrize(
     "feature_list",  # defines parameter for fixture features_to_test()
     [
+        # TODO: temporary fix for Iss#3591
+        # [
+        #     ("binary", [BATCH_SIZE, 1]),
+        # ],
         [
             ("binary", [BATCH_SIZE, 1]),
-        ],
-        [
-            ("binary", [BATCH_SIZE, 1]),
             ("binary", [BATCH_SIZE, 1]),
         ],
-        [
-            ("number", [BATCH_SIZE, 1]),
-        ],
+        # TODO: temporary fix for Iss#3591
+        # [
+        #     ("number", [BATCH_SIZE, 1]),
+        # ],
         [
             ("number", [BATCH_SIZE, 1]),
             ("number", [BATCH_SIZE, 1]),


### PR DESCRIPTION
# Code Pull Requests

This is a temporary work-around for Issue #3591.

Comment out corner cases that cause failure in tabtransformer combiner unit test.

Root cause appears to be a recent change in PyTorch `LayerNorm` implementation.  See cited issue for details.


