### PR TITLE
Updated characters, underscore and comma preprocessors to be TorchScriptable.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -78,7 +78,6 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1 wget
 
       - name: Setup macOS
@@ -231,7 +230,6 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -289,7 +287,6 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -347,7 +344,6 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -405,7 +401,6 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -463,7 +458,6 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -505,7 +499,6 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -547,7 +540,6 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -587,7 +579,6 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1 wget
 
       - name: Setup macOS
@@ -230,6 +231,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -287,6 +289,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -344,6 +347,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -401,6 +405,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -458,6 +463,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -499,6 +505,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -540,6 +547,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS
@@ -579,6 +587,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
+          sudo apt-get update
           sudo apt-get install -y cmake libsndfile1
 
       - name: Setup macOS

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -29,11 +29,7 @@ from ludwig.utils.nlp_utils import load_nlp_pipeline, process_text
 logger = logging.getLogger(__name__)
 torchtext_version = torch.torch_version.TorchVersion(torchtext.__version__)
 
-SPACE_PUNCTUATION_REGEX = re.compile(r"\w+|[^\w\s]")
-COMMA_REGEX = re.compile(r"\s*,\s*")
-UNDERSCORE_REGEX = re.compile(r"\s*_\s*")
-
-TORCHSCRIPT_COMPATIBLE_TOKENIZERS = {"space", "space_punct"}
+TORCHSCRIPT_COMPATIBLE_TOKENIZERS = {"space", "space_punct", "comma", "underscore", "characters"}
 TORCHTEXT_0_12_0_TOKENIZERS = {"sentencepiece", "clip", "gpt2bpe"}
 TORCHTEXT_0_13_0_TOKENIZERS = {"bert"}
 
@@ -50,12 +46,59 @@ class BaseTokenizer:
         pass
 
 
-class CharactersToListTokenizer(BaseTokenizer):
-    def __call__(self, text):
-        return [char for char in text]
+class StringSplitTokenizer(torch.nn.Module):
+    def __init__(self, split_string, **kwargs):
+        super().__init__()
+        self.split_string = split_string
+
+    def forward(self, v: Union[str, List[str], torch.Tensor]) -> Any:
+        if isinstance(v, torch.Tensor):
+            raise ValueError(f"Unsupported input: {v}")
+
+        inputs: List[str] = []
+        # Ludwig calls map on List[str] objects, so we need to handle individual strings as well.
+        if isinstance(v, str):
+            inputs.append(v)
+        else:
+            inputs.extend(v)
+
+        tokens: List[List[str]] = []
+        for sequence in inputs:
+            split_sequence = sequence.strip().split(self.split_string)
+            token_sequence: List[str] = []
+            for token in self.get_tokens(split_sequence):
+                if len(token) > 0:
+                    token_sequence.append(token)
+            tokens.append(token_sequence)
+
+        return tokens[0] if isinstance(v, str) else tokens
+
+    def get_tokens(self, tokens: List[str]) -> List[str]:
+        return tokens
 
 
-class SpaceStringToListTokenizer(torch.nn.Module):
+class SpaceStringToListTokenizer(StringSplitTokenizer):
+    """Implements torchscript-compatible whitespace tokenization."""
+
+    def __init__(self, **kwargs):
+        super().__init__(split_string=" ", **kwargs)
+
+
+class UnderscoreStringToListTokenizer(StringSplitTokenizer):
+    """Implements torchscript-compatible whitespace tokenization."""
+
+    def __init__(self, **kwargs):
+        super().__init__(split_string="_", **kwargs)
+
+
+class CommaStringToListTokenizer(StringSplitTokenizer):
+    """Implements torchscript-compatible whitespace tokenization."""
+
+    def __init__(self, **kwargs):
+        super().__init__(split_string=",", **kwargs)
+
+
+class CharactersToListTokenizer(torch.nn.Module):
     """Implements torchscript-compatible whitespace tokenization."""
 
     def __init__(self, **kwargs):
@@ -74,7 +117,7 @@ class SpaceStringToListTokenizer(torch.nn.Module):
 
         tokens: List[List[str]] = []
         for sequence in inputs:
-            split_sequence = sequence.strip().split(" ")
+            split_sequence = [char for char in sequence]
             token_sequence: List[str] = []
             for token in self.get_tokens(split_sequence):
                 if len(token) > 0:
@@ -140,16 +183,6 @@ class SpacePunctuationStringToListTokenizer(torch.nn.Module):
             tokens.append(token_sequence)
 
         return tokens[0] if isinstance(v, str) else tokens
-
-
-class UnderscoreStringToListTokenizer(BaseTokenizer):
-    def __call__(self, text):
-        return UNDERSCORE_REGEX.split(text.strip())
-
-
-class CommaStringToListTokenizer(BaseTokenizer):
-    def __call__(self, text):
-        return COMMA_REGEX.split(text.strip())
 
 
 class UntokenizedStringToListTokenizer(BaseTokenizer):
@@ -855,10 +888,10 @@ tokenizer_registry = {
     "space": SpaceStringToListTokenizer,
     "space_punct": SpacePunctuationStringToListTokenizer,
     "ngram": NgramTokenizer,
-    # Tokenizers not compatible with torchscript
     "characters": CharactersToListTokenizer,
     "underscore": UnderscoreStringToListTokenizer,
     "comma": CommaStringToListTokenizer,
+    # Tokenizers not compatible with torchscript
     "untokenized": UntokenizedStringToListTokenizer,
     "stripped": StrippedStringToListTokenizer,
     "english_tokenize": EnglishTokenizer,

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -14,7 +14,6 @@ input_features:
 """
 
 import logging
-import re
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Union
 

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -85,21 +85,21 @@ class SpaceStringToListTokenizer(StringSplitTokenizer):
 
 
 class UnderscoreStringToListTokenizer(StringSplitTokenizer):
-    """Implements torchscript-compatible whitespace tokenization."""
+    """Implements torchscript-compatible underscore tokenization."""
 
     def __init__(self, **kwargs):
         super().__init__(split_string="_", **kwargs)
 
 
 class CommaStringToListTokenizer(StringSplitTokenizer):
-    """Implements torchscript-compatible whitespace tokenization."""
+    """Implements torchscript-compatible comma tokenization."""
 
     def __init__(self, **kwargs):
         super().__init__(split_string=",", **kwargs)
 
 
 class CharactersToListTokenizer(torch.nn.Module):
-    """Implements torchscript-compatible whitespace tokenization."""
+    """Implements torchscript-compatible characters tokenization."""
 
     def __init__(self, **kwargs):
         super().__init__()

--- a/tests/ludwig/utils/test_tokenizers.py
+++ b/tests/ludwig/utils/test_tokenizers.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torchtext
 
-from ludwig.utils.tokenizers import EnglishLemmatizeFilterTokenizer, NgramTokenizer
+from ludwig.utils.tokenizers import EnglishLemmatizeFilterTokenizer, NgramTokenizer, StringSplitTokenizer
 
 TORCHTEXT_0_14_0_HF_NAMES = [
     "bert-base-uncased",
@@ -71,6 +71,13 @@ def test_ngram_tokenizer():
     ]
     tokens = tokenizer(inputs)
     assert tokens == tokens_expected
+
+
+def test_string_split_tokenizer():
+    inputs = "Multiple,Elements,Are here!"
+    tokenizer = StringSplitTokenizer(",")
+    tokens = tokenizer(inputs)
+    assert tokens == ["Multiple", "Elements", "Are here!"]
 
 
 def test_english_lemmatize_filter_tokenizer():


### PR DESCRIPTION
The `comma`, `underscore` and `characters` preprocessors are not currently TorchScriptable because they do not implement the TorchScript Module methods. As part of this PR, we now have a general `StringSplitTokenizer` that can be re-used across the various defaults we support. Unfortunately, since TorchScript only supports basic data types, `CharactersToListTokenizer` had to be written as a separate class instead of using Lamda Function.

Will help users run into this error less often:
```
ValueError: comma is not supported by torchscript. Please use one of {'sentencepiece', 'space_punct', 'clip', 
'gpt2bpe', 'bert', 'space'}.
```

This covered by the `tests/integration_tests/test_torchscript.py::test_torchscript_e2e_text` test because this PR updates `TORCHSCRIPT_COMPATIBLE_TOKENIZERS` to include the new TorchScriptable tokenizers.