### PR TITLE
fixed typo in EfficientNet's model variant from v2_ to v2_s

### DIFF
--- a/ludwig/schema/encoders/image/torchvision.py
+++ b/ludwig/schema/encoders/image/torchvision.py
@@ -101,7 +101,7 @@ class TVEfficientNetEncoderConfig(TVBaseEncoderConfig):
             "b5",
             "b6",
             "b7",
-            "v2_",
+            "v2_s",
             "v2_m",
             "v2_l",
         ],


### PR DESCRIPTION
# Code Pull Requests

Fixed a typo in `EfficientNet`'s model variant that broke training

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
