### PR TITLE
Increment epochs based on last_batch() instead of at the end of the train loop.

### DIFF
--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -644,7 +644,7 @@ def test_api_callbacks_fixed_train_steps_less_than_one_epoch(tmpdir, csv_filenam
     )
 
     assert mock_callback.on_epoch_start.call_count == 1
-    assert mock_callback.on_epoch_end.call_count == 1
+    assert mock_callback.on_epoch_end.call_count == 0
     # The total number of batches is the number of train_steps
     assert mock_callback.on_batch_end.call_count == total_batches
     # The total number of evals is the number of times checkpoints are made


### PR DESCRIPTION
`self._train_loop()` trains over a full epoch of data or up to the last training step, whichever is sooner, so we should only increment epochs when `last_batch()` is `True` as a check within `self._train_loop()`.

This fixes a potential issue with the last epoch being 1 too high when the training runway concludes partway through an epoch.