### PR TITLE
Dynamically set `max_new_tokens` based on output feature length, GMSL and model window size

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -21,6 +21,7 @@ from ludwig.utils.data_utils import clear_data_cache
 from ludwig.utils.llm_utils import (
     add_left_padding,
     generate_merged_ids,
+    get_context_len,
     pad_target_tensor_for_fine_tuning,
     realign_target_and_prediction_tensors_for_inference,
     remove_left_padding,
@@ -126,13 +127,7 @@ class LLM(BaseModel):
         self.curr_device = next(self.model.parameters()).device
         logger.info("Done.")
 
-        # Determines the maximum length of the context (input + output tokens)
-        if hasattr(self.model_config, "max_sequence_length"):
-            self.context_len = self.model_config.max_sequence_length
-        elif hasattr(self.model_config, "max_position_embeddings"):
-            self.context_len = self.model_config.max_position_embeddings
-        else:
-            self.context_len = 2048
+        self.context_len = get_context_len(self.model_config)
 
         # TODO(Arnav): This needs be more flexible to account for RoPE Scaling
         # When merging input IDs and target IDs for LLM fine-tuning, we want to make sure that the merged tensor is

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -206,13 +206,11 @@ class LLM(BaseModel):
         # CodeLlama to avoid getting an error. This workaround can be found here:
         # (https://github.com/huggingface/transformers/issues/25353#issuecomment-1669339754)
         self.generation.pad_token_id = self.tokenizer.pad_token_id
-        self.max_new_tokens = self.generation.max_new_tokens or self.generation.max_length
+        self.max_new_tokens = self.generation.max_new_tokens
         # max input length value copied from FastChat
-        # https://github.com/lm-sys/FastChat/blob/0e958b852a14f4bef5f0e9d7a5e7373477329cf2/fastchat/serve/inference.py#L180 # noqa E501
-        if self.model_config.is_encoder_decoder:
-            self.max_input_length = self.context_len - self.max_new_tokens - 8
-        else:
-            self.max_input_length = self.context_len
+        # https://github.com/lm-sys/FastChat/blob/0e958b852a14f4bef5f0e9d7a5e7373477329cf2/fastchat/serve/inference.py#L183 # noqa E501
+        self.max_input_length = self.context_len - self.max_new_tokens - 8
+        assert self.max_input_length > 0
 
     @property
     def output_feature_decoder(self) -> OutputFeature:

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -206,10 +206,13 @@ class LLM(BaseModel):
         # CodeLlama to avoid getting an error. This workaround can be found here:
         # (https://github.com/huggingface/transformers/issues/25353#issuecomment-1669339754)
         self.generation.pad_token_id = self.tokenizer.pad_token_id
-        self.max_new_tokens = self.generation.max_new_tokens
+        self.max_new_tokens = self.generation.max_new_tokens or self.generation.max_length
         # max input length value copied from FastChat
-        # https://github.com/lm-sys/FastChat/blob/0e958b852a14f4bef5f0e9d7a5e7373477329cf2/fastchat/serve/inference.py#L183  # noqa E501
-        self.max_input_length = self.context_len - self.max_new_tokens - 8
+        # https://github.com/lm-sys/FastChat/blob/0e958b852a14f4bef5f0e9d7a5e7373477329cf2/fastchat/serve/inference.py#L180 # noqa E501
+        if self.model_config.is_encoder_decoder:
+            self.max_input_length = self.context_len - self.max_new_tokens - 8
+        else:
+            self.max_input_length = self.context_len
 
     @property
     def output_feature_decoder(self) -> OutputFeature:

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -208,9 +208,8 @@ class LLM(BaseModel):
         self.generation.pad_token_id = self.tokenizer.pad_token_id
         self.max_new_tokens = self.generation.max_new_tokens
         # max input length value copied from FastChat
-        # https://github.com/lm-sys/FastChat/blob/0e958b852a14f4bef5f0e9d7a5e7373477329cf2/fastchat/serve/inference.py#L183 # noqa E501
+        # https://github.com/lm-sys/FastChat/blob/0e958b852a14f4bef5f0e9d7a5e7373477329cf2/fastchat/serve/inference.py#L183  # noqa E501
         self.max_input_length = self.context_len - self.max_new_tokens - 8
-        assert self.max_input_length > 0
 
     @property
     def output_feature_decoder(self) -> OutputFeature:

--- a/ludwig/schema/model_types/base.py
+++ b/ludwig/schema/model_types/base.py
@@ -30,7 +30,7 @@ from ludwig.schema.model_types.utils import (
     sanitize_and_filter_combiner_entities_,
     set_derived_feature_columns_,
     set_hyperopt_defaults_,
-    set_llm_tokenizers,
+    set_llm_parameters,
     set_preprocessing_parameters,
     set_tagger_decoder_parameters,
     set_validation_parameters,
@@ -69,8 +69,8 @@ class ModelConfig(schema_utils.BaseMarshmallowConfig, ABC):
         set_tagger_decoder_parameters(self)
         sanitize_and_filter_combiner_entities_(self)
 
-        # Set preprocessing parameters for text features for LLM model type
-        set_llm_tokenizers(self)
+        # Reconcile LLM parameters
+        set_llm_parameters(self)
 
         # Reconcile conflicting preprocessing parameters
         set_preprocessing_parameters(self)

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -5,6 +5,7 @@ import warnings
 from typing import Any, Dict, List, Mapping, Set, TYPE_CHECKING
 
 from marshmallow import ValidationError
+from transformers import AutoConfig
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import (
@@ -29,9 +30,11 @@ from ludwig.constants import (
 from ludwig.features.feature_utils import compute_feature_hash
 from ludwig.schema.features.utils import output_config_registry
 from ludwig.schema.hyperopt.scheduler import BaseHyperbandSchedulerConfig
+from ludwig.schema.llms.generation import LLMGenerationConfig
 from ludwig.schema.trainer import ECDTrainerConfig
 from ludwig.types import HyperoptConfigDict, ModelConfigDict
 from ludwig.utils.data_utils import get_sanitized_feature_name
+from ludwig.utils.llm_utils import get_context_len
 
 if TYPE_CHECKING:
     from ludwig.schema.model_types.base import ModelConfig
@@ -346,17 +349,41 @@ def _set_llm_tokenizers(config: "ModelConfig") -> None:
             output_feature.decoder.fallback_label = output_feature.preprocessing.fallback_label
 
 
+def _get_maximum_possible_sequence_length(config: "ModelConfig", default_max_sequence_length: int) -> int:
+    """Returns the maximum possible sequence length for the LLM model based on the model config."""
+    max_possible_sequence_length = default_max_sequence_length
+    if config.output_features[0].preprocessing.max_sequence_length is not None:
+        # Note: We don't need to check for max between feature.preprocessing.max_sequence_length and
+        # defaults.text.preprocessing.max_sequence_length because the latter is only applied to input features.
+        max_possible_sequence_length = max(
+            default_max_sequence_length, config.output_features[0].preprocessing.max_sequence_length
+        )
+    elif config.preprocessing.global_max_sequence_length is not None:
+        # This is not perfect since it includes tokens from both input + output features, but this at least
+        # ensures that max possible of the sequence length is used. It is very likely that the model learns
+        # to generate sequences than this value.
+        max_possible_sequence_length = max(
+            max_possible_sequence_length, config.preprocessing.global_max_sequence_length
+        )
+    elif max_possible_sequence_length == default_max_sequence_length:
+        # It's possible that both max_sequence_length and global_max_sequence_length are not set, in which case
+        # we should fall back to the window size of the pretrained model. By this point, because of schema validation
+        # checks, we know that the base_model exists so we can safely grab the base model's config.
+        # TODO (Arnav): Figure out how to factor in rope scaling factor into this calculation.
+        model_config = AutoConfig.from_pretrained(config.base_model)
+        max_possible_sequence_length = get_context_len(model_config)
+        # Artifically leave a buffer of half the total model window size to trade off
+        # runtime while likely covering a majority of the max sequence length.
+        max_possible_sequence_length = max_possible_sequence_length // 2
+    return max_possible_sequence_length
+
+
 def _set_generation_max_new_tokens(config: "ModelConfig") -> None:
     """Sets the max_new_tokens parameter in the generation config to the max sequence length of the output
     features.
 
     This ensures that the generation config is set to the correct value for the LLM model type.
     """
-    from transformers import AutoConfig
-
-    from ludwig.schema.llms.generation import LLMGenerationConfig
-    from ludwig.utils.llm_utils import get_context_len
-
     _DEFAULT_MAX_SEQUENCE_LENGTH = LLMGenerationConfig().max_new_tokens
     if config.generation.max_new_tokens != _DEFAULT_MAX_SEQUENCE_LENGTH:
         # Max new tokens is explicitly set by user, so don't override
@@ -367,30 +394,7 @@ def _set_generation_max_new_tokens(config: "ModelConfig") -> None:
         # TODO: Add better support for category output features
         return
 
-    max_possible_sequence_length = _DEFAULT_MAX_SEQUENCE_LENGTH
-    if config.output_features[0].preprocessing.max_sequence_length is not None:
-        # Note: We don't need to check for max between feature.preprocessing.max_sequence_length and
-        # defaults.text.preprocessing.max_sequence_length because the latter is only applied to input features.
-        max_possible_sequence_length = max(
-            _DEFAULT_MAX_SEQUENCE_LENGTH, config.output_features[0].preprocessing.max_sequence_length
-        )
-    elif config.preprocessing.global_max_sequence_length is not None:
-        # This is not perfect since it includes tokens from both input + output features, but this at least
-        # ensures that max possible of the sequence length is used. It is very likely that the model learns
-        # to generate sequences than this value.
-        max_possible_sequence_length = max(
-            max_possible_sequence_length, config.preprocessing.global_max_sequence_length
-        )
-    elif max_possible_sequence_length == _DEFAULT_MAX_SEQUENCE_LENGTH:
-        # It's possible that both max_sequence_length and global_max_sequence_length are not set, in which case
-        # we should fall back to the window size of the pretrained model. By this point, because of schema validation
-        # checks, we know that the base_model exists so we can safely grab the base model's config.
-        # TODO (Arnav): Figure out how to factor in rope scaling factor into this calculation.
-        model_config = AutoConfig.from_pretrained(config.base_model)
-        max_possible_sequence_length = get_context_len(model_config)
-        # Artifically leave a buffer of half the total model window size to trade off
-        # runtime while likely covering a majority of the max sequence length.
-        max_possible_sequence_length = max_possible_sequence_length // 2
+    max_possible_sequence_length = _get_maximum_possible_sequence_length(config, _DEFAULT_MAX_SEQUENCE_LENGTH)
 
     logger.info(
         f"Setting generation max_new_tokens to {max_possible_sequence_length} to correspond with the max "

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -389,14 +389,25 @@ def _set_generation_max_new_tokens(config: "ModelConfig") -> None:
     if max_possible_sequence_length == default_max_sequence_length:
         model_config = AutoConfig.from_pretrained(config.base_model)
         max_possible_sequence_length = get_context_len(model_config)
-
-    logger.info(
-        f"Setting generation max_new_tokens to {max_possible_sequence_length} to correspond with the max "
-        "sequence length assigned to the output feature or the global max sequence length. This will ensure that "
-        "the correct number of tokens are generated at inference time. To override this behavior, set "
-        "`generation.max_new_tokens` to a different value in your Ludwig config."
-    )
-    config.generation.max_new_tokens = max_possible_sequence_length
+        # Max length only works if max_new_tokens is not set.
+        # If max_new_tokens is set, then we need to set max_length to None to ensure that the correct number of tokens
+        # are generated (input + output tokens), otherwise we will exceed the bounds of generation resulting in errors.
+        config.generation.max_new_tokens = None
+        config.generation.max_length = max_possible_sequence_length
+        logger.info(
+            f"Setting generation max_length to {max_possible_sequence_length} to correspond with the max sequence "
+            "length assigned to the output feature or the global max sequence length. This will ensure that the "
+            "correct number of tokens are generated at inference time. To override this behavior, set "
+            "`generation.max_length` to a different value in your Ludwig config."
+        )
+    else:
+        logger.info(
+            f"Setting generation max_new_tokens to {max_possible_sequence_length} to correspond with the max "
+            "sequence length assigned to the output feature or the global max sequence length. This will ensure that "
+            "the correct number of tokens are generated at inference time. To override this behavior, set "
+            "`generation.max_new_tokens` to a different value in your Ludwig config."
+        )
+        config.generation.max_new_tokens = max_possible_sequence_length
 
 
 @DeveloperAPI

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -384,6 +384,7 @@ def _set_generation_max_new_tokens(config: "ModelConfig") -> None:
     # It's possible that both max_sequence_length and global_max_sequence_length are not set, in which case
     # we should fall back to the window size of the pretrained model. By this point, because of schema validation
     # checks, we know that the base_model exists so we can safely grab the base model's config.
+    # TODO (Arnav): Figure out how to factor in rope scaling factor into this calculation.
     if max_possible_sequence_length == default_max_sequence_length:
         model_config = AutoConfig.from_pretrained(config.base_model)
         # Determines the maximum length of the context (input + output tokens)

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -389,25 +389,26 @@ def _set_generation_max_new_tokens(config: "ModelConfig") -> None:
     if max_possible_sequence_length == default_max_sequence_length:
         model_config = AutoConfig.from_pretrained(config.base_model)
         max_possible_sequence_length = get_context_len(model_config)
-        # Max length only works if max_new_tokens is not set.
-        # If max_new_tokens is set, then we need to set max_length to None to ensure that the correct number of tokens
-        # are generated (input + output tokens), otherwise we will exceed the bounds of generation resulting in errors.
-        config.generation.max_new_tokens = None
-        config.generation.max_length = max_possible_sequence_length
-        logger.info(
-            f"Setting generation max_length to {max_possible_sequence_length} to correspond with the max sequence "
-            "length assigned to the output feature or the global max sequence length. This will ensure that the "
-            "correct number of tokens are generated at inference time. To override this behavior, set "
-            "`generation.max_length` to a different value in your Ludwig config."
-        )
-    else:
-        logger.info(
-            f"Setting generation max_new_tokens to {max_possible_sequence_length} to correspond with the max "
-            "sequence length assigned to the output feature or the global max sequence length. This will ensure that "
-            "the correct number of tokens are generated at inference time. To override this behavior, set "
-            "`generation.max_new_tokens` to a different value in your Ludwig config."
-        )
-        config.generation.max_new_tokens = max_possible_sequence_length
+    #     # Max length only works if max_new_tokens is not set.
+    #     # If max_new_tokens is set, then we need to set max_length to None to ensure that the correct number of tokens
+    #     # are generated (input + output tokens), otherwise we will exceed the bounds of generation
+    #     # resulting in errors.
+    #     config.generation.max_new_tokens = max_possible_sequence_length - 8
+    #     config.generation.max_length = max_possible_sequence_length
+    #     logger.info(
+    #         f"Setting generation max_length to {max_possible_sequence_length} to correspond with the max sequence "
+    #         "length assigned to the output feature or the global max sequence length. This will ensure that the "
+    #         "correct number of tokens are generated at inference time. To override this behavior, set "
+    #         "`generation.max_length` to a different value in your Ludwig config."
+    #     )
+    # else:
+    logger.info(
+        f"Setting generation max_new_tokens to {max_possible_sequence_length} to correspond with the max "
+        "sequence length assigned to the output feature or the global max sequence length. This will ensure that "
+        "the correct number of tokens are generated at inference time. To override this behavior, set "
+        "`generation.max_new_tokens` to a different value in your Ludwig config."
+    )
+    config.generation.max_new_tokens = max_possible_sequence_length
 
 
 @DeveloperAPI

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -389,6 +389,9 @@ def _set_generation_max_new_tokens(config: "ModelConfig") -> None:
     if max_possible_sequence_length == default_max_sequence_length:
         model_config = AutoConfig.from_pretrained(config.base_model)
         max_possible_sequence_length = get_context_len(model_config)
+        # Artifically leave a buffer for now to prevent the following error:
+        # RuntimeError: index 512 is out of bounds for dimension 1 with size 512
+        max_possible_sequence_length -= 32
     #     # Max length only works if max_new_tokens is not set.
     #     # If max_new_tokens is set, then we need to set max_length to None to ensure that the correct number of tokens
     #     # are generated (input + output tokens), otherwise we will exceed the bounds of generation

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -374,19 +374,18 @@ def _set_generation_max_new_tokens(config: "ModelConfig") -> None:
         max_possible_sequence_length = max(
             _DEFAULT_MAX_SEQUENCE_LENGTH, config.output_features[0].preprocessing.max_sequence_length
         )
-    if config.preprocessing.global_max_sequence_length is not None:
+    elif config.preprocessing.global_max_sequence_length is not None:
         # This is not perfect since it includes tokens from both input + output features, but this at least
         # ensures that max possible of the sequence length is used. It is very likely that the model learns
         # to generate sequences than this value.
         max_possible_sequence_length = max(
             max_possible_sequence_length, config.preprocessing.global_max_sequence_length
         )
-
-    # It's possible that both max_sequence_length and global_max_sequence_length are not set, in which case
-    # we should fall back to the window size of the pretrained model. By this point, because of schema validation
-    # checks, we know that the base_model exists so we can safely grab the base model's config.
-    # TODO (Arnav): Figure out how to factor in rope scaling factor into this calculation.
-    if max_possible_sequence_length == _DEFAULT_MAX_SEQUENCE_LENGTH:
+    elif max_possible_sequence_length == _DEFAULT_MAX_SEQUENCE_LENGTH:
+        # It's possible that both max_sequence_length and global_max_sequence_length are not set, in which case
+        # we should fall back to the window size of the pretrained model. By this point, because of schema validation
+        # checks, we know that the base_model exists so we can safely grab the base model's config.
+        # TODO (Arnav): Figure out how to factor in rope scaling factor into this calculation.
         model_config = AutoConfig.from_pretrained(config.base_model)
         max_possible_sequence_length = get_context_len(model_config)
         # Artifically leave a buffer of half the total model window size to trade off

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -355,6 +355,7 @@ def _set_generation_max_new_tokens(config: "ModelConfig") -> None:
     from transformers import AutoConfig
 
     from ludwig.schema.llms.generation import LLMGenerationConfig
+    from ludwig.utils.llm_utils import get_context_len
 
     default_max_sequence_length = LLMGenerationConfig().max_new_tokens
     if config.generation.max_new_tokens != default_max_sequence_length:
@@ -387,15 +388,7 @@ def _set_generation_max_new_tokens(config: "ModelConfig") -> None:
     # TODO (Arnav): Figure out how to factor in rope scaling factor into this calculation.
     if max_possible_sequence_length == default_max_sequence_length:
         model_config = AutoConfig.from_pretrained(config.base_model)
-        # Determines the maximum length of the context (input + output tokens)
-        if hasattr(model_config, "max_sequence_length"):
-            max_possible_sequence_length = model_config.max_sequence_length
-        elif hasattr(model_config, "max_position_embeddings"):
-            max_possible_sequence_length = model_config.max_position_embeddings
-        else:
-            # Fallback to 2048 for now.
-            # TODO: Determine this dynamically
-            max_possible_sequence_length = 2048
+        max_possible_sequence_length = get_context_len(model_config)
 
     logger.info(
         f"Setting generation max_new_tokens to {max_possible_sequence_length} to correspond with the max "

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -363,7 +363,7 @@ def _set_generation_max_new_tokens(config: "ModelConfig") -> None:
 
     if config.output_features[0].type != TEXT:
         # This is trickier to set for other output features, so don't override for now.
-        # TODO: Add support for other category features
+        # TODO: Add better support for category output features
         return
 
     max_possible_sequence_length = default_max_sequence_length

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -1008,4 +1008,6 @@ def test_max_new_tokens_override_fallback_to_model_window_size():
     }
 
     config_obj = ModelConfig.from_dict(config)
+    # Base model context length is 2048 tokens by default
+    # Since we fallback to setting max_new_tokens to the model context length / 2, we expect it to be 1024 tokens
     assert config_obj.generation.max_new_tokens == 1024

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -958,7 +958,7 @@ def test_max_new_tokens_override_no_changes_to_max_new_tokens():
         MODEL_TYPE: MODEL_LLM,
         BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
         INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
-        # Default value for max_sequence_length is 32
+        # Default value for generation.max_sequence_length is 32
         OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
         "generation": {"max_new_tokens": 64},
     }
@@ -974,7 +974,7 @@ def test_max_new_tokens_override_large_max_sequence_length():
         MODEL_TYPE: MODEL_LLM,
         BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
         INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
-        # Default value for max_sequence_length is 32
+        # Default value for generation.max_sequence_length is 32
         OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text", "preprocessing": {"max_sequence_length": 100}}],
     }
 
@@ -989,7 +989,7 @@ def test_max_new_tokens_override_large_global_max_sequence_length():
         MODEL_TYPE: MODEL_LLM,
         BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
         INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
-        # Default value for max_sequence_length is 32
+        # Default value for generation.max_sequence_length is 32
         OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
         PREPROCESSING: {"global_max_sequence_length": 100},
     }
@@ -1003,10 +1003,9 @@ def test_max_new_tokens_override_fallback_to_model_window_size():
         MODEL_TYPE: MODEL_LLM,
         BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
         INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
-        # Default value for max_sequence_length is 32
+        # Default value for generation.max_sequence_length is 32
         OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
     }
 
     config_obj = ModelConfig.from_dict(config)
-    assert config_obj.generation.max_new_tokens is None
-    assert config_obj.generation.max_length == 2048
+    assert config_obj.generation.max_new_tokens == 1024

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -1008,4 +1008,5 @@ def test_max_new_tokens_override_fallback_to_model_window_size():
     }
 
     config_obj = ModelConfig.from_dict(config)
-    assert config_obj.generation.max_new_tokens == 2048
+    assert config_obj.generation.max_new_tokens is None
+    assert config_obj.generation.max_length == 2048

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -950,3 +950,62 @@ def test_llm_quantization_backend_compatibility():
         ModelConfig.from_dict(config)
 
     ray.shutdown()
+
+
+def test_max_new_tokens_override_no_changes_to_max_new_tokens():
+    """Tests that the default value for max_new_tokens is respected when explicitly set in the config."""
+    config = {
+        MODEL_TYPE: MODEL_LLM,
+        BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+        INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
+        # Default value for max_sequence_length is 32
+        OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
+        "generation": {"max_new_tokens": 64},
+    }
+
+    config_obj = ModelConfig.from_dict(config)
+    assert config_obj.generation.max_new_tokens == 64
+
+
+def test_max_new_tokens_override_large_max_sequence_length():
+    """Tests that the default value for max_new_tokens is overridden when max_sequence_length is set to a large
+    value than the default max_new_tokens."""
+    config = {
+        MODEL_TYPE: MODEL_LLM,
+        BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+        INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
+        # Default value for max_sequence_length is 32
+        OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text", "preprocessing": {"max_sequence_length": 100}}],
+    }
+
+    config_obj = ModelConfig.from_dict(config)
+    assert config_obj.generation.max_new_tokens == 100
+
+
+def test_max_new_tokens_override_large_global_max_sequence_length():
+    """Tests that the default value for max_new_tokens is overridden when global_max_sequence_length is set to a
+    larger value than the default max_new_tokens."""
+    config = {
+        MODEL_TYPE: MODEL_LLM,
+        BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+        INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
+        # Default value for max_sequence_length is 32
+        OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
+        PREPROCESSING: {"global_max_sequence_length": 100},
+    }
+
+    config_obj = ModelConfig.from_dict(config)
+    assert config_obj.generation.max_new_tokens == 100
+
+
+def test_max_new_tokens_override_fallback_to_model_window_size():
+    config = {
+        MODEL_TYPE: MODEL_LLM,
+        BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+        INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
+        # Default value for max_sequence_length is 32
+        OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
+    }
+
+    config_obj = ModelConfig.from_dict(config)
+    assert config_obj.generation.max_new_tokens == 2048

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -952,62 +952,60 @@ def test_llm_quantization_backend_compatibility():
     ray.shutdown()
 
 
-def test_max_new_tokens_override_no_changes_to_max_new_tokens():
-    """Tests that the default value for max_new_tokens is respected when explicitly set in the config."""
-    config = {
-        MODEL_TYPE: MODEL_LLM,
-        BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
-        INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
-        # Default value for generation.max_sequence_length is 32
-        OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
-        "generation": {"max_new_tokens": 64},
-    }
+class TestMaxNewTokensOverride:
+    def test_max_new_tokens_override_no_changes_to_max_new_tokens(self):
+        """Tests that the default value for max_new_tokens is respected when explicitly set in the config."""
+        config = {
+            MODEL_TYPE: MODEL_LLM,
+            BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+            INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
+            # Default value for generation.max_sequence_length is 32
+            OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
+            "generation": {"max_new_tokens": 64},
+        }
 
-    config_obj = ModelConfig.from_dict(config)
-    assert config_obj.generation.max_new_tokens == 64
+        config_obj = ModelConfig.from_dict(config)
+        assert config_obj.generation.max_new_tokens == 64
 
+    def test_max_new_tokens_override_large_max_sequence_length(self):
+        """Tests that the default value for max_new_tokens is overridden when max_sequence_length is set to a large
+        value than the default max_new_tokens."""
+        config = {
+            MODEL_TYPE: MODEL_LLM,
+            BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+            INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
+            # Default value for generation.max_sequence_length is 32
+            OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text", "preprocessing": {"max_sequence_length": 100}}],
+        }
 
-def test_max_new_tokens_override_large_max_sequence_length():
-    """Tests that the default value for max_new_tokens is overridden when max_sequence_length is set to a large
-    value than the default max_new_tokens."""
-    config = {
-        MODEL_TYPE: MODEL_LLM,
-        BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
-        INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
-        # Default value for generation.max_sequence_length is 32
-        OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text", "preprocessing": {"max_sequence_length": 100}}],
-    }
+        config_obj = ModelConfig.from_dict(config)
+        assert config_obj.generation.max_new_tokens == 100
 
-    config_obj = ModelConfig.from_dict(config)
-    assert config_obj.generation.max_new_tokens == 100
+    def test_max_new_tokens_override_large_global_max_sequence_length(self):
+        """Tests that the default value for max_new_tokens is overridden when global_max_sequence_length is set to
+        a larger value than the default max_new_tokens."""
+        config = {
+            MODEL_TYPE: MODEL_LLM,
+            BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+            INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
+            # Default value for generation.max_sequence_length is 32
+            OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
+            PREPROCESSING: {"global_max_sequence_length": 100},
+        }
 
+        config_obj = ModelConfig.from_dict(config)
+        assert config_obj.generation.max_new_tokens == 100
 
-def test_max_new_tokens_override_large_global_max_sequence_length():
-    """Tests that the default value for max_new_tokens is overridden when global_max_sequence_length is set to a
-    larger value than the default max_new_tokens."""
-    config = {
-        MODEL_TYPE: MODEL_LLM,
-        BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
-        INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
-        # Default value for generation.max_sequence_length is 32
-        OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
-        PREPROCESSING: {"global_max_sequence_length": 100},
-    }
+    def test_max_new_tokens_override_fallback_to_model_window_size(self):
+        config = {
+            MODEL_TYPE: MODEL_LLM,
+            BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+            INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
+            # Default value for generation.max_sequence_length is 32
+            OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
+        }
 
-    config_obj = ModelConfig.from_dict(config)
-    assert config_obj.generation.max_new_tokens == 100
-
-
-def test_max_new_tokens_override_fallback_to_model_window_size():
-    config = {
-        MODEL_TYPE: MODEL_LLM,
-        BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
-        INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
-        # Default value for generation.max_sequence_length is 32
-        OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
-    }
-
-    config_obj = ModelConfig.from_dict(config)
-    # Base model context length is 2048 tokens by default
-    # Since we fallback to setting max_new_tokens to the model context length / 2, we expect it to be 1024 tokens
-    assert config_obj.generation.max_new_tokens == 1024
+        config_obj = ModelConfig.from_dict(config)
+        # Base model context length is 2048 tokens by default
+        # Since we fallback to setting max_new_tokens to the model context length / 2, we expect it to be 1024 tokens
+        assert config_obj.generation.max_new_tokens == 1024


### PR DESCRIPTION
TLDR; This fixes a bug in `model.evaluation()` that caused underreporting of performance metrics in a majority of cases. By setting max_new_tokens to the largest possible value _needed_, we ensure that the metric number from `model.evaluate()` are a good representation of true model performance.

---

This PR updates the config validation setter methods to ensure that the `generation.max_new_tokens` parameter in the model configuration is set correctly based on the maximum sequence length of the output features. This ensures accurate token generation for LLM model types. It also includes handling for different cases and provides informative logging for configuration changes. 

Specifically:
1. If the user sets max_new_tokens in generation to a value != the default value, it is respected as is.
2. Otherwise, we fall back to the max_sequence_length set for the `output` feature since that is the max number of tokens it learns during fine-tuning.
3. Otherwise, we fall back to the global_max_sequence_length if neither case 1 or case 2 are met. This is an overestimation of the number of required tokens, but it is acceptable for now.
4. Finally, if none of case 1, 2 or 3 are met, set max_new_tokens to the model's window size / 2. This feels like a good tradeoff of inference/evaluation time vs likely covering a majority of the total tokens allocated to the output feature. Can update this value in the future.