### PR TITLE
[MAINTENACE] Improve typehints and use constants instead of common hardcoded string values.

### DIFF
--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -197,6 +197,8 @@ EARLY_STOP = "early_stop"
 EPOCHS = "epochs"
 BATCH_SIZE = "batch_size"
 EVAL_BATCH_SIZE = "eval_batch_size"
+EFFECTIVE_BATCH_SIZE = "effective_batch_size"
+MAX_BATCH_SIZE = "max_batch_size"
 DEFAULT_BATCH_SIZE = "auto"
 FALLBACK_BATCH_SIZE = 128
 # The smallest batch size that is supported on Ludwig.

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -5,7 +5,17 @@ import torch
 from packaging.version import parse as parse_version
 
 from ludwig.api_annotations import DeveloperAPI
-from ludwig.constants import AUTO, LOSS, MAX_POSSIBLE_BATCH_SIZE, MODEL_ECD, MODEL_GBM, MODEL_LLM, TRAINING
+from ludwig.constants import (
+    AUTO,
+    EFFECTIVE_BATCH_SIZE,
+    LOSS,
+    MAX_BATCH_SIZE,
+    MAX_POSSIBLE_BATCH_SIZE,
+    MODEL_ECD,
+    MODEL_GBM,
+    MODEL_LLM,
+    TRAINING,
+)
 from ludwig.error import ConfigValidationError
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.lr_scheduler import LRSchedulerConfig, LRSchedulerDataclassField
@@ -218,7 +228,7 @@ class ECDTrainerConfig(BaseTrainerConfig):
             "one of `batch_size` or `gradient_accumulation_steps` must be set to something other than 'auto', and "
             "consequently will be set following the formula given above."
         ),
-        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["effective_batch_size"],
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD][EFFECTIVE_BATCH_SIZE],
         field_options=[
             schema_utils.PositiveInteger(default=128, description="", allow_none=False),
             schema_utils.StringOptions(options=["auto"], default="auto", allow_none=False),
@@ -248,7 +258,7 @@ class ECDTrainerConfig(BaseTrainerConfig):
             "Auto batch size tuning and increasing batch size on plateau will be capped at this value. The default "
             "value is 2^40."
         ),
-        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["max_batch_size"],
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD][MAX_BATCH_SIZE],
     )
 
     gradient_accumulation_steps: Union[int, str] = schema_utils.OneOfOptionsField(


### PR DESCRIPTION
### Scope
This small change provides two quality-of-life improvements:
* Enable more of the type hints to be used without the quotation marks.
* For common configuration strings, use defined constants (instead of hardcoded values).

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
