### PR TITLE
Unpin transformers in favor of 4.36.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,7 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
-huggingface-hub>=0.19.0
-transformers @ git+https://github.com/huggingface/transformers@73de5108e172112bc620cfc0ceebfd27730dba11
+transformers
 tifffile
 imagecodecs
 tokenizers>=0.13.3


### PR DESCRIPTION
They just issued a patch release for our bug, so we can unpin. There's also no reason to pin huggingface-hub since Ludwig will install the right version based on `transformers`.