### PR TITLE
FIX: docker build error for ludwig-gpu

### DIFF
--- a/docker/ludwig-gpu/Dockerfile
+++ b/docker/ludwig-gpu/Dockerfile
@@ -9,7 +9,7 @@
 #   model serving
 #
 
-FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-devel
+FROM pytorch/pytorch:2.0.1-cuda11.7-cudnn8-devel
 
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
 RUN sh -c 'echo "APT { Get { AllowUnauthenticated \"1\"; }; };" > /etc/apt/apt.conf.d/99allow_unauth' && \
@@ -21,7 +21,7 @@ RUN sh -c 'echo "APT { Get { AllowUnauthenticated \"1\"; }; };" > /etc/apt/apt.c
     rm -f /etc/apt/sources.list.d/cuda.list /etc/apt/apt.conf.d/99allow_unauth cuda-keyring_1.0-1_all.deb && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC F60F4B3D7FA2AF80
 
-RUN apt-get -y update && apt-get -y install \
+RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" apt-get -y install \
     git \
     libsndfile1 \
     cmake \


### PR DESCRIPTION
Update base image to Ubuntu 18.04 to 20.04 to resolve this error in the build for for docker image `ludwig-gpu`.

```
#12 7.755 Unpacking cuda-keyring (1.0-1) ...
#12 7.779 Setting up cuda-keyring (1.0-1) ...
#12 7.861 Warning: apt-key output should not be parsed (stdout is not a terminal)
#12 7.881 Executing: /tmp/apt-key-gpghome.JznHdaISEj/gpg.1.sh --keyserver keyserver.ubuntu.com --recv-keys A4B469963BF863CC F60F4B3D7FA2AF80
#12 7.943 gpg: keyserver receive failed: Cannot assign requested address
```

With EOSS for 18.04, it appears some of of the Ubuntu resources are being decommissioned: https://askubuntu.com/questions/1481617/randomly-get-gpg-keyserver-receive-failed-cannot-assign-requested-address