### PR TITLE
Add function to free GPU memory

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1824,6 +1824,11 @@ class LudwigModel:
         if self.model is None or self._user_config is None or self.training_set_metadata is None:
             raise ValueError("Model has not been trained or loaded")
 
+    def free_gpu_memory(self):
+        device = torch.device("cpu")  # Have to move the model to CPU to free GPU memory
+        self.model.model.to(device)
+        torch.cuda.empty_cache()
+
     @staticmethod
     def create_model(config_obj: Union[ModelConfig, dict], random_seed: int = default_random_seed) -> BaseModel:
         """Instantiates BaseModel object.

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1825,9 +1825,13 @@ class LudwigModel:
             raise ValueError("Model has not been trained or loaded")
 
     def free_gpu_memory(self):
-        device = torch.device("cpu")  # Have to move the model to CPU to free GPU memory
-        self.model.model.to(device)
-        torch.cuda.empty_cache()
+        """Manually moves the model to CPU to force GPU memory to be freed.
+
+        For more context: https://discuss.pytorch.org/t/how-can-we-release-gpu-memory-cache/14530/35
+        """
+        if torch.cuda.is_available():
+            self.model.model.to(torch.device("cpu"))
+            torch.cuda.empty_cache()
 
     @staticmethod
     def create_model(config_obj: Union[ModelConfig, dict], random_seed: int = default_random_seed) -> BaseModel:


### PR DESCRIPTION
Used this discussion page as a reference: https://discuss.pytorch.org/t/how-can-we-release-gpu-memory-cache/14530/27

Added a function to LudwigModel to free GPU memory. Compared to the function in the discussion page, I did not move the individual parameters in a loop but instead just moved the entire model to CPU (this is clearer logic to read and results in a small amount of extra GPU memory freed), and I did not call `del` or `gc.collect()` (these two calls did not seem to impact GPU memory).

Credit to @justinxzhao for writing and testing the code.