### PR TITLE
Revert hack that leads to OOM during fine-tuning

### DIFF
--- a/ludwig/distributed/base.py
+++ b/ludwig/distributed/base.py
@@ -48,15 +48,6 @@ class DistributedStrategy(ABC):
         """
         pass
 
-    def eval(self, model: nn.Module):
-        model.eval()
-
-    def train(self, model: nn.Module, prev_model_training_mode: bool = None):
-        if prev_model_training_mode is not None:
-            model.train(prev_model_training_mode)
-        else:
-            model.train()
-
     def prepare_for_inference(self, model: nn.Module) -> nn.Module:
         return model
 
@@ -207,10 +198,6 @@ class DistributedStrategy(ABC):
 
 
 class LocalStrategy(DistributedStrategy):
-    def __init__(self):
-        super().__init__()
-        self.module_name_to_prev_training_mode = {}
-
     def prepare(
         self,
         model: nn.Module,
@@ -218,28 +205,6 @@ class LocalStrategy(DistributedStrategy):
         base_learning_rate: float,
     ) -> tuple[nn.Module, Optimizer]:
         return model, create_optimizer(model, trainer_config.optimizer, base_learning_rate)
-
-    def eval(self, model):
-        # HACK(geoffrey): use vanilla model.eval()
-        # when https://github.com/huggingface/transformers/issues/28023 is resolved.
-        for module_name, module in model.named_modules():
-            self.module_name_to_prev_training_mode[module_name] = module.training
-            module.eval()
-
-    def train(self, model, prev_model_training_mode=None):
-        """If mode is None, restore previous training mode."""
-        # HACK(geoffrey): use vanilla model.train(prev_model_training_mode)
-        # when https://github.com/huggingface/transformers/issues/28023 is resolved.
-        # This hack ignores module.training updates if the model is already in training mode
-        # (to avoid touching LoRA configuration). Otherwise, the model was in eval mode, so we
-        # restore the previous training mode. We do not use prev_model_training_mode because we store the history
-        # as a dictionary mapping to training mode to each module.
-        if model.training:
-            return
-
-        for module_name, module in model.named_modules():
-            if module_name in self.module_name_to_prev_training_mode:
-                module.train(self.module_name_to_prev_training_mode[module_name])
 
     def size(self) -> int:
         return 1

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -987,7 +987,8 @@ class Trainer(BaseTrainer):
                     # epoch init
                     start_time = time.time()
 
-                    self.distributed.train(self.dist_model)
+                    # Reset the metrics at the start of the next epoch
+                    self.dist_model.train()  # Sets model to training mode.
                     self.model.reset_metrics()
 
                     self.callback(lambda c: c.on_epoch_start(self, progress_tracker, save_path))

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
-transformers>=4.36.0
+transformers>=4.36.2
 tifffile
 imagecodecs
 tokenizers>=0.13.3


### PR DESCRIPTION
A few weeks ago, we merged https://github.com/ludwig-ai/ludwig/pull/3830 to temporarily get around an issue of fine-tuning with gradient checkpointing that was introduced with Transformers 4.36. The original issue can be seen here: https://github.com/huggingface/transformers/issues/28023

Since then, they've released a patch release (Transformers 4.36.2) that fixes the original issue for all model types, including Llama-2, Mixtral, Phi etc. However, it seems like the overall interaction between the new transformers version and our hacky fix leads to memory ballooning because we manually map each module to the correct mode, and in the process, set some modules to train mode when they shouldn't be which causes the memory to balloon. 

This PR is no longer needed if transformers is set to use 4.36.2 since it has the patch release. I've pinned the minimum version of transformers to this version as part of this PR. 