### PR TITLE
Add k eval predictions to mlflow for LLM fine-tuning

### DIFF
--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -226,7 +226,7 @@ def _log_mlflow_loop(q: queue.Queue, log_artifacts: bool = True):
             break
 
         if log_metrics is not None:
-            if log_metrics["llm_eval_examples"] is not None:
+            if "llm_eval_examples" in log_metrics and log_metrics["llm_eval_examples"] is not None:
                 mlflow.log_table(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
                 # Delete the table from the metrics dict so we don't try to log it with the other metrics
                 del log_metrics["llm_eval_examples"]
@@ -247,7 +247,7 @@ def _log_mlflow(log_metrics, steps, save_path, should_continue, log_artifacts: b
     This is used when save_in_background is False.
     """
     if log_metrics is not None:
-        if log_metrics["llm_eval_examples"] is not None:
+        if "llm_eval_examples" in log_metrics and log_metrics["llm_eval_examples"] is not None:
             mlflow.log_table(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
             # Delete the table from the metrics dict so we don't try to log it with the other metrics
             del log_metrics["llm_eval_examples"]

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -228,6 +228,7 @@ def _log_mlflow_loop(q: queue.Queue, log_artifacts: bool = True):
         if log_metrics is not None:
             if log_metrics["llm_eval_examples"] is not None:
                 mlflow.log_table(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
+                # Delete the table from the metrics dict so we don't try to log it with the other metrics
                 del log_metrics["llm_eval_examples"]
         mlflow.log_metrics(log_metrics, step=steps)
 
@@ -248,6 +249,7 @@ def _log_mlflow(log_metrics, steps, save_path, should_continue, log_artifacts: b
     if log_metrics is not None:
         if log_metrics["llm_eval_examples"] is not None:
             mlflow.log_table(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
+            # Delete the table from the metrics dict so we don't try to log it with the other metrics
             del log_metrics["llm_eval_examples"]
         mlflow.log_metrics(log_metrics, step=steps)
         if log_artifacts:

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -242,6 +242,11 @@ def _log_mlflow(log_metrics, steps, save_path, should_continue, log_artifacts: b
     This is used when save_in_background is False.
     """
     if log_metrics is not None:
+        if log_metrics["llm_outputs"] is not None:
+            mlflow.llm.log_predictions(
+                inputs=log_metrics["llm_outputs"]["inputs"], outputs=log_metrics["llm_outputs"]["outputs"]
+            )
+            del log_metrics["llm_outputs"]
         mlflow.log_metrics(log_metrics, step=steps)
         if log_artifacts:
             _log_model(save_path)

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -225,6 +225,14 @@ def _log_mlflow_loop(q: queue.Queue, log_artifacts: bool = True):
             # Break out of the loop if we're not going to log anything.
             break
 
+        if log_metrics is not None:
+            if log_metrics["llm_outputs"] is not None:
+                mlflow.llm.log_predictions(
+                    inputs=log_metrics["llm_outputs"]["inputs"],
+                    prompts=[0] * len(log_metrics["llm_outputs"]["inputs"]),  # This is a workaround
+                    outputs=log_metrics["llm_outputs"]["outputs"],
+                )
+                del log_metrics["llm_outputs"]
         mlflow.log_metrics(log_metrics, step=steps)
 
         if not q.empty():
@@ -241,10 +249,13 @@ def _log_mlflow(log_metrics, steps, save_path, should_continue, log_artifacts: b
 
     This is used when save_in_background is False.
     """
+    # breakpoint()
     if log_metrics is not None:
         if log_metrics["llm_outputs"] is not None:
             mlflow.llm.log_predictions(
-                inputs=log_metrics["llm_outputs"]["inputs"], outputs=log_metrics["llm_outputs"]["outputs"]
+                inputs=log_metrics["llm_outputs"]["inputs"],
+                prompts=[0] * len(log_metrics["llm_outputs"]["inputs"]),
+                outputs=log_metrics["llm_outputs"]["outputs"],
             )
             del log_metrics["llm_outputs"]
         mlflow.log_metrics(log_metrics, step=steps)

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -227,11 +227,7 @@ def _log_mlflow_loop(q: queue.Queue, log_artifacts: bool = True):
 
         if log_metrics is not None:
             if log_metrics["llm_eval_examples"] is not None:
-                mlflow.llm.log_predictions(
-                    inputs=log_metrics["llm_eval_examples"]["inputs"],
-                    prompts=log_metrics["llm_eval_examples"]["targets"],
-                    outputs=log_metrics["llm_eval_examples"]["outputs"],
-                )
+                mlflow.log_table(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
                 del log_metrics["llm_eval_examples"]
         mlflow.log_metrics(log_metrics, step=steps)
 
@@ -251,11 +247,7 @@ def _log_mlflow(log_metrics, steps, save_path, should_continue, log_artifacts: b
     """
     if log_metrics is not None:
         if log_metrics["llm_eval_examples"] is not None:
-            mlflow.llm.log_predictions(
-                inputs=log_metrics["llm_eval_examples"]["inputs"],
-                prompts=log_metrics["llm_eval_examples"]["targets"],
-                outputs=log_metrics["llm_eval_examples"]["outputs"],
-            )
+            mlflow.log_table(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
             del log_metrics["llm_eval_examples"]
         mlflow.log_metrics(log_metrics, step=steps)
         if log_artifacts:

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -226,13 +226,13 @@ def _log_mlflow_loop(q: queue.Queue, log_artifacts: bool = True):
             break
 
         if log_metrics is not None:
-            if log_metrics["llm_outputs"] is not None:
+            if log_metrics["llm_eval_examples"] is not None:
                 mlflow.llm.log_predictions(
-                    inputs=log_metrics["llm_outputs"]["inputs"],
-                    prompts=[0] * len(log_metrics["llm_outputs"]["inputs"]),  # This is a workaround
-                    outputs=log_metrics["llm_outputs"]["outputs"],
+                    inputs=log_metrics["llm_eval_examples"]["inputs"],
+                    prompts=log_metrics["llm_eval_examples"]["targets"],
+                    outputs=log_metrics["llm_eval_examples"]["outputs"],
                 )
-                del log_metrics["llm_outputs"]
+                del log_metrics["llm_eval_examples"]
         mlflow.log_metrics(log_metrics, step=steps)
 
         if not q.empty():
@@ -251,13 +251,13 @@ def _log_mlflow(log_metrics, steps, save_path, should_continue, log_artifacts: b
     """
     # breakpoint()
     if log_metrics is not None:
-        if log_metrics["llm_outputs"] is not None:
+        if log_metrics["llm_eval_examples"] is not None:
             mlflow.llm.log_predictions(
-                inputs=log_metrics["llm_outputs"]["inputs"],
-                prompts=[0] * len(log_metrics["llm_outputs"]["inputs"]),
-                outputs=log_metrics["llm_outputs"]["outputs"],
+                inputs=log_metrics["llm_eval_examples"]["inputs"],
+                prompts=[0] * len(log_metrics["llm_eval_examples"]["inputs"]),
+                outputs=log_metrics["llm_eval_examples"]["outputs"],
             )
-            del log_metrics["llm_outputs"]
+            del log_metrics["llm_eval_examples"]
         mlflow.log_metrics(log_metrics, step=steps)
         if log_artifacts:
             _log_model(save_path)

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -249,12 +249,11 @@ def _log_mlflow(log_metrics, steps, save_path, should_continue, log_artifacts: b
 
     This is used when save_in_background is False.
     """
-    # breakpoint()
     if log_metrics is not None:
         if log_metrics["llm_eval_examples"] is not None:
             mlflow.llm.log_predictions(
                 inputs=log_metrics["llm_eval_examples"]["inputs"],
-                prompts=[0] * len(log_metrics["llm_eval_examples"]["inputs"]),
+                prompts=log_metrics["llm_eval_examples"]["targets"],
                 outputs=log_metrics["llm_eval_examples"]["outputs"],
             )
             del log_metrics["llm_eval_examples"]

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -404,16 +404,6 @@ class LlmFineTunePredictor(Predictor):
                     # and other tensor alignment.
                     self.model.update_metrics_finetune_llm(targets, preds)
 
-                    # There is only one input and output feature for fine-tuning LLMs.
-                    input_key = list(example_inputs.keys())[0]
-                    output_key = list(example_outputs.keys())[0]
-
-                    # Surface the input and output for the user
-                    for i in range(len(example_inputs[input_key])):
-                        logger.info(f"Input: {example_inputs[input_key][i]}")
-                        logger.info(f"Output: {example_outputs[output_key][i]}")
-                        logger.info("--------------------")
-
                     # accumulate predictions from batch for each output feature
                     if collect_predictions:
                         self._accumulate_preds(

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -351,7 +351,9 @@ class LlmFineTunePredictor(Predictor):
         """
         prev_model_training_mode = self.dist_model.training  # store previous model training mode
         self.dist_model.eval()  # set model to eval mode
-
+        example_inputs = defaultdict(list)
+        example_targets = defaultdict(list)
+        example_outputs = defaultdict(list)
         with torch.no_grad():
             with dataset.initialize_batcher(
                 self._batch_size, should_shuffle=False, distributed=self._distributed
@@ -388,6 +390,13 @@ class LlmFineTunePredictor(Predictor):
                     outputs = self._predict_on_inputs((inputs, targets))
                     preds = self.model.outputs_to_predictions(outputs)
 
+                    for key in inputs:
+                        example_inputs[key].extend(inputs[key])
+                    for key in targets:
+                        example_targets[key].extend(targets[key])
+                    for key in preds:
+                        example_outputs[key].extend(preds[key]["predictions"])
+
                     # Need to pass through a custom fine-tune metric function because we need to transform
                     # the targets into the right format for loss calculation (requires padding with -100s to the left)
                     # and other tensor alignment.
@@ -416,9 +425,10 @@ class LlmFineTunePredictor(Predictor):
             metrics = self.model.get_metrics()
             self.model.reset_metrics()
 
-            self.dist_model.train(prev_model_training_mode)  # Restores previous model training mode.
+            inp_tar_out_dict = {"inputs": example_inputs, "targets": example_targets, "outputs": example_outputs}
 
-            return metrics, from_numpy_dataset(predictions)
+            self.dist_model.train(prev_model_training_mode)  # Restores previous model training mode.
+            return metrics, from_numpy_dataset(predictions), inp_tar_out_dict
 
 
 def calculate_overall_stats(output_features, predictions, dataset, training_set_metadata):

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -427,10 +427,14 @@ class LlmFineTunePredictor(Predictor):
             metrics = self.model.get_metrics()
             self.model.reset_metrics()
 
-            inp_tar_out_dict = {"inputs": example_inputs, "targets": example_targets, "outputs": example_outputs}
+            input_target_output_dict = {
+                "inputs": example_inputs,
+                "targets": example_targets,
+                "outputs": example_outputs,
+            }
 
             self.dist_model.train(prev_model_training_mode)  # Restores previous model training mode.
-            return metrics, from_numpy_dataset(predictions), inp_tar_out_dict
+            return metrics, from_numpy_dataset(predictions), input_target_output_dict
 
 
 def calculate_overall_stats(output_features, predictions, dataset, training_set_metadata):

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -345,9 +345,11 @@ class LlmFineTunePredictor(Predictor):
             collect_logits: Return model logits and final layer activations.
 
         Returns:
-            Tuple of dictionaries of (metrics, predictions). The keys of metrics are determined by the metrics in the
-            model config. The keys of the predictions dictionary depend on which values are requested by the caller:
-            collect_predictions, collect_logits.
+            Tuple of dictionaries of (metrics, predictions, input/target/output dictionary). The keys of metrics are
+            determined by the metrics in the model config. The keys of the predictions dictionary depend on which values
+            are requested by the caller: collect_predictions, collect_logits. The keys of the input/target/output
+            dictionary are "inputs", "targets", and "outputs". The values of each of these keys are dictionaries of
+            feature names to lists of tensors. The tensors are the inputs, targets, and outputs for each batch.
         """
         prev_model_training_mode = self.dist_model.training  # store previous model training mode
         self.dist_model.eval()  # set model to eval mode

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -404,6 +404,16 @@ class LlmFineTunePredictor(Predictor):
                     # and other tensor alignment.
                     self.model.update_metrics_finetune_llm(targets, preds)
 
+                    # There is only one input and output feature for fine-tuning LLMs.
+                    input_key = list(example_inputs.keys())[0]
+                    output_key = list(example_outputs.keys())[0]
+
+                    # Surface the input and output for the user
+                    for i in range(len(example_inputs[input_key])):
+                        logger.info(f"Input: {example_inputs[input_key][i]}")
+                        logger.info(f"Output: {example_outputs[output_key][i]}")
+                        logger.info("--------------------")
+
                     # accumulate predictions from batch for each output feature
                     if collect_predictions:
                         self._accumulate_preds(

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -639,7 +639,6 @@ class Trainer(BaseTrainer):
         all_losses: Dict[str, torch.Tensor],
         early_stopping_steps: int,
         checkpoint_manager: CheckpointManager,
-        num_eval_examples: int = 5,
     ) -> bool:
         """Runs evaluation over training, validation, and test sets.
 

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -455,6 +455,11 @@ class FineTuneTrainer(Trainer):
             for out in input_target_output_dict["outputs"][key]:
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
+        for i in range(len(llm_eval_examples["inputs"])):
+            logger.info(f"Input: {llm_eval_examples['inputs'][i]}")
+            logger.info(f"Output: {llm_eval_examples['outputs'][i]}")
+            logger.info("--------------------")
+
         progress_tracker.llm_eval_examples = llm_eval_examples
         return append_metrics(self.model, dataset_name, metrics, metrics_log, progress_tracker)
 

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -434,7 +434,7 @@ class FineTuneTrainer(Trainer):
         predictor = LlmFineTunePredictor(
             self.model, batch_size=batch_size, distributed=self.distributed, report_tqdm_to_ray=self.report_tqdm_to_ray
         )
-        metrics, _, inp_tar_out_dict = predictor.batch_evaluation(
+        metrics, _, input_target_output_dict = predictor.batch_evaluation(
             dataset, collect_predictions=False, dataset_name=dataset_name
         )
         # Setting collect_predictions=True currently causes an error when doing batch evaluation because the outputs
@@ -443,16 +443,16 @@ class FineTuneTrainer(Trainer):
         tokenizer = self.dist_model.tokenizer
 
         llm_eval_examples = {"inputs": [], "targets": [], "outputs": []}
-        for key in inp_tar_out_dict["inputs"]:
-            for inp in inp_tar_out_dict["inputs"][key]:
+        for key in input_target_output_dict["inputs"]:
+            for inp in input_target_output_dict["inputs"][key]:
                 llm_eval_examples["inputs"].append(tokenizer.decode(inp, skip_special_tokens=True))
 
-        for key in inp_tar_out_dict["targets"]:
-            for tar in inp_tar_out_dict["targets"][key]:
+        for key in input_target_output_dict["targets"]:
+            for tar in input_target_output_dict["targets"][key]:
                 llm_eval_examples["targets"].append(tokenizer.decode(tar, skip_special_tokens=True))
 
-        for key in inp_tar_out_dict["outputs"]:
-            for out in inp_tar_out_dict["outputs"][key]:
+        for key in input_target_output_dict["outputs"]:
+            for out in input_target_output_dict["outputs"][key]:
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
         progress_tracker.llm_eval_examples = llm_eval_examples

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -183,7 +183,7 @@ class ProgressTracker:
 
         # This should be an dictionary whose keys are "inputs", "targets", and "outputs" and whose values are dicts.
         # The keys of each subdict are the names of the input/target/output features and the values are lists of
-        # example tensors.
+        # example tensors. This is only set for LLM fine-tuning.
         self.llm_eval_examples = llm_eval_examples
 
         # Best metrics.

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -109,6 +109,7 @@ class ProgressTracker:
         best_eval_train_metrics: Dict[str, Dict[str, float]],
         best_eval_validation_metrics: Dict[str, Dict[str, float]],
         best_eval_test_metrics: Dict[str, Dict[str, float]],
+        llm_outputs: Dict[str, List[str]] = None,
     ):
         """JSON-serializable holder object that stores information related to training progress.
 
@@ -179,6 +180,7 @@ class ProgressTracker:
         self.train_metrics = train_metrics
         self.validation_metrics = validation_metrics
         self.test_metrics = test_metrics
+        self.llm_outputs = llm_outputs
 
         # Best metrics.
         self.best_eval_train_metrics = best_eval_train_metrics
@@ -210,6 +212,7 @@ class ProgressTracker:
             "best_valid_metric": self.best_eval_metric_value,
             "num_reductions_lr": self.num_reductions_learning_rate,
             "num_increases_bs": self.num_increases_batch_size,
+            "llm_outputs": self.llm_outputs,
         }
         for metrics_dict_name in [
             "train_metrics",

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -180,6 +180,10 @@ class ProgressTracker:
         self.train_metrics = train_metrics
         self.validation_metrics = validation_metrics
         self.test_metrics = test_metrics
+
+        # This should be an dictionary whose keys are "inputs", "targets", and "outputs" and whose values are dicts.
+        # The keys of each subdict are the names of the input/target/output features and the values are lists of
+        # example tensors.
         self.llm_eval_examples = llm_eval_examples
 
         # Best metrics.

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -109,7 +109,7 @@ class ProgressTracker:
         best_eval_train_metrics: Dict[str, Dict[str, float]],
         best_eval_validation_metrics: Dict[str, Dict[str, float]],
         best_eval_test_metrics: Dict[str, Dict[str, float]],
-        llm_outputs: Dict[str, List[str]] = None,
+        llm_eval_examples: Dict[str, List[str]] = None,
     ):
         """JSON-serializable holder object that stores information related to training progress.
 
@@ -180,7 +180,7 @@ class ProgressTracker:
         self.train_metrics = train_metrics
         self.validation_metrics = validation_metrics
         self.test_metrics = test_metrics
-        self.llm_outputs = llm_outputs
+        self.llm_eval_examples = llm_eval_examples
 
         # Best metrics.
         self.best_eval_train_metrics = best_eval_train_metrics
@@ -212,7 +212,7 @@ class ProgressTracker:
             "best_valid_metric": self.best_eval_metric_value,
             "num_reductions_lr": self.num_reductions_learning_rate,
             "num_increases_bs": self.num_increases_batch_size,
-            "llm_outputs": self.llm_outputs,
+            "llm_eval_examples": self.llm_eval_examples,
         }
         for metrics_dict_name in [
             "train_metrics",

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -216,11 +216,15 @@ class ProgressTracker:
             "best_valid_metric": self.best_eval_metric_value,
             "num_reductions_lr": self.num_reductions_learning_rate,
             "num_increases_bs": self.num_increases_batch_size,
-            "llm_eval_examples": self.llm_eval_examples,  # This is a non-numerical metric
-            # This should be an dictionary whose keys are "inputs", "targets", and "outputs" and whose values are dicts.
-            # The keys of each subdict are the names of the input/target/output features and the values are lists of
-            # example tensors.
         }
+
+        # This is a non-numerical metric that is only for LLM fine-tuning
+        # This should be an dictionary whose keys are "inputs", "targets", and "outputs" and whose values are dicts.
+        # The keys of each subdict are the names of the input/target/output features and the values are lists of
+        # example tensors.
+        if self.llm_eval_examples:
+            log_metrics["llm_eval_examples"] = self.llm_eval_examples
+
         for metrics_dict_name in [
             "train_metrics",
             "validation_metrics",

--- a/ludwig/utils/trainer_utils.py
+++ b/ludwig/utils/trainer_utils.py
@@ -216,7 +216,10 @@ class ProgressTracker:
             "best_valid_metric": self.best_eval_metric_value,
             "num_reductions_lr": self.num_reductions_learning_rate,
             "num_increases_bs": self.num_increases_batch_size,
-            "llm_eval_examples": self.llm_eval_examples,
+            "llm_eval_examples": self.llm_eval_examples,  # This is a non-numerical metric
+            # This should be an dictionary whose keys are "inputs", "targets", and "outputs" and whose values are dicts.
+            # The keys of each subdict are the names of the input/target/output features and the values are lists of
+            # example tensors.
         }
         for metrics_dict_name in [
             "train_metrics",

--- a/tests/ludwig/utils/test_trainer_utils.py
+++ b/tests/ludwig/utils/test_trainer_utils.py
@@ -105,7 +105,6 @@ def test_progress_tracker_empty():
         "best_eval_metric_epoch": 0,
         "checkpoint_number": 0,
         "last_improvement_steps": 0,
-        "llm_eval_examples": None,
     }
 
 
@@ -151,11 +150,15 @@ def test_progress_tracker():
         "tune_checkpoint_num": 0,
         "validation_metrics.combined.loss": 0.2,
         "last_improvement_steps": 0,
-        "llm_eval_examples": None,
     }
 
 
 def test_full_progress_tracker():
+    llm_eval_examples = {
+        "inputs": {"input": [1, 2, 3]},
+        "targets": {"output": [1, 2, 3]},
+        "outputs": {"output": [1, 2, 3]},
+    }
     progress_tracker = trainer_utils.ProgressTracker(
         **{
             BATCH_SIZE: 128,
@@ -255,6 +258,7 @@ def test_full_progress_tracker():
                     ]
                 },
             },
+            "llm_eval_examples": llm_eval_examples,
         }
     )
 
@@ -296,7 +300,11 @@ def test_full_progress_tracker():
         "validation_metrics.Survived.loss": 4.473,
         "validation_metrics.Survived.roc_auc": 0.671,
         "validation_metrics.combined.loss": 4.473,
-        "llm_eval_examples": None,
+        "llm_eval_examples": {
+            "inputs": {"input": [1, 2, 3]},
+            "targets": {"output": [1, 2, 3]},
+            "outputs": {"output": [1, 2, 3]},
+        },
     }
 
 

--- a/tests/ludwig/utils/test_trainer_utils.py
+++ b/tests/ludwig/utils/test_trainer_utils.py
@@ -105,6 +105,7 @@ def test_progress_tracker_empty():
         "best_eval_metric_epoch": 0,
         "checkpoint_number": 0,
         "last_improvement_steps": 0,
+        "llm_eval_examples": None,
     }
 
 
@@ -150,6 +151,7 @@ def test_progress_tracker():
         "tune_checkpoint_num": 0,
         "validation_metrics.combined.loss": 0.2,
         "last_improvement_steps": 0,
+        "llm_eval_examples": None,
     }
 
 
@@ -294,6 +296,7 @@ def test_full_progress_tracker():
         "validation_metrics.Survived.loss": 4.473,
         "validation_metrics.Survived.roc_auc": 0.671,
         "validation_metrics.combined.loss": 4.473,
+        "llm_eval_examples": None,
     }
 
 


### PR DESCRIPTION
Adds LLM predictions to MLFlow during evaluation. Local behavior shows inputs, outputs, and prompts added to a csv file in the MLFlow logs.
