### PR TITLE
Uncap the torchmetrics version, so we can get fixes in 1.0+.

### DIFF
--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -136,7 +136,7 @@ class RMSEMetric(MeanSquaredError, LudwigMetric):
     """Root mean squared error metric."""
 
     def __init__(self, **kwargs):
-        super().__init__(squared=False, **kwargs)
+        super().__init__(squared=False)
 
 
 @register_metric(PRECISION, [BINARY], MAXIMIZE, PROBABILITIES)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ marshmallow-jsonschema
 marshmallow-dataclass==8.5.4
 tensorboard
 nltk    # Required for rouge scores.
-torchmetrics>=0.11.0,<=0.11.4
+torchmetrics>=0.11.0
 torchinfo
 filelock
 psutil==5.9.4


### PR DESCRIPTION
While trying to figure out why my air-gapped installation and deployment of Ludwig was failing to detect my cached copy of the `punkt` tokenizer for `nltk`, I came across https://github.com/Lightning-AI/torchmetrics/issues/1779 which got merged into `torchmetrics==1.0.0`... but Ludwig was avoiding that version.  So I forcibly installed `torchmetrics==1.2.0` (latest) in my image (after installing Ludwig), ignored `pip`'s words of caution, and managed to run some LoRA-based fine-tuning without a hitch!  Since that code path worked okay with the updated library, I'm submitting this PR to remove the pin and leaning on CI to help identify if there are issues on other code paths or if it's truly safe to release.