### PR TITLE
Add check to ensure selected backend works with quantization for LLMs 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
-transformers>=4.33.0
+transformers>=4.33.2
 tokenizers>=0.13.3
 spacy>=2.3
 PyYAML>=3.12,<6.0.1,!=5.4.* #Exlude PyYAML 5.4.* due to incompatibility with awscli


### PR DESCRIPTION
Quantization can only be used with a local backend. This PR modifies our existing checks since they were not robust enough to catch the 4 total cases we should be accounting for. 
