### PR TITLE
[Maintenance] Bump minimum tokenizers to 0.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pydantic<2.0
 transformers>=4.36.0
 tifffile
 imagecodecs
-tokenizers>=0.14
+tokenizers>=0.15
 spacy>=2.3
 PyYAML>=3.12,<6.0.1,!=5.4.* #Exlude PyYAML 5.4.* due to incompatibility with awscli
 absl-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pydantic<2.0
 transformers>=4.36.0
 tifffile
 imagecodecs
-tokenizers>=0.13.3
+tokenizers>=0.14
 spacy>=2.3
 PyYAML>=3.12,<6.0.1,!=5.4.* #Exlude PyYAML 5.4.* due to incompatibility with awscli
 absl-py


### PR DESCRIPTION
Required for transformers 4.36

```
The conflict is caused by:
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
    ludwig 0.9.dev0 depends on tokenizers>=0.13.3
    ludwig[test] 0.9.dev0 depends on tokenizers>=0.13.3
    transformers 4.36.2 depends on tokenizers<0.19 and >=0.14
    ludwig 0.9.dev0 depends on tokenizers>=0.13.3
    ludwig[test] 0.9.dev0 depends on tokenizers>=0.13.3
    transformers 4.36.1 depends on tokenizers<0.19 and >=0.14
    ludwig 0.9.dev0 depends on tokenizers>=0.13.3
    ludwig[test] 0.9.dev0 depends on tokenizers>=0.13.3
    transformers 4.36.0 depends on tokenizers<0.19 and >=0.14
```

Tokenizers 0.14 is linked to huggingface hub < 0.17, but transformers 4.36 requires huggingface hub >= 0.19