### PR TITLE
Add utility function for uploading local folders to huggingface hub

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -956,6 +956,12 @@ class LudwigModel:
 
         self.model.save_dequantized_base_model(save_path)
 
+        logger.info(
+            "If you want to upload this model to huggingface.co, run the following Python commands: \n"
+            "from ludwig.utils.hf_utils import upload_model_to_hfhub; \n"
+            f"upload_model_to_hfhub(repo_id='desired/huggingface/repo/name', folder_path={save_path})"
+        )
+
     def generate(
         self,
         input_strings: Union[str, List[str]],

--- a/ludwig/utils/hf_utils.py
+++ b/ludwig/utils/hf_utils.py
@@ -4,12 +4,14 @@ import tempfile
 from os import PathLike
 from typing import Optional, Tuple, Type, Union
 
+from huggingface_hub import HfApi
 from transformers import AutoTokenizer, PreTrainedModel
 from transformers.tokenization_utils import PreTrainedTokenizer
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.utils.error_handling_utils import default_retry
 from ludwig.utils.fs_utils import download, path_exists
+from ludwig.utils.upload_utils import hf_hub_login
 
 logger = logging.getLogger(__name__)
 
@@ -107,3 +109,83 @@ def load_pretrained_hf_model_with_hub_fallback(
 
     # Fallback to HF hub.
     return load_pretrained_hf_model_from_hub(model_class, pretrained_model_name_or_path, **pretrained_kwargs), True
+
+
+def upload_folder_to_hfhub(
+    repo_id: str,
+    folder_path: str,
+    token: Optional[str] = None,
+    repo_type: Optional[str] = "model",
+    private: Optional[bool] = False,
+    path_in_repo: Optional[str] = None,  # defaults to root of repo
+    commit_message: Optional[str] = None,
+    commit_description: Optional[str] = None,
+) -> None:
+    """Uploads a local folder to the Hugging Face Model Hub.
+
+    Args:
+        repo_id (str): The ID of the target repository on the Hugging Face Model Hub.
+        folder_path (str): The local path to the folder to be uploaded.
+        token (str, optional): The authentication token for the Hugging Face account.
+            If not provided, it will attempt to log in using the `hf_hub_login` function.
+        repo_type (str, optional): The type of the repository ('model', 'dataset', or 'space').
+            Defaults to 'model'.
+        private (bool, optional): If True, the repository will be private; otherwise, it will be public.
+            Defaults to False.
+        path_in_repo (str, optional): The relative path within the repository where the folder should be uploaded.
+            Defaults to None, which means the root of the repository.
+        commit_message (str, optional): A message for the commit associated with the upload.
+        commit_description (str, optional): A description for the commit associated with the upload.
+
+    Raises:
+        FileNotFoundError: If the specified folder does not exist.
+        ValueError: If the specified folder is empty, a file, or if an invalid 'repo_type' is provided.
+        ValueError: If authentication fails with an invalid token.
+        ValueError: If the upload process fails for any reason.
+
+    Returns:
+        None
+    """
+    # Make sure the folder exists
+    if not os.path.exists(folder_path):
+        raise FileNotFoundError(f"Folder {folder_path} does not exist.")
+
+    # Make sure the folder is not empty
+    if not os.listdir(folder_path):
+        raise ValueError(f"Folder {folder_path} is empty.")
+
+    # Make sure the folder is not a file
+    if os.path.isfile(folder_path):
+        raise ValueError(f"Folder {folder_path} is a file. Please provide a folder.")
+
+    if repo_type not in {"model", "dataset", "space"}:
+        raise ValueError(f"Invalid repo_type {repo_type}. Valid values are 'model', 'dataset', and 'space'.")
+
+    # Login to the hub
+    if token is None:
+        api = hf_hub_login()
+    else:
+        try:
+            api = HfApi(token=token)
+        except Exception as e:
+            raise ValueError("Invalid token") from e
+
+    # Create the repo if it doesn't exist. This is a no-op if the repo already exists
+    # This is required because the API doesn't allow uploading to a non-existent repo
+    if not api.repo_exists(repo_id, repo_type=repo_type):
+        logger.info(f"{repo_id} does not exist. Creating.")
+        api.create_repo(repo_id, private=private, exist_ok=True, repo_type=repo_type)
+
+    # Upload the folder
+    try:
+        logger.info(f"Uploading folder {folder_path} to repo {repo_id}.")
+        api.upload_folder(
+            repo_id=repo_id,
+            folder_path=folder_path,
+            repo_type=repo_type,
+            path_in_repo=path_in_repo,
+            commit_message=commit_message,
+            commit_description=commit_description,
+        )
+    except Exception as e:
+        raise ValueError(f"Failed to upload folder {folder_path} to repo {repo_id}") from e

--- a/ludwig/utils/upload_utils.py
+++ b/ludwig/utils/upload_utils.py
@@ -103,26 +103,32 @@ class BaseModelUpload(ABC):
             )
 
 
+def hf_hub_login():
+    """Login to huggingface hub using the token stored in ~/.cache/huggingface/token and returns a HfApi client
+    object that can be used to interact with HF Hub."""
+    cached_token_path = os.path.join(os.path.expanduser("~"), ".cache", "huggingface", "token")
+
+    if not os.path.exists(cached_token_path):
+        login(add_to_git_credential=True)
+
+    with open(cached_token_path) as f:
+        hf_token = f.read()
+
+    hf_api = HfApi(token=hf_token)
+    assert hf_api.token == hf_token
+
+    return hf_api
+
+
 class HuggingFaceHub(BaseModelUpload):
     def __init__(self):
         self.api = None
         self.login()
 
     def login(self):
-        """Login to huggingface hub using the token stored in ~/.cache/huggingface/token and returns a HfApi client
+        """Login to huggingface hub using the token stored in ~/.cache/huggingface/token and return a HfApi client
         object that can be used to interact with HF Hub."""
-        cached_token_path = os.path.join(os.path.expanduser("~"), ".cache", "huggingface", "token")
-
-        if not os.path.exists(cached_token_path):
-            login(add_to_git_credential=True)
-
-        with open(cached_token_path) as f:
-            hf_token = f.read()
-
-        hf_api = HfApi(token=hf_token)
-        assert hf_api.token == hf_token
-
-        self.api = hf_api
+        self.api = hf_hub_login()
 
     @staticmethod
     def _validate_upload_parameters(

--- a/tests/ludwig/utils/test_hf_utils.py
+++ b/tests/ludwig/utils/test_hf_utils.py
@@ -1,11 +1,16 @@
 import os
+import shutil
 from typing import Type
 
 import pytest
 from transformers import AlbertModel, BertModel, BertTokenizer
 
 from ludwig.encoders.text_encoders import ALBERTEncoder, BERTEncoder
-from ludwig.utils.hf_utils import load_pretrained_hf_model_from_hub, load_pretrained_hf_model_with_hub_fallback
+from ludwig.utils.hf_utils import (
+    load_pretrained_hf_model_from_hub,
+    load_pretrained_hf_model_with_hub_fallback,
+    upload_folder_to_hfhub,
+)
 
 
 @pytest.mark.parametrize(
@@ -44,3 +49,43 @@ def test_load_pretrained_hf_model_with_hub_fallback(tmpdir):
 
     # Clean up.
     del os.environ["LUDWIG_PRETRAINED_MODELS_DIR"]
+
+
+@pytest.fixture
+def tmp_folder_with_file(tmpdir):
+    # Create a temporary folder
+    tmp_folder = str(tmpdir.mkdir("tmp_folder"))
+
+    # Create a file within the temporary folder
+    file_path = os.path.join(tmp_folder, "test_file.txt")
+    with open(file_path, "w") as f:
+        f.write("Test content")
+
+    yield tmp_folder
+
+    # Clean up: Remove the temporary folder and its contents
+    shutil.rmtree(tmp_folder)
+
+
+def test_upload_folder_to_hfhub_folder_not_exist():
+    with pytest.raises(FileNotFoundError, match=r"Folder .* does not exist."):
+        upload_folder_to_hfhub("test_repo", "/nonexistent_folder")
+
+
+def test_upload_folder_to_hfhub_folder_empty(tmpdir):
+    empty_folder = str(tmpdir.mkdir("empty_folder"))
+    with pytest.raises(ValueError, match=r"Folder .* is empty."):
+        upload_folder_to_hfhub("test_repo", empty_folder)
+
+
+def test_upload_folder_to_hfhub_folder_is_file(tmpdir):
+    file_path = str(tmpdir.join("test_file.txt"))
+    with open(file_path, "w") as f:
+        f.write("Test content")
+    with pytest.raises(ValueError, match=r"Folder .* is a file. Please provide a folder."):
+        upload_folder_to_hfhub("test_repo", file_path)
+
+
+def test_upload_folder_to_hfhub_invalid_repo_type(tmp_folder_with_file):
+    with pytest.raises(ValueError, match=r"Invalid repo_type .*"):
+        upload_folder_to_hfhub("test_repo", tmp_folder_with_file, repo_type="invalid_type")


### PR DESCRIPTION
This is useful for uploading any local files to huggingface hub. In particular, I use this for saving dequantized base model weights. Usage is very simple!

```python
from ludwig.utils.hf_utils import upload_folder_to_hfhub
upload_folder_to_hfhub(repo_id="", folder_path="")
```

This will create a repository on huggingface hub if it doesn't exist, and upload all files in the local folder to huggingface hub at that repo id.

There are a variety of **optional** **parameters** that can be specified:
- repo_type (str, optional): The type of the repository ('model', 'dataset', or 'space'). Defaults to 'model'.
- private (bool, optional): If True, the repository will be private; otherwise, it will be public. Defaults to False.
- path_in_repo (str, optional): The relative path within the repository where the folder should be uploaded. Defaults to None, which means the root of the repository.
- commit_message (str, optional): A message for the commit associated with the upload.
- commit_description (str, optional): A description for the commit associated with the upload.

--- 

Here's an example of how I used it:

```python
>>> from ludwig.utils.hf_utils import upload_folder_to_hfhub
>>> upload_folder_to_hfhub(repo_id="arnavgrg/codallama-7b-instruct-nf4-fp16-upscaled", folder_path="/home/ray/codellama-7b-instruct-upscaled")
arnavgrg/codallama-7b-instruct-nf4-fp16-upscaled does not exist. Creating.
Uploading folder /home/ray/codellama-7b-instruct-upscaled to repo arnavgrg/codallama-7b-instruct-nf4-fp16-upscaled.
tokenizer.model: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 500k/500k [00:00<00:00, 1.00MB/s]
model-00003-of-00003.safetensors: 100%|████████████████████████████████████████████████████████████████████████████████| 3.59G/3.59G [01:35<00:00, 37.8MB/s]
model-00001-of-00003.safetensors: 100%|████████████████████████████████████████████████████████████████████████████████| 4.94G/4.94G [02:03<00:00, 40.1MB/s]
model-00002-of-00003.safetensors: 100%|████████████████████████████████████████████████████████████████████████████████| 4.95G/4.95G [02:03<00:00, 40.1MB/s]
Upload 4 LFS files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [02:03<00:00, 30.89s/it]
```

and the artifacts live here: https://huggingface.co/arnavgrg/codallama-7b-instruct-nf4-fp16-upscaled/tree/main

<img width="1698" alt="Screenshot 2023-12-05 at 9 05 35 PM" src="https://github.com/ludwig-ai/ludwig/assets/106701836/fa4c6827-6dc7-4d80-8ffd-0cbe686597f2">