### PR TITLE
Raise error if output feature name is in the prompt template

### DIFF
--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -723,8 +723,8 @@ def check_prompt_requirements(config: "ModelConfig") -> None:  # noqa: F821
         output_feature_col = config.output_features[0].column
         if output_feature_col in template_refs:
             raise ConfigValidationError(
-                "Prompt template should not contain the output feature name. The output feature is automatically "
-                "added to the end of the prompt template merged with the input at training time."
+                "Prompt template should not have a reference to the output feature. The output feature is "
+                "automatically added to the end of the prompt template merged with the input at training time."
             )
 
 

--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -719,9 +719,9 @@ def check_prompt_requirements(config: "ModelConfig") -> None:  # noqa: F821
                     "a JSON-serialized representation of non-output feature columns."
                 )
 
-        # Raise an error if template has a placeholder for the output feature name.
-        output_feature_name = config.output_features[0].name
-        if output_feature_name in template_refs:
+        # Raise an error if template has a placeholder for the output feature name (column).
+        output_feature_col = config.output_features[0].column
+        if output_feature_col in template_refs:
             raise ConfigValidationError(
                 "Prompt template should not contain the output feature name. The output feature is automatically "
                 "added to the end of the prompt template merged with the input at training time."

--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -719,6 +719,14 @@ def check_prompt_requirements(config: "ModelConfig") -> None:  # noqa: F821
                     "a JSON-serialized representation of non-output feature columns."
                 )
 
+        # Raise an error if template has a placeholder for the output feature name.
+        output_feature_name = config.output_features[0].name
+        if output_feature_name in template_refs:
+            raise ConfigValidationError(
+                "Prompt template should not contain the output feature name. The output feature is automatically "
+                "added to the end of the prompt template merged with the input at training time."
+            )
+
 
 @register_config_check
 def check_sample_ratio_and_size_compatible(config: "ModelConfig") -> None:

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -493,7 +493,7 @@ def test_check_prompt_requirements():
     config["prompt"] = {"template": "{input1}"}
     ModelConfig.from_dict(config)
 
-    # Raise an error if template has a placeholder for the output feature name.
+    # Raise an error if template has a placeholder for the output feature.
     config["prompt"] = {"template": "{input1}: {output1}"}
     with pytest.raises(ConfigValidationError):
         ModelConfig.from_dict(config)

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -468,9 +468,9 @@ def test_check_prompt_requirements():
     config = {
         "model_type": "llm",
         "input_features": [
-            text_feature(name="test1", column="col1", encoder={"type": "passthrough"}),
+            text_feature(name="input1", column="col1", encoder={"type": "passthrough"}),
         ],
-        "output_features": [text_feature()],
+        "output_features": [text_feature(name="output1")],
         "base_model": "opt-350m",
     }
 
@@ -489,6 +489,14 @@ def test_check_prompt_requirements():
 
     config["prompt"] = {"task": "Some task", "template": "{__task__}"}
     ModelConfig.from_dict(config)
+
+    config["prompt"] = {"template": "{input1}"}
+    ModelConfig.from_dict(config)
+
+    # Raise an error if template has a placeholder for the output feature name.
+    config["prompt"] = {"template": "{input1}: {output1}"}
+    with pytest.raises(ConfigValidationError):
+        ModelConfig.from_dict(config)
 
 
 def test_check_sample_ratio_and_size_compatible():


### PR DESCRIPTION
This is a problem since we always merge the tokens from the output feature at the end of the input feature + prompt tokens before making the forward pass through the LLM at fine-tuning time, so this would end up creating 2 instances of the output feature tokens incorrectly. 

This PR tries to mitigate this earlier by raising an error at config validation time.