### PR TITLE
Add default steps_per_checkpoint

### DIFF
--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -208,7 +208,7 @@ class ECDTrainerConfig(BaseTrainerConfig):
     )
 
     steps_per_checkpoint: int = schema_utils.NonNegativeInteger(
-        default=0,
+        default=1000,
         description=(
             "How often the model is checkpointed. Also dictates maximum evaluation frequency. If 0 the model is "
             "checkpointed after every epoch."
@@ -849,7 +849,7 @@ class LLMTrainerConfig(BaseTrainerConfig):
     )
 
     steps_per_checkpoint: int = schema_utils.NonNegativeInteger(
-        default=0,
+        default=1000,
         description="Number of steps per checkpoint in the LLM trainer.",
     )
 


### PR DESCRIPTION
Add a default steps_per_checkpoint of 1000. [This line](https://github.com/ludwig-ai/ludwig/blob/266a36c49733320fd44aba01d49d12db330dfd62/ludwig/utils/trainer_utils.py#L280) takes care of setting the final steps_per_checkpoint to be `min(steps_per_epoch, steps_per_checkpoint)`