### PR TITLE
[MAINTENANCE] Fix the linting warnings in two backend component classes.

### DIFF
--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -150,9 +150,6 @@ class Backend(ABC):
 
 
 class LocalPreprocessingMixin:
-    def __init__(self) -> None:
-        pass
-
     @property
     def df_engine(self):
         return PANDAS
@@ -196,9 +193,6 @@ class LocalPreprocessingMixin:
 
 
 class LocalTrainingMixin:
-    def __init__(self) -> None:
-        pass
-
     @staticmethod
     def initialize():
         init_dist_strategy("local")
@@ -241,9 +235,6 @@ class LocalTrainingMixin:
 
 
 class RemoteTrainingMixin:
-    def __init__(self) -> None:
-        pass
-
     def sync_model(self, model):
         pass
 

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -150,6 +150,9 @@ class Backend(ABC):
 
 
 class LocalPreprocessingMixin:
+    def __init__(self) -> None:
+        pass
+
     @property
     def df_engine(self):
         return PANDAS
@@ -158,8 +161,9 @@ class LocalPreprocessingMixin:
     def supports_multiprocessing(self):
         return True
 
+    @staticmethod
     def read_binary_files(
-        self, column: pd.Series, map_fn: Optional[Callable] = None, file_size: Optional[int] = None
+        column: pd.Series, map_fn: Optional[Callable] = None, file_size: Optional[int] = None
     ) -> pd.Series:
         column = column.fillna(np.nan).replace([np.nan], [None])  # normalize NaNs to None
 
@@ -181,7 +185,8 @@ class LocalPreprocessingMixin:
 
         return pd.Series(result, index=column.index, name=column.name)
 
-    def batch_transform(self, df: DataFrame, batch_size: int, transform_fn: Callable, name: str = None) -> DataFrame:
+    @staticmethod
+    def batch_transform(df: DataFrame, batch_size: int, transform_fn: Callable, name: str = None) -> DataFrame:
         name = name or "Batch Transform"
         batches = to_batches(df, batch_size)
         transform = transform_fn()
@@ -191,10 +196,15 @@ class LocalPreprocessingMixin:
 
 
 class LocalTrainingMixin:
-    def initialize(self):
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    def initialize():
         init_dist_strategy("local")
 
-    def initialize_pytorch(self, *args, **kwargs):
+    @staticmethod
+    def initialize_pytorch(*args, **kwargs):
         initialize_pytorch(*args, **kwargs)
 
     def create_trainer(self, config: BaseTrainerConfig, model: BaseModel, **kwargs) -> "BaseTrainer":  # noqa: F821
@@ -207,7 +217,8 @@ class LocalTrainingMixin:
 
         return trainer_cls(config=config, model=model, **kwargs)
 
-    def create_predictor(self, model: BaseModel, **kwargs):
+    @staticmethod
+    def create_predictor(model: BaseModel, **kwargs):
         from ludwig.models.predictor import get_predictor_cls
 
         return get_predictor_cls(model.type())(model, **kwargs)
@@ -215,25 +226,33 @@ class LocalTrainingMixin:
     def sync_model(self, model):
         pass
 
-    def broadcast_return(self, fn):
+    @staticmethod
+    def broadcast_return(fn):
         return fn()
 
-    def is_coordinator(self):
+    @staticmethod
+    def is_coordinator() -> bool:
         return True
 
-    def tune_batch_size(self, evaluator_cls: Type[BatchSizeEvaluator], dataset_len: int) -> int:
+    @staticmethod
+    def tune_batch_size(evaluator_cls: Type[BatchSizeEvaluator], dataset_len: int) -> int:
         evaluator = evaluator_cls()
         return evaluator.select_best_batch_size(dataset_len)
 
 
 class RemoteTrainingMixin:
+    def __init__(self) -> None:
+        pass
+
     def sync_model(self, model):
         pass
 
-    def broadcast_return(self, fn):
+    @staticmethod
+    def broadcast_return(fn):
         return fn()
 
-    def is_coordinator(self):
+    @staticmethod
+    def is_coordinator() -> bool:
         return True
 
 
@@ -274,7 +293,7 @@ class DataParallelBackend(LocalPreprocessingMixin, Backend, ABC):
 
     def __init__(self, **kwargs):
         super().__init__(dataset_manager=PandasDatasetManager(self), **kwargs)
-        self._distributed: DistributedStrategy = None
+        self._distributed: Optional[DistributedStrategy] = None
 
     @abstractmethod
     def initialize(self):

--- a/ludwig/data/dataframe/pandas.py
+++ b/ludwig/data/dataframe/pandas.py
@@ -41,7 +41,8 @@ class PandasEngine(DataFrameEngine):
     def compute(self, data):
         return data
 
-    def concat(self, dfs):
+    @staticmethod
+    def concat(dfs) -> pd.DataFrame:
         return pd.concat(dfs)
 
     def from_pandas(self, df):
@@ -65,7 +66,8 @@ class PandasEngine(DataFrameEngine):
     def split(self, df, probabilities):
         return split_by_slices(df.iloc, len(df), probabilities)
 
-    def remove_empty_partitions(self, df):
+    @staticmethod
+    def remove_empty_partitions(df: pd.DataFram) -> pd.DataFrame:
         return df
 
     def to_parquet(self, df, path, index=False):
@@ -86,10 +88,12 @@ class PandasEngine(DataFrameEngine):
 
         return from_pandas(df)
 
-    def from_ray_dataset(self, dataset) -> pd.DataFrame:
+    @staticmethod
+    def from_ray_dataset(dataset) -> pd.DataFrame:
         return dataset.to_pandas()
 
-    def reset_index(self, df):
+    @staticmethod
+    def reset_index(df) -> pd.DataFrame:
         return df.reset_index(drop=True)
 
     @property

--- a/ludwig/data/dataframe/pandas.py
+++ b/ludwig/data/dataframe/pandas.py
@@ -67,7 +67,7 @@ class PandasEngine(DataFrameEngine):
         return split_by_slices(df.iloc, len(df), probabilities)
 
     @staticmethod
-    def remove_empty_partitions(df: pd.DataFram) -> pd.DataFrame:
+    def remove_empty_partitions(df: pd.DataFrame) -> pd.DataFrame:
         return df
 
     def to_parquet(self, df, path, index=False):


### PR DESCRIPTION
### Scope
* Resolving linting warnings -- making some methods static and including the proper type hints.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
