### PR TITLE
[Maintenance] Fix deprecation warning for CharErrorRate

### DIFF
--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Generator, Optional, Type
 
 import torch
 from torch import Tensor, tensor
-from torchmetrics import CharErrorRate, MeanAbsoluteError, MeanAbsolutePercentageError
+from torchmetrics import MeanAbsoluteError, MeanAbsolutePercentageError
 from torchmetrics import MeanMetric as _MeanMetric
 from torchmetrics import MeanSquaredError, Metric
 from torchmetrics.classification import (
@@ -33,7 +33,7 @@ from torchmetrics.classification import (
 )
 from torchmetrics.functional.regression.r2 import _r2_score_compute, _r2_score_update
 from torchmetrics.metric import jit_distributed_available
-from torchmetrics.text import BLEUScore, WordErrorRate
+from torchmetrics.text import BLEUScore, CharErrorRate, WordErrorRate
 from torchmetrics.text.perplexity import Perplexity
 from torchmetrics.text.rouge import ROUGEScore
 


### PR DESCRIPTION
Fixes the following warning:
```
 FutureWarning: Importing `CharErrorRate` from `torchmetrics` was deprecated and will be removed in 2.0. Import `CharErrorRate` from `torchmetrics.text` instead.
```