### PR TITLE
Log LLM test set evaluation outputs to CSV files under the model log directory, stamped by checkpoint number.

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -695,7 +695,7 @@ class Trainer(BaseTrainer):
             llm_eval_examples = progress_tracker.llm_eval_examples
             dict_save_dir = os.path.join(os.path.dirname(checkpoint_manager.directory), "llm_eval_examples")
             os.makedirs(dict_save_dir, exist_ok=True)
-            dict_save_path = os.path.join(dict_save_dir, f"llm_eval_examples_{progress_tracker.checkpoint_number}.json")
+            dict_save_path = os.path.join(dict_save_dir, f"{progress_tracker.checkpoint_number}.json")
             with open(dict_save_path, "w") as outfile:
                 json.dump(llm_eval_examples, outfile)
 

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -15,6 +15,7 @@
 # ==============================================================================
 """This module contains the class and auxiliary methods of a model."""
 import contextlib
+import json
 import logging
 import math
 import os
@@ -690,6 +691,13 @@ class Trainer(BaseTrainer):
                 self.eval_batch_size,
                 progress_tracker,
             )
+
+            llm_eval_examples = progress_tracker.llm_eval_examples
+            dict_save_dir = os.path.join(os.path.dirname(checkpoint_manager.directory), "llm_eval_examples")
+            os.makedirs(dict_save_dir, exist_ok=True)
+            dict_save_path = os.path.join(dict_save_dir, f"llm_eval_examples_{progress_tracker.checkpoint_number}.json")
+            with open(dict_save_path, "w") as outfile:
+                json.dump(llm_eval_examples, outfile)
 
             self.write_eval_summary(
                 summary_writer=validation_summary_writer,

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -15,7 +15,7 @@
 # ==============================================================================
 """This module contains the class and auxiliary methods of a model."""
 import contextlib
-import json
+import csv
 import logging
 import math
 import os
@@ -28,6 +28,7 @@ import time
 from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np
+import pandas as pd
 import psutil
 import torch
 from torch.utils.tensorboard import SummaryWriter
@@ -695,9 +696,12 @@ class Trainer(BaseTrainer):
             llm_eval_examples = progress_tracker.llm_eval_examples
             dict_save_dir = os.path.join(os.path.dirname(checkpoint_manager.directory), "llm_eval_examples")
             os.makedirs(dict_save_dir, exist_ok=True)
-            dict_save_path = os.path.join(dict_save_dir, f"{progress_tracker.checkpoint_number}.json")
+            dict_save_path = os.path.join(dict_save_dir, f"{progress_tracker.checkpoint_number}.csv")
+            llm_eval_examples = pd.DataFrame(llm_eval_examples).to_dict(orient="records")
             with open(dict_save_path, "w") as outfile:
-                json.dump(llm_eval_examples, outfile)
+                writer = csv.DictWriter(outfile, fieldnames=["inputs", "targets", "outputs"])
+                writer.writeheader()
+                writer.writerows(llm_eval_examples)
 
             self.write_eval_summary(
                 summary_writer=validation_summary_writer,


### PR DESCRIPTION
Bypass MLFlow to log LLM outputs because of complications regarding the different MLFlow methods (log_dict does not interact well with our current MLFlow endpoint).

This is what the directory structure looks like: 
<img width="183" alt="image" src="https://github.com/ludwig-ai/ludwig/assets/72055086/f380b0a2-baee-4054-9a35-7567a08949f2">