### PR TITLE
fix: Check underlying model device type when moving 8-bit quantized models to GPU at eval

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -919,7 +919,7 @@ class Trainer(BaseTrainer):
                         # to a RuntimeError in `load_state_dict`. Explicitly call `model.cuda()` to make sure the
                         # matrices are part of model state. This workaround is necessary because the matrices are
                         # deleted during the model's forward pass.
-                        if self.device.type == "cuda":
+                        if self.model.model.device.type == "cuda":
                             self.model.model.cuda()
                         _, unexpected_keys = self.model.load_state_dict(state_dict, strict=False)
                         only_weights_format_keys = ["weights_format" in k for k in unexpected_keys]


### PR DESCRIPTION
Check `self.model.model.device.type == 'cuda'` rather than `self.device.type` when moving 8-bit models to GPU for #3606. In Trainer, `self.device` holds the string `"cuda"`, so checking `self.device.type` raises an AttributeError. Since we work with `self.model.model` directly in the following code block, it makes sense to bypass the Trainer and LLM objects, and get the model device from the model itself.