### PR TITLE
Allow hyperopt config to be loaded from a file

### DIFF
--- a/ludwig/hyperopt/run.py
+++ b/ludwig/hyperopt/run.py
@@ -205,7 +205,7 @@ def hyperopt(
     else:
         config_dict = config
 
-    if HYPEROPT not in config:
+    if HYPEROPT not in config_dict:
         raise ValueError("Hyperopt Section not present in config")
 
     # backwards compatibility


### PR DESCRIPTION
Currently a bug in the main Ludwig hyperopt codepath where it assumes the config is an object, but the passed in config also allows the config to be a "str". If it is a str, then we assume it's a path and load the config from disk. Unfortunately, our check to make sure that the 'hyperopt' section of the config is present is incorrect. 

This was reported in #3850 and closes this issue. 