### PR TITLE
Bump min support transformers to 4.33.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
-transformers
+transformers>=4.33.0
 tokenizers>=0.13.3
 spacy>=2.3
 PyYAML>=3.12,<6.0.1,!=5.4.* #Exlude PyYAML 5.4.* due to incompatibility with awscli


### PR DESCRIPTION
Recent support for CodeLlama is only available in 4.33.0, but this import lies on the critical import path in Ludwig:

```
tests/conftest.py:35: in <module>
    from ludwig.hyperopt.run import hyperopt
ludwig/hyperopt/run.py:11: in <module>
    from ludwig.api import LudwigModel
ludwig/api.py:78: in <module>
    from ludwig.models.registry import model_type_registry
ludwig/models/registry.py:5: in <module>
    from ludwig.models.llm import LLM
ludwig/models/llm.py:22: in <module>
    from ludwig.utils.llm_utils import (
ludwig/utils/llm_utils.py:7: in <module>
    from transformers import (
E   ImportError: cannot import name 'CodeLlamaTokenizer' from 'transformers' (/opt/homebrew/anaconda3/envs/ludwig/lib/python3.11/site-packages/transformers/__init__.py)
```