### PR TITLE
[FEATURE] Include Mistral-7B model in list of supported base models

### DIFF
--- a/ludwig/schema/llms/base_model.py
+++ b/ludwig/schema/llms/base_model.py
@@ -31,7 +31,7 @@ MODEL_PRESETS = {
     "gpt-j-6b": "EleutherAI/gpt-j-6b",
     "pythia-2.8b": "EleutherAI/pythia-2.8b",
     "pythia-12b": "EleutherAI/pythia-12b",
-    "mistral-7b": "mistralai/Mistral-7B-v0.1",
+    "mistral": "mistralai/Mistral-7B-v0.1",
 }
 
 

--- a/ludwig/schema/llms/base_model.py
+++ b/ludwig/schema/llms/base_model.py
@@ -31,7 +31,7 @@ MODEL_PRESETS = {
     "gpt-j-6b": "EleutherAI/gpt-j-6b",
     "pythia-2.8b": "EleutherAI/pythia-2.8b",
     "pythia-12b": "EleutherAI/pythia-12b",
-    "mistral": "mistralai/Mistral-7B-v0.1",
+    "mistral-7b": "mistralai/Mistral-7B-v0.1",
 }
 
 

--- a/ludwig/schema/llms/base_model.py
+++ b/ludwig/schema/llms/base_model.py
@@ -31,6 +31,7 @@ MODEL_PRESETS = {
     "gpt-j-6b": "EleutherAI/gpt-j-6b",
     "pythia-2.8b": "EleutherAI/pythia-2.8b",
     "pythia-12b": "EleutherAI/pythia-12b",
+    "mistral-7b": "mistralai/Mistral-7B-v0.1",
 }
 
 


### PR DESCRIPTION
### Scope
* This change adds the "shortcut" to the HuggingFace location for the new Mistral-7B model.

### Remarks
* Please note that using Mistral-7B requires the latest HuggingFace transformers library (e.g., `pip install --upgrade git+https://github.com/huggingface/transformers` is advisable for the near term, until official release is verified).

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
