### PR TITLE
QoL: Default to using fast tokenizer for Llama models

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, GenerationConfig, LlamaConfig, PreTrainedModel
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, GenerationConfig, PreTrainedModel
 
 from ludwig.constants import IGNORE_INDEX_TOKEN_ID, LOGITS, MODEL_LLM, PREDICTIONS, TEXT
 from ludwig.features.base_feature import ModuleWrapper, OutputFeature
@@ -153,11 +153,7 @@ class LLM(BaseModel):
             self.global_max_sequence_length = self.context_len
 
         # Initialize tokenizer
-        use_fast = True
-        if isinstance(self.model_config, LlamaConfig):
-            # HACK: Llama fast tokenizer takes about 2-4 minutes to load, so we disable it for now.
-            use_fast = False
-        self.tokenizer = AutoTokenizer.from_pretrained(self.config_obj.base_model, use_fast=use_fast)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.config_obj.base_model)
         set_pad_token(self.tokenizer)
 
         self.generation = GenerationConfig(**self.config_obj.generation.to_dict())

--- a/ludwig/utils/hf_utils.py
+++ b/ludwig/utils/hf_utils.py
@@ -4,7 +4,7 @@ import tempfile
 from os import PathLike
 from typing import Optional, Tuple, Type, Union
 
-from transformers import AutoConfig, AutoTokenizer, LlamaConfig, PreTrainedModel
+from transformers import AutoTokenizer, PreTrainedModel
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 from ludwig.api_annotations import DeveloperAPI
@@ -45,12 +45,6 @@ def load_pretrained_hf_tokenizer(
     Returns:
         The pretrained tokenizer object.
     """
-
-    # HACK: Llama fast tokenizer takes about 2-4 minutes to load, so we disable it for now.
-    config = AutoConfig.from_pretrained(pretrained_model_name_or_path)
-    if isinstance(config, LlamaConfig):
-        pretrained_kwargs["use_fast"] = False
-
     return AutoTokenizer.from_pretrained(pretrained_model_name_or_path, **pretrained_kwargs)
 
 

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -434,7 +434,7 @@ def test_llm_training_with_gradient_checkpointing(tmpdir, csv_filename, use_adap
 
     config = {
         MODEL_TYPE: MODEL_LLM,
-        BASE_MODEL: "HuggingFaceM4/tiny-random-LlamaForCausalLM",
+        BASE_MODEL: "hf-internal-testing/tiny-random-BartModel",
         INPUT_FEATURES: input_features,
         OUTPUT_FEATURES: output_features,
         TRAINER: {


### PR DESCRIPTION
Quality of life improvement - we used to set use_fast to False since the tokenizer was not natively written so it would take 2-4 minutes to load, however in newer `transformers` versions there is first class support so we no longer have to do this.