### PR TITLE
[MAINTENANCE] Restrict "fsspec" to not include the latest version "2023.10.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ PyYAML>=3.12,<6.0.1,!=5.4.* #Exlude PyYAML 5.4.* due to incompatibility with aws
 absl-py
 kaggle
 requests
-fsspec[http]
+fsspec[http]<2023.10.0
 dataclasses-json
 jsonschema>=4.5.0,<4.7
 marshmallow


### PR DESCRIPTION
### Scope
The version `2023.10.0` or the `fsspec` library was released on 10/21/2023.  Unfortunately, it breaks the `builder.py::as_dataset()` method of the HuggingFace "datasets" library version in use with the error `NotImplementedError: Loading a dataset cached in a LocalFileSystem is not supported.` being raised.  Hence, we restrict the `fsspec` version for the time being.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
