### PR TITLE
Limit ray versions to keep 2.4 out of the picture.

### DIFF
--- a/requirements_distributed.txt
+++ b/requirements_distributed.txt
@@ -3,7 +3,7 @@ dask[dataframe]<2023.4.0
 pyarrow
 
 # requirements for ray
-ray[default,data,serve,tune]>=2.2.0,<2.5
+ray[default,data,serve,tune]>=2.2.0,<2.4
 tensorboardX<2.3
 GPUtil
 tblib


### PR DESCRIPTION
# Code Pull Requests

- Set a stricter limit on the `ray` version, so `2.4.0` doesn't cause anyone else any issues.
