### PR TITLE
[MAINTENANCE] Adding typehint annotations in backend and data components and fixing mypy errors.

### DIFF
--- a/ludwig/data/dataset/base.py
+++ b/ludwig/data/dataset/base.py
@@ -14,10 +14,13 @@
 # limitations under the License.
 # ==============================================================================
 
+from __future__ import annotations
+
 import contextlib
 from abc import ABC, abstractmethod
-from typing import Iterable, Optional
+from typing import Iterable
 
+from ludwig.data.batcher.base import Batcher
 from ludwig.distributed import DistributedStrategy
 from ludwig.features.base_feature import BaseFeature
 from ludwig.utils.defaults import default_random_seed
@@ -26,7 +29,7 @@ from ludwig.utils.types import DataFrame
 
 class Dataset(ABC):
     @abstractmethod
-    def __len__(self):
+    def __len__(self) -> int:
         raise NotImplementedError()
 
     @contextlib.contextmanager
@@ -38,36 +41,36 @@ class Dataset(ABC):
         random_seed: int = default_random_seed,
         ignore_last: bool = False,
         distributed: DistributedStrategy = None,
-    ):
+    ) -> Batcher:
         raise NotImplementedError()
 
     @abstractmethod
-    def to_df(self, features: Optional[Iterable[BaseFeature]] = None) -> DataFrame:
+    def to_df(self, features: Iterable[BaseFeature] | None = None) -> DataFrame:
         raise NotImplementedError()
 
     @abstractmethod
-    def to_scalar_df(self, features: Optional[Iterable[BaseFeature]] = None) -> DataFrame:
+    def to_scalar_df(self, features: Iterable[BaseFeature] | None = None) -> DataFrame:
         raise NotImplementedError()
 
     @property
-    def in_memory_size_bytes(self):
+    def in_memory_size_bytes(self) -> int:
         raise NotImplementedError()
 
 
 class DatasetManager(ABC):
     @abstractmethod
-    def create(self, dataset, config, training_set_metadata):
+    def create(self, dataset, config, training_set_metadata) -> Dataset:
         raise NotImplementedError()
 
     @abstractmethod
-    def save(self, cache_path, dataset, config, training_set_metadata, tag):
+    def save(self, cache_path, dataset, config, training_set_metadata, tag) -> Dataset:
         raise NotImplementedError()
 
     @abstractmethod
-    def can_cache(self, skip_save_processed_input):
+    def can_cache(self, skip_save_processed_input) -> bool:
         raise NotImplementedError()
 
     @property
     @abstractmethod
-    def data_format(self):
+    def data_format(self) -> str:
         raise NotImplementedError()

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -13,13 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+
+from __future__ import annotations
+
 import contextlib
-from typing import Iterable, Optional
+from typing import Iterable
 
 import numpy as np
 from pandas import DataFrame
 
+from ludwig.backend.base import Backend
 from ludwig.constants import PREPROCESSING, TRAINING
+from ludwig.data.batcher.base import Batcher
 from ludwig.data.batcher.random_access import RandomAccessBatcher
 from ludwig.data.dataset.base import Dataset, DatasetManager
 from ludwig.data.sampler import DistributedSampler
@@ -42,13 +47,13 @@ class PandasDataset(Dataset):
             dataset = load_hdf5(dataset)
         self.dataset = to_numpy_dataset(dataset)
 
-    def to_df(self, features: Optional[Iterable[BaseFeature]] = None) -> DataFrame:
+    def to_df(self, features: Iterable[BaseFeature] | None = None) -> DataFrame:
         """Convert the dataset to a Pandas DataFrame."""
         if features:
             return from_numpy_dataset({feature.feature_name: self.dataset[feature.proc_column] for feature in features})
         return from_numpy_dataset(self.dataset)
 
-    def to_scalar_df(self, features: Optional[Iterable[BaseFeature]] = None) -> DataFrame:
+    def to_scalar_df(self, features: Iterable[BaseFeature] | None = None) -> DataFrame:
         return to_scalar_df(self.to_df(features))
 
     def get(self, proc_column, idx=None):
@@ -76,18 +81,18 @@ class PandasDataset(Dataset):
         indices = indices[:, np.argsort(indices[1])]
         return im_data[indices[2, :]]
 
-    def get_dataset(self):
+    def get_dataset(self) -> dict[str, np.ndarray]:
         return self.dataset
 
     def __len__(self):
         return self.size
 
     @property
-    def processed_data_fp(self) -> Optional[str]:
+    def processed_data_fp(self) -> str | None:
         return self.data_hdf5_fp
 
     @property
-    def in_memory_size_bytes(self):
+    def in_memory_size_bytes(self) -> int:
         df = self.to_df()
         return df.memory_usage(deep=True).sum() if df is not None else 0
 
@@ -100,7 +105,7 @@ class PandasDataset(Dataset):
         ignore_last: bool = False,
         distributed: DistributedStrategy = None,
         augmentation_pipeline=None,
-    ):
+    ) -> Batcher:
         sampler = DistributedSampler(
             len(self), shuffle=should_shuffle, random_seed=random_seed, distributed=distributed
         )
@@ -115,21 +120,21 @@ class PandasDataset(Dataset):
 
 
 class PandasDatasetManager(DatasetManager):
-    def __init__(self, backend):
-        self.backend = backend
+    def __init__(self, backend: Backend):
+        self.backend: Backend = backend
 
-    def create(self, dataset, config, training_set_metadata):
+    def create(self, dataset, config, training_set_metadata) -> Dataset:
         return PandasDataset(dataset, get_proc_features(config), training_set_metadata.get(DATA_TRAIN_HDF5_FP))
 
-    def save(self, cache_path, dataset, config, training_set_metadata, tag):
+    def save(self, cache_path, dataset, config, training_set_metadata, tag) -> Dataset:
         save_hdf5(cache_path, dataset)
         if tag == TRAINING:
             training_set_metadata[DATA_TRAIN_HDF5_FP] = cache_path
         return dataset
 
-    def can_cache(self, skip_save_processed_input):
+    def can_cache(self, skip_save_processed_input) -> bool:
         return self.backend.is_coordinator() and not skip_save_processed_input
 
     @property
-    def data_format(self):
+    def data_format(self) -> str:
         return "hdf5"

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -17,12 +17,11 @@
 from __future__ import annotations
 
 import contextlib
-from typing import Iterable
+from typing import Iterable, TYPE_CHECKING
 
 import numpy as np
 from pandas import DataFrame
 
-from ludwig.backend.base import Backend
 from ludwig.constants import PREPROCESSING, TRAINING
 from ludwig.data.batcher.base import Batcher
 from ludwig.data.batcher.random_access import RandomAccessBatcher
@@ -35,6 +34,9 @@ from ludwig.utils.dataframe_utils import from_numpy_dataset, to_numpy_dataset, t
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.fs_utils import download_h5
 from ludwig.utils.misc_utils import get_proc_features
+
+if TYPE_CHECKING:
+    from ludwig.backend.base import Backend
 
 
 class PandasDataset(Dataset):


### PR DESCRIPTION
### Scope
* Adding typehint annotations in backend and data components.
* Fixing a number of `mypy` errors (many more remain).

Note: this involved removing `create_trainer()` from `LocalTrainingMixin` and putting it directly into `LocalBackend` so as to satisfy the interface requirements of the `Backend` class.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
