### PR TITLE
Remove dicts from comparison metrics during visualization

### DIFF
--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1503,11 +1503,7 @@ def compare_performance(
         metric_names = metric_names_sets[0]
         for metric_names_set in metric_names_sets:
             metric_names = metric_names.intersection(metric_names_set)
-        if LOSS in metric_names:
-            metric_names.remove(LOSS)
-        for name in ignore_names:
-            if name in metric_names:
-                metric_names.remove(name)
+        metric_names = metric_names - ignore_names
         metrics_dict = {name: [] for name in metric_names}
 
         for test_stats_per_model in test_stats_per_model_list:

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1480,7 +1480,15 @@ def compare_performance(
     compare_performance([a_evaluation_stats, b_evaluation_stats], model_names=["A", "B"])
     ```
     """
-    ignore_names = ["overall_stats", "confusion_matrix", "per_class_stats", "predictions", "probabilities"]
+    ignore_names = [
+        "overall_stats",
+        "confusion_matrix",
+        "per_class_stats",
+        "predictions",
+        "probabilities",
+        "roc_curve",
+        "precision_recall_curve",
+    ]
 
     filename_template = "compare_performance_{}." + file_format
     filename_template_path = generate_filename_template_path(output_directory, filename_template)
@@ -1494,7 +1502,6 @@ def compare_performance(
         metric_names = metric_names_sets[0]
         for metric_names_set in metric_names_sets:
             metric_names = metric_names.intersection(metric_names_set)
-        metric_names.remove(LOSS)
         for name in ignore_names:
             if name in metric_names:
                 metric_names.remove(name)

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1480,7 +1480,7 @@ def compare_performance(
     compare_performance([a_evaluation_stats, b_evaluation_stats], model_names=["A", "B"])
     ```
     """
-    ignore_names = [
+    ignore_names = {
         "overall_stats",
         "confusion_matrix",
         "per_class_stats",
@@ -1488,7 +1488,8 @@ def compare_performance(
         "probabilities",
         "roc_curve",
         "precision_recall_curve",
-    ]
+        LOSS,
+    }
 
     filename_template = "compare_performance_{}." + file_format
     filename_template_path = generate_filename_template_path(output_directory, filename_template)

--- a/ludwig/visualize.py
+++ b/ludwig/visualize.py
@@ -1502,6 +1502,8 @@ def compare_performance(
         metric_names = metric_names_sets[0]
         for metric_names_set in metric_names_sets:
             metric_names = metric_names.intersection(metric_names_set)
+        if LOSS in metric_names:
+            metric_names.remove(LOSS)
         for name in ignore_names:
             if name in metric_names:
                 metric_names.remove(name)


### PR DESCRIPTION
Currently, Ludwig visualization seems to be slightly broken when passing in test_statistics. We try to compare metrics that contain dict values instead of floats, causing the code to break.

This adds the dict metrics to our list of ignored metrics during visualization.