### PR TITLE
Pin Transformers to < 4.36

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
-transformers>=4.33.2
+transformers>=4.33.2,<4.36.0
 tifffile
 imagecodecs
 tokenizers>=0.13.3


### PR DESCRIPTION
Transformers 4.36 was released today and seems to bring with it some strange issues during the backward pass at training time that need to be addressed. 

Pinning for now as we investigate how to make Ludwig compatible with the latest version of transformers