### PR TITLE
[MAINTENANCE] Partially reconcile type hints, fix some warnings, and fix comments in parts of the codebase.

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -269,11 +269,11 @@ class LudwigModel:
         self,
         config: Union[str, dict],
         logging_level: int = logging.ERROR,
-        backend: Union[Backend, str, None] = None,
-        gpus: Union[str, int, List[int], None] = None,
+        backend: Optional[Union[Backend, str]] = None,
+        gpus: Optional[Union[str, int, List[int]]] = None,
         gpu_memory_limit: Optional[float] = None,
         allow_parallel_threads: bool = True,
-        callbacks: Union[List[Callback], None] = None,
+        callbacks: Optional[List[Callback]] = None,
     ) -> None:
         """Constructor for the Ludwig Model class.
 
@@ -326,29 +326,29 @@ class LudwigModel:
 
         # setup model
         self.model = None
-        self.training_set_metadata: Union[str, dict, None] = None
+        self.training_set_metadata: Optional[str, dict] = None
 
         # online training state
         self._online_trainer = None
 
     def train(
         self,
-        dataset: Union[str, dict, pd.DataFrame, None] = None,
-        training_set: Union[str, dict, pd.DataFrame, Dataset, None] = None,
-        validation_set: Union[str, dict, pd.DataFrame, Dataset, None] = None,
-        test_set: Union[str, dict, pd.DataFrame, Dataset, None] = None,
-        training_set_metadata: Union[str, dict, None] = None,
-        data_format: Union[str, None] = None,
+        dataset: Optional[Union[str, dict, pd.DataFrame]] = None,
+        training_set: Optional[Union[str, dict, pd.DataFrame, Dataset]] = None,
+        validation_set: Optional[Union[str, dict, pd.DataFrame, Dataset]] = None,
+        test_set: Optional[Union[str, dict, pd.DataFrame, Dataset]] = None,
+        training_set_metadata: Optional[Union[str, dict]] = None,
+        data_format: Optional[str] = None,
         experiment_name: str = "api_experiment",
         model_name: str = "run",
-        model_resume_path: Union[str, None] = None,
+        model_resume_path: Optional[str] = None,
         skip_save_training_description: bool = False,
         skip_save_training_statistics: bool = False,
         skip_save_model: bool = False,
         skip_save_progress: bool = False,
         skip_save_log: bool = False,
         skip_save_processed_input: bool = False,
-        output_directory: Union[str, None] = "results",
+        output_directory: Optional[str] = "results",
         random_seed: int = default_random_seed,
         **kwargs,
     ) -> TrainingResults:
@@ -744,7 +744,7 @@ class LudwigModel:
     def train_online(
         self,
         dataset: Union[str, dict, pd.DataFrame],
-        training_set_metadata: Union[str, dict] = None,
+        training_set_metadata: Optional[Union[str, dict]] = None,
         data_format: str = "auto",
         random_seed: int = default_random_seed,
     ) -> None:
@@ -892,11 +892,11 @@ class LudwigModel:
 
     def predict(
         self,
-        dataset: Union[str, dict, pd.DataFrame] = None,
+        dataset: Optional[Union[str, dict, pd.DataFrame]] = None,
         data_format: str = None,
         split: str = FULL,
         batch_size: int = 128,
-        generation_config: Optional[Dict] = None,
+        generation_config: Optional[dict] = None,
         skip_save_unprocessed_output: bool = True,
         skip_save_predictions: bool = True,
         output_directory: str = "results",
@@ -1003,8 +1003,8 @@ class LudwigModel:
 
     def evaluate(
         self,
-        dataset: Union[str, dict, pd.DataFrame] = None,
-        data_format: str = None,
+        dataset: Optional[Union[str, dict, pd.DataFrame]] = None,
+        data_format: Optional[str] = None,
         split: str = FULL,
         batch_size: Optional[int] = None,
         skip_save_unprocessed_output: bool = True,
@@ -1224,16 +1224,16 @@ class LudwigModel:
 
     def experiment(
         self,
-        dataset: Union[str, dict, pd.DataFrame] = None,
-        training_set: Union[str, dict, pd.DataFrame] = None,
-        validation_set: Union[str, dict, pd.DataFrame] = None,
-        test_set: Union[str, dict, pd.DataFrame] = None,
-        training_set_metadata: Union[str, dict] = None,
-        data_format: str = None,
+        dataset: Optional[Union[str, dict, pd.DataFrame]] = None,
+        training_set: Optional[Union[str, dict, pd.DataFrame]] = None,
+        validation_set: Optional[Union[str, dict, pd.DataFrame]] = None,
+        test_set: Optional[Union[str, dict, pd.DataFrame]] = None,
+        training_set_metadata: Optional[Union[str, dict]] = None,
+        data_format: Optional[str] = None,
         experiment_name: str = "experiment",
         model_name: str = "run",
-        model_load_path: str = None,
-        model_resume_path: str = None,
+        model_load_path: Optional[str] = None,
+        model_resume_path: Optional[str] = None,
         eval_split: str = TEST,
         skip_save_training_description: bool = False,
         skip_save_training_statistics: bool = False,
@@ -1438,7 +1438,7 @@ class LudwigModel:
         self,
         layer_names: List[str],
         dataset: Union[str, Dict[str, list], pd.DataFrame],
-        data_format: str = None,
+        data_format: Optional[str] = None,
         split: str = FULL,
         batch_size: int = 128,
         **kwargs,
@@ -1491,12 +1491,12 @@ class LudwigModel:
 
     def preprocess(
         self,
-        dataset: Union[str, dict, pd.DataFrame, None] = None,
-        training_set: Union[str, dict, pd.DataFrame, None] = None,
-        validation_set: Union[str, dict, pd.DataFrame, None] = None,
-        test_set: Union[str, dict, pd.DataFrame, None] = None,
-        training_set_metadata: Union[str, dict, None] = None,
-        data_format: Union[str, None] = None,
+        dataset: Optional[Union[str, dict, pd.DataFrame]] = None,
+        training_set: Optional[Union[str, dict, pd.DataFrame]] = None,
+        validation_set: Optional[Union[str, dict, pd.DataFrame]] = None,
+        test_set: Optional[Union[str, dict, pd.DataFrame]] = None,
+        training_set_metadata: Optional[Union[str, dict]] = None,
+        data_format: Optional[str] = None,
         skip_save_processed_input: bool = True,
         random_seed: int = default_random_seed,
         **kwargs,
@@ -1584,8 +1584,8 @@ class LudwigModel:
     def load(
         model_dir: str,
         logging_level: int = logging.ERROR,
-        backend: Union[Backend, str] = None,
-        gpus: Union[str, int, List[int]] = None,
+        backend: Optional[Union[Backend, str]] = None,
+        gpus: Optional[Union[str, int, List[int]]] = None,
         gpu_memory_limit: Optional[float] = None,
         allow_parallel_threads: bool = True,
         callbacks: List[Callback] = None,
@@ -1923,10 +1923,10 @@ def kfold_cross_validate(
     skip_collect_overall_stats: bool = False,
     output_directory: str = "results",
     random_seed: int = default_random_seed,
-    gpus: Union[str, int, List[int]] = None,
+    gpus: Optional[Union[str, int, List[int]]] = None,
     gpu_memory_limit: Optional[float] = None,
     allow_parallel_threads: bool = True,
-    backend: Union[Backend, str] = None,
+    backend: Optional[Union[Backend, str]] = None,
     logging_level: int = logging.INFO,
     **kwargs,
 ) -> Tuple[dict, dict]:

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -111,7 +111,7 @@ logger = logging.getLogger(__name__)
 
 @PublicAPI
 @dataclass
-class EvaluationFrequency:
+class EvaluationFrequency:  # noqa F821
     """Represents the frequency of periodic evaluation of a metric during training. For example:
 
     "every epoch"
@@ -130,7 +130,7 @@ class EvaluationFrequency:
 
 @PublicAPI
 @dataclass
-class TrainingStats:
+class TrainingStats:  # noqa F821
     """Training stats were previously represented as a tuple or a dict.
 
     This class replaces those while preserving dict and tuple-like behavior (unpacking, [] access).
@@ -159,7 +159,7 @@ class TrainingStats:
 
 @PublicAPI
 @dataclass
-class PreprocessedDataset:
+class PreprocessedDataset:  # noqa F821
     training_set: Dataset
     validation_set: Dataset
     test_set: Dataset
@@ -175,7 +175,7 @@ class PreprocessedDataset:
 
 @PublicAPI
 @dataclass
-class TrainingResults:
+class TrainingResults:  # noqa F821
     train_stats: TrainingStats
     preprocessed_data: PreprocessedDataset
     output_directory: str
@@ -1027,7 +1027,7 @@ class LudwigModel:
             `'html'` (file containing a single HTML `<table>`), `'json'`, `'jsonl'`,
             `'parquet'`, `'pickle'` (pickled Pandas DataFrame), `'sas'`, `'spss'`,
             `'stata'`, `'tsv'`.
-        :param: split: (str, default= `'full'`): if the input dataset contains
+        :param split: (str, default=`'full'`): if the input dataset contains
             a split column, this parameter indicates which split of the data
             to use. Possible values are `'full'`, `'training'`, `'validation'`, `'test'`.
         :param batch_size: (int, default: None) size of batch to use when making
@@ -1439,7 +1439,6 @@ class LudwigModel:
         data_format: str = None,
         split: str = FULL,
         batch_size: int = 128,
-        debug: bool = False,
         **kwargs,
     ) -> list:
         """Loads a pre-trained model model and input data to collect the values of the activations contained in the
@@ -1457,7 +1456,7 @@ class LudwigModel:
             `'html'` (file containing a single HTML `<table>`), `'json'`, `'jsonl'`,
             `'parquet'`, `'pickle'` (pickled Pandas DataFrame), `'sas'`, `'spss'`,
             `'stata'`, `'tsv'`.
-        :param: split: (str, default= `'full'`): if the input dataset contains
+        :param split: (str, default= `'full'`): if the input dataset contains
             a split column, this parameter indicates which split of the data
             to use. Possible values are `'full'`, `'training'`, `'validation'`, `'test'`.
         :param batch_size: (int, default: 128) size of batch to use when making
@@ -1532,9 +1531,6 @@ class LudwigModel:
                 dataset is provided it is preprocessed and cached by saving an HDF5
                 and JSON files to avoid running the preprocessing again. If this
                 parameter is `False`, the HDF5 and JSON file are not saved.
-            :param output_directory: (str, default: `'results'`) the directory that
-                will contain the training statistics, TensorBoard logs, the saved
-                model and the training progress files.
             :param random_seed: (int, default: `42`) a random seed that will be
                 used anywhere there is a call to a random number generator: data
                 splitting, parameter initialization and training set shuffling
@@ -1728,8 +1724,8 @@ class LudwigModel:
         training_set_metadata_path = os.path.join(save_path, TRAIN_SET_METADATA_FILE_NAME)
         save_json(training_set_metadata_path, self.training_set_metadata)
 
+    @staticmethod
     def upload_to_hf_hub(
-        self,
         repo_id: str,
         model_path: str,
         repo_type: str = "model",

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -269,11 +269,11 @@ class LudwigModel:
         self,
         config: Union[str, dict],
         logging_level: int = logging.ERROR,
-        backend: Union[Backend, str] = None,
-        gpus: Union[str, int, List[int]] = None,
+        backend: Union[Backend, str, None] = None,
+        gpus: Union[str, int, List[int], None] = None,
         gpu_memory_limit: Optional[float] = None,
         allow_parallel_threads: bool = True,
-        callbacks: List[Callback] = None,
+        callbacks: Union[List[Callback], None] = None,
     ) -> None:
         """Constructor for the Ludwig Model class.
 
@@ -305,7 +305,7 @@ class LudwigModel:
             self.config_fp = config
         else:
             config_dict = copy.deepcopy(config)
-            self.config_fp = None
+            self.config_fp = None  # type: ignore [assignment]
 
         self._user_config = upgrade_config_dict_to_latest_version(config_dict)
 
@@ -326,29 +326,29 @@ class LudwigModel:
 
         # setup model
         self.model = None
-        self.training_set_metadata = None
+        self.training_set_metadata: Union[str, dict, None] = None
 
         # online training state
         self._online_trainer = None
 
     def train(
         self,
-        dataset: Union[str, dict, pd.DataFrame] = None,
-        training_set: Union[str, dict, pd.DataFrame, Dataset] = None,
-        validation_set: Union[str, dict, pd.DataFrame, Dataset] = None,
-        test_set: Union[str, dict, pd.DataFrame, Dataset] = None,
-        training_set_metadata: Union[str, dict] = None,
-        data_format: str = None,
+        dataset: Union[str, dict, pd.DataFrame, None] = None,
+        training_set: Union[str, dict, pd.DataFrame, Dataset, None] = None,
+        validation_set: Union[str, dict, pd.DataFrame, Dataset, None] = None,
+        test_set: Union[str, dict, pd.DataFrame, Dataset, None] = None,
+        training_set_metadata: Union[str, dict, None] = None,
+        data_format: Union[str, None] = None,
         experiment_name: str = "api_experiment",
         model_name: str = "run",
-        model_resume_path: str = None,
+        model_resume_path: Union[str, None] = None,
         skip_save_training_description: bool = False,
         skip_save_training_statistics: bool = False,
         skip_save_model: bool = False,
         skip_save_progress: bool = False,
         skip_save_log: bool = False,
         skip_save_processed_input: bool = False,
-        output_directory: str = "results",
+        output_directory: Union[str, None] = "results",
         random_seed: int = default_random_seed,
         **kwargs,
     ) -> TrainingResults:
@@ -540,7 +540,7 @@ class LudwigModel:
                             f"{output_directory}/{experiment_name}/model/model_hyperparameters.json"
                         )
 
-                preprocessed_data = self.preprocess(
+                preprocessed_data = self.preprocess(  # type: ignore[assignment]
                     dataset=dataset,
                     training_set=training_set,
                     validation_set=validation_set,
@@ -569,8 +569,10 @@ class LudwigModel:
 
                 if not skip_save_model:
                     # save train set metadata
-                    os.makedirs(model_dir, exist_ok=True)
-                    save_json(os.path.join(model_dir, TRAIN_SET_METADATA_FILE_NAME), training_set_metadata)
+                    os.makedirs(model_dir, exist_ok=True)  # type: ignore[arg-type]
+                    save_json(  # type: ignore[arg-type]
+                        os.path.join(model_dir, TRAIN_SET_METADATA_FILE_NAME), training_set_metadata
+                    )
 
                 logger.info("\nDataset Statistics")
                 logger.info(tabulate(dataset_statistics, headers="firstrow", tablefmt="fancy_grid"))
@@ -1489,12 +1491,12 @@ class LudwigModel:
 
     def preprocess(
         self,
-        dataset: Union[str, dict, pd.DataFrame] = None,
-        training_set: Union[str, dict, pd.DataFrame] = None,
-        validation_set: Union[str, dict, pd.DataFrame] = None,
-        test_set: Union[str, dict, pd.DataFrame] = None,
-        training_set_metadata: Union[str, dict] = None,
-        data_format: str = None,
+        dataset: Union[str, dict, pd.DataFrame, None] = None,
+        training_set: Union[str, dict, pd.DataFrame, None] = None,
+        validation_set: Union[str, dict, pd.DataFrame, None] = None,
+        test_set: Union[str, dict, pd.DataFrame, None] = None,
+        training_set_metadata: Union[str, dict, None] = None,
+        data_format: Union[str, None] = None,
         skip_save_processed_input: bool = True,
         random_seed: int = default_random_seed,
         **kwargs,

--- a/ludwig/models/base.py
+++ b/ludwig/models/base.py
@@ -277,6 +277,10 @@ class BaseModel(LudwigModule, metaclass=ABCMeta):
     def eval_loss_metric(self) -> LudwigMetric:
         return self._eval_loss_metric.module
 
+    @eval_loss_metric.setter
+    def eval_loss_metric(self, value: LudwigMetric) -> None:
+        self._eval_loss_metric.module = value
+
     @property
     def eval_additional_losses_metrics(self) -> LudwigMetric:
         return self._eval_additional_losses_metrics.module

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -421,7 +421,7 @@ class LLM(BaseModel):
                         f"Input length {input_ids_sample_no_padding.shape[1]} is "
                         f"greater than max input length {self.max_input_length}. Truncating."
                     )
-                    input_ids_sample_no_padding = input_ids_sample_no_padding[:, -self.max_input_length :]
+                    input_ids_sample_no_padding = input_ids_sample_no_padding[:, -self.max_input_length :]  # noqa E203
 
                 input_lengths.append(input_ids_sample_no_padding.shape[1])
 

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -136,7 +136,7 @@ class LLM(BaseModel):
             self.context_len = 2048
 
         # max input length value copied from FastChat
-        # https://github.com/lm-sys/FastChat/blob/0e958b852a14f4bef5f0e9d7a5e7373477329cf2/fastchat/serve/inference.py#L183  # noqa
+        # https://github.com/lm-sys/FastChat/blob/0e958b852a14f4bef5f0e9d7a5e7373477329cf2/fastchat/serve/inference.py#L183  # noqa E501
         self.max_new_tokens = self.config_obj.generation.max_new_tokens
         self.max_input_length = self.context_len - self.max_new_tokens - 8
 

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -192,9 +192,11 @@ class LLM(BaseModel):
         # Extract the decoder object for the forward pass
         self._output_feature_decoder = ModuleWrapper(self.output_features.items()[0][1])
 
+        self.attention_masks = None
+
         clear_data_cache()
 
-    def create_feature_dict(self) -> LudwigFeatureDict:
+    def create_feature_dict(self) -> DictWrapper:
         return DictWrapper(LudwigFeatureDict())
 
     def set_generation_config(self, generation_config_dict):
@@ -728,6 +730,7 @@ class LLM(BaseModel):
 
         return _targets
 
-    def get_augmentation_pipelines(self) -> AugmentationPipelines:
+    @staticmethod
+    def get_augmentation_pipelines() -> AugmentationPipelines:
         """Returns the augmentation pipeline for this model."""
         return AugmentationPipelines({})

--- a/ludwig/schema/llms/peft.py
+++ b/ludwig/schema/llms/peft.py
@@ -474,7 +474,8 @@ def AdapterDataclassField(default: Optional[str] = None):
         def get_schema_from_registry(self, key: str) -> Type[schema_utils.BaseMarshmallowConfig]:
             return adapter_registry[key]
 
-        def _jsonschema_type_mapping(self):
+        @staticmethod
+        def _jsonschema_type_mapping():
             return {
                 "oneOf": [
                     {

--- a/ludwig/schema/llms/peft.py
+++ b/ludwig/schema/llms/peft.py
@@ -175,7 +175,7 @@ class BasePromptLearningConfig(BaseAdapterConfig):
 #                 "Must provide `prompt_tuning_init_text` when `prompt_tuning_init` is set to `TEXT`."
 #             )
 
-#     type: str = schema_utils.ProtectedString("prompt_tuning")
+"""#     type: str = schema_utils.ProtectedString("prompt_tuning")"""  # Quotes allow mypy to run without syntax errors.
 
 #     prompt_tuning_init: str = schema_utils.StringOptions(
 #         ["RANDOM", "TEXT"],
@@ -212,7 +212,7 @@ class BasePromptLearningConfig(BaseAdapterConfig):
 # class PrefixTuningConfig(BasePromptLearningConfig):
 #     """Adapted from https://github.com/huggingface/peft/blob/main/src/peft/tuners/prefix_tuning.py."""
 
-#     type: str = schema_utils.ProtectedString("prefix_tuning")
+"""#     type: str = schema_utils.ProtectedString("prefix_tuning")"""  # Quotes allow mypy to run without syntax errors.
 
 #     encoder_hidden_size: Optional[int] = schema_utils.Integer(
 #         default=None,
@@ -244,7 +244,7 @@ class BasePromptLearningConfig(BaseAdapterConfig):
 # @register_adapter("p_tuning")
 # @ludwig_dataclass
 # class PTuningConfig(BasePromptLearningConfig):
-#     type: str = schema_utils.ProtectedString("p_tuning")
+"""#     type: str = schema_utils.ProtectedString("p_tuning")"""  # Quotes allow mypy to run without syntax errors.
 
 #     encoder_reparameterization_type: str = schema_utils.StringOptions(
 #         ["MLP", "LSTM"],

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -189,6 +189,12 @@ class Trainer(BaseTrainer):
         self.gradient_clipping_config = create_clipper(config.gradient_clipping)
 
         self.config = config
+
+        self.base_learning_rate = None
+        self.dist_model = None
+        self.optimizer = None
+        self.scheduler = None
+
         self.prepare()
 
         # Setup for automatic mixed precision (AMP)
@@ -759,7 +765,6 @@ class Trainer(BaseTrainer):
         )
 
         # ====== Setup session =======
-        checkpoint_manager = None
         checkpoint = self.distributed.create_checkpoint_handle(
             dist_model=self.dist_model, model=self.model, optimizer=self.optimizer, scheduler=self.scheduler
         )
@@ -1375,8 +1380,8 @@ class Trainer(BaseTrainer):
                 signal.signal(signal.SIGINT, self.original_sigint_handler)
             sys.exit(1)
 
+    @staticmethod
     def resume_files_exist(
-        self,
         training_progress_tracker_path: str,
         training_checkpoint_path: str,
     ) -> bool:

--- a/ludwig/utils/dataset_utils.py
+++ b/ludwig/utils/dataset_utils.py
@@ -96,12 +96,16 @@ def get_repeatable_train_val_test_split(
 
 
 def generate_dataset_statistics(
-    training_set: Dataset, validation_set: Union[Dataset, None], test_set: Union[Dataset, None]
+    training_set: Dataset,
+    validation_set: Union[str, dict, pd.DataFrame, Dataset, None],
+    test_set: Union[str, dict, pd.DataFrame, Dataset, None],
 ) -> List[Tuple[str, int, int]]:
     from ludwig.benchmarking.utils import format_memory
 
-    dataset_statistics = [["Dataset", "Size (Rows)", "Size (In Memory)"]]
-    dataset_statistics.append(["Training", len(training_set), format_memory(training_set.in_memory_size_bytes)])
+    dataset_statistics = [
+        ["Dataset", "Size (Rows)", "Size (In Memory)"],
+        ["Training", len(training_set), format_memory(training_set.in_memory_size_bytes)],
+    ]
     if validation_set is not None:
         dataset_statistics.append(
             ["Validation", len(validation_set), format_memory(validation_set.in_memory_size_bytes)]

--- a/ludwig/utils/dataset_utils.py
+++ b/ludwig/utils/dataset_utils.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import pandas as pd
 from sklearn.model_selection import train_test_split
@@ -97,8 +97,8 @@ def get_repeatable_train_val_test_split(
 
 def generate_dataset_statistics(
     training_set: Dataset,
-    validation_set: Union[str, dict, pd.DataFrame, Dataset, None],
-    test_set: Union[str, dict, pd.DataFrame, Dataset, None],
+    validation_set: Optional[Union[str, dict, pd.DataFrame, Dataset]],
+    test_set: Optional[Union[str, dict, pd.DataFrame, Dataset]],
 ) -> List[Tuple[str, int, int]]:
     from ludwig.benchmarking.utils import format_memory
 

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -454,53 +454,95 @@ def _verify_lm_lora_finetuning_layers(
 @pytest.mark.parametrize(
     "finetune_strategy,adapter_args",
     [
-        (None, {}),
-        ("lora", {}),
-        ("lora", {"r": 4, "dropout": 0.1}),
-        ("lora", {POSTPROCESSOR: {MERGE_ADAPTER_INTO_BASE_MODEL: True, PROGRESSBAR: True}}),
-        ("lora", {POSTPROCESSOR: {MERGE_ADAPTER_INTO_BASE_MODEL: False}}),
-        ("adalora", {}),
-        ("adalora", {"init_r": 8, "beta1": 0.8}),
-        ("adalora", {POSTPROCESSOR: {MERGE_ADAPTER_INTO_BASE_MODEL: True, PROGRESSBAR: True}}),
-        ("adalora", {POSTPROCESSOR: {MERGE_ADAPTER_INTO_BASE_MODEL: False}}),
-        ("adaption_prompt", {}),
-        ("adaption_prompt", {"adapter_len": 6, "adapter_layers": 1}),
-        # (
+        pytest.param(
+            None,
+            {},
+            id="full",
+        ),
+        pytest.param(
+            "lora",
+            {},
+            id="lora-defaults",
+        ),
+        pytest.param(
+            "lora",
+            {"r": 4, "dropout": 0.1},
+            id="lora-modified-defaults",
+        ),
+        pytest.param(
+            "lora",
+            {POSTPROCESSOR: {MERGE_ADAPTER_INTO_BASE_MODEL: True, PROGRESSBAR: True}},
+            id="lora_merged",
+        ),
+        pytest.param(
+            "lora",
+            {POSTPROCESSOR: {MERGE_ADAPTER_INTO_BASE_MODEL: False}},
+            id="lora_not_merged",
+        ),
+        pytest.param(
+            "adalora",
+            {},
+            id="adalora-defaults",
+        ),
+        pytest.param(
+            "adalora",
+            {"init_r": 8, "beta1": 0.8},
+            id="adalora-modified-defaults",
+        ),
+        pytest.param(
+            "adalora",
+            {POSTPROCESSOR: {MERGE_ADAPTER_INTO_BASE_MODEL: True, PROGRESSBAR: True}},
+            id="adalora_merged",
+        ),
+        pytest.param(
+            "adalora",
+            {POSTPROCESSOR: {MERGE_ADAPTER_INTO_BASE_MODEL: False}},
+            id="adalora_not_merged",
+        ),
+        pytest.param(
+            "adaption_prompt",
+            {},
+            id="adaption_prompt-defaults",
+        ),
+        pytest.param(
+            "adaption_prompt",
+            {"adapter_len": 6, "adapter_layers": 1},
+            id="adaption_prompt-modified-defaults",
+        ),
+        # pytest.param(
         #     "prompt_tuning",
         #     {
         #         "num_virtual_tokens": 8,
         #         "prompt_tuning_init": "RANDOM",
         #     },
+        #     id="prompt_tuning_init_random",
         # ),
-        # (
+        # pytest.param(
         #     "prompt_tuning",
         #     {
         #         "num_virtual_tokens": 8,
         #         "prompt_tuning_init": "TEXT",
         #         "prompt_tuning_init_text": "Classify if the review is positive, negative, or neutral: ",
         #     },
+        #     id="prompt_tuning_init_text",
         # ),
-        # ("prefix_tuning", {"num_virtual_tokens": 8}),
-        # ("p_tuning", {"num_virtual_tokens": 8, "encoder_reparameterization_type": "MLP"}),
-        # ("p_tuning", {"num_virtual_tokens": 8, "encoder_reparameterization_type": "LSTM"}),
-    ],
-    ids=[
-        "full",
-        "lora-defaults",
-        "lora-modified-defaults",
-        "lora_merged",
-        "lora_not_merged",
-        "adalora-defaults",
-        "adalora-modified-defaults",
-        "adalora_merged",
-        "adalora_not_merged",
-        "adaption_prompt-defaults",
-        "adaption_prompt-modified-defaults",
-        # "prompt_tuning_init_random",
-        # "prompt_tuning_init_text",
-        # "prefix_tuning",
-        # "p_tuning_mlp_reparameterization",
-        # "p_tuning_lstm_reparameterization",
+        # pytest.param(
+        #     "prefix_tuning",
+        #     {
+        #         "num_virtual_tokens": 8,
+        #     },
+        #     id="prefix_tuning",
+        # ),
+        pytest.param(
+            "p_tuning",
+            {"num_virtual_tokens": 8, "encoder_reparameterization_type": "MLP"},
+            id="p_tuning_mlp_reparameterization",
+        ),
+        pytest.param(
+            "p_tuning",
+            {"num_virtual_tokens": 8, "encoder_reparameterization_type": "LSTM"},
+            id="p_tuning_lstm_reparameterization",
+        ),
     ],
 )
 def test_llm_finetuning_strategies(tmpdir, csv_filename, backend, finetune_strategy, adapter_args):

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -533,16 +533,16 @@ def _verify_lm_lora_finetuning_layers(
         #     },
         #     id="prefix_tuning",
         # ),
-        pytest.param(
-            "p_tuning",
-            {"num_virtual_tokens": 8, "encoder_reparameterization_type": "MLP"},
-            id="p_tuning_mlp_reparameterization",
-        ),
-        pytest.param(
-            "p_tuning",
-            {"num_virtual_tokens": 8, "encoder_reparameterization_type": "LSTM"},
-            id="p_tuning_lstm_reparameterization",
-        ),
+        # pytest.param(
+        #     "p_tuning",
+        #     {"num_virtual_tokens": 8, "encoder_reparameterization_type": "MLP"},
+        #     id="p_tuning_mlp_reparameterization",
+        # ),
+        # pytest.param(
+        #     "p_tuning",
+        #     {"num_virtual_tokens": 8, "encoder_reparameterization_type": "LSTM"},
+        #     id="p_tuning_lstm_reparameterization",
+        # ),
     ],
 )
 def test_llm_finetuning_strategies(tmpdir, csv_filename, backend, finetune_strategy, adapter_args):

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -356,7 +356,7 @@ def _prepare_finetuning_test(
 
 
 def _finetune_strategy_requires_cuda(finetune_strategy_name: str, quantization_args: Union[dict, None]) -> bool:
-    """This method returns whether or not a given finetine_strategy requires CUDA.
+    """This method returns whether a given finetine_strategy requires CUDA.
 
     For all finetune strategies, except "qlora", the decision is based just on the name of the finetine_strategy; in the
     case of qlora, if the quantization dictionary is non-empty (i.e., contains quantization specifications), then the
@@ -382,8 +382,8 @@ def _verify_lm_lora_finetuning_layers(
     expected_lora_in_features: int,
     expected_lora_out_features: int,
 ) -> bool:
-    """This method verifies that LoRA finetuning layers have correct types and shapes, depending on whether or not
-    the optional "model.merge_and_unload()" method (based on the "merge_adapter_into_base_model" directive) was
+    """This method verifies that LoRA finetuning layers have correct types and shapes, depending on whether the
+    optional "model.merge_and_unload()" method (based on the "merge_adapter_into_base_model" directive) was
     executed.
 
     If merge_adapter_into_base_model is True, then both LoRA projection layers, V and Q, in the attention layer must
@@ -555,7 +555,7 @@ def test_llm_finetuning_strategies(tmpdir, csv_filename, backend, finetune_strat
     model = LudwigModel.load(os.path.join(str(tmpdir), "api_experiment_run", "model"), backend=backend)
 
     base_model = LLM(ModelConfig.from_dict(config))
-    assert not _compare_models(base_model, model.model)
+    assert not _compare_models(base_model, model.model)  # noqa F821
 
     preds, _ = model.predict(dataset=prediction_df, output_directory=str(tmpdir))
     preds = convert_preds(preds)
@@ -567,12 +567,18 @@ def test_llm_finetuning_strategies(tmpdir, csv_filename, backend, finetune_strat
 @pytest.mark.parametrize(
     "finetune_strategy,adapter_args,quantization",
     [
-        ("lora", {}, {"bits": 4}),  # qlora
-        ("lora", {}, {"bits": 8}),  # qlora 8-bit
-    ],
-    ids=[
-        "qlora-4bit",
-        "qlora-8bit",
+        pytest.param(
+            "lora",
+            {},
+            {"bits": 4},
+            id="qlora-4bit",
+        ),
+        pytest.param(
+            "lora",
+            {},
+            {"bits": 8},
+            id="qlora-8bit",
+        ),
     ],
 )
 def test_llm_finetuning_strategies_quantized(tmpdir, csv_filename, finetune_strategy, adapter_args, quantization):
@@ -595,7 +601,7 @@ def test_llm_finetuning_strategies_quantized(tmpdir, csv_filename, finetune_stra
     model = LudwigModel.load(os.path.join(str(tmpdir), "api_experiment_run", "model"))
 
     base_model = LLM(ModelConfig.from_dict(config))
-    assert not _compare_models(base_model, model.model)
+    assert not _compare_models(base_model, model.model)  # noqa F821
 
     preds, _ = model.predict(dataset=prediction_df, output_directory=str(tmpdir))
     preds = convert_preds(preds)
@@ -778,8 +784,6 @@ def test_load_pretrained_adapter_weights(adapter):
     from peft import PeftModel
     from transformers import PreTrainedModel
 
-    weights = ""
-    model = ""
     if adapter == "lora":
         weights = "Infernaught/test_adapter_weights"
         base_model = TEST_MODEL_NAME
@@ -886,15 +890,15 @@ def test_local_path_loading():
     from huggingface_hub import snapshot_download
 
     # Download the model to a local directory
-    LOCAL_PATH = "~/test_local_path_loading"
-    REPO_ID = "HuggingFaceH4/tiny-random-LlamaForCausalLM"
-    os.makedirs(LOCAL_PATH, exist_ok=True)
-    snapshot_download(repo_id=REPO_ID, local_dir=LOCAL_PATH)
+    local_path: str = "~/test_local_path_loading"
+    repo_id: str = "HuggingFaceH4/tiny-random-LlamaForCausalLM"
+    os.makedirs(local_path, exist_ok=True)
+    snapshot_download(repo_id=repo_id, local_dir=local_path)
 
     # Load the model using the local path
     config1 = {
         MODEL_TYPE: MODEL_LLM,
-        BASE_MODEL: LOCAL_PATH,
+        BASE_MODEL: local_path,
         INPUT_FEATURES: [text_feature(name="input", encoder={"type": "passthrough"})],
         OUTPUT_FEATURES: [text_feature(name="output")],
     }
@@ -904,7 +908,7 @@ def test_local_path_loading():
     # Load the model using the repo id
     config2 = {
         MODEL_TYPE: MODEL_LLM,
-        BASE_MODEL: REPO_ID,
+        BASE_MODEL: repo_id,
         INPUT_FEATURES: [text_feature(name="input", encoder={"type": "passthrough"})],
         OUTPUT_FEATURES: [text_feature(name="output")],
     }

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -180,6 +180,11 @@ def generate_data(
     :param output_features: schema
     :param filename: path to the file where data is stored
     :param nan_percent: percent of values in a feature to be NaN
+    :param with_split: If True, then new column "split" is created, containing integer values as follows:
+        0 -- for training set;
+        1 -- for validation set;
+        2 -- for test set.
+
     :return:
     """
     df = generate_data_as_dataframe(input_features, output_features, num_examples, nan_percent, with_split=with_split)
@@ -197,10 +202,15 @@ def generate_data_as_dataframe(
     """Helper method to generate synthetic data based on input, output feature specs.
 
     Args:
-        num_examples: number of examples to generate
         input_features: schema
         output_features: schema
+        num_examples: number of examples to generate
         nan_percent: percent of values in a feature to be NaN
+        with_split: If True, then new column "split" is created, containing integer values as follows:
+            0 -- for training set;
+            1 -- for validation set;
+            2 -- for test set.
+
     Returns:
         A pandas DataFrame
     """
@@ -520,6 +530,12 @@ def run_experiment(
 
     :param input_features: list of input feature dictionaries
     :param output_features: list of output feature dictionaries
+    :param config: A dictionary containing the Ludwig model configuration
+    :param skip_save_processed_input: (bool, default: `False`) if input
+    dataset is provided it is preprocessed and cached by saving an HDF5
+    and JSON files to avoid running the preprocessing again. If this
+    parameter is `False`, the HDF5 and JSON file are not saved.
+    :param backend: (Union[Backend, str]) `Backend` or string name
     **kwargs you may also pass extra parameters to the experiment as keyword
     arguments
     :return: None
@@ -767,8 +783,8 @@ def create_data_set_to_use(data_format, raw_data, nan_percent=0.0):
     # https://stackoverflow.com/questions/16490261/python-pandas-write-dataframe-to-fixed-width-file-to-fwf
     from tabulate import tabulate
 
-    def to_fwf(df, fname):
-        content = tabulate(df.values.tolist(), list(df.columns), tablefmt="plain")
+    def to_fwf(df_: pd.DataFrame, fname: str):
+        content = tabulate(df_.values.tolist(), list(df_.columns), tablefmt="plain")
         open(fname, "w").write(content)
 
     pd.DataFrame.to_fwf = to_fwf

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -783,8 +783,8 @@ def create_data_set_to_use(data_format, raw_data, nan_percent=0.0):
     # https://stackoverflow.com/questions/16490261/python-pandas-write-dataframe-to-fixed-width-file-to-fwf
     from tabulate import tabulate
 
-    def to_fwf(df_: pd.DataFrame, fname: str):
-        content = tabulate(df_.values.tolist(), list(df_.columns), tablefmt="plain")
+    def to_fwf(df: pd.DataFrame, fname: str):
+        content = tabulate(df.values.tolist(), list(df.columns), tablefmt="plain")
         open(fname, "w").write(content)
 
     pd.DataFrame.to_fwf = to_fwf


### PR DESCRIPTION
This set of changes aides towards improving code elegance.

It consists of the following improvements in parts of the codebase:
* Solving IDE warnings;
* Adding type hints;
* Fixing broken docstrings;
* Fixing PEP8 warnings and setting up `noqa` and `type ignore` escapes.

Much work towards these improvements can be done; this serves only as a small set surrounding LLM related modules.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
