### PR TITLE
Add sample_size as a global preprocessing parameter

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1824,6 +1824,11 @@ class LudwigModel:
         if self.model is None or self._user_config is None or self.training_set_metadata is None:
             raise ValueError("Model has not been trained or loaded")
 
+    def free_gpu_memory(self):
+        device = torch.device("cpu")  # Have to move the model to CPU to free GPU memory
+        self.model.model.to(device)
+        torch.cuda.empty_cache()
+
     @staticmethod
     def create_model(config_obj: Union[ModelConfig, dict], random_seed: int = default_random_seed) -> BaseModel:
         """Instantiates BaseModel object.

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1832,7 +1832,7 @@ class LudwigModel:
         if torch.cuda.is_available():
             self.model.model.to(torch.device("cpu"))
             torch.cuda.empty_cache()
-          
+
     @staticmethod
     def create_model(config_obj: Union[ModelConfig, dict], random_seed: int = default_random_seed) -> BaseModel:
         """Instantiates BaseModel object.

--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -691,3 +691,11 @@ def check_prompt_requirements(config: "ModelConfig") -> None:  # noqa: F821
                     "A template must contain at least one reference to a column or the sample keyword {__sample__} for "
                     "a JSON-serialized representation of non-output feature columns."
                 )
+
+
+@register_config_check
+def check_sample_ratio_and_cap_compatible(config: "ModelConfig") -> None:
+    sample_ratio = config.preprocessing.sample_ratio
+    sample_cap = config.preprocessing.sample_cap
+    if sample_cap and sample_ratio < 1.0:
+        raise ConfigValidationError("sample_cap cannot be used when sample_ratio < 1.0")

--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -696,6 +696,6 @@ def check_prompt_requirements(config: "ModelConfig") -> None:  # noqa: F821
 @register_config_check
 def check_sample_ratio_and_cap_compatible(config: "ModelConfig") -> None:
     sample_ratio = config.preprocessing.sample_ratio
-    sample_cap = config.preprocessing.sample_cap
-    if sample_cap and sample_ratio < 1.0:
-        raise ConfigValidationError("sample_cap cannot be used when sample_ratio < 1.0")
+    sample_size = config.preprocessing.sample_size
+    if sample_size and sample_ratio < 1.0:
+        raise ConfigValidationError("sample_size cannot be used when sample_ratio < 1.0")

--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -694,8 +694,8 @@ def check_prompt_requirements(config: "ModelConfig") -> None:  # noqa: F821
 
 
 @register_config_check
-def check_sample_ratio_and_cap_compatible(config: "ModelConfig") -> None:
+def check_sample_ratio_and_size_compatible(config: "ModelConfig") -> None:
     sample_ratio = config.preprocessing.sample_ratio
     sample_size = config.preprocessing.sample_size
-    if sample_size and sample_ratio < 1.0:
+    if sample_size is not None and sample_ratio < 1.0:
         raise ConfigValidationError("sample_size cannot be used when sample_ratio < 1.0")

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1402,7 +1402,9 @@ def _get_sampled_dataset_df(dataset_df, df_engine, sample_ratio, sample_cap, ran
 
     if sample_cap:
         if sample_cap < len(dataset_df):
-            dataset_df = dataset_df.sample(n=sample_cap, random_state=random_seed)
+            # Cannot use 'n' parameter when using dask DataFrames -- only 'frac' is supported
+            sample_ratio = sample_cap / len(dataset_df)
+            dataset_df = dataset_df.sample(frac=sample_ratio, random_state=random_seed)
         else:
             logger.warning("sample_cap is larger than dataset size, ignoring sample_cap")
 

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1201,8 +1201,8 @@ def build_dataset(
 
     if mode == "training":
         sample_ratio = global_preprocessing_parameters["sample_ratio"]
-        sample_cap = global_preprocessing_parameters["sample_cap"]
-        dataset_df = _get_sampled_dataset_df(dataset_df, df_engine, sample_ratio, sample_cap, random_seed)
+        sample_size = global_preprocessing_parameters["sample_size"]
+        dataset_df = _get_sampled_dataset_df(dataset_df, df_engine, sample_ratio, sample_size, random_seed)
 
     # If persisting DataFrames in memory is enabled, we want to do this after
     # each batch of parallel ops in order to avoid redundant computation
@@ -1389,7 +1389,7 @@ def embed_fixed_features(
     return results
 
 
-def _get_sampled_dataset_df(dataset_df, df_engine, sample_ratio, sample_cap, random_seed):
+def _get_sampled_dataset_df(dataset_df, df_engine, sample_ratio, sample_size, random_seed):
     if sample_ratio < 1.0:
         if not df_engine.partitioned and len(dataset_df) * sample_ratio < 1:
             raise ValueError(
@@ -1400,13 +1400,13 @@ def _get_sampled_dataset_df(dataset_df, df_engine, sample_ratio, sample_cap, ran
         logger.debug(f"sample {sample_ratio} of data")
         dataset_df = dataset_df.sample(frac=sample_ratio, random_state=random_seed)
 
-    if sample_cap:
-        if sample_cap < len(dataset_df):
+    if sample_size:
+        if sample_size < len(dataset_df):
             # Cannot use 'n' parameter when using dask DataFrames -- only 'frac' is supported
-            sample_ratio = sample_cap / len(dataset_df)
+            sample_ratio = sample_size / len(dataset_df)
             dataset_df = dataset_df.sample(frac=sample_ratio, random_state=random_seed)
         else:
-            logger.warning("sample_cap is larger than dataset size, ignoring sample_cap")
+            logger.warning("sample_size is larger than dataset size, ignoring sample_size")
 
     return dataset_df
 

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1211,6 +1211,15 @@ def build_dataset(
             logger.debug(f"sample {sample_ratio} of data")
             dataset_df = dataset_df.sample(frac=sample_ratio, random_state=random_seed)
 
+        sample_cap = global_preprocessing_parameters["sample_cap"]
+        if sample_cap:
+            if sample_ratio < 1.0:
+                raise ValueError("sample_cap cannot be used when sample_ratio < 1.0")
+            if sample_cap < len(dataset_df):
+                dataset_df = dataset_df.sample(n=sample_cap, random_state=random_seed)
+            else:
+                logger.info("sample_cap is larger than dataset size, ignoring sample_cap")
+
     # If persisting DataFrames in memory is enabled, we want to do this after
     # each batch of parallel ops in order to avoid redundant computation
     dataset_df = df_engine.persist(dataset_df)

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1390,10 +1390,11 @@ def embed_fixed_features(
 
 
 def _get_sampled_dataset_df(dataset_df, df_engine, sample_ratio, sample_size, random_seed):
+    df_len = len(dataset_df)
     if sample_ratio < 1.0:
-        if not df_engine.partitioned and len(dataset_df) * sample_ratio < 1:
+        if not df_engine.partitioned and df_len * sample_ratio < 1:
             raise ValueError(
-                f"sample_ratio {sample_ratio} is too small for dataset of length {len(dataset_df)}. "
+                f"sample_ratio {sample_ratio} is too small for dataset of length {df_len}. "
                 f"Please increase sample_ratio or use a larger dataset."
             )
 
@@ -1401,9 +1402,9 @@ def _get_sampled_dataset_df(dataset_df, df_engine, sample_ratio, sample_size, ra
         dataset_df = dataset_df.sample(frac=sample_ratio, random_state=random_seed)
 
     if sample_size:
-        if sample_size < len(dataset_df):
+        if sample_size < df_len:
             # Cannot use 'n' parameter when using dask DataFrames -- only 'frac' is supported
-            sample_ratio = sample_size / len(dataset_df)
+            sample_ratio = sample_size / df_len
             dataset_df = dataset_df.sample(frac=sample_ratio, random_state=random_seed)
         else:
             logger.warning("sample_size is larger than dataset size, ignoring sample_size")

--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -279,9 +279,11 @@ def get_input_tensors(
 
     :return: A list of variables, one for each input feature. Shape of each variable is [batch size, embedding size].
     """
-    # Ignore sample_ratio from the model config, since we want to explain all the data.
+    # Ignore sample_ratio and sample_cap from the model config, since we want to explain all the data.
     sample_ratio_bak = model.config_obj.preprocessing.sample_ratio
+    sample_cap_bak = model.config_obj.preprocessing.sample_cap
     model.config_obj.preprocessing.sample_ratio = 1.0
+    model.config_obj.preprocessing.sample_cap = None
 
     config = model.config_obj.to_dict()
     training_set_metadata = copy.deepcopy(model.training_set_metadata)
@@ -302,8 +304,9 @@ def get_input_tensors(
         callbacks=model.callbacks,
     )
 
-    # Restore sample_ratio
+    # Restore sample_ratio and sample_cap
     model.config_obj.preprocessing.sample_ratio = sample_ratio_bak
+    model.config_obj.preprocessing.sample_cap = sample_cap_bak
 
     # Make sure the number of rows in the preprocessed dataset matches the number of rows in the input data
     assert (

--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -279,11 +279,11 @@ def get_input_tensors(
 
     :return: A list of variables, one for each input feature. Shape of each variable is [batch size, embedding size].
     """
-    # Ignore sample_ratio and sample_cap from the model config, since we want to explain all the data.
+    # Ignore sample_ratio and sample_size from the model config, since we want to explain all the data.
     sample_ratio_bak = model.config_obj.preprocessing.sample_ratio
-    sample_cap_bak = model.config_obj.preprocessing.sample_cap
+    sample_size_bak = model.config_obj.preprocessing.sample_size
     model.config_obj.preprocessing.sample_ratio = 1.0
-    model.config_obj.preprocessing.sample_cap = None
+    model.config_obj.preprocessing.sample_size = None
 
     config = model.config_obj.to_dict()
     training_set_metadata = copy.deepcopy(model.training_set_metadata)
@@ -304,9 +304,9 @@ def get_input_tensors(
         callbacks=model.callbacks,
     )
 
-    # Restore sample_ratio and sample_cap
+    # Restore sample_ratio and sample_size
     model.config_obj.preprocessing.sample_ratio = sample_ratio_bak
-    model.config_obj.preprocessing.sample_cap = sample_cap_bak
+    model.config_obj.preprocessing.sample_size = sample_size_bak
 
     # Make sure the number of rows in the preprocessed dataset matches the number of rows in the input data
     assert (

--- a/ludwig/schema/metadata/configs/preprocessing.yaml
+++ b/ludwig/schema/metadata/configs/preprocessing.yaml
@@ -59,7 +59,7 @@ sample_size:
         - 1000
     expected_impact: 2
     suggested_values: Depends on data size
-    ui_display_name: Sample Cap
+    ui_display_name: Sample Size
 column:
     expected_impact: 3
     ui_display_name: Split Column

--- a/ludwig/schema/metadata/configs/preprocessing.yaml
+++ b/ludwig/schema/metadata/configs/preprocessing.yaml
@@ -44,6 +44,22 @@ sample_ratio:
     expected_impact: 2
     suggested_values: Depends on data size
     ui_display_name: Sample Ratio
+sample_cap:
+    default_value_reasoning:
+        The default value is None because we do not want to shrink
+        the dataset by default, and we do not know the size of an arbitrary dataset.
+        By setting the default to None, we fall back on the sample_ratio to determine
+        the size of the dataset.
+    description_implications:
+        Decreases the amount of data you are inputting into
+        the model. Could be useful if you have more data than you need and you are
+        concerned with computational costs. More useful than sample_ratio if you
+        know the exact number of samples you want to train on instead of knowing the proportion.
+    example_value:
+        - 1000
+    expected_impact: 2
+    suggested_values: Depends on data size
+    ui_display_name: Sample Cap
 column:
     expected_impact: 3
     ui_display_name: Split Column

--- a/ludwig/schema/metadata/configs/preprocessing.yaml
+++ b/ludwig/schema/metadata/configs/preprocessing.yaml
@@ -44,7 +44,7 @@ sample_ratio:
     expected_impact: 2
     suggested_values: Depends on data size
     ui_display_name: Sample Ratio
-sample_cap:
+sample_size:
     default_value_reasoning:
         The default value is None because we do not want to shrink
         the dataset by default, and we do not know the size of an arbitrary dataset.

--- a/ludwig/schema/preprocessing.py
+++ b/ludwig/schema/preprocessing.py
@@ -18,12 +18,12 @@ class PreprocessingConfig(schema_utils.BaseMarshmallowConfig):
         parameter_metadata=PREPROCESSING_METADATA["sample_ratio"],
     )
 
-    sample_cap: float = schema_utils.NonNegativeInteger(
+    sample_size: float = schema_utils.NonNegativeInteger(
         default=None,
         allow_none=True,
         description="The maximum number of samples from the dataset to use. Cannot be set if sample_ratio is set to be "
         "< 1.0. If sample_ratio is set to 1.0, this will override the number of samples to used.",
-        parameter_metadata=PREPROCESSING_METADATA["sample_cap"],
+        parameter_metadata=PREPROCESSING_METADATA["sample_size"],
     )
 
     oversample_minority: float = schema_utils.NonNegativeFloat(

--- a/ludwig/schema/preprocessing.py
+++ b/ludwig/schema/preprocessing.py
@@ -18,6 +18,14 @@ class PreprocessingConfig(schema_utils.BaseMarshmallowConfig):
         parameter_metadata=PREPROCESSING_METADATA["sample_ratio"],
     )
 
+    sample_cap: float = schema_utils.NonNegativeInteger(
+        default=None,
+        allow_none=True,
+        description="The maximum number of samples from the dataset to use. Cannot be set if sample_ratio is set to be "
+        "< 1.0. If sample_ratio is set to 1.0, this will override the number of samples to used.",
+        parameter_metadata=PREPROCESSING_METADATA["sample_cap"],
+    )
+
     oversample_minority: float = schema_utils.NonNegativeFloat(
         default=None,
         allow_none=True,

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -196,7 +196,7 @@ def test_sample_size(backend, tmpdir, ray_cluster_2cpu):
     count = len(train_set) + len(val_set) + len(test_set)
     assert sample_size == count
 
-    # Check that sample cap is disabled when doing preprocessing for prediction
+    # Check that sample size is disabled when doing preprocessing for prediction
     dataset, _ = preprocess_for_prediction(
         model.config_obj.to_dict(),
         dataset=data_csv,

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -169,9 +169,9 @@ def test_sample_ratio_deterministic(backend, tmpdir, ray_cluster_2cpu):
         pytest.param("ray", id="ray", marks=pytest.mark.distributed),
     ],
 )
-def test_sample_cap(backend, tmpdir, ray_cluster_2cpu):
+def test_sample_size(backend, tmpdir, ray_cluster_2cpu):
     num_examples = 100
-    sample_cap = 25
+    sample_size = 25
 
     input_features = [sequence_feature(encoder={"reduce_output": "sum"}), audio_feature(folder=tmpdir)]
     output_features = [category_feature(decoder={"vocab_size": 5}, reduce_input="sum")]
@@ -184,7 +184,7 @@ def test_sample_cap(backend, tmpdir, ray_cluster_2cpu):
         TRAINER: {
             EPOCHS: 2,
         },
-        PREPROCESSING: {"sample_cap": sample_cap},
+        PREPROCESSING: {"sample_size": sample_size},
     }
 
     model = LudwigModel(config, backend=backend)
@@ -194,7 +194,7 @@ def test_sample_cap(backend, tmpdir, ray_cluster_2cpu):
     )
 
     count = len(train_set) + len(val_set) + len(test_set)
-    assert sample_cap == count
+    assert sample_size == count
 
     # Check that sample cap is disabled when doing preprocessing for prediction
     dataset, _ = preprocess_for_prediction(
@@ -205,7 +205,7 @@ def test_sample_cap(backend, tmpdir, ray_cluster_2cpu):
         include_outputs=True,
         backend=model.backend,
     )
-    assert "sample_cap" in model.config_obj.preprocessing.to_dict()
+    assert "sample_size" in model.config_obj.preprocessing.to_dict()
     assert len(dataset) == num_examples
 
 
@@ -216,14 +216,14 @@ def test_sample_cap(backend, tmpdir, ray_cluster_2cpu):
         pytest.param("ray", id="ray", marks=pytest.mark.distributed),
     ],
 )
-def test_sample_cap_deterministic(backend, tmpdir, ray_cluster_2cpu):
+def test_sample_size_deterministic(backend, tmpdir, ray_cluster_2cpu):
     """Ensures that the sampled dataset is the same when using a random seed.
 
     model.preprocess returns a PandasPandasDataset object when using local backend, and returns a RayDataset object when
     using the Ray backend.
     """
     num_examples = 100
-    sample_cap = 30
+    sample_size = 30
 
     input_features = [binary_feature()]
     output_features = [category_feature()]
@@ -234,7 +234,7 @@ def test_sample_cap_deterministic(backend, tmpdir, ray_cluster_2cpu):
     config = {
         INPUT_FEATURES: input_features,
         OUTPUT_FEATURES: output_features,
-        PREPROCESSING: {"sample_cap": sample_cap},
+        PREPROCESSING: {"sample_size": sample_size},
     }
 
     model1 = LudwigModel(config, backend=backend)
@@ -250,8 +250,8 @@ def test_sample_cap_deterministic(backend, tmpdir, ray_cluster_2cpu):
     )
 
     # Ensure sizes are the same
-    assert sample_cap == len(train_set_1) + len(val_set_1) + len(test_set_1)
-    assert sample_cap == len(train_set_2) + len(val_set_2) + len(test_set_2)
+    assert sample_size == len(train_set_1) + len(val_set_1) + len(test_set_1)
+    assert sample_size == len(train_set_2) + len(val_set_2) + len(test_set_2)
 
     # Ensure actual rows are the same
     if backend == "local":

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -486,3 +486,35 @@ def test_check_prompt_requirements():
 
     config["prompt"] = {"task": "Some task", "template": "{__task__}"}
     ModelConfig.from_dict(config)
+
+
+def test_check_sample_ratio_and_size_compatible():
+    config = {
+        "input_features": [binary_feature()],
+        "output_features": [binary_feature()],
+        "model_type": "ecd",
+    }
+    ModelConfig.from_dict(
+        {
+            "input_features": [binary_feature()],
+            "output_features": [binary_feature()],
+            "model_type": "ecd",
+        }
+    )
+
+    config["preprocessing"] = {"sample_size": 10}
+    ModelConfig.from_dict(config)
+
+    config["preprocessing"]["sample_ratio"] = 1
+    ModelConfig.from_dict(config)
+
+    config["preprocessing"]["sample_ratio"] = 0.1
+    with pytest.raises(ConfigValidationError):
+        ModelConfig.from_dict(config)
+
+    config["preprocessing"]["sample_size"] = 0
+    with pytest.raises(ConfigValidationError):
+        ModelConfig.from_dict(config)
+
+    del config["preprocessing"]["sample_size"]
+    ModelConfig.from_dict(config)


### PR DESCRIPTION
Adds sample_size as a global preprocessing parameter, allowing users to specify exactly how many samples they want to train on instead of having to calculate the sample_ratio. Adds two integration tests to verify sample_size works as intended.