### PR TITLE
Add per-device logging to tensorboard

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -474,6 +474,13 @@ class Trainer(BaseTrainer):
                 train_summary_writer.add_scalar(
                     f"cuda/device{i}/total_memory_occupied", torch.cuda.mem_get_info(device=device)[1], global_step=step
                 )
+
+                # Total memory used.
+                train_summary_writer.add_scalar(
+                    f"cuda/device{i}/total_memory_used",
+                    torch.cuda.mem_get_info(device=device)[1] - torch.cuda.mem_get_info(device=device)[0],
+                    global_step=step,
+                )
         train_summary_writer.flush()
 
     def is_cpu_training(self):

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -405,80 +405,86 @@ class Trainer(BaseTrainer):
             for i in range(torch.cuda.device_count()):
                 device = torch.device(f"cuda:{i}")
                 memory_stats = torch.cuda.memory_stats(device=device)
+                gb_memory_stats = {k: v / (1000**3) for k, v in memory_stats.items()}
                 # Allocated bytes.
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/allocated_bytes.all.current",
-                    memory_stats["allocated_bytes.all.current"],
+                    f"cuda/device{i}/allocated_gb.all.current",
+                    gb_memory_stats["allocated_bytes.all.current"],
                     global_step=step,
                 )
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/allocated_bytes.all.peak",
-                    memory_stats["allocated_bytes.all.peak"],
+                    f"cuda/device{i}/allocated_gb.all.peak",
+                    gb_memory_stats["allocated_bytes.all.peak"],
                     global_step=step,
                 )
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/allocated_bytes.all.allocated",
-                    memory_stats["allocated_bytes.all.allocated"],
+                    f"cuda/device{i}/allocated_gb.all.allocated",
+                    gb_memory_stats["allocated_bytes.all.allocated"],
                     global_step=step,
                 )
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/allocated_bytes.all.freed",
-                    memory_stats["allocated_bytes.all.freed"],
+                    f"cuda/device{i}/allocated_gb.all.freed",
+                    gb_memory_stats["allocated_bytes.all.freed"],
                     global_step=step,
                 )
 
                 # Reserved bytes.
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/reserved_bytes.all.current",
-                    memory_stats["reserved_bytes.all.current"],
+                    f"cuda/device{i}/reserved_gb.all.current",
+                    gb_memory_stats["reserved_bytes.all.current"],
                     global_step=step,
                 )
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/reserved_bytes.all.peak", memory_stats["reserved_bytes.all.peak"], global_step=step
+                    f"cuda/device{i}/reserved_gb.all.peak", gb_memory_stats["reserved_bytes.all.peak"], global_step=step
                 )
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/reserved_bytes.all.allocated",
-                    memory_stats["reserved_bytes.all.allocated"],
+                    f"cuda/device{i}/reserved_gb.all.allocated",
+                    gb_memory_stats["reserved_bytes.all.allocated"],
                     global_step=step,
                 )
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/reserved_bytes.all.freed",
-                    memory_stats["reserved_bytes.all.freed"],
+                    f"cuda/device{i}/reserved_gb.all.freed",
+                    gb_memory_stats["reserved_bytes.all.freed"],
                     global_step=step,
                 )
 
                 # Active bytes.
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/active_bytes.all.current",
-                    memory_stats["active_bytes.all.current"],
+                    f"cuda/device{i}/active_gb.all.current",
+                    gb_memory_stats["active_bytes.all.current"],
                     global_step=step,
                 )
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/active_bytes.all.peak", memory_stats["active_bytes.all.peak"], global_step=step
+                    f"cuda/device{i}/active_gb.all.peak", gb_memory_stats["active_bytes.all.peak"], global_step=step
                 )
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/active_bytes.all.allocated",
-                    memory_stats["active_bytes.all.allocated"],
+                    f"cuda/device{i}/active_gb.all.allocated",
+                    gb_memory_stats["active_bytes.all.allocated"],
                     global_step=step,
                 )
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/active_bytes.all.freed", memory_stats["active_bytes.all.freed"], global_step=step
+                    f"cuda/device{i}/active_gb.all.freed", gb_memory_stats["active_bytes.all.freed"], global_step=step
                 )
 
                 # Global free memory.
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/global_free_memory", torch.cuda.mem_get_info(device=device)[0], global_step=step
+                    f"cuda/device{i}/global_free_memory_gb",
+                    torch.cuda.mem_get_info(device=device)[0] / (1000**3),
+                    global_step=step,
                 )
 
                 # Total memory occupied.
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/total_memory_occupied", torch.cuda.mem_get_info(device=device)[1], global_step=step
+                    f"cuda/device{i}/total_memory_occupied_gb",
+                    torch.cuda.mem_get_info(device=device)[1] / (1000**3),
+                    global_step=step,
                 )
 
                 # Total memory used.
                 train_summary_writer.add_scalar(
-                    f"cuda/device{i}/total_memory_used",
-                    torch.cuda.mem_get_info(device=device)[1] - torch.cuda.mem_get_info(device=device)[0],
+                    f"cuda/device{i}/total_memory_used_gb",
+                    (torch.cuda.mem_get_info(device=device)[1] - torch.cuda.mem_get_info(device=device)[0])
+                    / (1000**3),
                     global_step=step,
                 )
         train_summary_writer.flush()

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -27,6 +27,7 @@ import time
 from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np
+import nvidia_smi
 import psutil
 import torch
 from torch.utils.tensorboard import SummaryWriter
@@ -451,6 +452,16 @@ class Trainer(BaseTrainer):
             # Total memory occupied.
             train_summary_writer.add_scalar(
                 "cuda/total_memory_occupied", torch.cuda.mem_get_info()[1], global_step=step
+            )
+
+        # Log nvidia-smi stats
+        nvidia_smi.nvmlInit()
+        device_count = nvidia_smi.nvmlDeviceGetCount()
+        for i in range(device_count):
+            handle = nvidia_smi.nvmlDeviceGetHandleByIndex(i)
+            mem = nvidia_smi.nvmlDeviceGetMemoryInfo(handle)
+            train_summary_writer.add_scalar(
+                f"nvidia-smi/total_memory_used_device{i}", (mem.total - mem.free) / (1024**2), global_step=step
             )
 
         train_summary_writer.flush()

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ marshmallow-jsonschema
 marshmallow-dataclass==8.5.4
 tensorboard
 nltk    # Required for rouge scores.
-nvidia-ml-py3
 torchmetrics>=0.11.0,<=0.11.4
 torchinfo
 filelock

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ marshmallow-jsonschema
 marshmallow-dataclass==8.5.4
 tensorboard
 nltk    # Required for rouge scores.
+nvidia-ml-py3
 torchmetrics>=0.11.0,<=0.11.4
 torchinfo
 filelock


### PR DESCRIPTION
This PR adds nvidia-smi logging to tensorboard (specifically, it logs how much memory is being used over time). The numbers are not exactly the same as those outputted by nvidia-smi in the command line (the tensorboard logs show larger numbers than those shown by nvidia-smi in the command line), but are quite close.

[EDIT] After further investigation, nvidia-smi logging is unnecessary. This PR now offers per-device tensorboard logging and adds a new metric -- total_memory_used -- which should be more or less equivalent to what nvidia-smi shows.