### PR TITLE
Add eval_steps as a flag to help speed up eval

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -2151,6 +2151,14 @@ def _preprocess_file_for_training(
         features, split_dataset(data, preprocessing_params, backend, random_seed)
     )
 
+    if config["preprocessing"]["eval_steps"]:
+        num_val_samples = int(
+            config["preprocessing"]["eval_steps"] * len(validation_data) / (len(validation_data) + len(test_data))
+        )
+        num_test_samples = config["preprocessing"]["eval_steps"] - num_val_samples
+        validation_data = validation_data.head(num_val_samples)
+        test_data = test_data.head(num_test_samples)
+
     if dataset and backend.is_coordinator() and not skip_save_processed_input:
         logger.debug("writing split file")
         splits_df = concatenate_splits(training_data, validation_data, test_data, backend)
@@ -2219,6 +2227,14 @@ def _preprocess_df_for_training(
     training_set, validation_set, test_set = drop_extra_cols(
         features, split_dataset(data, preprocessing_params, backend, random_seed)
     )
+
+    if config["preprocessing"]["eval_steps"]:
+        num_val_samples = int(
+            config["preprocessing"]["eval_steps"] * len(validation_set) / (len(validation_set) + len(test_set))
+        )
+        num_test_samples = config["preprocessing"]["eval_steps"] - num_val_samples
+        validation_set = validation_set.head(num_val_samples)
+        test_set = test_set.head(num_test_samples)
 
     logger.info("Building dataset: DONE")
     if preprocessing_params["oversample_minority"] or preprocessing_params["undersample_majority"]:

--- a/ludwig/schema/metadata/configs/preprocessing.yaml
+++ b/ludwig/schema/metadata/configs/preprocessing.yaml
@@ -60,6 +60,19 @@ sample_size:
     expected_impact: 2
     suggested_values: Depends on data size
     ui_display_name: Sample Size
+eval_steps:
+    default_value_reasoning:
+        The default value is None because we do not want to lower the number of evaluation steps
+        by default, and we do not know the size of an arbitrary dataset.
+        By setting the default to None, we simply evaluate on the full evaluation set.
+    description_implications:
+        Effectively samples from the evaluation set. Could be useful if want to shorten the amount
+        of time evaluation takes.
+    example_value:
+        - 1000
+    expected_impact: 2
+    suggested_values: Depends on data size
+    ui_display_name: Evaluation Steps
 column:
     expected_impact: 3
     ui_display_name: Split Column

--- a/ludwig/schema/preprocessing.py
+++ b/ludwig/schema/preprocessing.py
@@ -26,6 +26,13 @@ class PreprocessingConfig(schema_utils.BaseMarshmallowConfig):
         parameter_metadata=PREPROCESSING_METADATA["sample_size"],
     )
 
+    eval_steps: float = schema_utils.NonNegativeInteger(
+        default=None,
+        allow_none=True,
+        description="The number of steps to use for evaluation. If None, the entire dataset will be used.",
+        parameter_metadata=PREPROCESSING_METADATA["eval_steps"],
+    )
+
     oversample_minority: float = schema_utils.NonNegativeFloat(
         default=None,
         allow_none=True,


### PR DESCRIPTION
`eval_steps` effectively samples from the validation and test sets, taking the first few samples of each, depending on the `eval_steps` set in the config and the ratio of validation set size to test set size.