### PR TITLE
Add LLM Text Encoder

### DIFF
--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -2415,6 +2415,8 @@ class LLMEncoder(Encoder):
 
         self.attention_masks = None
 
+        self.prepare_for_training()
+
         clear_data_cache()
 
     @staticmethod

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -2408,7 +2408,6 @@ class LLMEncoder(Encoder):
         #        max_sequence_length if max_sequence_length <= self.context_len else self.context_len
         #     )
         # else:
-        print(f"CONTEXT LENGTH: {self.context_len}")
         self.max_sequence_length = self.context_len
 
         # Initialize tokenizer

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -2421,6 +2421,10 @@ class LLMEncoder(Encoder):
 
         self.prepare_for_training()
 
+        if not self.config.adapter:
+            out_module = list(self.model.modules())[-1]
+            out_module.requires_grad_(requires_grad=False)
+
         clear_data_cache()
 
     @staticmethod

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -2455,5 +2455,12 @@ class LLMEncoder(Encoder):
     def forward(self, inputs: torch.Tensor, mask: Optional[torch.Tensor] = None):
         pass
 
-    def save(self):
-        pass
+    def _save_to_state_dict(self, destination: Dict, prefix: str, keep_vars: bool):
+        # This is called by `torch.nn.Module.state_dict()` under the hood. `state_dict()` does additional work to
+        # prep the dictionary, get submodule state, and run hooks. Overriding this method only impacts the
+        # contents of the stat_dict.
+        # get_peft_model_state_dict geneates a state dict that only contains the adapter weights
+        from peft.utils.save_and_load import get_peft_model_state_dict
+
+        sd = get_peft_model_state_dict(self.model)
+        destination.update(sd)

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -2459,8 +2459,11 @@ class LLMEncoder(Encoder):
         # This is called by `torch.nn.Module.state_dict()` under the hood. `state_dict()` does additional work to
         # prep the dictionary, get submodule state, and run hooks. Overriding this method only impacts the
         # contents of the stat_dict.
-        # get_peft_model_state_dict geneates a state dict that only contains the adapter weights
-        from peft.utils.save_and_load import get_peft_model_state_dict
+        if self.encoder_config.adapter:
+            # get_peft_model_state_dict geneates a state dict that only contains the adapter weights
+            from peft.utils.save_and_load import get_peft_model_state_dict
 
-        sd = get_peft_model_state_dict(self.model)
-        destination.update(sd)
+            sd = get_peft_model_state_dict(self.model)
+            destination.update(sd)
+        else:
+            super()._save_to_state_dict(destination, prefix=prefix, keep_vars=keep_vars)

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -42,6 +42,7 @@ from ludwig.schema.encoders.text_encoders import (
     FlauBERTConfig,
     GPT2Config,
     GPTConfig,
+    LLMEncoderConfig,
     LongformerConfig,
     MT5Config,
     RoBERTaConfig,
@@ -2383,7 +2384,7 @@ class TfIdfEncoder(Encoder):
 @DeveloperAPI
 @register_encoder("llm", [TEXT])
 class LLMEncoder(Encoder):
-    def __init__(self, max_sequence_length: int, encoder_config=None, **kwargs):
+    def __init__(self, max_sequence_length: int, encoder_config: LLMEncoderConfig = None, **kwargs):
         self.encoder_config = encoder_config
 
         self.model_name = self.encoder_config.base_model
@@ -2413,6 +2414,21 @@ class LLMEncoder(Encoder):
         self.attention_masks = None
 
         clear_data_cache()
+
+    @staticmethod
+    def get_schema_cls() -> Type[BaseEncoderConfig]:
+        return LLMEncoderConfig
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size([self.max_sequence_length])
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size([self.max_sequence_length])
+
+    def get_embedding_layer(self) -> nn.Module:
+        return self
 
     def prepare_for_training(self):
         pass

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -20,7 +20,6 @@ from ludwig.utils.augmentation_utils import AugmentationPipelines
 from ludwig.utils.data_utils import clear_data_cache
 from ludwig.utils.llm_quantization_utils import convert_quantized_linear_to_linear
 from ludwig.utils.llm_utils import (
-    _MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION,
     add_left_padding,
     generate_merged_ids,
     get_context_len,

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -7,7 +7,10 @@ from ludwig.schema import utils as schema_utils
 from ludwig.schema.encoders.sequence_encoders import SequenceEncoderConfig
 from ludwig.schema.encoders.text.hf_model_params import DebertaModelParams
 from ludwig.schema.encoders.utils import register_encoder_config
+from ludwig.schema.llms.base_model import BaseModelDataclassField
+from ludwig.schema.llms.model_parameters import ModelParametersConfig, ModelParametersConfigField
 from ludwig.schema.llms.peft import AdapterDataclassField, BaseAdapterConfig
+from ludwig.schema.llms.quantization import QuantizationConfig, QuantizationConfigField
 from ludwig.schema.metadata import ENCODER_METADATA
 from ludwig.schema.metadata.parameter_metadata import INTERNAL_ONLY, ParameterMetadata
 from ludwig.schema.utils import ludwig_dataclass
@@ -3170,3 +3173,14 @@ class TfIdfEncoderConfig(SequenceEncoderConfig):
 
     def can_cache_embeddings(self) -> bool:
         return True
+
+
+@DeveloperAPI
+@register_encoder_config("llm", TEXT, model_types=[MODEL_ECD])
+@ludwig_dataclass
+class LLMEncoder(HFEncoderConfig):
+    type: str = schema_utils.ProtectedString("llm")
+    base_model: str = BaseModelDataclassField()
+    adapter: Optional[BaseAdapterConfig] = AdapterDataclassField()
+    quantization: Optional[QuantizationConfig] = QuantizationConfigField().get_default_field()
+    model_parameters: Optional[ModelParametersConfig] = ModelParametersConfigField().get_default_field()

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -3178,9 +3178,10 @@ class TfIdfEncoderConfig(SequenceEncoderConfig):
 @DeveloperAPI
 @register_encoder_config("llm", TEXT, model_types=[MODEL_ECD])
 @ludwig_dataclass
-class LLMEncoderConfig(HFEncoderConfig):
+class LLMEncoderConfig(SequenceEncoderConfig):
     type: str = schema_utils.ProtectedString("llm")
     base_model: str = BaseModelDataclassField()
+    max_sequence_length: int = schema_utils.Integer(default=None, allow_none=True, parameter_metadata=INTERNAL_ONLY)
     adapter: Optional[BaseAdapterConfig] = AdapterDataclassField()
     quantization: Optional[QuantizationConfig] = QuantizationConfigField().get_default_field()
     model_parameters: Optional[ModelParametersConfig] = ModelParametersConfigField().get_default_field()

--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -3178,7 +3178,7 @@ class TfIdfEncoderConfig(SequenceEncoderConfig):
 @DeveloperAPI
 @register_encoder_config("llm", TEXT, model_types=[MODEL_ECD])
 @ludwig_dataclass
-class LLMEncoder(HFEncoderConfig):
+class LLMEncoderConfig(HFEncoderConfig):
     type: str = schema_utils.ProtectedString("llm")
     base_model: str = BaseModelDataclassField()
     adapter: Optional[BaseAdapterConfig] = AdapterDataclassField()

--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -214,7 +214,7 @@ class MultiNodeCheckpoint(Checkpoint):
 
         # Remove frozen parameter weights from state_dict for adapters and pretrained models
         for n, p in self.model.named_parameters():
-            if not p.requires_grad:
+            if n in state and not p.requires_grad:
                 del state[n]
 
         return state

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 import tempfile
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, TYPE_CHECKING, Union
 
 import torch
 import torch.nn.functional as F
@@ -9,12 +9,15 @@ from bitsandbytes.nn.modules import Embedding
 from transformers import AutoConfig, AutoModelForCausalLM, PreTrainedModel, PreTrainedTokenizer
 
 from ludwig.constants import IGNORE_INDEX_TOKEN_ID, LOGITS, PREDICTIONS, PROBABILITIES
-from ludwig.schema.encoders.text_encoders import LLMEncoderConfig
-from ludwig.schema.model_types.llm import LLMModelConfig
 from ludwig.schema.trainer import LLMTrainerConfig
 from ludwig.utils.error_handling_utils import default_retry
 from ludwig.utils.logging_utils import log_once
 from ludwig.utils.model_utils import find_embedding_layer_with_path
+
+if TYPE_CHECKING:
+    from ludwig.schema.encoders.text_encoders import LLMEncoderConfig
+    from ludwig.schema.model_types.llm import LLMModelConfig
+
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +27,7 @@ FALLBACK_CONTEXT_LEN = 2048
 
 @default_retry(tries=8)
 def load_pretrained_from_config(
-    config_obj: Union[LLMModelConfig, LLMEncoderConfig],
+    config_obj: Union["LLMModelConfig", "LLMEncoderConfig"],
     model_config: Optional[AutoConfig] = None,
     weights_save_path: Optional[str] = None,
 ) -> PreTrainedModel:

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -46,7 +46,8 @@ def load_pretrained_from_config(
         # Apply quantization configuration at model load time
         load_kwargs["torch_dtype"] = getattr(torch, config_obj.quantization.bnb_4bit_compute_dtype)
         load_kwargs["quantization_config"] = config_obj.quantization.to_bitsandbytes()
-        load_kwargs["device_map"] = "auto"
+        if config_obj.base_model not in _MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION:
+            load_kwargs["device_map"] = "auto"
 
     if config_obj.model_parameters:
         # Add any model specific parameters to the load kwargs

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -15,10 +15,12 @@ from ludwig.constants import (
     BACKEND,
     BASE_MODEL,
     BATCH_SIZE,
+    COMBINER,
     EPOCHS,
     GENERATION,
     INPUT_FEATURES,
     MERGE_ADAPTER_INTO_BASE_MODEL,
+    MODEL_ECD,
     MODEL_LLM,
     MODEL_TYPE,
     OUTPUT_FEATURES,
@@ -1190,3 +1192,25 @@ def test_llm_finetuning_with_embedding_noise(
     preds = convert_preds(preds)
 
     assert preds
+
+
+def test_llm_encoding(tmpdir):
+    dataset_path = os.path.join(tmpdir, "llm_classification_data.csv")
+
+    encoder_config = {
+        TYPE: "llm",
+        BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+    }
+
+    config = {
+        MODEL_TYPE: MODEL_ECD,
+        INPUT_FEATURES: [text_feature(name="input", encoder=encoder_config)],
+        OUTPUT_FEATURES: [category_feature(name="output")],
+        COMBINER: {TYPE: "sequence"},
+        TRAINER: {EPOCHS: 1},
+    }
+
+    generate_data(input_features=config[INPUT_FEATURES], output_features=config[OUTPUT_FEATURES], filename=dataset_path)
+
+    model = LudwigModel(config)
+    model.train(dataset=dataset_path)

--- a/tests/ludwig/encoders/test_llm_encoders.py
+++ b/tests/ludwig/encoders/test_llm_encoders.py
@@ -1,0 +1,137 @@
+import copy
+
+import pytest
+import torch
+from transformers import AutoConfig, PreTrainedModel
+
+from ludwig.encoders.text_encoders import LLMEncoder
+from ludwig.schema.encoders.text_encoders import LLMEncoderConfig
+from ludwig.schema.llms.peft import LoraConfig
+from ludwig.utils.llm_utils import get_context_len
+
+# import os
+
+
+@pytest.fixture()
+def encoder_config() -> LLMEncoderConfig:
+    return LLMEncoderConfig(
+        type="llm",
+        max_sequence_length=256,
+        base_model="HuggingFaceH4/tiny-random-LlamaForCausalLM",
+        adapter=None,
+        quantization=None,
+    )
+
+
+@pytest.fixture()
+def encoder_config_with_adapter(encoder_config) -> LLMEncoderConfig:
+    config = copy.deepcopy(encoder_config)
+    config.adapter = LoraConfig()
+    return config
+
+
+@pytest.fixture()
+def model_config(encoder_config):
+    return AutoConfig.from_pretrained(encoder_config.base_model)
+
+
+class TestLLMEncoder:
+    def test_init(self, encoder_config: LLMEncoderConfig, encoder_config_with_adapter: LLMEncoderConfig, model_config):
+        # Test initializing without an adapter
+        encoder = LLMEncoder(encoder_config=encoder_config)
+
+        assert encoder.model_name == encoder_config.base_model
+        assert isinstance(encoder.model, PreTrainedModel)
+        assert all(map(lambda k: "lora_" not in k, encoder.state_dict().keys()))  # Check adapter was not initialized
+        assert encoder.input_shape == torch.Size([encoder_config.max_sequence_length])
+        assert encoder.output_shape == torch.Size([encoder_config.max_sequence_length, model_config.hidden_size])
+
+        # Test initializing with an adapter
+        from peft import PeftModel
+
+        encoder = LLMEncoder(encoder_config=encoder_config_with_adapter)
+
+        assert encoder.model_name == encoder_config.base_model
+        assert isinstance(encoder.model, PeftModel)
+        assert any(map(lambda k: "lora_" in k, encoder.state_dict().keys()))  # Check adapter was initialized
+        assert encoder.input_shape == torch.Size([encoder_config.max_sequence_length])
+        assert encoder.output_shape == torch.Size([encoder_config.max_sequence_length, model_config.hidden_size])
+
+        # Test that max sequence length falls back to the context length when too large
+        context_len = get_context_len(model_config)
+        cl_config = copy.deepcopy(encoder_config)
+        cl_config.max_sequence_length = context_len + 1
+
+        encoder = LLMEncoder(encoder_config=cl_config)
+
+        assert encoder.model_name == encoder_config.base_model
+        assert isinstance(encoder.model, PreTrainedModel)
+        assert all(map(lambda k: "lora_" not in k, encoder.state_dict().keys()))  # Check adapter was not initialized
+        assert encoder.input_shape == torch.Size([context_len])
+        assert encoder.output_shape == torch.Size([context_len, model_config.hidden_size])
+
+    def test_save_to_state_dict(self, encoder_config: LLMEncoderConfig, tmpdir):
+        # With no adapter, the state dict should only contain the model parameters
+        encoder = LLMEncoder(encoder_config=encoder_config)
+        assert all(map(lambda k: "lora_" not in k, encoder.state_dict().keys()))
+
+    def test_save_to_state_dict_adapter(self, encoder_config_with_adapter: LLMEncoderConfig, tmpdir):
+        # With an adapter, the state dict should only contain adapter parameters
+        encoder = LLMEncoder(encoder_config=encoder_config_with_adapter)
+        assert all(map(lambda k: "lora_" in k, encoder.state_dict().keys()))
+
+    def test_load_from_state_dict(self, encoder_config: LLMEncoderConfig):
+        def weights_init(m):
+            """Reinitialize the weights of a torch module."""
+            if hasattr(m, "weight") and m.weight.ndim > 1:
+                torch.nn.init.xavier_uniform_(m.weight.data)
+
+        # Create two encoders from the same config
+        encoder1 = LLMEncoder(encoder_config=encoder_config)
+        encoder2 = LLMEncoder(encoder_config=encoder_config)
+
+        # Reinitialize the weights of one encoder so the two are not identical
+        encoder2.apply(weights_init)
+
+        # Ensure that the weights are different
+        encoder1_sd = encoder1.state_dict()
+        encoder2_sd = encoder2.state_dict()
+        assert any(map(lambda k: not torch.equal(encoder1_sd[k], encoder2_sd[k]), encoder1_sd.keys()))
+
+        # Load the weights of encoder1 back into encoder2 and ensure the weights are equal
+        encoder2.load_state_dict(encoder1_sd)
+        encoder2_sd = encoder2.state_dict()
+        assert all(map(lambda k: torch.equal(encoder1_sd[k], encoder2_sd[k]), encoder1_sd.keys()))
+
+    # def test_load_from_state_dict_adapter(self, encoder_config_with_adapter: LLMEncoderConfig):
+    #     def weights_init(m):
+    #         """Reinitialize the weights of a torch module."""
+    #         if hasattr(m, "weight") and m.weight.ndim > 1:
+    #             torch.nn.init.xavier_uniform_(m.weight.data)
+
+    #     # Create two encoders from the same config
+    #     encoder1 = LLMEncoder(encoder_config=encoder_config_with_adapter)
+    #     encoder2 = LLMEncoder(encoder_config=encoder_config_with_adapter)
+
+    #     encoder2.apply(weights_init)
+
+    #     encoder1_sd = encoder1.state_dict()
+    #     encoder2_sd = encoder2.state_dict()
+    #     adapter_keys = [k for k in encoder1_sd.keys() if "lora_" in k and "weight" in k]
+    #     model_keys = [k for k in encoder1_sd.keys() if "lora_" not in k]
+
+    #     # The LoRA weights should no longer be equal
+    #     assert all(map(lambda k: not torch.equal(encoder1_sd[k], encoder2_sd[k]), adapter_keys))
+
+    #     # The remaining weights should also no longer be equal
+    #     assert all(map(lambda k: not torch.equal(encoder1_sd[k], encoder2_sd[k]), model_keys))
+
+    #     # Load the weights of encoder1 back into encoder2
+    #     encoder2.load_state_dict(encoder1_sd)
+    #     encoder2_sd = encoder2.state_dict()
+
+    #     # The LoRA weights should now be equal again
+    #     assert all(map(lambda k: torch.equal(encoder1_sd[k], encoder2_sd[k]), adapter_keys))
+
+    #     # The remaining weights should still be unequal
+    #     assert all(map(lambda k: not torch.equal(encoder1_sd[k], encoder2_sd[k]), model_keys))


### PR DESCRIPTION
# Overview

This adds a text encoder for ECD that wraps a pretrained LLM and passes the model's hidden state downstream to the combiner. We reuse large portions of the LLM model type's utitilies, refactored as utility functions rather than `LLM` methods.

## LLM Encoder

The encoder subclasses `SequenceEncoder` and implements custom behavior for working with LLMs, with pieces borrowed from `LLM`. Whereas the `LLM` model type is focused on text generation, the encoder is focused on 1) passing hidden state downstream for predictive tasks and 2) packaging the adapter with the rest of the ECD architecture. Major methods include

- `__init__`: Loads the pretrained model and adapter from config
- `forward`: Takes tokenized text as input and returns the hidden state of the last layer
- `_save_to_state_dict`: Normally, adapter weights are saved with `PEFTModel.save_pretrained`, which writes the weights to file. In ECD, however, additional parameters need to be recorded, particularly the combiner and decoder weights. Since these weights will have been trained alongside a particular adapter, we want to package them together. This method adds custom logic to extract adapter weights as part of the dictionary returned by `model.state_dict()`.
- `load_from_state_dict`: Under the hood, PEFT alters the names of the adapter parameters. This leads to errors loading the state dict back in. This adds additional logic to load the state dict with a PEFT utility then update the `load_state_dict` args to reflect that the adapter state was loaded in.

## Refactored `LLM` Methods

The following methods have been moved from the `LLM` class into `ludwig.utils.llm_utils`:

- `initialize_adapter`: This now takes a `PretrainedModel` as an argumentand returns a `PEFTModel`
- `load_pretrained_from_config`: This was moved from `ludwig.models.llm` with no changes
- `to_device`: This now takes a model and device as arguments and returns the model on device and destination device

