### PR TITLE
[CI] Fix failing tests on master

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -910,7 +910,7 @@ class Trainer(BaseTrainer):
                     # TODO (jeffkinnison): Determine why `SCB` and `CB` are deleted from parameter state
                     if (
                         hasattr(self.model.config_obj, "quantization")
-                        and hasattr(self.model.config_obj.quantization, "bits")
+                        and self.model.config_obj.quantization
                         and self.model.config_obj.quantization.bits == 8
                     ):
                         # If the model was previously placed on GPU, 8-bit parameter state will be updated with several

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -908,7 +908,11 @@ class Trainer(BaseTrainer):
 
                     # For a full explanation of this 8-bit workaround, see https://github.com/ludwig-ai/ludwig/pull/3606
                     # TODO (jeffkinnison): Determine why `SCB` and `CB` are deleted from parameter state
-                    if hasattr(self.model.config_obj, "quantization") and self.model.config_obj.quantization.bits == 8:
+                    if (
+                        hasattr(self.model.config_obj, "quantization")
+                        and hasattr(self.model.config_obj.quantization, "bits")
+                        and self.model.config_obj.quantization.bits == 8
+                    ):
                         # If the model was previously placed on GPU, 8-bit parameter state will be updated with several
                         # matrices containing quantization information. These are recorded matrices are recorded in the
                         # training checkpoint state dicts, but do not necessarily exist in the parameter object, leading


### PR DESCRIPTION
Adds a conditional block to make sure quantization config is set before inspecting attributes of the quantization config