### PR TITLE
Pin getdaft<0.2 in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,8 @@ sacremoses
 sentencepiece
 
 # requirements for daft
-getdaft
+# NOTE: Pinned to <0.2 because of deprecation of fsspec argument in Daft
+getdaft<0.2
 
 # requirement for various paged and 8-bit optimizers
 bitsandbytes<0.41.0


### PR DESCRIPTION
# Code Pull Requests

Adds an upper-bound to the version of `getdaft`, since Daft introduces a backward-incompatible change in v0.2.0 that deprecates passing in fsspec filesystems into its APIs.

To pass credentials, Daft now includes a `IOConfig` API that can be used.