### PR TITLE
enh: Updating requirements to pin `huggingface-hub>=0.19.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
+huggingface-hub>=0.19.0
 transformers @ git+https://github.com/huggingface/transformers@73de5108e172112bc620cfc0ceebfd27730dba11
 tifffile
 imagecodecs


### PR DESCRIPTION
Follow on from #3832 to also pin huggingface-hub to latest version.