### PR TITLE
fix: Pin pydantic to >=2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ torch>=1.13.0
 torchaudio
 torchtext
 torchvision
-pydantic<2.0
+pydantic>=2.0
 huggingface-hub>=0.19.0
 transformers @ git+https://github.com/huggingface/transformers@73de5108e172112bc620cfc0ceebfd27730dba11
 tifffile


### PR DESCRIPTION
We pinned pydantic to 1.x in #3537 to resolve an incompatibility with `transformers`. #3834 pinned `huggingface-hub to 0.19, which requires `pydantic` 2.x. This PR is to resolve this and any other dependency issues.