### PR TITLE
Add default LoRA target modules for Mixtral and Mixtral instruct

### DIFF
--- a/ludwig/schema/llms/base_model.py
+++ b/ludwig/schema/llms/base_model.py
@@ -41,6 +41,9 @@ MODEL_PRESETS = {
     # Mistral
     "mistral-7b": "mistralai/Mistral-7B-v0.1",
     "mistral-7b-instruct": "mistralai/Mistral-7B-Instruct-v0.1",
+    # Mixtral
+    "mixtral-8x7b": "mistralai/Mixtral-8x7B-v0.1",
+    "mixtral-8x7b-instruct": "mistralai/Mixtral-8x7B-Instruct-v0.1",
     # OPT
     "opt-350m": "facebook/opt-350m",
     "opt-1.3b": "facebook/opt-1.3b",

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -314,7 +314,7 @@ def set_llm_parameters(config: "ModelConfig") -> None:
     _set_generation_max_new_tokens(config)
 
     # HACK(Arnav): Set Mixtral target modules when using LoRA
-    # GitHub issue:
+    # GitHub issue: https://github.com/ludwig-ai/ludwig/issues/3853
     _set_mixtral_target_modules(config)
 
 


### PR DESCRIPTION
PEFT 0.7.1 doesn't have a default LoRA target module mapping: https://github.com/huggingface/peft/blob/8665e2b5719faa4e4b91749ddec09442927b53e0/src/peft/utils/constants.py#L49

This PR adds support to default to `q_proj` and `v_proj` for mixtral and mixtral instruct in the instance that the `target_modules` aren't explicitly specified for mixtral. 