### PR TITLE
QoL: Only log generation config being used once at inference time

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -412,7 +412,7 @@ class LLM(BaseModel):
         mask=None,
     ) -> Dict[str, torch.Tensor]:
         """Generates tokens using the model."""
-        logger.info(f"For generating text, using: {self.generation}")
+        log_once(f"For generating text, using: {self.generation}")
         input_ids, _ = self._unpack_inputs(inputs)
 
         with torch.no_grad():


### PR DESCRIPTION
Otherwise it's far too noisy because it prints out for each `eval_batch_size` batch size which is very noisy