### PR TITLE
[BUGFIX] Ensure that full base models and not only adapter weights get saved when merge_and_unload is set

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -648,9 +648,6 @@ class LudwigModel:
                     )
                     (self.model, train_trainset_stats, train_valiset_stats, train_testset_stats) = train_stats
 
-                    # For an LLM model trained with a LoRA adapter, handle merge and unload postprocessing directives.
-                    self._merge_and_unload()
-
                     # Calibrates output feature probabilities on validation set if calibration is enabled.
                     # Must be done after training, and before final model parameters are saved.
                     if self.backend.is_coordinator():
@@ -730,6 +727,9 @@ class LudwigModel:
                         callback.on_train_end(output_directory)
 
                 self.training_set_metadata = training_set_metadata
+
+                # For an LLM model trained with a LoRA adapter, handle merge and unload postprocessing directives.
+                self._merge_and_unload()
 
                 # Ensure model weights are saved to the driver if training was done remotely
                 if self.backend.is_coordinator() and not skip_save_model:

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -642,13 +642,22 @@ class LLM(BaseModel):
             predictions[of_name] = outputs
         return predictions
 
-    def save(self, save_path):
+    def save(self, save_path, save_base_model: bool = False):
         """Saves the model to the given path."""
         # TODO(travis): use the implementation of trainer itself to decide whether to save the model, to
         # avoid this hack
         if self.config_obj.trainer.type != "none":
             weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
             self.model.save_pretrained(weights_save_path)
+        else:
+            logger.info("Skipped saving LLM without weight adjustments.")
+
+    def save_base_model(self, save_path):
+        """Saves the base LLM model to the given path."""
+        # TODO: see the "TODO" statement from "LLM.save()" in this module.
+        if self.config_obj.trainer.type != "none":
+            weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
+            self.model.base_model.save_pretrained(weights_save_path)
         else:
             logger.info("Skipped saving LLM without weight adjustments.")
 

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -386,3 +386,12 @@ class file_lock(contextlib.AbstractContextManager):
     def __exit__(self, *args, **kwargs):
         if self.lock:
             return self.lock.__exit__(*args, **kwargs)
+
+
+@DeveloperAPI
+def list_file_names_in_directory(directory_name: str) -> list[str]:
+    file_path: pathlib.Path  # noqa [F842]  # incorrect flagging of "local variable is annotated but never used
+    file_names: list[str] = [
+        file_path.name for file_path in pathlib.Path(directory_name).iterdir() if file_path.is_file()
+    ]
+    return file_names

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -549,15 +549,16 @@ def test_llm_finetuning_strategies(tmpdir, csv_filename, backend, finetune_strat
     train_df, prediction_df, config = _prepare_finetuning_test(csv_filename, finetune_strategy, backend, adapter_args)
 
     model = LudwigModel(config)
-    model.train(dataset=train_df, output_directory=str(tmpdir), skip_save_processed_input=False)
+    output_directory: str = str(tmpdir)
+    model.train(dataset=train_df, output_directory=output_directory, skip_save_processed_input=False)
 
     # Make sure we can load the saved model and then use it for predictions
-    model = LudwigModel.load(os.path.join(str(tmpdir), "api_experiment_run", "model"), backend=backend)
+    model = LudwigModel.load(os.path.join(output_directory, "api_experiment_run", "model"), backend=backend)
 
     base_model = LLM(ModelConfig.from_dict(config))
     assert not _compare_models(base_model, model.model)  # noqa F821
 
-    preds, _ = model.predict(dataset=prediction_df, output_directory=str(tmpdir))
+    preds, _ = model.predict(dataset=prediction_df, output_directory=output_directory)
     preds = convert_preds(preds)
 
     assert preds

--- a/tests/ludwig/utils/test_fs_utils.py
+++ b/tests/ludwig/utils/test_fs_utils.py
@@ -6,7 +6,7 @@ from urllib.parse import quote
 
 import pytest
 
-from ludwig.utils.fs_utils import get_fs_and_path, safe_move_directory
+from ludwig.utils.fs_utils import get_fs_and_path, list_file_names_in_directory, safe_move_directory
 
 logger = logging.getLogger(__name__)
 
@@ -92,3 +92,18 @@ def test_safe_move_directory(tmpdir):
     assert os.path.exists(os.path.join(dst_dir, "file.txt"))
     with open(os.path.join(dst_dir, "file.txt")) as f:
         assert f.read() == "test"
+
+
+@pytest.mark.filesystem
+def test_list_file_names_in_directory(tmpdir):
+    my_dir = os.path.join(tmpdir, "my_dir")
+
+    os.mkdir(my_dir)
+
+    with open(os.path.join(my_dir, "my_file.txt"), "w") as f:
+        f.write("test_0")
+
+    with open(os.path.join(my_dir, "my_other_file.txt"), "w") as f:
+        f.write("test_1")
+
+    assert set(list_file_names_in_directory(directory_name=my_dir)) == {"my_file.txt", "my_other_file.txt"}


### PR DESCRIPTION
### Scope
* This change fixes an issue whereby after successful `merge_and_unload()` in terms of model layer structure, only the LoRA adapter weights are persisted.  The fix consists of recognizing that `merge_and_unload` was set and save the base model weights (in addition to fine-tuning weights) at the end of the training phase.  We only save adapter weights during the training; otherwise, the model might be fine-tuning the entire set of weights, instead of only the adapter weights.  Thanks to @arnavgarg1 for guidance.
* New tests check that the expected weights files are saved depending on whether or not `merge_and_unload` is set.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
