### PR TITLE
[BUGFIX] Remove spurious test directory at the end of the test_llm.py::test_local_path_loading test run

### DIFF
--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 from typing import Dict, Tuple, Union
 
 import numpy as np
@@ -885,13 +884,13 @@ def test_global_max_sequence_length_for_llms():
     assert model.global_max_sequence_length == 2048
 
 
-def test_local_path_loading():
+def test_local_path_loading(tmpdir):
     """Tests that local paths can be used to load models."""
 
     from huggingface_hub import snapshot_download
 
     # Download the model to a local directory
-    local_path: str = "~/test_local_path_loading"
+    local_path: str = f"{str(tmpdir)}/test_local_path_loading"
     repo_id: str = "HuggingFaceH4/tiny-random-LlamaForCausalLM"
     os.makedirs(local_path, exist_ok=True)
     snapshot_download(repo_id=repo_id, local_dir=local_path)
@@ -918,6 +917,3 @@ def test_local_path_loading():
 
     # Check that the models are the same
     assert _compare_models(model1.model, model2.model)
-
-    # Remove the test directory (created at "local_path")
-    shutil.rmtree(local_path)

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from typing import Dict, Tuple, Union
 
 import numpy as np
@@ -917,3 +918,6 @@ def test_local_path_loading():
 
     # Check that the models are the same
     assert _compare_models(model1.model, model2.model)
+
+    # Remove the test directory (created at "local_path")
+    shutil.rmtree(local_path)


### PR DESCRIPTION
### Scope
This change fixes the issue that after "tests/integration_tests/test_llm.py::test_local_path_loading" would run, a spurious directory would remain in the top directory of the Ludwig repository.  The fix consists of removing this directory after the assertions are done (as the last step of the test).

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
