### PR TITLE
Fix LLM integration tests that fail because of PEFT 0.7 release

### DIFF
--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -765,7 +765,7 @@ quantization section from your Ludwig configuration."""
             [
                 "README.md",
                 "adapter_config.json",
-                "adapter_model.bin",
+                "adapter_model.safetensors",
             ],
             id="lora_default_not_merged",
         ),
@@ -777,7 +777,7 @@ quantization section from your Ludwig configuration."""
             [
                 "README.md",
                 "adapter_config.json",
-                "adapter_model.bin",
+                "adapter_model.safetensors",
                 "config.json",
                 "generation_config.json",
                 "merges.txt",
@@ -797,7 +797,7 @@ quantization section from your Ludwig configuration."""
             [
                 "README.md",
                 "adapter_config.json",
-                "adapter_model.bin",
+                "adapter_model.safetensors",
             ],
             id="lora_custom_not_merged",
         ),
@@ -809,7 +809,7 @@ quantization section from your Ludwig configuration."""
             [
                 "README.md",
                 "adapter_config.json",
-                "adapter_model.bin",
+                "adapter_model.safetensors",
                 "config.json",
                 "generation_config.json",
                 "merges.txt",

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -406,6 +406,7 @@ def _verify_lm_lora_finetuning_layers(
     expected_lora_num_features_orig: tuple[int] = (expected_lora_in_features, expected_lora_out_features)
 
     file_names: list[str] = list_file_names_in_directory(directory_name=model_weights_directory)
+    breakpoint()
     assert set(file_names) == set(expected_file_names)
 
     target_module_name: str

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -406,7 +406,6 @@ def _verify_lm_lora_finetuning_layers(
     expected_lora_num_features_orig: tuple[int] = (expected_lora_in_features, expected_lora_out_features)
 
     file_names: list[str] = list_file_names_in_directory(directory_name=model_weights_directory)
-    breakpoint()
     assert set(file_names) == set(expected_file_names)
 
     target_module_name: str


### PR DESCRIPTION
Released an hour ago: https://pypi.org/project/peft/0.7.0/

Failing tests: https://github.com/ludwig-ai/ludwig/actions/runs/7117174820/job/19377310798

It seems like the latest version of PEFT writes the adapter weights as safetensors instead of binary files. 