### PR TITLE
[BUGFIX] Un-pin "transformers" version and update file names for saved merged model directory, because issue with "transformers" impacting "peft" has been fixed.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
-transformers>=4.33.2,<4.35.0 # pinning since version 4.35.0 on 11/2/2023 causes IndexError in PEFT
+transformers>=4.33.2
 tokenizers>=0.13.3
 spacy>=2.3
 PyYAML>=3.12,<6.0.1,!=5.4.* #Exlude PyYAML 5.4.* due to incompatibility with awscli

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -761,7 +761,7 @@ quantization section from your Ludwig configuration."""
                 "config.json",
                 "generation_config.json",
                 "merges.txt",
-                "pytorch_model.bin",  # If Transformers >4.34.1 is installed with PEFT 0.6.0, use "model.safetensors".
+                "model.safetensors",
                 "special_tokens_map.json",
                 "tokenizer.json",
                 "tokenizer_config.json",


### PR DESCRIPTION
### Scope
The pinning of `transformers` as per #3766 can now be reverted, because the issue has been fixed (`https://github.com/huggingface/transformers/issues/27278`).  In addition, as part of this fix, the directory that contains the saved merged fine-tuned model (base model plus adapter weights) now uses "safetensors"; hence, the relevant test has been updated.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
