### PR TITLE
fix LudwigProgressBar rendering on model resume

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -941,6 +941,7 @@ class Trainer(BaseTrainer):
 
                 progress_bar_config = {
                     "desc": "Training",
+                    "initial": progress_tracker.steps,
                     "total": self.total_steps,
                     "disable": is_progressbar_disabled(),
                     "file": sys.stdout,


### PR DESCRIPTION
When a model was resumed from a checkpoint, the progress bar shown would start from 0, giving the user the impression that training was starting from scratch. This PR fixes that. 

NOTE: the internal step counter was correct and is unaffected by this change.