### PR TITLE
[WIP] Create a binary decoder with a TART reasoning module

### DIFF
--- a/ludwig/decoders/tart_decoders.py
+++ b/ludwig/decoders/tart_decoders.py
@@ -85,12 +85,12 @@ class BinaryTARTDecoder(Decoder):
         self.pca_is_fit = False
 
         # The embedding protocol determines how the inputs are averaged for processing by the reasoning module.
-        self.embedding_protocol = get_embedding_protocol(self.config.embedding_protocol)
+        self.embedding_protocol = get_embedding_protocol(self.decoder_config.embedding_protocol)
 
         # Combiner/LLM output is potentially very large, so it is reduced with PCA.
         self.pca = Dense(
             input_size,
-            self.config.num_pca_components,
+            self.decoder_config.num_pca_components,
             use_bias=False,
             weights_initializer=weights_initializer,
             bias_initializer=bias_initializer,
@@ -98,8 +98,8 @@ class BinaryTARTDecoder(Decoder):
 
         # Transform the reduced input to work with the reasoning module.
         self.dense1 = Dense(
-            self.config.num_pca_components,
-            self.config.embedding_size,
+            self.decoder_config.num_pca_components,
+            self.decoder_config.embedding_size,
             use_bias=use_bias,
             weights_initializer=weights_initializer,
             bias_initializer=bias_initializer,
@@ -107,21 +107,21 @@ class BinaryTARTDecoder(Decoder):
 
         # Set up the encoder/backbone of the reasoning head. We use
         self._backbone_config = GPT2Config(
-            n_positions=2 * self.config.max_sequence_length,
-            n_embd=self.config.embedding_size,
-            n_layer=self.config.num_layers,
-            n_head=self.config.num_heads,
+            n_positions=2 * self.decoder_config.max_sequence_length,
+            n_embd=self.decoder_config.embedding_size,
+            n_layer=self.decoder_config.num_layers,
+            n_head=self.decoder_config.num_heads,
             resid_pdrop=0.0,
             embd_pdrop=0.0,
             attn_pdrop=0.0,
             use_cache=False,
         )
 
-        self.reasoning_module = GPT2Model(self.backbone_config)
+        self.reasoning_module = GPT2Model(self._backbone_config)
 
         # Transform the embeddings to the output feature shape.
         self.dense2 = Dense(
-            self.config.embedding_size,
+            self.decoder_config.embedding_size,
             1,
             use_bias=use_bias,
             weights_initializer=weights_initializer,
@@ -164,7 +164,7 @@ class BinaryTARTDecoder(Decoder):
 
 
 @register_embedding_protocol("vanilla")
-def vanilla_embedding(inputs: List[torch.Tensor]) -> torch.Tensor:
+def vanilla_embeddings(inputs: List[torch.Tensor]) -> torch.Tensor:
     pass
 
 

--- a/ludwig/decoders/tart_decoders.py
+++ b/ludwig/decoders/tart_decoders.py
@@ -150,6 +150,11 @@ class BinaryTARTDecoder(Decoder):
         return self.pca.input_shape
 
     def forward(self, inputs, mask=None):
+        if not self.pca_is_fit:
+            raise RuntimeError(
+                "Attempting to use a TART decoder without first fitting it to the data. Please run `ludwig train` "
+                "with this config before predicting."
+            )
         x = self.pca(inputs)
         x = self.dense1(x)
         x = self.reasoning_module(x)

--- a/ludwig/decoders/tart_decoders.py
+++ b/ludwig/decoders/tart_decoders.py
@@ -9,6 +9,7 @@ from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import BINARY
 from ludwig.decoders.base import Decoder
 from ludwig.decoders.registry import register_decoder
+from ludwig.schema.decoders.base import TARTDecoderConfig
 from ludwig.utils.registry import Registry
 from ludwig.utils.torch_utils import Dense
 
@@ -143,7 +144,7 @@ class BinaryTARTDecoder(Decoder):
 
     @staticmethod
     def get_schema_cls():
-        pass
+        return TARTDecoderConfig
 
     @property
     def input_shape(self):

--- a/ludwig/decoders/tart_decoders.py
+++ b/ludwig/decoders/tart_decoders.py
@@ -1,6 +1,7 @@
 import logging
-from typing import Callable, List
+from typing import Callable, List, Union
 
+import numpy as np
 import torch
 from sklearn.decomposition import PCA
 from transformers import GPT2Config, GPT2Model
@@ -50,7 +51,7 @@ def register_embedding_protocol(name: str) -> Callable:
         An inner function to use as a decorator.
     """
 
-    def wrap(func):
+    def wrap(func: Callable) -> Callable:
         """Register an embedding protocol function by name.
 
         Args:
@@ -128,7 +129,7 @@ class BinaryTARTDecoder(Decoder):
             bias_initializer=bias_initializer,
         )
 
-    def fit_pca(self, inputs: List[torch.Tensor]):
+    def fit_pca(self, inputs: Union[np.ndarray, List[np.ndarray]]):
         """Fit a PCA model to vanilla or LOO embedded inputs.
 
         Args:
@@ -147,10 +148,10 @@ class BinaryTARTDecoder(Decoder):
         return TARTDecoderConfig
 
     @property
-    def input_shape(self):
-        return self.pca.input_shape
+    def input_shape(self) -> torch.Size:
+        return self.pca.dense.in_features
 
-    def forward(self, inputs, mask=None):
+    def forward(self, inputs, mask=None) -> torch.Tensor:
         if not self.pca_is_fit:
             raise RuntimeError(
                 "Attempting to use a TART decoder without first fitting it to the data. Please run `ludwig train` "

--- a/ludwig/decoders/tart_decoders.py
+++ b/ludwig/decoders/tart_decoders.py
@@ -1,0 +1,153 @@
+import logging
+from typing import Callable, List
+
+import torch
+from transformers import GPT2Config, GPT2Model
+
+from ludwig.api_annotations import DeveloperAPI
+from ludwig.constants import BINARY
+from ludwig.decoders.base import Decoder
+from ludwig.decoders.registry import register_decoder
+from ludwig.utils.registry import Registry
+from ludwig.utils.torch_utils import Dense
+
+logger = logging.getLogger(__name__)
+
+
+_embedding_protocol_registry = Registry()
+
+
+@DeveloperAPI
+def get_embedding_protocol(name: str) -> Callable:
+    """Get a registered embedding protocol by name.
+
+    Args:
+        name: The name of the embedding protocol
+
+    Returns:
+        The embedding protocol function registered to `name`.
+    """
+    try:
+        protocol = _embedding_protocol_registry[name]
+    except KeyError as e:
+        raise ValueError(
+            f"The TART embedding protocol {name} does not exist. Please update your configuration to use one of the "
+            f"following: {', '.join(_embedding_protocol_registry.keys())}."
+        ) from e
+
+    return protocol
+
+
+@DeveloperAPI
+def register_embedding_protocol(name: str) -> Callable:
+    """Register an embedding protocol function by name.
+
+    Args:
+        name: The name to register the protocol under.
+
+    Returns:
+        An inner function to use as a decorator.
+    """
+
+    def wrap(func):
+        """Register an embedding protocol function by name.
+
+        Args:
+            func: The function to register
+
+        Returns:
+            `func` unaltered.
+        """
+        _embedding_protocol_registry[name] = func
+        return func
+
+    return wrap
+
+
+@DeveloperAPI
+@register_decoder("tart", [BINARY])
+class BinaryTARTDecoder(Decoder):
+    """"""
+
+    def __init__(
+        self,
+        input_size: int,
+        use_bias: bool = True,
+        weights_initializer: str = "xavier_uniform",
+        bias_initializer: str = "zeros",
+        decoder_config=None,
+        **kwargs,
+    ):
+        super().__init__()
+
+        # The embedding protocol determines how the inputs are averaged for processing by the reasoning module.
+        self.embedding_protocol = get_embedding_protocol(self.config.embedding_protocol)
+
+        # Combiner/LLM output is potentially very large, so it is reduced with PCA.
+        self.pca = Dense(
+            input_size,
+            self.config.num_pca_components,
+            use_bias=use_bias,
+            weights_initializer=weights_initializer,
+            bias_initializer=bias_initializer,
+        )
+
+        # Transform the reduced inputs to ma
+        self.dense1 = Dense(
+            self.config.num_pca_components,
+            self.config.embedding_size,
+            use_bias=use_bias,
+            weights_initializer=weights_initializer,
+            bias_initializer=bias_initializer,
+        )
+
+        # Set up the encoder/backbone of the reasoning head. We use
+        self._backbone_config = GPT2Config(
+            n_positions=2 * self.config.max_sequence_length,
+            n_embd=self.config.embedding_size,
+            n_layer=self.config.num_layers,
+            n_head=self.config.num_heads,
+            resid_pdrop=0.0,
+            embd_pdrop=0.0,
+            attn_pdrop=0.0,
+            use_cache=False,
+        )
+
+        self.reasoning_module = GPT2Model(self.backbone_config)
+
+        # Tranform the embeddings to the output feature shape.
+        self.dense2 = Dense(
+            self.config.embedding_size,
+            1,
+            use_bias=use_bias,
+            weights_initializer=weights_initializer,
+            bias_initializer=bias_initializer,
+        )
+
+    def set_pca_state(self, state):
+        pass
+
+    @staticmethod
+    def get_schema_cls():
+        pass
+
+    @property
+    def input_shape(self):
+        return self.pca.input_shape
+
+    def forward(self, inputs, mask=None):
+        x = self.pca(inputs)
+        x = self.dense1(x)
+        x = self.reasoning_module(x)
+        y = self.dense2(x)
+        return y
+
+
+@register_embedding_protocol("vanilla")
+def vanilla_embedding(inputs: List[torch.Tensor]) -> torch.Tensor:
+    pass
+
+
+@register_embedding_protocol("loo")
+def loo_embeddings(inputs: List[torch.Tensor]) -> torch.Tensor:
+    pass

--- a/tests/ludwig/decoders/test_tart_decoders.py
+++ b/tests/ludwig/decoders/test_tart_decoders.py
@@ -16,16 +16,16 @@ def default_tart_decoder_schema():
 
 
 class TestBinaryTARTDecoder:
-    def create_sample_input(self, config):
-        return np.random.rand(1024, config.max_sequence_length).astype(np.float32)
+    def create_sample_input(self, decoder_config):
+        return np.random.rand(1024, decoder_config.max_sequence_length).astype(np.float32)
 
-    def create_decoder_from_config(self, config):
+    def create_decoder_from_config(self, decoder_config):
         return BinaryTARTDecoder(
-            config.max_sequence_length,
+            decoder_config.max_sequence_length,
             use_bias=True,
             weights_initializer="xavier_uniform",
             bias_initializer="zeros",
-            decoder_config=config,
+            decoder_config=decoder_config,
         )
 
     def test__init__(self, default_tart_decoder_schema: TARTDecoderConfig):
@@ -103,6 +103,7 @@ class TestBinaryTARTDecoder:
 
         input = self.create_sample_input(default_tart_decoder_schema)
 
+        # For simplicity, assume batch size 1
         with pytest.raises(RuntimeError):
             decoder(torch.unsqueeze(torch.from_numpy(input), 0))
 

--- a/tests/ludwig/decoders/test_tart_decoders.py
+++ b/tests/ludwig/decoders/test_tart_decoders.py
@@ -1,4 +1,8 @@
+import copy
+
+import numpy as np
 import pytest
+import torch
 from transformers import GPT2Config, GPT2Model
 
 from ludwig.decoders.tart_decoders import BinaryTARTDecoder, get_embedding_protocol
@@ -12,6 +16,9 @@ def default_tart_decoder_schema():
 
 
 class TestBinaryTARTDecoder:
+    def create_sample_input(self, config):
+        return np.ndarray((config.max_sequence_length, 1024))
+
     def test__init__(self, default_tart_decoder_schema: TARTDecoderConfig):
         decoder = BinaryTARTDecoder(
             default_tart_decoder_schema.max_sequence_length,
@@ -26,31 +33,56 @@ class TestBinaryTARTDecoder:
         assert decoder.embedding_protocol is get_embedding_protocol(decoder.decoder_config.embedding_protocol)
 
         assert isinstance(decoder.pca, Dense)
-        # assert decoder.pca.size() == (
-        #     decoder.decoder_config.max_sequence_length,
-        #     decoder.decoder_config.num_pca_components,
-        # )
+        assert decoder.pca.dense.in_features == decoder.decoder_config.max_sequence_length
 
         assert isinstance(decoder.dense1, Dense)
-        # assert decoder.dense1.size() == (
-        #     decoder.decoder_config.num_pca_components,
-        #     decoder.decoder_config.embedding_size,
-        # )
+        assert decoder.dense1.dense.in_features == decoder.decoder_config.num_pca_components
 
         assert isinstance(decoder._backbone_config, GPT2Config)
+        assert decoder._backbone_config.model_type == "gpt2"
+        assert decoder._backbone_config.n_embd == decoder.decoder_config.embedding_size
+        assert decoder._backbone_config.n_head == decoder.decoder_config.num_heads
+        assert decoder._backbone_config.n_layer == decoder.decoder_config.num_layers
+
         assert isinstance(decoder.reasoning_module, GPT2Model)
 
         assert isinstance(decoder.dense2, Dense)
-        # assert decoder.dense2.size() == (decoder.decoder_config.embedding_size, 1)
+        assert decoder.dense2.dense.in_features == decoder.decoder_config.embedding_size
 
     def test_fit_pca(self, default_tart_decoder_schema: TARTDecoderConfig):
-        pass
+        decoder = BinaryTARTDecoder(
+            default_tart_decoder_schema.max_sequence_length,
+            use_bias=True,
+            weights_initializer="xavier_uniform",
+            bias_initializer="zeros",
+            decoder_config=default_tart_decoder_schema,
+        )
+
+        input = self.create_sample_input(default_tart_decoder_schema)
+
+        original_pca_weights = copy.deepcopy(decoder.pca.dense.weight)
+
+        decoder.fit_pca(input)
+
+        assert torch.nequal(original_pca_weights, decoder.pca.dense.weight)
 
     def test_get_schema_cls(self):
         assert BinaryTARTDecoder.get_schema_cls() is TARTDecoderConfig
 
     def test_input_shape(self, default_tart_decoder_schema: TARTDecoderConfig):
-        pass
+        decoder = BinaryTARTDecoder(
+            default_tart_decoder_schema.max_sequence_length,
+            use_bias=True,
+            weights_initializer="xavier_uniform",
+            bias_initializer="zeros",
+            decoder_config=default_tart_decoder_schema,
+        )
+
+        import pprint
+
+        pprint.pprint(help(decoder))
+
+        assert decoder.input_shape == 256
 
     def test_forward(self, default_tart_decoder_schema: TARTDecoderConfig):
         pass

--- a/tests/ludwig/decoders/test_tart_decoders.py
+++ b/tests/ludwig/decoders/test_tart_decoders.py
@@ -1,0 +1,56 @@
+import pytest
+from transformers import GPT2Config, GPT2Model
+
+from ludwig.decoders.tart_decoders import BinaryTARTDecoder, loo_embeddings  # , vanilla_embeddings
+from ludwig.schema.decoders.base import TARTDecoderConfig
+from ludwig.utils.torch_utils import Dense
+
+
+@pytest.fixture(scope="module")
+def default_tart_decoder_schema():
+    return TARTDecoderConfig()
+
+
+class TestBinaryTARTDecoder:
+    def test__init__(self, default_tart_decoder_schema: TARTDecoderConfig):
+        decoder = BinaryTARTDecoder(
+            default_tart_decoder_schema.max_sequence_length,
+            use_bias=True,
+            weights_initializer="xavier_uniform",
+            bias_initializer="zeros",
+            decoder_config=default_tart_decoder_schema,
+        )
+
+        assert decoder.decoder_config is default_tart_decoder_schema
+        assert not decoder.pca_is_fit
+        assert decoder.embedding_protocol is loo_embeddings
+
+        assert isinstance(decoder.pca, Dense)
+        # assert decoder.pca.size() == (
+        #     decoder.decoder_config.max_sequence_length,
+        #     decoder.decoder_config.num_pca_components,
+        # )
+
+        assert isinstance(decoder.dense1, Dense)
+        # assert decoder.dense1.size() == (
+        #     decoder.decoder_config.num_pca_components,
+        #     decoder.decoder_config.embedding_size,
+        # )
+
+        assert isinstance(decoder._backbone_config, GPT2Config)
+        assert isinstance(decoder.reasoning_module, GPT2Model)
+
+        assert isinstance(decoder.dense2, Dense)
+        # assert decoder.dense2.size() == (decoder.decoder_config.embedding_size, 1)
+
+    def test_fit_pca(self, default_tart_decoder_schema: TARTDecoderConfig):
+        pass
+
+    def test_get_schema_cls(self):
+        assert BinaryTARTDecoder.get_schema_cls() is TARTDecoderConfig
+
+    def test_input_shape(self, default_tart_decoder_schema: TARTDecoderConfig):
+        pass
+
+    def test_forward(self, default_tart_decoder_schema: TARTDecoderConfig):
+        pass

--- a/tests/ludwig/decoders/test_tart_decoders.py
+++ b/tests/ludwig/decoders/test_tart_decoders.py
@@ -17,11 +17,11 @@ def default_tart_decoder_schema():
 
 class TestBinaryTARTDecoder:
     def create_sample_input(self, decoder_config):
-        return np.random.rand(1024, decoder_config.max_sequence_length).astype(np.float32)
+        return np.random.rand(decoder_config.max_sequence_length, 1024).astype(np.float32)
 
     def create_decoder_from_config(self, decoder_config):
         return BinaryTARTDecoder(
-            decoder_config.max_sequence_length,
+            1024,
             use_bias=True,
             weights_initializer="xavier_uniform",
             bias_initializer="zeros",
@@ -30,7 +30,7 @@ class TestBinaryTARTDecoder:
 
     def test__init__(self, default_tart_decoder_schema: TARTDecoderConfig):
         decoder = BinaryTARTDecoder(
-            default_tart_decoder_schema.max_sequence_length,
+            1024,
             use_bias=True,
             weights_initializer="xavier_uniform",
             bias_initializer="zeros",
@@ -83,7 +83,7 @@ class TestBinaryTARTDecoder:
 
     def test_input_shape(self, default_tart_decoder_schema: TARTDecoderConfig):
         decoder = BinaryTARTDecoder(
-            default_tart_decoder_schema.max_sequence_length,
+            1024,
             use_bias=True,
             weights_initializer="xavier_uniform",
             bias_initializer="zeros",
@@ -94,7 +94,7 @@ class TestBinaryTARTDecoder:
 
     def test_forward(self, default_tart_decoder_schema: TARTDecoderConfig):
         decoder = BinaryTARTDecoder(
-            default_tart_decoder_schema.max_sequence_length,
+            1024,
             use_bias=True,
             weights_initializer="xavier_uniform",
             bias_initializer="zeros",
@@ -102,10 +102,13 @@ class TestBinaryTARTDecoder:
         )
 
         input = self.create_sample_input(default_tart_decoder_schema)
+        labels = torch.FloatTensor(1, default_tart_decoder_schema.max_sequence_length, 1)
 
         # For simplicity, assume batch size 1
         with pytest.raises(RuntimeError):
-            decoder(torch.unsqueeze(torch.from_numpy(input), 0))
+            decoder(torch.unsqueeze(torch.from_numpy(input), 0), labels)
 
         decoder.fit_pca(input)
-        decoder(torch.unsqueeze(torch.from_numpy(input), 0))
+        predictions = decoder(torch.unsqueeze(torch.from_numpy(input), 0), labels)
+
+        assert predictions.size() == (1, 1)

--- a/tests/ludwig/decoders/test_tart_decoders.py
+++ b/tests/ludwig/decoders/test_tart_decoders.py
@@ -1,7 +1,7 @@
 import pytest
 from transformers import GPT2Config, GPT2Model
 
-from ludwig.decoders.tart_decoders import BinaryTARTDecoder, loo_embeddings  # , vanilla_embeddings
+from ludwig.decoders.tart_decoders import BinaryTARTDecoder, get_embedding_protocol
 from ludwig.schema.decoders.base import TARTDecoderConfig
 from ludwig.utils.torch_utils import Dense
 
@@ -23,7 +23,7 @@ class TestBinaryTARTDecoder:
 
         assert decoder.decoder_config is default_tart_decoder_schema
         assert not decoder.pca_is_fit
-        assert decoder.embedding_protocol is loo_embeddings
+        assert decoder.embedding_protocol is get_embedding_protocol(decoder.decoder_config.embedding_protocol)
 
         assert isinstance(decoder.pca, Dense)
         # assert decoder.pca.size() == (


### PR DESCRIPTION
This adds a TART reasoning module as a binary decoder.

TODOs:

[] Add the vanilla and LOO embedding protocols
[] Add an embeddings cache
[] Tests