### PR TITLE
Retry LLM model downloads from HF Hub with exponential backoff when there is a Read timeout

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -18,6 +18,7 @@ from ludwig.schema.features.base import BaseOutputFeatureConfig, FeatureCollecti
 from ludwig.schema.model_types.llm import LLMModelConfig
 from ludwig.utils.augmentation_utils import AugmentationPipelines
 from ludwig.utils.data_utils import clear_data_cache
+from ludwig.utils.error_handling_utils import default_retry
 from ludwig.utils.llm_utils import (
     add_left_padding,
     generate_merged_ids,
@@ -72,6 +73,7 @@ class DictWrapper:
         self.obj.update(modules)
 
 
+@default_retry(tries=8)
 def load_pretrained_from_config(
     config_obj: LLMModelConfig,
     model_config: Optional[AutoConfig] = None,

--- a/tests/ludwig/utils/test_error_handling_utils.py
+++ b/tests/ludwig/utils/test_error_handling_utils.py
@@ -1,0 +1,51 @@
+import pytest
+
+from ludwig.constants import TRIES
+from ludwig.utils.error_handling_utils import default_retry
+
+
+def test_default_retry_success():
+    ctr = 0
+
+    @default_retry()
+    def flaky_function():
+        nonlocal ctr
+        if ctr < TRIES - 1:
+            ctr += 1
+            raise Exception(f"Ctr: {ctr} too low.")
+
+        return
+
+    flaky_function()
+
+
+def test_default_retry_failure():
+    ctr = 0
+
+    @default_retry()
+    def flaky_function():
+        nonlocal ctr
+        if ctr < TRIES:
+            ctr += 1
+            raise Exception(f"Ctr: {ctr} too low.")
+
+        return
+
+    with pytest.raises(Exception):
+        flaky_function()
+
+
+def test_default_retry_success_custom_num_tries():
+    CUSTOM_TRIES = 3
+    ctr = 0
+
+    @default_retry(tries=CUSTOM_TRIES)
+    def flaky_function():
+        nonlocal ctr
+        if ctr < CUSTOM_TRIES - 1:
+            ctr += 1
+            raise Exception(f"Ctr: {ctr} too low.")
+
+        return
+
+    flaky_function()


### PR DESCRIPTION
Retries when this transient error occurs while downloading an LLM from HF Hub

```
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='cdn-lfs.huggingface.co', port=443): Read timed out. 
```

Also adds a suite of new tests to ensure that the default_retry decorator that exists in Ludwig works as intended.