### PR TITLE
[FEATURE] Allow typehints without the quotes.

### DIFF
--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -20,7 +20,7 @@ import time
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Any, Callable
+from typing import Any, Callable, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -40,7 +40,6 @@ from ludwig.distributed import init_dist_strategy
 from ludwig.distributed.base import DistributedStrategy
 from ludwig.models.base import BaseModel
 from ludwig.schema.trainer import BaseTrainerConfig
-from ludwig.trainers.base import BaseTrainer
 from ludwig.types import HyperoptConfigDict
 from ludwig.utils.audio_utils import read_audio_from_path
 from ludwig.utils.batch_size_tuner import BatchSizeEvaluator
@@ -50,6 +49,9 @@ from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.system_utils import Resources
 from ludwig.utils.torch_utils import initialize_pytorch
 from ludwig.utils.types import DataFrame, Series
+
+if TYPE_CHECKING:
+    from ludwig.trainers.base import BaseTrainer
 
 
 @DeveloperAPI


### PR DESCRIPTION
### Scope
* Due to the problem of cycles within the Python annotation (e.g., a typehint could be used first before its declaration), we often have to enclose a typehint  within the quotes (and have to add a "# noqa F821" at the end).  However, if we add the import `from __future__ import annotations` at the top of the module, then we can use the typehint explicitly.  (Please see `https://peps.python.org/pep-0563/` for the details.).  Additional benefits include the need to import fewer types from `typing`, since the standard Python types can be used for typehints (e.g., `list[int]` instead of `List[int]`, etc.) and the ability to enclose all types that are being imported for the typehinting purposes only to be packaged under the `typing.TYPE_CHECKING` condition.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
