### PR TITLE
Fix: Prevent memory from ballooning during post-training evaluation

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -23,8 +23,8 @@ from ludwig.utils.llm_utils import (
     add_left_padding,
     generate_merged_ids,
     get_context_len,
+    get_realigned_target_and_prediction_tensors_for_inference,
     pad_target_tensor_for_fine_tuning,
-    realign_target_and_prediction_tensors_for_inference,
     remove_left_padding,
     set_pad_token,
 )
@@ -532,7 +532,7 @@ class LLM(BaseModel):
         for of_name, of_obj in self.output_features.items():
             if isinstance(of_obj, TextOutputFeature):
                 # Align the target length with the predictions length to enable text metric evaluation.
-                _targets, _predictions = realign_target_and_prediction_tensors_for_inference(
+                _targets, _predictions = get_realigned_target_and_prediction_tensors_for_inference(
                     targets, predictions, of_name, self.tokenizer
                 )
                 of_obj.update_metrics(_targets[of_name], _predictions[of_name], self.tokenizer)
@@ -634,7 +634,7 @@ class LLM(BaseModel):
         for of_name, of_obj in self.output_features.items():
             if isinstance(of_obj, TextOutputFeature):
                 # Align the target length with the predictions length to enable text metric evaluation.
-                _targets, _predictions = realign_target_and_prediction_tensors_for_inference(
+                _targets, _predictions = get_realigned_target_and_prediction_tensors_for_inference(
                     targets, predictions, of_name, self.tokenizer
                 )
                 of_eval_loss = of_obj.eval_loss(_targets[of_name], _predictions[of_name])

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -257,16 +257,6 @@ class Predictor(BasePredictor):
                     preds = self.model.outputs_to_predictions(outputs)
                     self.model.update_metrics(targets, preds)
 
-                    # Max New tokens: 64
-                    # When max_seq_len set for output feature to 256
-                    # prediction: [eval_batch_size, 256]
-                    # probabilities: [eval_batch_size, 256, vocab_size]
-
-                    # Max New tokens: 64
-                    # When max_seq_len not set >> 256
-                    # prediction: [eval_batch_size, row_with_most_tokens]
-                    # probabilities: [eval_batch_size, row_with_most_tokens, vocab_size]
-
                     # accumulate predictions from batch for each output feature
                     if collect_predictions:
                         self._accumulate_preds(
@@ -284,11 +274,6 @@ class Predictor(BasePredictor):
 
             # consolidate predictions from each batch to a single tensor
             if collect_predictions:
-                # predictions: [dataset, worst_case_length]
-                # probabilities: [dataset, worst_case_length, vocab_size]
-                # vs
-                # predictions: [dataset, 256]
-                # probabilities: [dataset, 256, vocab_size]
                 self._concat_preds(predictions)
 
             metrics = self.model.get_metrics()

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -257,6 +257,16 @@ class Predictor(BasePredictor):
                     preds = self.model.outputs_to_predictions(outputs)
                     self.model.update_metrics(targets, preds)
 
+                    # Max New tokens: 64
+                    # When max_seq_len set for output feature to 256
+                    # prediction: [eval_batch_size, 256]
+                    # probabilities: [eval_batch_size, 256, vocab_size]
+
+                    # Max New tokens: 64
+                    # When max_seq_len not set >> 256
+                    # prediction: [eval_batch_size, row_with_most_tokens]
+                    # probabilities: [eval_batch_size, row_with_most_tokens, vocab_size]
+
                     # accumulate predictions from batch for each output feature
                     if collect_predictions:
                         self._accumulate_preds(
@@ -274,6 +284,11 @@ class Predictor(BasePredictor):
 
             # consolidate predictions from each batch to a single tensor
             if collect_predictions:
+                # predictions: [dataset, worst_case_length]
+                # probabilities: [dataset, worst_case_length, vocab_size]
+                # vs
+                # predictions: [dataset, 256]
+                # probabilities: [dataset, 256, vocab_size]
                 self._concat_preds(predictions)
 
             metrics = self.model.get_metrics()

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 from typing import Dict, Tuple
 
@@ -424,26 +425,30 @@ def realign_target_and_prediction_tensors_for_inference(
     if not pad_value:
         pad_value = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
 
+    zeros_to_add = (
+        target_length - prediction_length if target_length > prediction_length else prediction_length - target_length
+    )
+
+    # We don't want to modify the original targets and predictions tensors, so we create a copy of them.
+    _targets = copy.deepcopy(targets)
+    _predictions = copy.deepcopy(predictions)
+
     # Align target and prediction tensors for text to text metric computation
     if target_length > prediction_length:
         # Pad the predictions.
-        zeros_to_add = target_length - prediction_length
-
-        predictions[of_name][PREDICTIONS] = F.pad(
-            predictions[of_name][PREDICTIONS], (0, zeros_to_add), value=pad_value
+        _predictions[of_name][PREDICTIONS] = F.pad(
+            _predictions[of_name][PREDICTIONS], (0, zeros_to_add), value=pad_value
         ).to(torch.int64)
 
-        predictions[of_name][PROBABILITIES] = F.pad(predictions[of_name][PROBABILITIES], (0, 0, 0, zeros_to_add)).to(
+        _predictions[of_name][PROBABILITIES] = F.pad(_predictions[of_name][PROBABILITIES], (0, 0, 0, zeros_to_add)).to(
             torch.float32
         )
 
-        predictions[of_name][LOGITS] = F.pad(predictions[of_name][LOGITS], (0, 0, 0, zeros_to_add)).to(torch.float32)
+        _predictions[of_name][LOGITS] = F.pad(_predictions[of_name][LOGITS], (0, 0, 0, zeros_to_add)).to(torch.float32)
     else:
-        zeros_to_add = prediction_length - target_length
+        _targets[of_name] = F.pad(_targets[of_name], (0, zeros_to_add), value=pad_value).to(torch.int64)
 
-        targets[of_name] = F.pad(targets[of_name], (0, zeros_to_add), value=pad_value).to(torch.int64)
-
-    return targets, predictions
+    return _targets, _predictions
 
 
 def update_embedding_layer(model: AutoModelForCausalLM, config_obj: LLMTrainerConfig) -> AutoModelForCausalLM:

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -389,7 +389,7 @@ def _get_decoded_targets_and_predictions(
     return decoded_targets, decoded_predictions
 
 
-def realign_target_and_prediction_tensors_for_inference(
+def get_realigned_target_and_prediction_tensors_for_inference(
     targets: Dict[str, torch.Tensor],
     predictions: Dict[str, Dict[str, torch.Tensor]],
     of_name: str,

--- a/tests/ludwig/utils/test_llm_utils.py
+++ b/tests/ludwig/utils/test_llm_utils.py
@@ -283,7 +283,11 @@ def test_realign_target_and_prediction_tensors_for_inference(tokenizer):
         targets, predictions, of_name, tokenizer
     )
 
-    assert predictions == updated_predictions
+    for key in updated_predictions.keys():
+        assert torch.equal(updated_predictions[key][PREDICTIONS], predictions[key][PREDICTIONS])
+        assert torch.equal(updated_predictions[key][PROBABILITIES], predictions[key][PROBABILITIES])
+        assert torch.equal(updated_predictions[key][LOGITS], predictions[key][LOGITS])
+
     assert torch.equal(updated_targets[of_name], torch.tensor([[78, 79, 504, 76, 397, 84, 0, 1, 1]]))
 
     # Scenario 3: Target length is longer than the prediction tensor, so we need to realign them
@@ -299,7 +303,7 @@ def test_realign_target_and_prediction_tensors_for_inference(tokenizer):
         targets, predictions, of_name, tokenizer
     )
 
-    assert targets == updated_targets
+    assert torch.equal(updated_targets[of_name], targets[of_name])
 
     assert torch.equal(updated_predictions[of_name][PREDICTIONS], torch.tensor([[78, 79, 504, 76, 397, 84, 0, 1, 1]]))
     assert updated_predictions[of_name][PROBABILITIES].shape[1] == targets[of_name].shape[1]

--- a/tests/ludwig/utils/test_llm_utils.py
+++ b/tests/ludwig/utils/test_llm_utils.py
@@ -10,9 +10,9 @@ from ludwig.utils.llm_utils import (
     find_last_matching_index,
     generate_merged_ids,
     get_context_len,
+    get_realigned_target_and_prediction_tensors_for_inference,
     has_padding_token,
     pad_target_tensor_for_fine_tuning,
-    realign_target_and_prediction_tensors_for_inference,
     remove_left_padding,
     set_pad_token,
 )
@@ -247,7 +247,7 @@ def test_pad_target_tensor_for_fine_tuning():
     assert torch.equal(expected_target[of_name], updated_targets[of_name])
 
 
-def test_realign_target_and_prediction_tensors_for_inference(tokenizer):
+def test_get_realigned_target_and_prediction_tensors_for_inference(tokenizer):
     of_name = "out_1"
     vocab_size = 8
 
@@ -260,7 +260,7 @@ def test_realign_target_and_prediction_tensors_for_inference(tokenizer):
             LOGITS: torch.randn(1, 7, vocab_size).to(torch.float32),
         }
     }
-    updated_targets, updated_predictions = realign_target_and_prediction_tensors_for_inference(
+    updated_targets, updated_predictions = get_realigned_target_and_prediction_tensors_for_inference(
         targets, predictions, of_name, tokenizer
     )
 
@@ -279,7 +279,7 @@ def test_realign_target_and_prediction_tensors_for_inference(tokenizer):
             LOGITS: torch.randn(1, 9, vocab_size).to(torch.float32),
         }
     }
-    updated_targets, updated_predictions = realign_target_and_prediction_tensors_for_inference(
+    updated_targets, updated_predictions = get_realigned_target_and_prediction_tensors_for_inference(
         targets, predictions, of_name, tokenizer
     )
 
@@ -299,7 +299,7 @@ def test_realign_target_and_prediction_tensors_for_inference(tokenizer):
             LOGITS: torch.randn(1, 7, vocab_size).to(torch.float32),
         }
     }
-    updated_targets, updated_predictions = realign_target_and_prediction_tensors_for_inference(
+    updated_targets, updated_predictions = get_realigned_target_and_prediction_tensors_for_inference(
         targets, predictions, of_name, tokenizer
     )
 


### PR DESCRIPTION
The previous implementation of this function was modifying the target and prediction tensors in place, which is incorrect. It didn't matter at training time because the modified tensors are what we needed to calculate metrics.

However, at prediction time, we aggregate the prediction tensors and this causes the prediction tensor shapes during aggregation to have the wrong shape/size. Specifically in this code block here: https://github.com/ludwig-ai/ludwig/blob/master/ludwig/models/predictor.py#L256

- Line 256 returns the a dictionary with the right tensors shapes
- Line 257 transforms the dictionary structure and preserves the right tensor shapes
- Line 258 updates the metrics, but the issue comes from the fact that we realign tensors to have the correct shape [here](https://github.com/ludwig-ai/ludwig/blob/master/ludwig/models/llm.py#L535), and then we return the modified tensors. However, the implementation [here](https://github.com/ludwig-ai/ludwig/blob/master/ludwig/utils/llm_utils.py#L391) modifies the tensors inside the target or predictions dictionaries in place. When the outputs (targets) are long, then it means that the tensor shapes go from:

    - `output_predictions`: (batch_size, max_new_tokens)
    - `output_probabilities`: (batch_size, max_new_tokens, vocab_size)
To
    - `output_predictions`: (batch_size, max_tokens_in_target)
    - `output_probabilities`: (batch_size, max_tokens_in_target, vocab_size)

And `max_tokens_in_target` can be >> `max_new_tokens`. For e.g., `max_tokens_in_target` could be 300 for the output feature, but you may only want to generate the first 64 so you set `max_new_tokens` to 64. 

This was happening beneath the surface, which is why it wasn't caught so far, and it didn't matter at training time but it definitely has an effect on CPU memory at evaluation time because we [accumulate the predictions](https://github.com/ludwig-ai/ludwig/blob/master/ludwig/models/predictor.py#L262) and then [concat the accumulated predictions from batches into a single prediction tensor](https://github.com/ludwig-ai/ludwig/blob/master/ludwig/models/predictor.py#L277), which means the size can be many multiples larger than the actual size we'd like (just `max_new_tokens` per row for evaluation).   