### PR TITLE
Add support for dequantizing 4-bit bitsandbytes base models into fp16

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -914,7 +914,7 @@ class LudwigModel:
         trainer.eval_batch_size = self.config_obj.trainer.eval_batch_size
         trainer.gradient_accumulation_steps = self.config_obj.trainer.gradient_accumulation_steps
 
-    def save_upscaled_quantized_model(self, save_path: str) -> None:
+    def save_dequantized_base_model(self, save_path: str) -> None:
         """Upscales quantized weights of a model to fp16 and saves the result in a specified folder.
 
         Args:
@@ -954,7 +954,7 @@ class LudwigModel:
         if not self.model:
             self.model = LudwigModel.create_model(self.config_obj)
 
-        self.model.save_upscaled_quantized_model(save_path)
+        self.model.save_dequantized_base_model(save_path)
 
     def generate(
         self,

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -915,7 +915,20 @@ class LudwigModel:
         trainer.gradient_accumulation_steps = self.config_obj.trainer.gradient_accumulation_steps
 
     def upscale_quantized_weights(self, save_path: str) -> None:
-        """Upscales quantized weights of a model and saves the result in a specified folder."""
+        """Upscales quantized weights of a model to fp16 and saves the result in a specified folder.
+
+        Args:
+            save_path (str): The path to the folder where the upscaled model weights will be saved.
+
+        Raises:
+            ValueError:
+                If the model type is not 'llm' or if quantization is not enabled or the number of bits is not 4 or 8.
+            RuntimeError:
+                If no GPU is available, as GPU is required for quantized models.
+
+        Returns:
+            None
+        """
         if self.config_obj.model_type != MODEL_LLM:
             raise ValueError(
                 f"Model type {self.config_obj.model_type} is not supported by this method. Only `llm` model type is "

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -935,17 +935,20 @@ class LudwigModel:
                 "supported."
             )
 
-        if not self.config_obj.quantization or self.config_obj.quantization.bits not in {4, 8}:
+        if not self.config_obj.quantization:
             raise ValueError(
-                "Quantization is not enabled or the number of bits is not 4 or 8. "
-                "This method only works with quantized models with 4 or 8 bits."
+                "Quantization is not enabled in your Ludwig model config. "
+                "To enable quantization, set `quantization` to `{'bits': 4}` or `{'bits': 8}` in your model config."
+            )
+
+        if self.config_obj.quantization.bits != 4:
+            raise ValueError(
+                "This method only works with quantized models with 4 bits. "
+                "Support for 8-bit quantized models will be added in a future release."
             )
 
         if not torch.cuda.is_available():
             raise RuntimeError("GPU is required for quantized models but no GPU found.")
-
-        if not save_path:
-            raise ValueError("save_path must be specified.")
 
         # Create the LLM model class instance with the loaded LLM if it hasn't been initialized yet.
         if not self.model:

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -914,7 +914,7 @@ class LudwigModel:
         trainer.eval_batch_size = self.config_obj.trainer.eval_batch_size
         trainer.gradient_accumulation_steps = self.config_obj.trainer.gradient_accumulation_steps
 
-    def upscale_quantized_weights(self, save_path: str) -> None:
+    def save_upscaled_quantized_model(self, save_path: str) -> None:
         """Upscales quantized weights of a model to fp16 and saves the result in a specified folder.
 
         Args:
@@ -947,25 +947,11 @@ class LudwigModel:
         if not save_path:
             raise ValueError("save_path must be specified.")
 
-        # Create the model if it hasn't been initialized yet.
+        # Create the LLM model class instance with the loaded LLM if it hasn't been initialized yet.
         if not self.model:
             self.model = LudwigModel.create_model(self.config_obj)
 
-        from ludwig.utils.llm_quantization_utils import convert_linear4bit_to_linear
-
-        # Dequantize the model weights and cast them to fp16 - replace quantized layers with appropriate
-        # linear layers in-place.
-        convert_linear4bit_to_linear(self.model)
-
-        # Override properties of the model to indicate that it is no longer quantized.
-        # This is also necessary to ensure that the model can be saved, otherwise it will raise an error like
-        # "You are calling `save_pretrained` on a 4-bit converted model. This is currently not supported"
-        # See: https://github.com/huggingface/transformers/blob/0ad4e7e6dad670a7151aaceb1af3c272a3bf73a8/src/transformers/modeling_utils.py#L2054 # noqa
-        self.model.is_loaded_in_4bit = False
-        self.model.is_loaded_in_8bit = False
-
-        # Save the model
-        self.model.save_pretrained(save_path)
+        self.model.save_upscaled_quantized_model(save_path)
 
     def generate(
         self,

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -20,7 +20,7 @@ from ludwig.schema.model_types.llm import LLMModelConfig
 from ludwig.utils.augmentation_utils import AugmentationPipelines
 from ludwig.utils.data_utils import clear_data_cache
 from ludwig.utils.error_handling_utils import default_retry
-from ludwig.utils.llm_quantization_utils import convert_linear4bit_to_linear
+from ludwig.utils.llm_quantization_utils import convert_quantized_linear_to_linear
 from ludwig.utils.llm_utils import (
     add_left_padding,
     generate_merged_ids,
@@ -691,7 +691,7 @@ class LLM(BaseModel):
         # Dequantize the model weights and cast them to fp16 - replace quantized layers with appropriate
         # linear layers in-place.
         logger.info("Upscaling quantized weights to fp16...")
-        convert_linear4bit_to_linear(self.model)
+        convert_quantized_linear_to_linear(self.model)
         logger.info("Done.")
 
         # Override properties of the model to indicate that it is no longer quantized.

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -676,8 +676,15 @@ class LLM(BaseModel):
         else:
             logger.info("Skipped saving LLM without weight adjustments.")
 
-    def save_upscaled_quantized_model(self, save_path):
-        """Saves the upscaled quantized model to the given path."""
+    def save_dequantized_base_model(self, save_path: str) -> None:
+        """Upscales quantized weights of a model to fp16 and saves the result in a folder specified by save_path.
+
+        Args:
+            save_path (str): The path to the folder where the upscaled model weights will be saved.
+
+        Returns:
+            None
+        """
         from peft import PeftModel
 
         if isinstance(self.model, PeftModel):

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -678,6 +678,16 @@ class LLM(BaseModel):
 
     def save_upscaled_quantized_model(self, save_path):
         """Saves the upscaled quantized model to the given path."""
+        from peft import PeftModel
+
+        if isinstance(self.model, PeftModel):
+            # Get the base model back by removing all the adapter modules without merging.
+            logger.warning(
+                "LLM model is currently wrapped in a PeftModel. Removing the adapter layers and saving the base model."
+                "Reload the model via LudwigModel.load() to use your trained adapter layers for inference."
+            )
+            self.model = self.model.unload()
+
         # Dequantize the model weights and cast them to fp16 - replace quantized layers with appropriate
         # linear layers in-place.
         logger.info("Upscaling quantized weights to fp16...")
@@ -692,12 +702,12 @@ class LLM(BaseModel):
         self.model.is_loaded_in_8bit = False
 
         # Save the model
-        logger.info(f"Saving the upscaled model to {save_path}")
+        logger.info(f"Saving upscaled model to {save_path}")
         self.model.save_pretrained(save_path)
         logger.info("Done.")
 
         # Save the tokenizer
-        logger.info(f"Saving the tokenizer to {save_path}")
+        logger.info(f"Saving tokenizer to {save_path}")
         self.tokenizer.save_pretrained(save_path)
         logger.info("Done.")
 

--- a/ludwig/utils/llm_quantization_utils.py
+++ b/ludwig/utils/llm_quantization_utils.py
@@ -25,21 +25,20 @@ class Linear4BitToLinear(nn.Module):
         """
         # Create a new Linear layer with the same shape
         new_linear_layer = nn.Linear(
-            linear4bit_layer.in_features, linear4bit_layer.out_features, bias=linear4bit_layer.bias is not None
+            linear4bit_layer.in_features,
+            linear4bit_layer.out_features,
+            bias=linear4bit_layer.bias is not None,
+            dtype=torch.float16,
         )
 
         # Dequantize the weight and bias from the Linear4bit layer and perform an in-place tensor replacement to update
         # the weights and bias in the new Linear layer. This is done to avoid creating a new tensor and copying the
-        # data, which is slow. The to() call is needed to ensure the new tensors have the same dtype as the original
-        # dequantized tensors, which is fp16. Otherwise, the new tensors will be fp32 by default.
+        # data, which is slow.
         new_linear_layer.weight.data.copy_(
             dequantize_4bit(linear4bit_layer.weight.data, linear4bit_layer.weight.quant_state)
         )
-        new_linear_layer.weight.data = new_linear_layer.weight.data.to(dtype=torch.float16)
-
         if linear4bit_layer.bias is not None:
             new_linear_layer.bias.data.copy_(linear4bit_layer.bias.data)
-            new_linear_layer.bias.data = new_linear_layer.bias.data.to(dtype=linear4bit_layer.bias.data.dtype)
 
         return new_linear_layer
 

--- a/ludwig/utils/llm_quantization_utils.py
+++ b/ludwig/utils/llm_quantization_utils.py
@@ -1,0 +1,38 @@
+from bitsandbytes.functional import dequantize_4bit
+from bitsandbytes.nn.modules import Linear4bit
+from torch import nn
+
+from ludwig.api_annotations import DeveloperAPI
+
+
+@DeveloperAPI
+class Linear4BitToLinear(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, linear4bit_layer):
+        # Create a new Linear layer with the same shape
+        new_linear_layer = nn.Linear(
+            linear4bit_layer.in_features, linear4bit_layer.out_features, bias=linear4bit_layer.bias is not None
+        )
+
+        # Copy the weight and bias from the Linear4Bit layer to the new Linear layer
+        # Dequantize the weight and bias from the Linear4bit layer
+        new_linear_layer.weight.data = dequantize_4bit(
+            linear4bit_layer.weight.data, linear4bit_layer.weight.quant_state
+        )
+        if linear4bit_layer.bias is not None:
+            new_linear_layer.bias.data = linear4bit_layer.bias.data
+
+        return new_linear_layer
+
+
+@DeveloperAPI
+def convert_linear4bit_to_linear(module):
+    for name, child in module.named_children():
+        if isinstance(child, Linear4bit):
+            # Replace Linear4Bit layer with a new Linear layer
+            setattr(module, name, Linear4BitToLinear()(child))
+        else:
+            # Recursively apply the conversion for nested modules
+            convert_linear4bit_to_linear(child)

--- a/ludwig/utils/llm_quantization_utils.py
+++ b/ludwig/utils/llm_quantization_utils.py
@@ -45,7 +45,7 @@ class Linear4BitToLinear(nn.Module):
 
 
 @DeveloperAPI
-def convert_linear4bit_to_linear(module):
+def convert_quantized_linear_to_linear(module):
     """Recursively converts Linear4Bit layers to standard Linear layers in a given module.
 
     Args:
@@ -60,4 +60,4 @@ def convert_linear4bit_to_linear(module):
             setattr(module, name, Linear4BitToLinear()(child))
         else:
             # Recursively apply the conversion for nested modules
-            convert_linear4bit_to_linear(child)
+            convert_quantized_linear_to_linear(child)

--- a/ludwig/utils/llm_quantization_utils.py
+++ b/ludwig/utils/llm_quantization_utils.py
@@ -7,40 +7,34 @@ from ludwig.api_annotations import DeveloperAPI
 
 
 @DeveloperAPI
-class Linear4BitToLinear(nn.Module):
+def linear4bit_to_linear(linear4bit_layer):
     """Converts a Linear4Bit layer to a standard Linear layer by dequantizing the weight values and copying the
-    dequantized weights to a new Linear layer."""
+    dequantized weights to a new Linear layer.
 
-    def __init__(self):
-        super().__init__()
+    Args:
+        linear4bit_layer (Linear4bit): The input Linear4Bit layer.
 
-    def forward(self, linear4bit_layer):
-        """Forward pass of the conversion.
+    Returns:
+        nn.Linear: A new Linear layer with dequantized weights and biases.
+    """
+    # Create a new Linear layer with the same shape
+    new_linear_layer = nn.Linear(
+        linear4bit_layer.in_features,
+        linear4bit_layer.out_features,
+        bias=linear4bit_layer.bias is not None,
+        dtype=torch.float16,
+    )
 
-        Args:
-            linear4bit_layer (Linear4bit): The input Linear4Bit layer.
+    # Dequantize the weight and bias from the Linear4bit layer and perform an in-place tensor replacement
+    # to update the weights and bias in the new Linear layer. This is done to avoid creating a new tensor
+    # and copying the data, which is slow.
+    new_linear_layer.weight.data.copy_(
+        dequantize_4bit(linear4bit_layer.weight.data, linear4bit_layer.weight.quant_state)
+    )
+    if linear4bit_layer.bias is not None:
+        new_linear_layer.bias.data.copy_(linear4bit_layer.bias.data)
 
-        Returns:
-            nn.Linear: A new Linear layer with dequantized weights and biases.
-        """
-        # Create a new Linear layer with the same shape
-        new_linear_layer = nn.Linear(
-            linear4bit_layer.in_features,
-            linear4bit_layer.out_features,
-            bias=linear4bit_layer.bias is not None,
-            dtype=torch.float16,
-        )
-
-        # Dequantize the weight and bias from the Linear4bit layer and perform an in-place tensor replacement to update
-        # the weights and bias in the new Linear layer. This is done to avoid creating a new tensor and copying the
-        # data, which is slow.
-        new_linear_layer.weight.data.copy_(
-            dequantize_4bit(linear4bit_layer.weight.data, linear4bit_layer.weight.quant_state)
-        )
-        if linear4bit_layer.bias is not None:
-            new_linear_layer.bias.data.copy_(linear4bit_layer.bias.data)
-
-        return new_linear_layer
+    return new_linear_layer
 
 
 @DeveloperAPI
@@ -56,7 +50,7 @@ def convert_quantized_linear_to_linear(module):
     for name, child in module.named_children():
         if isinstance(child, Linear4bit):
             # Replace Linear4Bit layer with a new Linear layer
-            setattr(module, name, Linear4BitToLinear()(child))
+            setattr(module, name, linear4bit_to_linear(child))
         else:
             # Recursively apply the conversion for nested modules
             convert_quantized_linear_to_linear(child)

--- a/ludwig/utils/llm_quantization_utils.py
+++ b/ludwig/utils/llm_quantization_utils.py
@@ -7,10 +7,21 @@ from ludwig.api_annotations import DeveloperAPI
 
 @DeveloperAPI
 class Linear4BitToLinear(nn.Module):
+    """Converts a Linear4Bit layer to a standard Linear layer by dequantizing the weight values and copying the
+    dequantized weights to a new Linear layer."""
+
     def __init__(self):
         super().__init__()
 
     def forward(self, linear4bit_layer):
+        """Forward pass of the conversion.
+
+        Args:
+            linear4bit_layer (Linear4bit): The input Linear4Bit layer.
+
+        Returns:
+            nn.Linear: A new Linear layer with dequantized weights and biases.
+        """
         # Create a new Linear layer with the same shape
         new_linear_layer = nn.Linear(
             linear4bit_layer.in_features, linear4bit_layer.out_features, bias=linear4bit_layer.bias is not None
@@ -29,6 +40,14 @@ class Linear4BitToLinear(nn.Module):
 
 @DeveloperAPI
 def convert_linear4bit_to_linear(module):
+    """Recursively converts Linear4Bit layers to standard Linear layers in a given module.
+
+    Args:
+        module (nn.Module): The input module containing potentially nested Linear4Bit layers.
+
+    Returns:
+        None
+    """
     for name, child in module.named_children():
         if isinstance(child, Linear4bit):
             # Replace Linear4Bit layer with a new Linear layer

--- a/ludwig/utils/llm_quantization_utils.py
+++ b/ludwig/utils/llm_quantization_utils.py
@@ -27,13 +27,14 @@ class Linear4BitToLinear(nn.Module):
             linear4bit_layer.in_features, linear4bit_layer.out_features, bias=linear4bit_layer.bias is not None
         )
 
-        # Copy the weight and bias from the Linear4Bit layer to the new Linear layer
-        # Dequantize the weight and bias from the Linear4bit layer
-        new_linear_layer.weight.data = dequantize_4bit(
-            linear4bit_layer.weight.data, linear4bit_layer.weight.quant_state
+        # Dequantize the weight and bias from the Linear4bit layer and perform an in-place tensor replacement to update
+        # the weights and bias in the new Linear layer. This is done to avoid creating a new tensor and copying the
+        # data, which is slow.
+        new_linear_layer.weight.data.copy_(
+            dequantize_4bit(linear4bit_layer.weight.data, linear4bit_layer.weight.quant_state)
         )
         if linear4bit_layer.bias is not None:
-            new_linear_layer.bias.data = linear4bit_layer.bias.data
+            new_linear_layer.bias.data.copy_(linear4bit_layer.bias.data)
 
         return new_linear_layer
 


### PR DESCRIPTION
This PR adds support for converting a quantized 4-bit base LLM model (in either `nf4` or `fp4` data types via bitsandbytes) into an upscaled float16 variant.

To use this function, it's as simple as:
1. Create a Ludwig config where quantization is set and bits = 4
2. Instantiate the LudwigModel class
3. Call `model.save_dequantized_base_model(save_path)`

You can also call this function after model training. The only caveat is that you will have to call `LudwigModel.load("/saved/artifact/path")` to reload the model with the trained adapter.

---

# Usage

```python
import yaml
from ludwig.api import LudwigModel

config = """
    model_type: llm
    base_model: meta-llama/Llama-2-7b-hf
    quantization:
        bits: 4
    ...
"""

config = yaml.safe_load(config)

model = LudwigModel(config)
... # Optionally call model.train(), but it's not required
model.save_dequantized_base_model("/src/llama-2-upscaled")
```

In the future, we will add support for dequantizing 8 bit models into fp16 as well.