### PR TITLE
Remove quantization config before saving dequantized weights to disk

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -632,7 +632,7 @@ class LLM(BaseModel):
         logger.info("Done.")
 
         # Remove the quantization configuration from the model
-        self.model.config.quantization_config = None
+        self.model.config.quantization_config = {}
 
         # Override properties of the model to indicate that it is no longer quantized.
         # This is also necessary to ensure that the model can be saved, otherwise it will raise an error like

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -631,6 +631,9 @@ class LLM(BaseModel):
         convert_quantized_linear_to_linear(self.model)
         logger.info("Done.")
 
+        # Remove the quantization configuration from the model
+        self.model.config.quantization_config = None
+
         # Override properties of the model to indicate that it is no longer quantized.
         # This is also necessary to ensure that the model can be saved, otherwise it will raise an error like
         # "You are calling `save_pretrained` on a 4-bit converted model. This is currently not supported"

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -632,6 +632,9 @@ class LLM(BaseModel):
         logger.info("Done.")
 
         # Remove the quantization configuration from the model
+        # The reason we can't delete the quantization config is because it is a property of the model and
+        # HF does some weird serialization of the config that causes an error when trying to access `self.model.config`
+        # after you try and delete a key from the config: TypeError: Object of type dtype is not JSON serializable.
         self.model.config.quantization_config = {}
 
         # Override properties of the model to indicate that it is no longer quantized.


### PR DESCRIPTION
This will prevent the quantization config from unnecessarily getting written to disk like it was before (doesn't actually cause any issues though):

```

  "_name_or_path": "meta-llama/Llama-2-7b-chat-hf",
  "architectures": [
    "LlamaForCausalLM"
  ],
  "attention_bias": false,
  "bos_token_id": 1,
  "eos_token_id": 2,
  "hidden_act": "silu",
  "hidden_size": 4096,
  "initializer_range": 0.02,
  "intermediate_size": 11008,
  "max_position_embeddings": 4096,
  "model_type": "llama",
  "num_attention_heads": 32,
  "num_hidden_layers": 32,
  "num_key_value_heads": 32,
  "pretraining_tp": 1,
  "quantization_config": {
    "bnb_4bit_compute_dtype": "float16",
    "bnb_4bit_quant_type": "nf4",
    "bnb_4bit_use_double_quant": true,
    "llm_int8_enable_fp32_cpu_offload": false,
    "llm_int8_has_fp16_weight": false,
    "llm_int8_skip_modules": null,
    "llm_int8_threshold": 6.0,
    "load_in_4bit": true,
    "load_in_8bit": false,
    "quant_method": "bitsandbytes"
  },
  "rms_norm_eps": 0.00001,
  "rope_scaling": null,
  "rope_theta": 10000.0,
  "tie_word_embeddings": false,
  "torch_dtype": "float16",
  "transformers_version": "4.35.2",
  "use_cache": true,
  "vocab_size": 32000
}
```

and changes it to 

```

  "_name_or_path": "meta-llama/Llama-2-7b-chat-hf",
  "architectures": [
    "LlamaForCausalLM"
  ],
  "attention_bias": false,
  "bos_token_id": 1,
  "eos_token_id": 2,
  "hidden_act": "silu",
  "hidden_size": 4096,
  "initializer_range": 0.02,
  "intermediate_size": 11008,
  "max_position_embeddings": 4096,
  "model_type": "llama",
  "num_attention_heads": 32,
  "num_hidden_layers": 32,
  "num_key_value_heads": 32,
  "pretraining_tp": 1,
  "quantization_config": {},
  "rms_norm_eps": 0.00001,
  "rope_scaling": null,
  "rope_theta": 10000.0,
  "tie_word_embeddings": false,
  "torch_dtype": "float16",
  "transformers_version": "4.35.2",
  "use_cache": true,
  "vocab_size": 32000
}
```