### PR TITLE
Fix dynamic generation config load during `model.predict`

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -936,20 +936,12 @@ class LudwigModel:
             callbacks=self.callbacks + (callbacks or []),
         )
 
-        # Set the generation config if it exists.
-        # model.reset_generation_config() is called after batch prediction.
-        if generation_config is not None:
-            self.model.set_generation_config(generation_config)
-
         logger.debug("Predicting")
         with self.backend.create_predictor(self.model, batch_size=batch_size) as predictor:
-            predictions = predictor.batch_predict(
-                dataset,
-            )
-
-            # If there was a generation config set prior to batch prediction, reset it.
-            if generation_config is not None:
-                self.model.reset_generation_config()
+            with self.model.use_generation_config(generation_config):
+                predictions = predictor.batch_predict(
+                    dataset,
+                )
 
             if self.backend.is_coordinator():
                 # if we are skipping all saving,

--- a/ludwig/decoders/utils.py
+++ b/ludwig/decoders/utils.py
@@ -34,8 +34,4 @@ def extract_generated_tokens(
                 generated_sequence, (0, max_new_tokens - generated_sequence.size()[0]), "constant", 0
             )
         generated_outputs.append(generated_sequence)
-
-    # Stack the predictions for each example in the batch
-    generated_outputs = torch.stack(generated_outputs, dim=0)
-
     return generated_outputs

--- a/ludwig/models/base.py
+++ b/ludwig/models/base.py
@@ -1,7 +1,8 @@
+import contextlib
 import logging
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
-from typing import Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -328,6 +329,14 @@ class BaseModel(LudwigModule, metaclass=ABCMeta):
     @abstractmethod
     def get_args(self):
         """Returns init arguments for constructing this model."""
+
+    @contextlib.contextmanager
+    def use_generation_config(self, generation_config: Dict[str, Any]):
+        if generation_config is not None:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} does not support generation_config. "
+            )
+        yield
 
 
 def create_input_feature(feature_config: BaseInputFeatureConfig, encoder_obj: Optional[Encoder]) -> InputFeature:

--- a/tests/ludwig/decoders/test_llm_decoders.py
+++ b/tests/ludwig/decoders/test_llm_decoders.py
@@ -1,0 +1,82 @@
+import pytest
+import torch
+
+from ludwig.constants import (
+    BASE_MODEL,
+    BACKEND,
+    GENERATION,
+    INPUT_FEATURES,
+    MODEL_TYPE,
+    OUTPUT_FEATURES,
+)
+from ludwig.decoders.llm_decoders import TextExtractorDecoder
+from ludwig.schema.model_config import ModelConfig
+from tests.integration_tests.utils import text_feature
+
+TEST_MODEL_NAME = "hf-internal-testing/tiny-random-GPTJForCausalLM"
+
+
+def test_text_extractor_decoder():
+    max_new_tokens = 4
+    
+    input_features = [
+        {
+            "name": "Question",
+            "type": "text",
+            "encoder": {"type": "passthrough"},
+        }
+    ]
+    output_features = [
+        text_feature(
+            output_feature=True, 
+            name="Answer", 
+            decoder={"type": "text_extractor"}
+        )
+    ]
+
+    config = {
+        MODEL_TYPE: "llm",
+        BASE_MODEL: TEST_MODEL_NAME,
+        GENERATION: {
+            "temperature": 0.1,
+            "top_p": 0.75,
+            "top_k": 40,
+            "num_beams": 4,
+            "max_new_tokens": max_new_tokens,
+        },
+        INPUT_FEATURES: input_features,
+        OUTPUT_FEATURES: output_features,
+        BACKEND: "local",
+    }
+    
+    config = ModelConfig.from_dict(config)
+    decoder_config = config.output_features[0].decoder
+    
+    decoder = TextExtractorDecoder(32, decoder_config)
+
+    inputs = [
+        torch.tensor([1, 1, 1, 2, 2, 2, 2]),     # baseline
+        torch.tensor([1, 1, 1, 2]),              # too short; test padding
+        torch.tensor([1, 1, 1, 1, 2, 2, 2]),     # test different input length
+    ]
+    input_lengths = [3, 3, 4]
+
+    # tests happy path
+    outputs = decoder.forward(inputs, llm_model_input_lengths=input_lengths)
+    assert outputs['predictions'].shape == (3, max_new_tokens)
+    # Create a Boolean mask for elements equal to 0 or 2 (padding or output)
+    mask = (outputs['predictions'] == 0) | (outputs['predictions'] == 2)
+    assert mask.all()
+    
+    # test overly long generation fails without updated max_new_tokens
+    inputs.append(torch.tensor([1, 1, 1, 2, 2, 2, 2, 2]))  # too long; test downstream failure)
+    input_lengths.append(3)
+    with pytest.raises(ValueError):
+        outputs = decoder.forward(inputs, llm_model_input_lengths=input_lengths)
+        
+    # test overly long generation succeeds with new max_new_tokens
+    new_max_new_tokens = 5
+    outputs = decoder.forward(inputs, llm_model_input_lengths=input_lengths, max_new_tokens=new_max_new_tokens)
+    assert outputs['predictions'].shape == (4, new_max_new_tokens)
+    mask = (outputs['predictions'] == 0) | (outputs['predictions'] == 2)
+    assert mask.all()


### PR DESCRIPTION
This PR fixes dynamic generation config loading during `model.predict`.

Their were two issues:
1. When passing in a generation config through model.predict, a fresh `transformers.GenerationConfig` was created, meaning that any existing parameters in `self.generation` were not respected by `llm.set_generation_config`. This is fixed by ensuring that we pass in `**{**self.generation.as_dict(), **new_generation_config_dict` as kwargs into the new GenerationConfig.
2. When setting a new generation config, we were not properly communicating with the `TextExtractorDecoder`, which is in charge of extracting the generated outputs from the model outputs. This is fixed by passing in `max_new_tokens` as a kwarg in the decoder forward pass.