### PR TITLE
Exclude getdaft on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ sacremoses
 sentencepiece
 
 # requirements for daft
-getdaft
+getdaft ; platform_system != "Windows"
 
 # requirement for various paged and 8-bit optimizers
 bitsandbytes<0.41.0


### PR DESCRIPTION
Daft requirement renders Windows install near impossible. Wheels are not available and build needs to have Strawberry Perl + Rust\Cargo and to be able to compile OpenSSL from source (and I've not been able to successfully do so).

Can we consider not requiring getdaft when in a Windows environment, to enable to use Ludwig, at least until wheels are available? (ref: https://github.com/Eventual-Inc/Daft/issues/235)

With this PR, Ludwig installs fine on Python 3.9 on Windows, and I am able to perform a titanic training