### PR TITLE
 fix: Handle missing and unexpected keys during LLMEncoder state dict load, part 2

### DIFF
--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -2535,7 +2535,7 @@ class LLMEncoder(Encoder):
         lists in `incompatible_keys` must be made in-place.
 
         Args:
-            module: The torch modulewith newly loaded state
+            module: The torch module with newly loaded state
             incompatible_keys: A tuple with the lists of missing and unexpected keys that were recorded while loading
         """
         # If no adapter was used, `LLMEncoder.load_state_dict` should use the default `torch.Module.load_state_dict`

--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -2552,7 +2552,7 @@ class LLMEncoder(Encoder):
             for k in missing_keys:
                 # Exclude any adapter weight--those should not be missing. Let torch handle that downstream.
                 if adapter_type_prefix not in k:
-                    sample_model_keys = [p for p in self.named_parameters() if p in k]
+                    sample_model_keys = [p for p, _ in self.named_parameters() if p in k]
                     if sample_model_keys:
                         sample_model_key = sample_model_keys[0]
                         sample_missing_key = k


### PR DESCRIPTION
Followup to #3841. When loading the state dict with fully-qualified parameter names, the post-load hook was unable to properly compare missing keys with local model parameter names. For example, when attempting to remove the key `encoder.model.base_model.model.model.embed_tokens.weight` from the missing keys list, the hook would only be have access to the parameter name `model.base_model.model.model.embed_tokens.weight`.

This adds a parameter name prefix computation to the hook and updates the load_state_dict unit tests to include a wrapper for validating that fully-qualified names are loaded correctly.