### PR TITLE
Move on_epoch_end and epoch increment to after run_evaluation loop.

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -1098,6 +1098,7 @@ class Trainer(BaseTrainer):
         """Completes up to one epoch through the data."""
         self.distributed.zero_grad(self.optimizer)
         batch_idx = 0
+        has_called_on_epoch_end = False
         while not batcher.last_batch() and progress_tracker.steps < self.total_steps:
             progress_tracker.learning_rate = self.optimizer.param_groups[0]["lr"]
             self.callback(lambda c: c.on_batch_start(self, progress_tracker, save_path))
@@ -1182,15 +1183,26 @@ class Trainer(BaseTrainer):
                     if self.is_coordinator():
                         progress_tracker.save(os.path.join(save_path, TRAINING_PROGRESS_TRACKER_FILE_NAME))
 
-                if should_break:
-                    return should_break
+                # If this was the last batch, then increment the epoch counter and invoke the `on_epoch_end` callback.
+                if not has_called_on_epoch_end and batcher.last_batch():
+                    progress_tracker.epoch += 1
+                    self.callback(lambda c: c.on_epoch_end(self, progress_tracker, save_path))
 
-            if batcher.last_batch():
-                # We have completed an epoch, so we need to increment the epoch counter. It's important to do this here
-                # instead of outside of the train loop since it's possible the train loop will exit early due to
-                # early stopping, or step-based training.
+                    # Ensures that we only call `on_epoch_end` once, for example, if evaluation is configured to run
+                    # several times per epoch.
+                    has_called_on_epoch_end = True
+
+                if should_break:
+                    return True
+
+            # If this was the last batch, then increment the epoch counter and invoke the `on_epoch_end` callback.
+            if not has_called_on_epoch_end and batcher.last_batch():
                 progress_tracker.epoch += 1
                 self.callback(lambda c: c.on_epoch_end(self, progress_tracker, save_path))
+
+                # Ensures that we only call `on_epoch_end` once, for example, if evaluation is configured to run
+                # several times per epoch.
+                has_called_on_epoch_end = True
 
         return False
 

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -1149,13 +1149,6 @@ class Trainer(BaseTrainer):
             # batch duration measurements when using timer callbacks.
             self.callback(lambda c: c.on_batch_end(self, progress_tracker, save_path, sync_step=should_step))
 
-            if batcher.last_batch():
-                # We have completed an epoch, so we need to increment the epoch counter. It's important to do this here
-                # instead of outside of the train loop since it's possible the train loop will exit early due to
-                # early stopping, or step-based training.
-                progress_tracker.epoch += 1
-                self.callback(lambda c: c.on_epoch_end(self, progress_tracker, save_path))
-
             if progress_tracker.steps % final_steps_per_checkpoint == 0:
                 if not self.skip_all_evaluation:
                     # Publishes metrics to MLFLow if there are any MLFlow callbacks.
@@ -1191,6 +1184,13 @@ class Trainer(BaseTrainer):
 
                 if should_break:
                     return should_break
+
+            if batcher.last_batch():
+                # We have completed an epoch, so we need to increment the epoch counter. It's important to do this here
+                # instead of outside of the train loop since it's possible the train loop will exit early due to
+                # early stopping, or step-based training.
+                progress_tracker.epoch += 1
+                self.callback(lambda c: c.on_epoch_end(self, progress_tracker, save_path))
 
         return False
 


### PR DESCRIPTION
https://github.com/ludwig-ai/ludwig/pull/3668 inadvertently moved the `on_epoch_end` callback to be invoked after the last batch has been processed, but before evaluation.

While technically still valid, this is a change from the previous behavior of `on_epoch_end` being called after evaluation, which may come as a surprise to users assuming evaluation results being present in `on_epoch_end`.

Note: `on_eval_end` is the recommended callback for handling fresh eval metrics.