### PR TITLE
Add support for gradient checkpointing for LLM fine-tuning

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -224,12 +224,6 @@ class LLM(BaseModel):
 
             from peft import get_peft_model
 
-            # Set requires_grad to False for all parameters in the base model
-            logger.info("Disabling gradient computation for all parameters in the model...")
-            for param in self.model.parameters():
-                param.requires_grad = False
-            logger.info("Done.")
-
             if self.config_obj.adapter.pretrained_adapter_weights:
                 logger.info(f"Using pretrained adapter weights: {self.config_obj.adapter.pretrained_adapter_weights}")
                 # If pretrained adapter weights are provided, we want to load them into the model
@@ -273,9 +267,6 @@ class LLM(BaseModel):
             logger.info(f"Fine-tuning with adapter: {self.config_obj.adapter.type}")
             self.model.print_trainable_parameters()
             logger.info("==================================================")
-
-            # print("==================================================")
-            # breakpoint()
 
     def prepare_for_training(self):
         # TODO: this implementation will not work if resuming from a previous checkpoint. Need to fix this.

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -224,7 +224,7 @@ class LLM(BaseModel):
 
             from peft import get_peft_model
 
-            # Set requires_grad to False for all parameters in the model
+            # Set requires_grad to False for all parameters in the base model
             logger.info("Disabling gradient computation for all parameters in the model...")
             for param in self.model.parameters():
                 param.requires_grad = False

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -224,6 +224,10 @@ class LLM(BaseModel):
 
             from peft import get_peft_model
 
+            # Set requires_grad to False for all parameters in the model
+            for param in self.model.parameters():
+                param.requires_grad = False
+
             if self.config_obj.adapter.pretrained_adapter_weights:
                 logger.info(f"Using pretrained adapter weights: {self.config_obj.adapter.pretrained_adapter_weights}")
                 # If pretrained adapter weights are provided, we want to load them into the model
@@ -267,6 +271,9 @@ class LLM(BaseModel):
             logger.info(f"Fine-tuning with adapter: {self.config_obj.adapter.type}")
             self.model.print_trainable_parameters()
             logger.info("==================================================")
+
+            # print("==================================================")
+            # breakpoint()
 
     def prepare_for_training(self):
         # TODO: this implementation will not work if resuming from a previous checkpoint. Need to fix this.

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -225,8 +225,10 @@ class LLM(BaseModel):
             from peft import get_peft_model
 
             # Set requires_grad to False for all parameters in the model
+            logger.info("Disabling gradient computation for all parameters in the model...")
             for param in self.model.parameters():
                 param.requires_grad = False
+            logger.info("Done.")
 
             if self.config_obj.adapter.pretrained_adapter_weights:
                 logger.info(f"Using pretrained adapter weights: {self.config_obj.adapter.pretrained_adapter_weights}")

--- a/ludwig/schema/metadata/configs/trainer.yaml
+++ b/ludwig/schema/metadata/configs/trainer.yaml
@@ -429,6 +429,17 @@ ecd:
             Suggested to enable this if training is proceeding very slowly in distributed training (and GPU
             utilization is low), or the batch size is very small and the loss curves look very spiky.
         ui_display_name: Gradient Accumulation Steps
+    enable_gradient_checkpointing:
+        expected_impact: 2
+        ui_display_name: Enable Gradient Checkpointing
+        default_value_reasoning:
+            Gradient checkpointing is a technique to reduce the memory footprint of the model by
+            trading compute for memory. This is useful when training very large models that do
+            not fit in memory. Gradient checkpointing works by recomputing the activations of the
+            model during the backward pass, rather than storing them in memory during the forward pass.
+            This is a tradeoff between compute and memory, as the activations need to be recomputed during
+            the backward pass, but the memory footprint is reduced. This is set to false by default because
+            it is not always beneficial to use gradient checkpointing, and it can sometimes slow down training.
     validation_field:
         default_value_reasoning:
             Concrete evaluation metrics are usually better than loss,

--- a/ludwig/schema/metadata/configs/trainer.yaml
+++ b/ludwig/schema/metadata/configs/trainer.yaml
@@ -434,7 +434,9 @@ ecd:
         ui_display_name: Enable Gradient Checkpointing
         default_value_reasoning:
             Gradient checkpointing is a technique to reduce the memory footprint of the model by
-            trading compute for memory. This is useful when training very large models that run into out of memory errors very quickly during training. It is particularly helpful when doing non-quantization based training (adapter based or full fine-tuning). Gradient checkpointing works by recomputing the activations of the
+            trading compute for memory. This is useful when training very large models that run into out of memory
+            errors very quickly during training. It is particularly helpful when doing non-quantization based training
+            (adapter based or full fine-tuning). Gradient checkpointing works by recomputing the activations of the
             model during the backward pass, rather than storing them in memory during the forward pass.
             This is a tradeoff between compute and memory, as the activations need to be recomputed during
             the backward pass, but the memory footprint is reduced. This is set to false by default because

--- a/ludwig/schema/metadata/configs/trainer.yaml
+++ b/ludwig/schema/metadata/configs/trainer.yaml
@@ -434,8 +434,7 @@ ecd:
         ui_display_name: Enable Gradient Checkpointing
         default_value_reasoning:
             Gradient checkpointing is a technique to reduce the memory footprint of the model by
-            trading compute for memory. This is useful when training very large models that do
-            not fit in memory. Gradient checkpointing works by recomputing the activations of the
+            trading compute for memory. This is useful when training very large models that run into out of memory errors very quickly during training. It is particularly helpful when doing non-quantization based training (adapter based or full fine-tuning). Gradient checkpointing works by recomputing the activations of the
             model during the backward pass, rather than storing them in memory during the forward pass.
             This is a tradeoff between compute and memory, as the activations need to be recomputed during
             the backward pass, but the memory footprint is reduced. This is set to false by default because

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -409,6 +409,13 @@ class ECDTrainerConfig(BaseTrainerConfig):
         parameter_metadata=TRAINER_METADATA[MODEL_ECD]["compile"],
     )
 
+    enable_gradient_checkpointing: bool = schema_utils.Boolean(
+        default=False,
+        description="Whether to enable gradient checkpointing, which trades compute for memory."
+        "This is useful for training very deep models with limited memory.",
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["enable_gradient_checkpointing"],
+    )
+
     def update_batch_size_grad_accum(self, num_workers: int):
         from ludwig.utils.trainer_utils import get_rendered_batch_size_grad_accum
 

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -225,7 +225,7 @@ class Trainer(BaseTrainer):
             elif not hasattr(self.compiled_model, "model") and not hasattr(
                 self.compiled_model.model, "gradient_checkpointing_enable"
             ):
-                logger.warning("Gradient checkpointing is not supported for this model. Skipping...")
+                logger.warning("Gradient checkpointing is not supported by this model. Skipping...")
             elif hasattr(self.compiled_model.model, "gradient_checkpointing_enable"):
                 self.compiled_model.model.gradient_checkpointing_enable()
                 self.compiled_model.model.enable_input_require_grads()

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -216,10 +216,10 @@ class Trainer(BaseTrainer):
         update_embedding_layer(self.compiled_model, self.config)
 
         # Enable gradient checkpointing
-        logger.info("Enabling gradient checkpointing")
-        self.compiled_model.model.gradient_checkpointing_enable()
+        logger.info("Enable input requires grad to true; no gradient checkpointing")
+        # self.compiled_model.model.gradient_checkpointing_enable()
         self.compiled_model.model.enable_input_require_grads()
-        logger.info("Enabled gradient checkpointing")
+        logger.info("Enabled input requires grad to true")
 
         self.dist_model, self.optimizer = self.distributed.prepare(
             self.compiled_model,

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -217,7 +217,8 @@ class Trainer(BaseTrainer):
 
         # Enable gradient checkpointing
         logger.info("Enabling gradient checkpointing")
-        self.compiled_model.gradient_checkpointing_enable()
+        self.compiled_model.model.gradient_checkpointing_enable()
+        self.compiled_model.model.enable_input_require_grads()
         logger.info("Enabled gradient checkpointing")
 
         self.dist_model, self.optimizer = self.distributed.prepare(

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -215,11 +215,14 @@ class Trainer(BaseTrainer):
         # We may need to replace the embedding layer when using 8-bit optimizers from bitsandbytes.
         update_embedding_layer(self.compiled_model, self.config)
 
-        # Enable gradient checkpointing
-        logger.info("Enable only gradient checkpointing")
-        self.compiled_model.model.gradient_checkpointing_enable()
-        self.compiled_model.model.enable_input_require_grads()
-        logger.info("Enabled only gradient checkpointing")
+        # Enable gradient checkpointing if configured
+        if self.config.enable_gradient_checkpointing:
+            if hasattr(self.compiled_model.model, "gradient_checkpointing_enable"):
+                self.compiled_model.model.gradient_checkpointing_enable()
+                self.compiled_model.model.enable_input_require_grads()
+                logger.info("Gradient checkpointing enabled during training.")
+            else:
+                logger.warning("Gradient checkpointing is not supported by the current model. Skipping.")
 
         self.dist_model, self.optimizer = self.distributed.prepare(
             self.compiled_model,

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -221,7 +221,7 @@ class Trainer(BaseTrainer):
             # TODO(Arnav): Add support for gradient checkpointing in the compiled model
             # when the model is an ECD model using torch.utils.checkpoint (torch.utils.checkpoint.sequential())
             if not isinstance(self.compiled_model, LLM):
-                logger.warning("Gradient checkpointing is currently only support for model_type: llm. Skipping...")
+                logger.warning("Gradient checkpointing is currently only supported for model_type: llm. Skipping...")
             elif not hasattr(self.compiled_model, "model") and not hasattr(
                 self.compiled_model.model, "gradient_checkpointing_enable"
             ):
@@ -229,7 +229,7 @@ class Trainer(BaseTrainer):
             elif hasattr(self.compiled_model.model, "gradient_checkpointing_enable"):
                 self.compiled_model.model.gradient_checkpointing_enable()
                 self.compiled_model.model.enable_input_require_grads()
-                logger.info("Gradient checkpointing enabled during training.")
+                logger.info("Gradient checkpointing enabled for training.")
             else:
                 raise RuntimeError("Error when trying to enable gradient checkpointing.")
 

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -218,7 +218,7 @@ class Trainer(BaseTrainer):
         # Enable gradient checkpointing
         logger.info("Enable only gradient checkpointing")
         self.compiled_model.model.gradient_checkpointing_enable()
-        # self.compiled_model.model.enable_input_require_grads()
+        self.compiled_model.model.enable_input_require_grads()
         logger.info("Enabled only gradient checkpointing")
 
         self.dist_model, self.optimizer = self.distributed.prepare(

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -216,10 +216,10 @@ class Trainer(BaseTrainer):
         update_embedding_layer(self.compiled_model, self.config)
 
         # Enable gradient checkpointing
-        logger.info("Enable input requires grad to true; no gradient checkpointing")
-        # self.compiled_model.model.gradient_checkpointing_enable()
-        self.compiled_model.model.enable_input_require_grads()
-        logger.info("Enabled input requires grad to true")
+        logger.info("Enable only gradient checkpointing")
+        self.compiled_model.model.gradient_checkpointing_enable()
+        # self.compiled_model.model.enable_input_require_grads()
+        logger.info("Enabled only gradient checkpointing")
 
         self.dist_model, self.optimizer = self.distributed.prepare(
             self.compiled_model,

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -214,6 +214,12 @@ class Trainer(BaseTrainer):
 
         # We may need to replace the embedding layer when using 8-bit optimizers from bitsandbytes.
         update_embedding_layer(self.compiled_model, self.config)
+
+        # Enable gradient checkpointing
+        logger.info("Enabling gradient checkpointing")
+        self.compiled_model.gradient_checkpointing_enable()
+        logger.info("Enabled gradient checkpointing")
+
         self.dist_model, self.optimizer = self.distributed.prepare(
             self.compiled_model,
             self.config,

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -362,8 +362,8 @@ def test_llm_few_shot_classification(tmpdir, backend, csv_filename, ray_cluster_
     ],
 )
 def test_llm_finetuning_strategies(tmpdir, csv_filename, backend, finetune_strategy, adapter_args, quantization):
-    # if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
-    #     pytest.skip("Skip: quantization requires GPU and none are available.")
+    if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
+        pytest.skip("Skip: quantization requires GPU and none are available.")
 
     input_features = [text_feature(name="input", encoder={"type": "passthrough"})]
     output_features = [text_feature(name="output")]

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -362,8 +362,8 @@ def test_llm_few_shot_classification(tmpdir, backend, csv_filename, ray_cluster_
     ],
 )
 def test_llm_finetuning_strategies(tmpdir, csv_filename, backend, finetune_strategy, adapter_args, quantization):
-    if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
-        pytest.skip("Skip: quantization requires GPU and none are available.")
+    # if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
+    #     pytest.skip("Skip: quantization requires GPU and none are available.")
 
     input_features = [text_feature(name="input", encoder={"type": "passthrough"})]
     output_features = [text_feature(name="output")]
@@ -421,6 +421,35 @@ def test_llm_finetuning_strategies(tmpdir, csv_filename, backend, finetune_strat
     preds = convert_preds(preds)
 
     assert preds
+
+
+@pytest.mark.parametrize("use_adapter", [True, False], ids=["with_adapter", "without_adapter"])
+def test_llm_training_with_gradient_checkpointing(tmpdir, csv_filename, use_adapter):
+    input_features = [text_feature(name="input", encoder={"type": "passthrough"})]
+    output_features = [text_feature(name="output")]
+
+    df = generate_data(input_features, output_features, filename=csv_filename, num_examples=25)
+
+    config = {
+        MODEL_TYPE: MODEL_LLM,
+        BASE_MODEL: "HuggingFaceM4/tiny-random-LlamaForCausalLM",
+        INPUT_FEATURES: input_features,
+        OUTPUT_FEATURES: output_features,
+        TRAINER: {
+            TYPE: "finetune",
+            BATCH_SIZE: 8,
+            EPOCHS: 1,
+            "enable_gradient_checkpointing": True,
+        },
+    }
+
+    if use_adapter:
+        config[ADAPTER] = {TYPE: "lora"}
+
+    model = LudwigModel(config)
+    assert model.config_obj.trainer.enable_gradient_checkpointing
+
+    model.train(dataset=df, output_directory=str(tmpdir), skip_save_processed_input=False)
 
 
 def test_lora_wrap_on_init():

--- a/tests/integration_tests/test_trainer.py
+++ b/tests/integration_tests/test_trainer.py
@@ -376,3 +376,35 @@ def test_gradient_accumulation(gradient_accumulation_steps: int, tmpdir):
     # convergence like gradient magnitudes, etc. Should also add distributed tests.
     model = LudwigModel(config, backend=LocalTestBackend(), logging_level=logging.INFO)
     model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv, output_directory=tmpdir)
+
+
+def test_enable_gradient_checkpointing(tmpdir, caplog):
+    """Test that gradient checkpointing is enabled when specified in the config and that it does not cause an error
+    when the model does not have support for gradient checkpointing."""
+    input_features = [text_feature()]
+    output_features = [category_feature(decoder={"vocab_size": 2}, reduce_input="sum")]
+
+    csv_filename = os.path.join(tmpdir, "training.csv")
+    data_csv = generate_data(input_features, output_features, csv_filename)
+    val_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "validation.csv"))
+    test_csv = shutil.copyfile(data_csv, os.path.join(tmpdir, "test.csv"))
+
+    config = {
+        "input_features": input_features,
+        "output_features": output_features,
+        "combiner": {"type": "concat", "output_size": 14},
+        TRAINER: {
+            "train_steps": 2,
+            "batch_size": 8,
+            "enable_gradient_checkpointing": True,
+        },
+    }
+
+    model = LudwigModel(config, backend=LocalTestBackend(), logging_level=logging.INFO)
+    assert model.config_obj.trainer.enable_gradient_checkpointing
+
+    model.train(training_set=data_csv, validation_set=val_csv, test_set=test_csv, output_directory=tmpdir)
+
+    # Check that the warning is emitted when the model does not support gradient checkpointing
+    # but does not prevent training from starting.
+    assert "Gradient checkpointing is only support for model_type: llm. Skipping..." in caplog.text

--- a/tests/integration_tests/test_trainer.py
+++ b/tests/integration_tests/test_trainer.py
@@ -407,4 +407,4 @@ def test_enable_gradient_checkpointing(tmpdir, caplog):
 
     # Check that the warning is emitted when the model does not support gradient checkpointing
     # but does not prevent training from starting.
-    assert "Gradient checkpointing is only support for model_type: llm. Skipping..." in caplog.text
+    assert "Gradient checkpointing is currently only supported for model_type: llm. Skipping..." in caplog.text


### PR DESCRIPTION
This PR adds support in the finetune trainer to optionally enabled `gradient_checkpointing`.

# What is gradient checkpointing?
Gradient checkpointing works by recomputing the activations of the model during the backward pass, rather than storing them in memory during the forward pass. This is a tradeoff between compute and memory, as the activations need to be recomputed during the backward pass, but the memory footprint is reduced. This is set to false by default because it is not always beneficial to use gradient checkpointing, and it can sometimes slow down training.
![image](https://github.com/ludwig-ai/ludwig/assets/106701836/c0f2e986-cba1-416a-9242-df6268e41749)

# How can you use gradient checkpointing in the config?
Gradient checkpointing is disabled by default. To enable it, you can simply set `enable_gradient_checkpointing` to True.

```yaml
trainer:
    enable_gradient_checkpointing: true
```

# When should I enable gradient checkpointing?
This is useful when training very large models that run into out of memory errors very quickly during training. It is particularly helpful when doing non-quantization based training (adapter based or full fine-tuning).