### PR TITLE
Move reusable LLM model methods to utility functions

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -248,7 +248,7 @@ class LLM(BaseModel):
         self.model = prepare_model_for_kbit_training(self.model, use_gradient_checkpointing=False)
 
     def to_device(self, device):
-        self.model = to_device(self.model, self.config_obj, self.curr_device)
+        self.model = to_device(self.model, device, self.config_obj, self.curr_device)
         self.curr_device = torch.device(device)
         return self
 

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -248,8 +248,8 @@ class LLM(BaseModel):
         self.model = prepare_model_for_kbit_training(self.model, use_gradient_checkpointing=False)
 
     def to_device(self, device):
-        self.model = to_device(self.model, device, self.config_obj, self.curr_device)
-        self.curr_device = torch.device(device)
+        self.model, device = to_device(self.model, device, self.config_obj, self.curr_device)
+        self.curr_device = device
         return self
 
     @classmethod

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -10,7 +10,6 @@ from peft import get_peft_model, MODEL_TYPE_TO_PEFT_MODEL_MAPPING, PeftConfig, P
 from transformers import AutoConfig, AutoModelForCausalLM, PreTrainedModel, PreTrainedTokenizer
 
 from ludwig.constants import IGNORE_INDEX_TOKEN_ID, LOGITS, PREDICTIONS, PROBABILITIES
-from ludwig.schema.model_types.llm import LLMModelConfig
 from ludwig.schema.trainer import LLMTrainerConfig
 from ludwig.utils.logging_utils import log_once
 from ludwig.utils.model_utils import find_embedding_layer_with_path
@@ -24,7 +23,7 @@ FALLBACK_CONTEXT_LEN = 2048
 def to_device(
     model: PreTrainedModel,
     device: Union[str, torch.DeviceObjType],
-    config_obj: LLMModelConfig,
+    config_obj: "LLMModelConfig",  # noqa F821
     curr_device: torch.DeviceObjType,
 ) -> Tuple[PreTrainedModel, torch.DeviceObjType]:
     """Move an LLM to the requested device, accounting for sharding and adapters.
@@ -89,7 +88,9 @@ def to_device(
     return model, device
 
 
-def initialize_adapter(model: PreTrainedModel, config_obj: LLMModelConfig) -> Union[PeftModel, PreTrainedModel]:
+def initialize_adapter(
+    model: PreTrainedModel, config_obj: "LLMModelConfig"  # noqa F821
+) -> Union[PeftModel, PreTrainedModel]:
     """Wrap a pretrained model with a PEFT model for fine-tuning.
 
     Args:

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -26,7 +26,7 @@ def to_device(
     device: Union[str, torch.DeviceObjType],
     config_obj: LLMModelConfig,
     curr_device: torch.DeviceObjType,
-) -> PreTrainedModel:
+) -> Tuple[PreTrainedModel, torch.DeviceObjType]:
     """Move an LLM to the requested device, accounting for sharding and adapters.
 
     Args:
@@ -41,7 +41,7 @@ def to_device(
 
     if device.type == curr_device.type:
         log_once(f"Model already on device'{device}'.")
-        return model
+        return model, device
     else:
         log_once(f"Moving LLM from '{curr_device}' to '{device}'.")
 
@@ -86,7 +86,7 @@ def to_device(
     else:
         model = model.to(device)
 
-    return model
+    return model, device
 
 
 def initialize_adapter(model: PreTrainedModel, config_obj: LLMModelConfig) -> Union[PeftModel, PreTrainedModel]:


### PR DESCRIPTION
This is a small PR to move two methods out of the LLM object and into utils so they can be reused for text encoders. The two methods/functions are:

- `initialize_adapter` - wraps a pretrained model with a PEFT model, with support for new and pretrained adapters
- `to_device` - moves a pretrained model to device with logic to shard the model over multiple GPUs.