### PR TITLE
[BUGFIX] Make sure that the "hyperopt" directory in the local repository path is deleted after test run is completed

### DIFF
--- a/tests/integration_tests/test_automl.py
+++ b/tests/integration_tests/test_automl.py
@@ -26,11 +26,12 @@ from tests.integration_tests.utils import (
 
 ray = pytest.importorskip("ray")
 
-import dask.dataframe as dd  # noqa
-from ray.tune.experiment.trial import Trial  # noqa
+import dask.dataframe as dd  # noqa E402
+from ray.tune.experiment.trial import Trial  # noqa E402
 
-from ludwig.automl import auto_train, create_auto_config, train_with_config  # noqa
-from ludwig.hyperopt.execution import RayTuneExecutor  # noqa
+from ludwig.automl import auto_train, create_auto_config, train_with_config  # noqa E402
+from ludwig.automl.automl import OUTPUT_DIR  # noqa E402
+from ludwig.hyperopt.execution import RayTuneExecutor  # noqa E402
 
 pytestmark = [pytest.mark.distributed, pytest.mark.integration_tests_c]
 
@@ -290,10 +291,12 @@ def test_train_with_config(time_budget, test_data_tabular_large, ray_cluster_2cp
 @pytest.mark.distributed
 def test_auto_train(test_data_tabular_large, ray_cluster_2cpu, tmpdir):
     _, ofeatures, dataset_csv = test_data_tabular_large
+    local_output_directory_path: str = f"{str(tmpdir)}/{OUTPUT_DIR}"
     results = auto_train(
         dataset=dataset_csv,
         target=ofeatures[0][NAME],
         time_limit_s=120,
+        output_directory=local_output_directory_path,
         user_config={"hyperopt": {"executor": {"num_samples": 2}}},
     )
 


### PR DESCRIPTION
### Scope
When the test `tests/integration_tests/test_automl.py::test_auto_train` is executed, the `"hyperopt"` directory remains in the main repository directory.  We clean this directory up by passing the `output_directory` argument to `auto_train()`.  By making this `output_directory` a relative path from the `tmpdir` fixture, it will be automatically deleted upon the completion of the test.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
