### PR TITLE
Place metric functions for BLEU and Rogue on correct devices when using multiple GPUs

### DIFF
--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -311,7 +311,8 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
                         # Decoded texts are only provided using the LLM model type.
                         if decoded_targets is not None and decoded_predictions is not None:
                             # Move metric function to the device of the predictions.
-                            # For CUDA, it can be computed on any of the GPUs since it uses all
+                            # For CUDA, it can be computed on any of the GPUs since it uses allgather to collect
+                            # the results from all GPUs and compute the final metric.
                             # We use 'predictions' as the key since it is always present in the predictions dict.
                             device = "cuda" if predictions["predictions"].is_cuda else "cpu"
                             metric_fn = metric_fn.to(device)

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -299,7 +299,9 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
             predictions: Dict of tensors returned by predictions().
         """
         if tokenizer is not None:
+            # Decode the targets and predictions to compute response-based metrics using the initialized tokenizer.
             decoded_targets, decoded_predictions = get_decoded_targets_and_predictions(targets, predictions, tokenizer)
+
         for metric_name, metric_fn in self._metric_functions.items():
             prediction_key = get_metric_tensor_input(metric_name)
             try:
@@ -308,6 +310,11 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
                         # RESPONSE metrics cannot be computed if decoded texts are not provided.
                         # Decoded texts are only provided using the LLM model type.
                         if decoded_targets is not None and decoded_predictions is not None:
+                            # Move metric function to the device of the predictions.
+                            # For CUDA, it can be computed on any of the GPUs since it uses all
+                            # We use 'predictions' as the key since it is always present in the predictions dict.
+                            device = 'cuda' if predictions['predictions'].is_cuda else 'cpu'
+                            metric_fn = metric_fn.to(device)
                             if metric_name == "bleu":
                                 # BLEU takes in targets as a list.
                                 metric_fn.update(decoded_predictions, [decoded_targets])

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -313,7 +313,7 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
                             # Move metric function to the device of the predictions.
                             # For CUDA, it can be computed on any of the GPUs since it uses all
                             # We use 'predictions' as the key since it is always present in the predictions dict.
-                            device = 'cuda' if predictions['predictions'].is_cuda else 'cpu'
+                            device = "cuda" if predictions["predictions"].is_cuda else "cpu"
                             metric_fn = metric_fn.to(device)
                             if metric_name == "bleu":
                                 # BLEU takes in targets as a list.


### PR DESCRIPTION
The issue was that the metric function wasn't being moved/placed on the right device, leading to a weird behavior for these metrics using the `response` prediction key because the inputs that are passed in are not tensors, they're lists of strings. However, it seems like these metric functions need to moved to CUDA (instead of staying on the CPU) so that when the metric_fn.compute() call is called to gather evaluation metric summaries, it does not run into this error:

```sh
RuntimeError: Tensors must be CUDA and dense
```

Tested successfully with:

1. Only CPU machine
2. Multi-GPU Quantized training (4 GPUs)
3. Multi-GPU DeepSpeed Stage 3 training (4 GPUs)

<img width="1027" alt="Screenshot 2023-09-27 at 4 50 09 PM" src="https://github.com/ludwig-ai/ludwig/assets/106701836/1fe303ab-7b25-47db-9bd3-80cd27702cb1">
