### PR TITLE
fix: Load 8-bit quantized models for eval after fine-tuning

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -384,6 +384,7 @@ class LLM(BaseModel):
         with torch.backends.cuda.sdp_kernel(enable_flash=True, enable_math=False, enable_mem_efficient=False) if (
             torch.cuda.is_available() and self.curr_device.type == "cuda"
         ) else contextlib.nullcontext():
+            # TODO (jeffkinnison): Determine why the 8-bit `SCB` and `CB` matrices are deleted in the forward pass
             model_outputs = self.model(input_ids=self.model_inputs, attention_mask=self.attention_masks).get(LOGITS)
 
         if self.output_feature_type != TEXT:

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -884,6 +884,9 @@ class Trainer(BaseTrainer):
                     if self.distributed.is_model_parallel():
                         # Assume the full weights cannot fit in memory on GPU
                         self.model = self.model.cpu()
+
+                    # For a full explanation of this 8-bit workaround, see https://github.com/ludwig-ai/ludwig/pull/3606
+                    # TODO (jeffkinnison): Investigate why `self.model` is seemingly not placed on GPU before this point
                     if hasattr(self.model.config_obj, "quantization") and self.model.config_obj.quantization.bits == 8:
                         if torch.cuda.is_available():
                             self.model.model.cuda()

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -894,7 +894,7 @@ class Trainer(BaseTrainer):
                         # to a RuntimeError in `load_state_dict`. Explicitly call `model.cuda()` to make sure the
                         # matrices are part of model state. This workaround is necessary because the matrices are
                         # deleted during the model's forward pass.
-                        if self.device == "cuda":
+                        if self.device.type == "cuda":
                             self.model.model.cuda()
                         _, unexpected_keys = self.model.load_state_dict(state_dict, strict=False)
                         only_weights_format_keys = ["weights_format" in k for k in unexpected_keys]

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -894,7 +894,7 @@ class Trainer(BaseTrainer):
                         # to a RuntimeError in `load_state_dict`. Explicitly call `model.cuda()` to make sure the
                         # matrices are part of model state. This workaround is necessary because the matrices are
                         # deleted during the model's forward pass.
-                        if self.device == torch.device("cuda"):
+                        if self.device == "cuda":
                             self.model.model.cuda()
                         _, unexpected_keys = self.model.load_state_dict(state_dict, strict=False)
                         only_weights_format_keys = ["weights_format" in k for k in unexpected_keys]

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -888,11 +888,20 @@ class Trainer(BaseTrainer):
                     # For a full explanation of this 8-bit workaround, see https://github.com/ludwig-ai/ludwig/pull/3606
                     # TODO (jeffkinnison): Investigate why `self.model` is seemingly not placed on GPU before this point
                     if hasattr(self.model.config_obj, "quantization") and self.model.config_obj.quantization.bits == 8:
+                        # If the model was previously placed on GPU, 8-bit parameter state will be updated with several
+                        # matrices containing quantization information. These are recorded matrices are recorded in the
+                        # training checkpoint state dicts, but do not necessarily exist in the parameter object, leading
+                        # to a RuntimeError in `load_state_dict`. Explicitly call `model.cuda()` to make sure the
+                        # matrices are part of model state.
                         if torch.cuda.is_available():
                             self.model.model.cuda()
-                            self.model.model.cpu()
                         _, unexpected_keys = self.model.load_state_dict(state_dict, strict=False)
                         only_weights_format_keys = ["weights_format" in k for k in unexpected_keys]
+
+                        # bitsandbytes adds a number of `weights_format` metadata fields to the state dict in
+                        # `Linear8bitLt._save_to_state_dict`. These contain information about how the 8-bit tensors
+                        # are tiled, but the fields themselves never exist in the module and get returned as unexpected
+                        # keys when loading the state dict. The
                         assert (
                             unexpected_keys == [] or only_weights_format_keys
                         ), f"Unexpected keys found in state dict: {unexpected_keys}"

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -551,6 +551,7 @@ def test_load_pretrained_adapter_weights(adapter):
 
 
 def _compare_models(model_1: torch.nn.Module, model_2: torch.nn.Module) -> bool:
+    # For a full explanation of this 8-bit workaround, see https://github.com/ludwig-ai/ludwig/pull/3606
     def filter_for_weight_format(i):
         """Remove bitsandbytes metadata keys added on state dict creation.
 


### PR DESCRIPTION
# Errors

After training or fine-tuning, the best model checkpoint is loaded for evaluation. When loading an 8-bit quantized model that was fine-tuned on GPU, the following errors occur:

1. With no handling, the call to load_state_dict [here](https://github.com/ludwig-ai/ludwig/blob/03a0da09f9d01141717f7caed462aa83cf891c26/ludwig/trainers/trainer.py#L887) raises `RuntimeError: Loading a quantized checkpoint into non-quantized Linear8bitLt is not supported. Please call module.cuda() before module.load_state_dict()"`
2. If 1. is handled, a number of unexpected keys are returned from load_state_dict and an AssertionError is raised

# Causes

These issues can be reproduced by running `tests/integration_tests/test_llm.py::test_llm_finetuning_strategies` with 8-bit quantization. Both issues are the result of custom handling in `bitsandbytes`. They are caused by

1. Moving an 8-bit parameter object to GPU [creates a number of metadata matrices](https://github.com/TimDettmers/bitsandbytes/blob/18e827d666fa2b70a12d539ccedc17aa51b2c97c/bitsandbytes/nn/modules.py#L290-L302) behind the scenes. These are added to model state on the fly during the move to GPU, and thus do not exist in a version of the model that has not been put on GPU. A check during `load_state_dict` in `bitsandbytes` raises the RuntimeError.
2. When saving a state dict, `bitsandbytes` adds a number of `weight_format` entries to the state dict behind the scenes. These are metadata entries that are used in `load_state_dict` to reconstruct the quantized parameters. Since these `weight_format` entries are never registered in model state, on load they are returned in the `unexpected_keys` list. On load for eval, we assert that no unexpected keys were returned.

# Workaround

This update puts in a workaround that addresses both issues. For 8-bit quantized models only, at the call to load_state_dict we first move the model to GPU and back to solve 1., then we ensure that the only unexpected keys are `weight_format` keys to handle 2. This should unblock 8-bit quantization for the time being, though we should double-check model quality.
