### PR TITLE
OnnxExporter

### DIFF
--- a/ludwig/model_export/base_model_exporter.py
+++ b/ludwig/model_export/base_model_exporter.py
@@ -2,10 +2,9 @@ from abc import ABC, abstractmethod
 
 import torch
 
-from ludwig.api import LudwigModel
-
 
 class LudwigTorchWrapper(torch.nn.Module):
+    """Base class that establishes the contract for exporting to different file formats."""
     def __init__(self, model):
         super(LudwigTorchWrapper, self).__init__()
         self.model = model

--- a/ludwig/model_export/base_model_exporter.py
+++ b/ludwig/model_export/base_model_exporter.py
@@ -1,0 +1,26 @@
+from abc import ABC, abstractmethod
+
+import torch
+
+from ludwig.api import LudwigModel
+
+
+class LudwigTorchWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super(LudwigTorchWrapper, self).__init__()
+        self.model = model
+
+    def forward(self, x):
+        return self.model({"image_path": x})
+
+
+class BaseModelExporter(ABC):
+
+    @abstractmethod
+    def export(self, model_path, export_path, export_args_override):
+        pass
+
+
+    @abstractmethod
+    def check_model_export(self, path):
+        pass

--- a/ludwig/model_export/base_model_exporter.py
+++ b/ludwig/model_export/base_model_exporter.py
@@ -5,8 +5,9 @@ import torch
 
 class LudwigTorchWrapper(torch.nn.Module):
     """Base class that establishes the contract for exporting to different file formats."""
+
     def __init__(self, model):
-        super(LudwigTorchWrapper, self).__init__()
+        super().__init__()
         self.model = model
 
     def forward(self, x):
@@ -14,11 +15,9 @@ class LudwigTorchWrapper(torch.nn.Module):
 
 
 class BaseModelExporter(ABC):
-
     @abstractmethod
     def export(self, model_path, export_path, export_args_override):
         pass
-
 
     @abstractmethod
     def check_model_export(self, path):

--- a/ludwig/model_export/onnx_exporter.py
+++ b/ludwig/model_export/onnx_exporter.py
@@ -1,0 +1,36 @@
+from abc import ABC, abstractmethod
+
+import torch
+import onnx
+from ludwig.api import LudwigModel
+import os
+from ludwig.model_export.base_model_exporter import LudwigTorchWrapper
+
+
+class OnnxExporter(ABC):
+
+    def export(self, model_path, export_path, output_model_name):
+
+        ludwig_model = LudwigModel.load(model_path)
+        model = LudwigTorchWrapper(ludwig_model.model)  # Wrap the model
+        model.eval()  # inference mode, is this needed.. I think onnx export does this for us
+
+        width = ludwig_model.config["input_features"][0]["preprocessing"]["width"]
+        height = ludwig_model.config["input_features"][0]["preprocessing"]["height"]
+        example_input = torch.randn(1, 3, width, height, requires_grad=True)
+
+        torch.onnx.export(
+            model,
+            example_input,
+            os.path.join(export_path, output_model_name),
+            opset_version=18,
+            export_params=True,
+            do_constant_folding=True,
+            input_names=["input"],
+            output_names=["combiner_hidden_1", "output", "combiner_hidden_2"],
+        )
+
+
+    def check_model_export(self, path):
+        onnx_model = onnx.load(path)
+        onnx.checker.check_model(onnx_model)

--- a/ludwig/model_export/onnx_exporter.py
+++ b/ludwig/model_export/onnx_exporter.py
@@ -4,10 +4,25 @@ import torch
 import onnx
 from ludwig.api import LudwigModel
 import os
-from ludwig.model_export.base_model_exporter import LudwigTorchWrapper
+from ludwig.model_export.base_model_exporter import LudwigTorchWrapper, BaseModelExporter
 
 
-class OnnxExporter(ABC):
+# Copyright (c) 2019 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+class OnnxExporter(BaseModelExporter):
+    """Class that abstracts the convertion of torch to onnx."""
 
     def export(self, model_path, export_path, output_model_name):
 

--- a/ludwig/model_export/onnx_exporter.py
+++ b/ludwig/model_export/onnx_exporter.py
@@ -1,10 +1,10 @@
-from abc import ABC, abstractmethod
-
-import torch
-import onnx
-from ludwig.api import LudwigModel
 import os
-from ludwig.model_export.base_model_exporter import LudwigTorchWrapper, BaseModelExporter
+
+import onnx
+import torch
+
+from ludwig.api import LudwigModel
+from ludwig.model_export.base_model_exporter import BaseModelExporter, LudwigTorchWrapper
 
 
 # Copyright (c) 2019 Uber Technologies, Inc.
@@ -25,7 +25,6 @@ class OnnxExporter(BaseModelExporter):
     """Class that abstracts the convertion of torch to onnx."""
 
     def export(self, model_path, export_path, output_model_name):
-
         ludwig_model = LudwigModel.load(model_path)
         model = LudwigTorchWrapper(ludwig_model.model)  # Wrap the model
         model.eval()  # inference mode, is this needed.. I think onnx export does this for us
@@ -44,7 +43,6 @@ class OnnxExporter(BaseModelExporter):
             input_names=["input"],
             output_names=["combiner_hidden_1", "output", "combiner_hidden_2"],
         )
-
 
     def check_model_export(self, path):
         onnx_model = onnx.load(path)

--- a/tests/ludwig/model_export/test_onnx_exporter.py
+++ b/tests/ludwig/model_export/test_onnx_exporter.py
@@ -1,19 +1,21 @@
 import unittest
-
-import torch
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from ludwig.api import LudwigModel
-
 from ludwig.model_export.base_model_exporter import LudwigTorchWrapper
 from ludwig.model_export.onnx_exporter import OnnxExporter
 
 
 class TestOnnxExporter(unittest.TestCase):
-    @patch.object(LudwigModel, 'load')
-    @patch.object(LudwigTorchWrapper, 'eval')
+    @patch.object(LudwigModel, "load")
+    @patch.object(LudwigTorchWrapper, "eval")
     @patch("torch.onnx")
-    def test_onnx_export(self, mock_onnx, mock_ludwig_torch_wrapper_eval, mock_ludwig_model_load, ):
+    def test_onnx_export(
+        self,
+        mock_onnx,
+        mock_ludwig_torch_wrapper_eval,
+        mock_ludwig_model_load,
+    ):
         sample_model_path = MagicMock()
         sample_export_path = MagicMock()
         sample_output_model_name = MagicMock()

--- a/tests/ludwig/model_export/test_onnx_exporter.py
+++ b/tests/ludwig/model_export/test_onnx_exporter.py
@@ -1,0 +1,27 @@
+import unittest
+
+import torch
+from unittest.mock import patch, MagicMock
+
+from ludwig.api import LudwigModel
+
+from ludwig.model_export.base_model_exporter import LudwigTorchWrapper
+from ludwig.model_export.onnx_exporter import OnnxExporter
+
+
+class TestOnnxExporter(unittest.TestCase):
+    @patch.object(LudwigModel, 'load')
+    @patch.object(LudwigTorchWrapper, 'eval')
+    @patch("torch.onnx")
+    def test_onnx_export(self, mock_onnx, mock_ludwig_torch_wrapper_eval, mock_ludwig_model_load, ):
+        sample_model_path = MagicMock()
+        sample_export_path = MagicMock()
+        sample_output_model_name = MagicMock()
+        mock_ludwig_model_load.return_value = MagicMock()
+        mock_onnx.export.return_value = MagicMock()
+        onnx_exporter = OnnxExporter()
+
+        onnx_exporter.export(sample_model_path, sample_export_path, sample_output_model_name)
+
+        mock_ludwig_torch_wrapper_eval.assert_called_once()
+        mock_ludwig_model_load.assert_called_once()


### PR DESCRIPTION
# Code Pull Requests

Please provide the following:

- a simple set of classes to do onnx export of pytorch models

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
