### PR TITLE
Fix MLFlow logging for sample outputs during evaluation.

### DIFF
--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -226,7 +226,7 @@ def _log_mlflow_loop(q: queue.Queue, log_artifacts: bool = True):
             break
 
         if "llm_eval_examples" in log_metrics and log_metrics["llm_eval_examples"] is not None:
-            mlflow.log_dict(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
+            # mlflow.log_dict(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
             # Delete the table from the metrics dict so we don't try to log it with the other metrics
             del log_metrics["llm_eval_examples"]
         mlflow.log_metrics(log_metrics, step=steps)
@@ -247,7 +247,7 @@ def _log_mlflow(log_metrics, steps, save_path, should_continue, log_artifacts: b
     """
     if log_metrics is not None:
         if "llm_eval_examples" in log_metrics and log_metrics["llm_eval_examples"] is not None:
-            mlflow.log_dict(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
+            # mlflow.log_dict(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
             # Delete the table from the metrics dict so we don't try to log it with the other metrics
             del log_metrics["llm_eval_examples"]
         mlflow.log_metrics(log_metrics, step=steps)

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -226,7 +226,7 @@ def _log_mlflow_loop(q: queue.Queue, log_artifacts: bool = True):
             break
 
         if "llm_eval_examples" in log_metrics and log_metrics["llm_eval_examples"] is not None:
-            mlflow.log_table(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
+            mlflow.log_dict(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
             # Delete the table from the metrics dict so we don't try to log it with the other metrics
             del log_metrics["llm_eval_examples"]
         mlflow.log_metrics(log_metrics, step=steps)
@@ -247,7 +247,7 @@ def _log_mlflow(log_metrics, steps, save_path, should_continue, log_artifacts: b
     """
     if log_metrics is not None:
         if "llm_eval_examples" in log_metrics and log_metrics["llm_eval_examples"] is not None:
-            mlflow.log_table(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
+            mlflow.log_dict(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
             # Delete the table from the metrics dict so we don't try to log it with the other metrics
             del log_metrics["llm_eval_examples"]
         mlflow.log_metrics(log_metrics, step=steps)

--- a/ludwig/contribs/mlflow/__init__.py
+++ b/ludwig/contribs/mlflow/__init__.py
@@ -225,11 +225,10 @@ def _log_mlflow_loop(q: queue.Queue, log_artifacts: bool = True):
             # Break out of the loop if we're not going to log anything.
             break
 
-        if log_metrics is not None:
-            if "llm_eval_examples" in log_metrics and log_metrics["llm_eval_examples"] is not None:
-                mlflow.log_table(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
-                # Delete the table from the metrics dict so we don't try to log it with the other metrics
-                del log_metrics["llm_eval_examples"]
+        if "llm_eval_examples" in log_metrics and log_metrics["llm_eval_examples"] is not None:
+            mlflow.log_table(log_metrics["llm_eval_examples"], artifact_file="llm_eval_examples.json")
+            # Delete the table from the metrics dict so we don't try to log it with the other metrics
+            del log_metrics["llm_eval_examples"]
         mlflow.log_metrics(log_metrics, step=steps)
 
         if not q.empty():

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -456,8 +456,8 @@ class FineTuneTrainer(Trainer):
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
         for i in range(len(llm_eval_examples["inputs"])):
-            logger.info(f"Input: {llm_eval_examples['inputs'][i]}")
-            logger.info(f"Output: {llm_eval_examples['outputs'][i]}")
+            logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")
+            logger.info(f"Output: {llm_eval_examples['outputs'][i].strip()}")
             logger.info("--------------------")
 
         progress_tracker.llm_eval_examples = llm_eval_examples

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -442,23 +442,25 @@ class FineTuneTrainer(Trainer):
 
         tokenizer = self.dist_model.tokenizer
 
+        # There should only be one key in the dict for LLMs
+        input_key = list(input_target_output_dict["inputs"].keys())[0]
+        num_examples = min(len(input_target_output_dict["inputs"][input_key]), 1000)
+
         llm_eval_examples = {"inputs": [], "targets": [], "outputs": []}
         for key in input_target_output_dict["inputs"]:
-            num_examples = min(len(input_target_output_dict["inputs"][key]), 5)
             for inp in input_target_output_dict["inputs"][key][:num_examples]:
                 llm_eval_examples["inputs"].append(tokenizer.decode(inp, skip_special_tokens=True))
 
         for key in input_target_output_dict["targets"]:
-            num_examples = min(len(input_target_output_dict["targets"][key]), 5)
             for tar in input_target_output_dict["targets"][key][:num_examples]:
                 llm_eval_examples["targets"].append(tokenizer.decode(tar, skip_special_tokens=True))
 
         for key in input_target_output_dict["outputs"]:
-            num_examples = min(len(input_target_output_dict["outputs"][key]), 5)
             for out in input_target_output_dict["outputs"][key][:num_examples]:
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
-        for i in range(len(llm_eval_examples["inputs"])):
+        num_examples_shown = min(len(llm_eval_examples["inputs"]), 5)
+        for i in range(num_examples_shown):
             logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")
             logger.info(f"Output: {llm_eval_examples['outputs'][i].strip()}")
             logger.info("--------------------")

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -444,15 +444,18 @@ class FineTuneTrainer(Trainer):
 
         llm_eval_examples = {"inputs": [], "targets": [], "outputs": []}
         for key in input_target_output_dict["inputs"]:
-            for inp in input_target_output_dict["inputs"][key]:
+            num_examples = min(len(input_target_output_dict["inputs"][key]), 5)
+            for inp in input_target_output_dict["inputs"][key][:num_examples]:
                 llm_eval_examples["inputs"].append(tokenizer.decode(inp, skip_special_tokens=True))
 
         for key in input_target_output_dict["targets"]:
-            for tar in input_target_output_dict["targets"][key]:
+            num_examples = min(len(input_target_output_dict["targets"][key]), 5)
+            for tar in input_target_output_dict["targets"][key][:num_examples]:
                 llm_eval_examples["targets"].append(tokenizer.decode(tar, skip_special_tokens=True))
 
         for key in input_target_output_dict["outputs"]:
-            for out in input_target_output_dict["outputs"][key]:
+            num_examples = min(len(input_target_output_dict["outputs"][key]), 5)
+            for out in input_target_output_dict["outputs"][key][:num_examples]:
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
         for i in range(len(llm_eval_examples["inputs"])):

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -27,6 +27,9 @@ from ludwig.utils.trainer_utils import append_metrics, get_new_progress_tracker,
 
 logger = logging.getLogger(__name__)
 
+MAX_EVALUATION_EXAMPLES = 1000
+MAX_EVALUATION_EXAMPLES_SHOWN = 5
+
 
 @register_llm_trainer("none")
 @register_llm_ray_trainer("none")
@@ -444,7 +447,7 @@ class FineTuneTrainer(Trainer):
 
         # There should only be one key in the dict for LLMs
         input_key = list(input_target_output_dict["inputs"].keys())[0]
-        num_examples = min(len(input_target_output_dict["inputs"][input_key]), 1000)
+        num_examples = min(len(input_target_output_dict["inputs"][input_key]), MAX_EVALUATION_EXAMPLES)
 
         llm_eval_examples = {"inputs": [], "targets": [], "outputs": []}
         for key in input_target_output_dict["inputs"]:
@@ -459,7 +462,7 @@ class FineTuneTrainer(Trainer):
             for out in input_target_output_dict["outputs"][key][:num_examples]:
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
-        num_examples_shown = min(len(llm_eval_examples["inputs"]), 5)
+        num_examples_shown = min(len(llm_eval_examples["inputs"]), MAX_EVALUATION_EXAMPLES_SHOWN)
         for i in range(num_examples_shown):
             logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")
             logger.info(f"Output: {llm_eval_examples['outputs'][i].strip()}")


### PR DESCRIPTION
- Swaps API to use `log_dict` instead of `log_table` since `log_dict` also works with MLFlow 1.x but `log_table` was only introduced in MLFlow 2.4
- Removes trailing newline spaces while logging k examples