### PR TITLE
Add support for IA3 PEFT Strategy

### DIFF
--- a/ludwig/schema/llms/peft.py
+++ b/ludwig/schema/llms/peft.py
@@ -461,6 +461,71 @@ class AdaptionPromptConfig(BaseAdapterConfig):
 
 
 @DeveloperAPI
+@register_adapter("ia3")
+@ludwig_dataclass
+class IA3Config(BaseAdapterConfig):
+    type: str = schema_utils.ProtectedString(
+        "ia3",
+        description=LLM_METADATA["adapter"]["ia3"]["type"].long_description,
+    )
+
+    target_modules: Optional[List[str]] = schema_utils.List(
+        default=None,
+        allow_none=True,
+        description="The names of the modules to apply (IA)^3 to.",
+        parameter_metadata=LLM_METADATA["adapter"]["ia3"]["target_modules"],
+    )
+
+    feedforward_modules: Optional[List[str]] = schema_utils.List(
+        default=None,
+        allow_none=True,
+        description=(
+            "The names of the modules to be treated as feedforward modules, as in the original paper. These modules "
+            "will have (IA)^3 vectors multiplied to the input, instead of the output. feedforward_modules must be a "
+            "name or a subset of names present in target_modules."
+        ),
+        parameter_metadata=LLM_METADATA["adapter"]["ia3"]["feedforward_modules"],
+    )
+
+    fan_in_fan_out: bool = schema_utils.Boolean(
+        default=False,
+        description=(
+            "Set this to True if the layer to replace stores weight like (fan_in, fan_out). For example, gpt-2 uses "
+            "Conv1D which stores weights like (fan_in, fan_out) and hence this should be set to True. "
+        ),
+        parameter_metadata=LLM_METADATA["adapter"]["ia3"]["fan_in_fan_out"],
+    )
+
+    modules_to_save: Optional[List[str]] = schema_utils.List(
+        list_type=str,
+        default=None,
+        allow_none=True,
+        description=(
+            "List of modules apart from (IA)^3 layers to be set as trainable and saved in the final checkpoint."
+        ),
+        parameter_metadata=LLM_METADATA["adapter"]["ia3"]["modules_to_save"],
+    )
+
+    init_ia3_weights: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether to initialize the vectors in the (IA)^3 layers, defaults to True.",
+        parameter_metadata=LLM_METADATA["adapter"]["ia3"]["init_ia3_weights"],
+    )
+
+    def to_config(self, task_type: str = None, **kwargs) -> "PeftConfig":
+        from peft import IA3Config as _IA3Config
+
+        return _IA3Config(
+            target_modules=self.target_modules,
+            feedforward_modules=self.feedforward_modules,
+            fan_in_fan_out=self.fan_in_fan_out,
+            modules_to_save=self.modules_to_save,
+            init_ia3_weights=self.init_ia3_weights,
+            task_type=task_type,
+        )
+
+
+@DeveloperAPI
 def get_adapter_conds():
     conds = []
     for adapter_type, adapter_cls in adapter_registry.items():

--- a/ludwig/schema/metadata/configs/llm.yaml
+++ b/ludwig/schema/metadata/configs/llm.yaml
@@ -146,6 +146,26 @@ adapter:
     adapter_layers:
       ui_display_name: Adapter Layers
       expected_impact: 3
+  ia3:
+    type:
+      long_description: |
+        [Infused Adapter by Inhibiting and Amplifying Inner Activations](https://arxiv.org/pdf/2205.05638.pdf), or IA3,
+        is a method that adds three learned vectors l_k, l_v, and l_ff, to rescale the keys and values of the self-attention and encoder-decoder attention layers, and the intermediate activation of the position-wise feed-forward network respectively.
+    target_modules:
+      ui_display_name: Target Modules
+      expected_impact: 3
+    feedforward_modules:
+      ui_display_name: Feedforward Modules
+      expected_impact: 3
+    fan_in_fan_out:
+      ui_display_name: Fan In Fan Out
+      expected_impact: 3
+    modules_to_save:
+      ui_display_name: Modules to Save
+      expected_impact: 3
+    init_ia3_weights:
+      ui_display_name: Init IA3 Weights
+      expected_impact: 3
 quantization:
   _oneOf:
     object:

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -535,6 +535,16 @@ def _verify_lm_lora_finetuning_layers(
             {"adapter_len": 6, "adapter_layers": 1},
             id="adaption_prompt-modified-defaults",
         ),
+        pytest.param(
+            "ia3",
+            {},
+            id="ia3-defaults",
+        ),
+        pytest.param(
+            "ia3",
+            {"init_ia3_weights": False},
+            id="ia3-modified-defaults",
+        ),
         # pytest.param(
         #     "prompt_tuning",
         #     {


### PR DESCRIPTION
Paper: https://arxiv.org/pdf/2205.05638.pdf

Adds support for a new PEFT strategy called IA3, which adds 2 learned vectors to the V and Q projections in attention heads, as well as a learned vector to the feed-forward network. The idea is that these learned vectors can help rescale the attention values and feed-forward network values. l_k, l_v, and l_ff are all initialized with ones so that the overall function computed by the model does not change when they are added.

IA3 makes mixed-task batches possible because each sequence of activations in the batch can be separately and cheaply multiplied by its associated learned task vector (in some ways, very similar to how you can train different rank decomposed matrices with LoRA for each task). In the event that a model will only be used on a single task, the modifications introduced by IA3 can also be applied to weight matrices permanently so that no elementwise multiplication is required and the model’s architecture remains unchanged. This is possible because element-wise multiplications performed in IA3 always co-occur with matrix multiplication, which means that there is no additional computational cost compared to the original model.