### PR TITLE
Add support for Phi-1 and Phi 1.5

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -21,6 +21,7 @@ from ludwig.utils.data_utils import clear_data_cache
 from ludwig.utils.error_handling_utils import default_retry
 from ludwig.utils.llm_quantization_utils import convert_quantized_linear_to_linear
 from ludwig.utils.llm_utils import (
+    _MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION,
     add_left_padding,
     generate_merged_ids,
     get_context_len,
@@ -87,7 +88,8 @@ def load_pretrained_from_config(
         # Apply quanitzation configuration at model load time
         load_kwargs["torch_dtype"] = getattr(torch, config_obj.quantization.bnb_4bit_compute_dtype)
         load_kwargs["quantization_config"] = config_obj.quantization.to_bitsandbytes()
-        load_kwargs["device_map"] = "auto"
+        if config_obj.base_model not in _MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION:
+            load_kwargs["device_map"] = "auto"
 
     if config_obj.model_parameters:
         # Add any model specific parameters to the load kwargs

--- a/ludwig/schema/llms/base_model.py
+++ b/ludwig/schema/llms/base_model.py
@@ -9,7 +9,7 @@ from ludwig.constants import BASE_MODEL
 from ludwig.error import ConfigValidationError
 from ludwig.schema.metadata import LLM_METADATA
 from ludwig.schema.metadata.parameter_metadata import convert_metadata_to_json
-from ludwig.utils.llm_utils import _PHI_MODEL_MAPPING
+from ludwig.utils.llm_utils import _PHI_BASE_MODEL_MAPPING
 
 # Maps a preset LLM name to the full slash-delimited HF path. If the user chooses a preset LLM, the preset LLM name is
 # replaced with the full slash-delimited HF path using this map, after JSON validation but before config object
@@ -73,8 +73,8 @@ def BaseModelDataclassField():
                 return MODEL_PRESETS[model_name]
             if os.path.isdir(model_name):
                 return model_name
-            if model_name in _PHI_MODEL_MAPPING:
-                return _PHI_MODEL_MAPPING[model_name]
+            if model_name in _PHI_BASE_MODEL_MAPPING:
+                return _PHI_BASE_MODEL_MAPPING[model_name]
             try:
                 AutoConfig.from_pretrained(model_name)
                 return model_name

--- a/ludwig/schema/llms/base_model.py
+++ b/ludwig/schema/llms/base_model.py
@@ -9,6 +9,7 @@ from ludwig.constants import BASE_MODEL
 from ludwig.error import ConfigValidationError
 from ludwig.schema.metadata import LLM_METADATA
 from ludwig.schema.metadata.parameter_metadata import convert_metadata_to_json
+from ludwig.utils.llm_utils import _PHI_MODEL_MAPPING
 
 # Maps a preset LLM name to the full slash-delimited HF path. If the user chooses a preset LLM, the preset LLM name is
 # replaced with the full slash-delimited HF path using this map, after JSON validation but before config object
@@ -72,6 +73,8 @@ def BaseModelDataclassField():
                 return MODEL_PRESETS[model_name]
             if os.path.isdir(model_name):
                 return model_name
+            if model_name in _PHI_MODEL_MAPPING:
+                return _PHI_MODEL_MAPPING[model_name]
             try:
                 AutoConfig.from_pretrained(model_name)
                 return model_name

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -34,7 +34,7 @@ from ludwig.schema.llms.generation import LLMGenerationConfig
 from ludwig.schema.trainer import ECDTrainerConfig
 from ludwig.types import HyperoptConfigDict, ModelConfigDict
 from ludwig.utils.data_utils import get_sanitized_feature_name
-from ludwig.utils.llm_utils import _PHI_MODEL_MAPPING, get_context_len
+from ludwig.utils.llm_utils import _PHI_BASE_MODEL_MAPPING, get_context_len
 
 if TYPE_CHECKING:
     from ludwig.schema.model_types.base import ModelConfig
@@ -319,15 +319,15 @@ def set_llm_parameters(config: "ModelConfig") -> None:
 
 def _replace_phi_model_with_supported_model(config: "ModelConfig") -> None:
     """Replaces the phi model with a supported model that is compatible with the LLM model type."""
-    if config.base_model not in _PHI_MODEL_MAPPING:
+    if config.base_model not in _PHI_BASE_MODEL_MAPPING:
         return
 
     logger.warning(
         f"{config.base_model} does not work correctly out of the box since it requires running remote code."
-        f"Replacing {config.base_model} with {_PHI_MODEL_MAPPING[config.base_model]} as the base LLM model."
+        f"Replacing {config.base_model} with {_PHI_BASE_MODEL_MAPPING[config.base_model]} as the base LLM model."
     )
 
-    config.base_model = _PHI_MODEL_MAPPING[config.base_model]
+    config.base_model = _PHI_BASE_MODEL_MAPPING[config.base_model]
 
 
 def _set_llm_tokenizers(config: "ModelConfig") -> None:

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -34,7 +34,7 @@ from ludwig.schema.llms.generation import LLMGenerationConfig
 from ludwig.schema.trainer import ECDTrainerConfig
 from ludwig.types import HyperoptConfigDict, ModelConfigDict
 from ludwig.utils.data_utils import get_sanitized_feature_name
-from ludwig.utils.llm_utils import get_context_len
+from ludwig.utils.llm_utils import _PHI_MODEL_MAPPING, get_context_len
 
 if TYPE_CHECKING:
     from ludwig.schema.model_types.base import ModelConfig
@@ -307,11 +307,27 @@ def set_llm_parameters(config: "ModelConfig") -> None:
     if config.model_type != MODEL_LLM:
         return
 
+    # Do an in-place replacement for Phi models since they don't work well out of the box
+    _replace_phi_model_with_supported_model(config)
+
     # Set preprocessing parameters for text features for LLM model type
     _set_llm_tokenizers(config)
 
     # Set max_new_tokens in generation config to the max sequence length of the output features
     _set_generation_max_new_tokens(config)
+
+
+def _replace_phi_model_with_supported_model(config: "ModelConfig") -> None:
+    """Replaces the phi model with a supported model that is compatible with the LLM model type."""
+    if config.base_model not in _PHI_MODEL_MAPPING:
+        return
+
+    logger.warning(
+        f"{config.base_model} does not work correctly out of the box since it requires running remote code."
+        f"Replacing {config.base_model} with {_PHI_MODEL_MAPPING[config.base_model]} as the base LLM model."
+    )
+
+    config.base_model = _PHI_MODEL_MAPPING[config.base_model]
 
 
 def _set_llm_tokenizers(config: "ModelConfig") -> None:

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -18,7 +18,13 @@ logger = logging.getLogger(__name__)
 
 FALLBACK_CONTEXT_LEN = 2048
 
-# Phi models as of Transformers 4.36.1 don't support "device_map='auto'" at model load time.
+# The official microsoft phi models don't work out of the box
+_PHI_MODEL_MAPPING = {
+    "microsoft/phi-1": "susnato/phi-1_dev",
+    "microsoft/phi-1.5": "susnato/phi-1_5_dev",
+}
+
+# The susnato Phi models as of Transformers 4.36.1 don't support "device_map='auto'" at model load time.
 _MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION = {"susnato/phi-1_dev", "susnato/phi-1_5_dev"}
 
 

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -20,7 +20,7 @@ FALLBACK_CONTEXT_LEN = 2048
 
 # The official microsoft phi models don't work out of the box because the weights aren't compatiable with HF
 # See https://github.com/huggingface/transformers/issues/28049 for more context.
-_PHI_MODEL_MAPPING = {
+_PHI_BASE_MODEL_MAPPING = {
     "microsoft/phi-1": "susnato/phi-1_dev",
     "microsoft/phi-1.5": "susnato/phi-1_5_dev",
 }

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -18,7 +18,8 @@ logger = logging.getLogger(__name__)
 
 FALLBACK_CONTEXT_LEN = 2048
 
-# The official microsoft phi models don't work out of the box
+# The official microsoft phi models don't work out of the box because the weights aren't compatiable with HF
+# See https://github.com/huggingface/transformers/issues/28049 for more context.
 _PHI_MODEL_MAPPING = {
     "microsoft/phi-1": "susnato/phi-1_dev",
     "microsoft/phi-1.5": "susnato/phi-1_5_dev",


### PR DESCRIPTION
In Transformers 4.36, the transformers library added support for Phi-1 and Phi-1.5 models from Microsoft. However, there are two caveats with using this model:

1. The original models, `microsofot/phi-1` and `micosoft/phi-1.5` don't work out of the box since they require `remote_code` to be trusted because the tensor operations are implemented through `einops` instead of PyTorch. Instead, in the original PR that adds support for Phi based models, they add two models that are supported (https://github.com/huggingface/transformers/pull/26170/files#diff-88cb36bfb13c1dc5f52bb952b74697a1c79e286a1a57e4ed3f20ecd5e9f8749bR25): 
- `susnato/phi-1_dev`
- `susnato/phi-1_5_dev`

This is the recommendation from official phi model docs on huggingface as well: https://huggingface.co/docs/transformers/main/model_doc/phi

```python
from transformers import PhiForCausalLM, AutoTokenizer

# define the model and tokenizer.
model = PhiForCausalLM.from_pretrained("susnato/phi-1_5_dev")
tokenizer = AutoTokenizer.from_pretrained("susnato/phi-1_5_dev")
```

My understanding is that someone from the huggingface team has converted the official weights into huggingface compatible weights under the two new mappings. I've filed an issue here to understand what the expected behavior is supposed to be: https://github.com/huggingface/transformers/issues/28049

2. Both `susnato/phi-1_dev` and `susnato/phi-1_5_dev` don't support to `device_map` auto model load kwarg that we set when we load models in quantized state, say when initializing the model using 4 bit quantization. However, it seems that the model weights get correctly loaded onto the right device depending on the quantization kwargs anyway, so we just skip using this load kwarg for phi based models.

Closes #3630