### PR TITLE
Avoid deprecation warnings on pandas Series.fillna

### DIFF
--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -775,7 +775,7 @@ def add_sequence_feature_column(df, col_name, seq_length):
         new_data.append(" ".join(str(j) for j in old_data[i - seq_length : i]))
 
     df[new_col_name] = new_data
-    df[new_col_name] = df[new_col_name].fillna(method="bfill")
+    df[new_col_name] = df[new_col_name].bfill()
 
 
 @DeveloperAPI


### PR DESCRIPTION
Series.fillna is deprecated starting from pandas 2.1.0 and the recommended solution is available since the minimum version supported.
Info on the deprecation on https://pandas.pydata.org/docs/reference/api/pandas.Series.fillna.html