### PR TITLE
Set default eval batch size to 2 for LLM fine-tuning

### DIFF
--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -881,6 +881,11 @@ class FineTuneTrainerConfig(ECDTrainerConfig):
         description="Base learning rate used for training in the LLM trainer.",
     )
 
+    eval_batch_size: int = schema_utils.PositiveInteger(
+        default=2,
+        description="Batch size used for evaluation in the LLM trainer.",
+    )
+
 
 @DeveloperAPI
 def get_model_type_jsonschema(model_type: str = MODEL_ECD):


### PR DESCRIPTION
Our current batch size tuning logic for eval batch size is more geared towards ECD than LLM.

For LLMs, we want to create synthetic data and push the largest possible "most computationally expensive" batches through during batch size tuning, but right now we just use batches that exist in the dataset. More on this in the future.

For now, let's set the default eval_batch_size is 2.