### PR TITLE
[MAINTENACE] Fixing method overload violations; providing typehints and method argument documentation

### DIFF
--- a/ludwig/datasets/loaders/dataset_loader.py
+++ b/ludwig/datasets/loaders/dataset_loader.py
@@ -55,7 +55,7 @@ class TqdmUpTo(tqdm):
             Total size (in tqdm units). If [default: None] remains unchanged.
         """
         if tsize is not None:
-            self.total = tsize
+            self.total = tsize  # noqa W0201
         self.update(b * bsize - self.n)  # will also set self.n = b * bsize
 
 
@@ -198,7 +198,8 @@ class DatasetLoader:
             return _list_of_strings(self.config.archive_filenames)
         return [os.path.basename(urlparse(url).path) for url in self.download_urls]
 
-    def get_mirror_download_paths(self, mirror: DatasetFallbackMirror):
+    @staticmethod
+    def get_mirror_download_paths(mirror: DatasetFallbackMirror):
         """Filenames for downloaded files inferred from mirror download_paths."""
         return _list_of_strings(mirror.download_paths)
 
@@ -284,7 +285,9 @@ class DatasetLoader:
             except Exception:
                 logger.exception("Failed to transform dataset")
 
-    def load(self, kaggle_username: str, kaggle_key: str | None = None, split: bool = False) -> pd.DataFrame:
+    def load(
+        self, kaggle_username: str, kaggle_key: str | None = None, split: bool = False
+    ) -> pd.DataFrame | list[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         """Loads the dataset, downloaded and processing it if needed.
 
         Note: This method is also responsible for splitting the data, returning a single dataframe if split=False, and a
@@ -454,7 +457,6 @@ class DatasetLoader:
             _list_of_strings(self.config.validation_filenames), root_dir=self.raw_dataset_dir
         )
         test_paths = _glob_multiple(_list_of_strings(self.config.test_filenames), root_dir=self.raw_dataset_dir)
-        dataframes = []
         if self.config.name == "hugging_face":
             dataframes = self._get_dataframe_with_fixed_splits_from_hf()
         else:
@@ -522,7 +524,8 @@ class DatasetLoader:
         """Last modified time of the processed dataset after downloading successfully."""
         return os.path.getmtime(self.processed_dataset_path)
 
-    def split(self, dataset: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    @staticmethod
+    def split(dataset: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         if SPLIT in dataset:
             dataset[SPLIT] = pd.to_numeric(dataset[SPLIT])
             training_set = dataset[dataset[SPLIT] == 0].drop(columns=[SPLIT])

--- a/ludwig/datasets/loaders/dataset_loader.py
+++ b/ludwig/datasets/loaders/dataset_loader.py
@@ -254,7 +254,7 @@ class DatasetLoader:
             else:
                 shutil.copy2(source, destination)
 
-    def _download_and_process(self, kaggle_username=None, kaggle_key=None):
+    def _download_and_process(self, kaggle_username: str | None = None, kaggle_key: str | None = None):
         """Loads the dataset, downloaded and processing it if needed.
 
         If dataset is already processed, does nothing.
@@ -286,7 +286,7 @@ class DatasetLoader:
                 logger.exception("Failed to transform dataset")
 
     def load(
-        self, kaggle_username: str, kaggle_key: str | None = None, split: bool = False
+        self, kaggle_username: str | None = None, kaggle_key: str | None = None, split: bool = False
     ) -> pd.DataFrame | list[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         """Loads the dataset, downloaded and processing it if needed.
 
@@ -306,7 +306,7 @@ class DatasetLoader:
             else:
                 return dataset_df
 
-    def download(self, kaggle_username=None, kaggle_key=None) -> list[str]:
+    def download(self, kaggle_username: str | None = None, kaggle_key: str | None = None) -> list[str]:
         if not os.path.exists(self.raw_dataset_dir):
             os.makedirs(self.raw_dataset_dir)
         if self.is_kaggle_dataset:

--- a/ludwig/datasets/loaders/hugging_face.py
+++ b/ludwig/datasets/loaders/hugging_face.py
@@ -48,7 +48,9 @@ class HFLoader(DatasetLoader):
             pandas_dict[split] = dataset_dict[split].to_pandas()
         return pandas_dict
 
-    def load(self, hf_id: str, hf_subsample: str | None = None, split: bool = False) -> pd.DataFrame:
+    def load(
+        self, hf_id: str, hf_subsample: str | None = None, split: bool = False
+    ) -> pd.DataFrame | list[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         """When load() is called, HFLoader calls the datasets API to return all of the data in a HuggingFace
         DatasetDict, converts it to a dictionary of pandas dataframes, and returns either three dataframes
         containing train, validation, and test data or one dataframe that is the concatenation of all three

--- a/ludwig/datasets/loaders/hugging_face.py
+++ b/ludwig/datasets/loaders/hugging_face.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from __future__ import annotations
+
 import logging
-from typing import Dict
+from typing import overload
 
 import datasets
 import pandas as pd
@@ -33,18 +35,18 @@ class HFLoader(DatasetLoader):
     identify which dataset and which subsample of that dataset to load in.
     """
 
-    def load_hf_to_dict(self, hf_id: str, hf_subsample: str) -> Dict[str, pd.DataFrame]:
+    @staticmethod
+    def load_hf_to_dict(hf_id: str, hf_subsample: str) -> dict[str, pd.DataFrame]:
         """Returns a map of split -> pd.DataFrame for the given HF dataset."""
-        dataset_dict: Dict[str, "datasets.arrow_dataset.Dataset"] = datasets.load_dataset(
-            path=hf_id, name=hf_subsample
-        )  # noqa
+        dataset_dict: dict[str, datasets.Dataset] = datasets.load_dataset(path=hf_id, name=hf_subsample)
         pandas_dict = {}
         for split in dataset_dict:
             # Convert from HF DatasetDict type to a dictionary of pandas dataframes
             pandas_dict[split] = dataset_dict[split].to_pandas()
         return pandas_dict
 
-    def load(self, hf_id, hf_subsample, split=False) -> pd.DataFrame:
+    @overload  # HuggingFace use-case requires different signature for "load()" than "DatasetLoader.load()" base class.
+    def load(self, hf_id: str, hf_subsample: str, split: bool = False) -> pd.DataFrame:  # type: ignore[override]
         """When load() is called, HFLoader calls the datasets API to return all of the data in a HuggingFace
         DatasetDict, converts it to a dictionary of pandas dataframes, and returns either three dataframes
         containing train, validation, and test data or one dataframe that is the concatenation of all three

--- a/ludwig/datasets/loaders/hugging_face.py
+++ b/ludwig/datasets/loaders/hugging_face.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import logging
-from typing import overload
 
 import datasets
 import pandas as pd
@@ -37,7 +36,11 @@ class HFLoader(DatasetLoader):
 
     @staticmethod
     def load_hf_to_dict(hf_id: str, hf_subsample: str) -> dict[str, pd.DataFrame]:
-        """Returns a map of split -> pd.DataFrame for the given HF dataset."""
+        """Returns a map of split -> pd.DataFrame for the given HF dataset.
+
+        :param hf_id: (str) path to dataset on HuggingFace platform
+        :param hf_subsample: (str) name of dataset configuration on HuggingFace platform
+        """
         dataset_dict: dict[str, datasets.Dataset] = datasets.load_dataset(path=hf_id, name=hf_subsample)
         pandas_dict = {}
         for split in dataset_dict:
@@ -45,12 +48,13 @@ class HFLoader(DatasetLoader):
             pandas_dict[split] = dataset_dict[split].to_pandas()
         return pandas_dict
 
-    @overload  # HuggingFace use-case requires different signature for "load()" than "DatasetLoader.load()" base class.
-    def load(self, hf_id: str, hf_subsample: str, split: bool = False) -> pd.DataFrame:  # type: ignore[override]
+    def load(self, hf_id: str, hf_subsample: str | None = None, split: bool = False) -> pd.DataFrame:
         """When load() is called, HFLoader calls the datasets API to return all of the data in a HuggingFace
         DatasetDict, converts it to a dictionary of pandas dataframes, and returns either three dataframes
         containing train, validation, and test data or one dataframe that is the concatenation of all three
         depending on whether `split` is set to True or False.
+
+        :param split: (bool) directive for how to interpret if dataset contains validation or test set (see below)
 
         Note that some datasets may not provide a validation set or a test set. In this case:
         - If split is True, the DataFrames corresponding to the missing sets are initialized to be empty
@@ -58,6 +62,9 @@ class HFLoader(DatasetLoader):
           validation/test split (i.e., there will be no 1s/2s)
 
         A train set should always be provided by Hugging Face.
+
+        :param hf_id: (str) path to dataset on HuggingFace platform
+        :param hf_subsample: (str) name of dataset configuration on HuggingFace platform
         """
         self.config.huggingface_dataset_id = hf_id
         self.config.huggingface_subsample = hf_subsample

--- a/ludwig/datasets/loaders/hugging_face.py
+++ b/ludwig/datasets/loaders/hugging_face.py
@@ -35,7 +35,7 @@ class HFLoader(DatasetLoader):
     """
 
     @staticmethod
-    def load_hf_to_dict(hf_id: str, hf_subsample: str) -> dict[str, pd.DataFrame]:
+    def load_hf_to_dict(hf_id: str | None = None, hf_subsample: str | None = None) -> dict[str, pd.DataFrame]:
         """Returns a map of split -> pd.DataFrame for the given HF dataset.
 
         :param hf_id: (str) path to dataset on HuggingFace platform
@@ -49,7 +49,7 @@ class HFLoader(DatasetLoader):
         return pandas_dict
 
     def load(
-        self, hf_id: str, hf_subsample: str | None = None, split: bool = False
+        self, hf_id: str | None = None, hf_subsample: str | None = None, split: bool = False
     ) -> pd.DataFrame | list[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         """When load() is called, HFLoader calls the datasets API to return all of the data in a HuggingFace
         DatasetDict, converts it to a dictionary of pandas dataframes, and returns either three dataframes

--- a/ludwig/datasets/loaders/hugging_face.py
+++ b/ludwig/datasets/loaders/hugging_face.py
@@ -48,6 +48,7 @@ class HFLoader(DatasetLoader):
             pandas_dict[split] = dataset_dict[split].to_pandas()
         return pandas_dict
 
+    # TODO(Alex): Standardize load() signature as interface method in DatasetLoader and adhere to it in all subclasses.
     def load(
         self, hf_id: str | None = None, hf_subsample: str | None = None, split: bool = False
     ) -> pd.DataFrame | list[pd.DataFrame, pd.DataFrame, pd.DataFrame]:


### PR DESCRIPTION
### Scope
* This change resolve the method signature inconsistency between `HFLoader` and its parent class `DatasetLoader` concerning the `load()` method, and its usage in "tests/ludwig/datasets/test_datasets.py::test_hf_dataset_loading".
* Method arguments are documented for `HFLoader.load()` and `DatasetLoader.load()`.
* Return typehints for `DatasetLoader` and `HFLoader` fixed to accurately reflect the types of return values.
* New style typehints are introduced, reducing the amount of `typing` imports required.
* Minor cleanup (e.g., make methods `static` using `@staticmethod` where appropriate; deleting unused variables).

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
