### PR TITLE
Fix calculation of dataset size

### DIFF
--- a/ludwig/data/batcher/test_batcher.py
+++ b/ludwig/data/batcher/test_batcher.py
@@ -1,0 +1,113 @@
+import logging
+
+import pandas as pd
+import yaml
+
+from ludwig.api import LudwigModel
+from ludwig.data.dataset.pandas import PandasDataset
+
+
+def test_pandas_size():
+    df = pd.DataFrame(
+        {"name": ["joe", "janice", "sara"], "mask": ["green", "black", "pink"], "weapon": ["stick", "gun", "gun"]}
+    )
+    config = yaml.safe_load(
+        """
+    model_type: llm
+    base_model: HuggingFaceH4/tiny-random-LlamaForCausalLM
+    input_features:
+    - name: name
+      type: text
+      preprocessing:
+        max_sequence_length: 256
+      column: name
+    output_features:
+    - name: weapon
+      type: text
+      preprocessing:
+        max_sequence_length: 256
+      column: weapon
+    preprocessing:
+      split:
+        type: random
+        probabilities:
+          - 1
+          - 0
+          - 0
+    """
+    )
+    model = LudwigModel(config=config, logging_level=logging.INFO)
+    data = model.preprocess(df, skip_save_processed_input=False)
+    training_set = data[0]
+    assert training_set.size == len(df)
+
+    # Check if string loading works as well
+    # data[0].data_hdf5_fp is the string filepath to the cached data from preprocessing
+    data_from_str = PandasDataset(data[0].data_hdf5_fp, data[0].features, None)
+    assert data_from_str.size == len(df)
+
+
+def test_pandas_batcher_use_all_samples():
+    df = pd.DataFrame(
+        {"name": ["joe", "janice", "sara"], "mask": ["green", "black", "pink"], "weapon": ["stick", "gun", "gun"]}
+    )
+    config = yaml.safe_load(
+        """
+    model_type: llm
+    base_model: HuggingFaceH4/tiny-random-LlamaForCausalLM
+    input_features:
+    - name: name
+      type: text
+      preprocessing:
+        max_sequence_length: 256
+      column: name
+    output_features:
+    - name: weapon
+      type: text
+      preprocessing:
+        max_sequence_length: 256
+      column: weapon
+    preprocessing:
+      split:
+        type: random
+        probabilities:
+          - 1
+          - 0
+          - 0
+    """
+    )
+    model = LudwigModel(config=config, logging_level=logging.INFO)
+    data = model.preprocess(df, skip_save_processed_input=False)
+    training_set = data[0]
+    features = training_set.dataset.keys()
+
+    batches = []
+    with training_set.initialize_batcher(batch_size=1) as batcher:
+        while not batcher.last_batch():
+            batch = batcher.next_batch()
+            batches.append(batch)
+    assert (len(batches)) == training_set.size
+
+    # Check to see if all items are used exactly once
+    for feature in features:
+        for i in range(len(training_set.dataset[feature])):
+            # Each of the arrays in the line below should contain the vector representation of a feature of sample i
+            assert (batches[i][feature].squeeze() == training_set.dataset[feature][i].squeeze()).all()
+
+    # Check if string loading works as well
+    batches = []
+    # data[0].data_hdf5_fp is the string filepath to the cached data from preprocessing
+    data_from_str = PandasDataset(data[0].data_hdf5_fp, data[0].features, None)
+    features = data_from_str.dataset.keys()
+
+    with data_from_str.initialize_batcher(batch_size=1) as batcher:
+        while not batcher.last_batch():
+            batch = batcher.next_batch()
+            batches.append(batch)
+    assert (len(batches)) == data_from_str.size
+
+    # Check to see if all items are used exactly once
+    for feature in features:
+        for i in range(len(data_from_str.dataset[feature])):
+            # Each of the arrays in the line below should contain the vector representation of a feature of sample i
+            assert (batches[i][feature].squeeze() == data_from_str.dataset[feature][i].squeeze()).all()

--- a/ludwig/data/dataset/pandas.py
+++ b/ludwig/data/dataset/pandas.py
@@ -43,11 +43,11 @@ class PandasDataset(Dataset):
     def __init__(self, dataset, features, data_hdf5_fp):
         self.features = features
         self.data_hdf5_fp = data_hdf5_fp
-        self.size = len(dataset)
 
         if isinstance(dataset, str):
             dataset = load_hdf5(dataset)
         self.dataset = to_numpy_dataset(dataset)
+        self.size = len(list(self.dataset.values())[0])
 
     def to_df(self, features: Iterable[BaseFeature] | None = None) -> DataFrame:
         """Convert the dataset to a Pandas DataFrame."""


### PR DESCRIPTION
We previously calculated a dataset's size from the length of whatever the "dataset" parameter was that was passed in. However, this parameter could have been a filepath, meaning that the dataset.size parameter would be set incorrectly, potentially causing index out of bound errors if the actual length of the dataset was shorter than the length of the filepath string.

This PR fixes this problem by calculating the size after the filepath has been processed into a dataset.