### PR TITLE
fix: adapter checkpoint loading on resume

### DIFF
--- a/ludwig/distributed/deepspeed.py
+++ b/ludwig/distributed/deepspeed.py
@@ -221,6 +221,11 @@ class DeepSpeedCheckpoint(Checkpoint):
 
         https://deepspeed.readthedocs.io/en/latest/model-checkpointing.html#loading-training-checkpoints
         """
+        # NOTE(geoffrey): `load_module_strict=False` because this code path is frequently used to load models trained
+        # using adapter-based fine-tuning, where the checkpoints only contain the adapter weights, and not the full
+        # model weights. This may lead to silent, unexpected behavior for resuming full model fine-tuning, 
+        # where all the model weights *must* be loaded in.
+        # TODO(geoffrey): Add a boolean arg to function to control load_module_strict behavior.
         _, client_state = self.model.load_checkpoint(save_path, load_lr_scheduler_states=False, load_module_strict=False)
         self.global_step = self._get_global_step(client_state, save_path)
         if self.scheduler is not None and "scheduler_state" in client_state:

--- a/ludwig/distributed/deepspeed.py
+++ b/ludwig/distributed/deepspeed.py
@@ -223,7 +223,7 @@ class DeepSpeedCheckpoint(Checkpoint):
         """
         # NOTE(geoffrey): `load_module_strict=False` because this code path is frequently used to load models trained
         # using adapter-based fine-tuning, where the checkpoints only contain the adapter weights, and not the full
-        # model weights. This may lead to silent, unexpected behavior for resuming full model fine-tuning, 
+        # model weights. This may lead to silent, unexpected behavior for resuming full model fine-tuning,
         # where all the model weights *must* be loaded in.
         # TODO(geoffrey): Add a boolean arg to function to control load_module_strict behavior.
         _, client_state = self.model.load_checkpoint(

--- a/ludwig/distributed/deepspeed.py
+++ b/ludwig/distributed/deepspeed.py
@@ -221,7 +221,7 @@ class DeepSpeedCheckpoint(Checkpoint):
 
         https://deepspeed.readthedocs.io/en/latest/model-checkpointing.html#loading-training-checkpoints
         """
-        _, client_state = self.model.load_checkpoint(save_path, load_lr_scheduler_states=False)
+        _, client_state = self.model.load_checkpoint(save_path, load_lr_scheduler_states=False, load_module_strict=False)
         self.global_step = self._get_global_step(client_state, save_path)
         if self.scheduler is not None and "scheduler_state" in client_state:
             self.scheduler.load_state_dict(client_state["scheduler_state"])


### PR DESCRIPTION
This PR ensures that DeepSpeed does not throw an error on resume when loading adapter checkpoints.

Adapter checkpoints only contain a subset of the model's weights. This means that strict checkpoint loading throws a RuntimeError that may look like the following: 
```
> /home/ray/anaconda3/lib/python3.8/site-packages/ludwig/trainers/trainer.py(839)train()
-> self.resume_weights_and_optimizer(training_checkpoints_path, checkpoint)
  /home/ray/anaconda3/lib/python3.8/site-packages/ludwig/trainers/trainer.py(1466)resume_weights_and_optimizer()
-> CheckpointManager.load_latest_checkpoint(checkpoint, model_weights_progress_path, self.device)
  /home/ray/anaconda3/lib/python3.8/site-packages/ludwig/utils/checkpoint_utils.py(332)load_latest_checkpoint()
-> checkpoint.load(last_ckpt, device)
  /home/ray/anaconda3/lib/python3.8/site-packages/ludwig/distributed/deepspeed.py(224)load()
-> _, client_state = self.model.load_checkpoint(save_path, load_lr_scheduler_states=False)
  /home/ray/anaconda3/lib/python3.8/site-packages/deepspeed/runtime/engine.py(2705)load_checkpoint()
-> load_path, client_states = self._load_checkpoint(load_dir,
  /home/ray/anaconda3/lib/python3.8/site-packages/deepspeed/runtime/engine.py(2773)_load_checkpoint()
-> self.load_module_state_dict(checkpoint=checkpoint,
  /home/ray/anaconda3/lib/python3.8/site-packages/deepspeed/runtime/engine.py(2568)load_module_state_dict()
-> self.module.load_state_dict(
  /home/ray/anaconda3/lib/python3.8/site-packages/torch/nn/modules/module.py(2041)load_state_dict()
-> raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
RuntimeError: Error(s) in loading state_dict for LLM:
Missing key(s) in state_dict: "model.base_model.model.model.embed_tokens.weight", "model.base_model.model.model.layers.0.self_attn.q_proj.weight", "model.base_model.model.model.layers.0.self_attn.k_proj.weight", "model.base_model.model.model.layers.0.self_attn.v_proj.weight", "model.base_model.model.model.layers.0.self_attn.o_proj.weight",
...
```

since the base model weights are not stored in the checkpoint. This PR ensures that this strict constraint is relaxed.