### PR TITLE
Fix issue while logging cuda device utilization to tensorboard

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -492,7 +492,7 @@ class Trainer(BaseTrainer):
                 # https://pytorch.org/docs/stable/generated/torch.cuda.utilization.html#torch.cuda.utilization
                 train_summary_writer.add_scalar(
                     f"cuda/device{i}/utilization",
-                    torch.cuda.device(i).utilization(),
+                    torch.cuda.utilization(device=device),
                     global_step=step,
                 )
         train_summary_writer.flush()


### PR DESCRIPTION
Fix for #3726 

```
2023-10-13T09:40:16Z [job] torch.cuda.device(i).utilization(),
2023-10-13T09:40:16Z [job] AttributeError: 'device' object has no attribute 'utilization'
```

API utilization from docs: https://pytorch.org/docs/stable/generated/torch.cuda.utilization.html#torch.cuda.utilization 

Tested on a GPU and this works correctly