### PR TITLE
Add codellama to tokenizer list for set_pad_token

### DIFF
--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -7,6 +7,7 @@ from bitsandbytes.nn.modules import Embedding
 from transformers import (
     AutoModelForCausalLM,
     CodeLlamaTokenizer,
+    CodeLlamaTokenizerFast,
     GPT2Tokenizer,
     GPT2TokenizerFast,
     LlamaTokenizer,
@@ -43,7 +44,14 @@ def set_pad_token(tokenizer: PreTrainedTokenizer):
     # https://github.com/huggingface/transformers/issues/2630#issuecomment-1290809338
     if any(
         isinstance(tokenizer, t)
-        for t in [GPT2Tokenizer, GPT2TokenizerFast, LlamaTokenizer, LlamaTokenizerFast, CodeLlamaTokenizer]
+        for t in [
+            GPT2Tokenizer,
+            GPT2TokenizerFast,
+            LlamaTokenizer,
+            LlamaTokenizerFast,
+            CodeLlamaTokenizer,
+            CodeLlamaTokenizerFast,
+        ]
     ):
         tokenizer.pad_token = tokenizer.eos_token
         tokenizer.pad_token_id = tokenizer.eos_token_id

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 from bitsandbytes.nn.modules import Embedding
 from transformers import (
     AutoModelForCausalLM,
+    CodeLlamaTokenizer,
     GPT2Tokenizer,
     GPT2TokenizerFast,
     LlamaTokenizer,
@@ -40,7 +41,10 @@ def set_pad_token(tokenizer: PreTrainedTokenizer):
     # These recommend using eos tokens instead
     # https://github.com/huggingface/transformers/issues/2648#issuecomment-616177044
     # https://github.com/huggingface/transformers/issues/2630#issuecomment-1290809338
-    if any(isinstance(tokenizer, t) for t in [GPT2Tokenizer, GPT2TokenizerFast, LlamaTokenizer, LlamaTokenizerFast]):
+    if any(
+        isinstance(tokenizer, t)
+        for t in [GPT2Tokenizer, GPT2TokenizerFast, LlamaTokenizer, LlamaTokenizerFast, CodeLlamaTokenizer]
+    ):
         tokenizer.pad_token = tokenizer.eos_token
         tokenizer.pad_token_id = tokenizer.eos_token_id
 

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -810,7 +810,13 @@ class HFTokenizer(BaseTokenizer):
     def _set_pad_token(self) -> None:
         """Sets the pad token and pad token ID for the tokenizer."""
 
-        from transformers import GPT2Tokenizer, GPT2TokenizerFast, LlamaTokenizer, LlamaTokenizerFast
+        from transformers import (
+            CodeLlamaTokenizer,
+            GPT2Tokenizer,
+            GPT2TokenizerFast,
+            LlamaTokenizer,
+            LlamaTokenizerFast,
+        )
 
         # Tokenizers might have the pad token id attribute since they tend to use the same base class, but
         # it can be set to None so we check for this explicitly.
@@ -822,7 +828,7 @@ class HFTokenizer(BaseTokenizer):
         # https://github.com/huggingface/transformers/issues/2648#issuecomment-616177044
         if any(
             isinstance(self.tokenizer, t)
-            for t in [GPT2Tokenizer, GPT2TokenizerFast, LlamaTokenizer, LlamaTokenizerFast]
+            for t in [GPT2Tokenizer, GPT2TokenizerFast, LlamaTokenizer, LlamaTokenizerFast, CodeLlamaTokenizer]
         ):
             if hasattr(self.tokenizer, "eos_token") and self.tokenizer.eos_token is not None:
                 logger.warning("No padding token id found. Using eos_token as pad_token.")

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -812,6 +812,7 @@ class HFTokenizer(BaseTokenizer):
 
         from transformers import (
             CodeLlamaTokenizer,
+            CodeLlamaTokenizerFast,
             GPT2Tokenizer,
             GPT2TokenizerFast,
             LlamaTokenizer,
@@ -828,7 +829,14 @@ class HFTokenizer(BaseTokenizer):
         # https://github.com/huggingface/transformers/issues/2648#issuecomment-616177044
         if any(
             isinstance(self.tokenizer, t)
-            for t in [GPT2Tokenizer, GPT2TokenizerFast, LlamaTokenizer, LlamaTokenizerFast, CodeLlamaTokenizer]
+            for t in [
+                GPT2Tokenizer,
+                GPT2TokenizerFast,
+                LlamaTokenizer,
+                LlamaTokenizerFast,
+                CodeLlamaTokenizer,
+                CodeLlamaTokenizerFast,
+            ]
         ):
             if hasattr(self.tokenizer, "eos_token") and self.tokenizer.eos_token is not None:
                 logger.warning("No padding token id found. Using eos_token as pad_token.")


### PR DESCRIPTION
Because CodeLlamaTokenizer does not have a `pad_token_id` set, this PR adds it to the list of tokenizers we set a pad_token explicitly for.
