### PR TITLE
fix: Add `name` and `description` classmethods to `IA3Config`

### DIFF
--- a/ludwig/schema/llms/peft.py
+++ b/ludwig/schema/llms/peft.py
@@ -524,6 +524,14 @@ class IA3Config(BaseAdapterConfig):
             task_type=task_type,
         )
 
+    @classmethod
+    def name(cls) -> str:
+        return "IA3"
+
+    @classmethod
+    def description(cls) -> str:
+        return LLM_METADATA["adapter"]["ia3"]["type"].long_description
+
 
 @DeveloperAPI
 def get_adapter_conds():


### PR DESCRIPTION
The adapter config objects have `name` and `description` classmethods that are used in the docs. `IA3Config` did not include implementations, so LLM config reference pages in the docs were not being rendered.