### PR TITLE
Add a utility to detect LLM usage in a config

### DIFF
--- a/ludwig/utils/config_utils.py
+++ b/ludwig/utils/config_utils.py
@@ -105,7 +105,7 @@ def has_pretrained_encoder(config: ModelConfig) -> bool:
     return False
 
 
-def is_or_uses_llm(config: Union[Dict[str, Any], ModelConfig]) -> bool:
+def config_uses_llm(config: Union[Dict[str, Any], ModelConfig]) -> bool:
     """Determine if a config uses an LLM.
 
     Args:

--- a/ludwig/utils/config_utils.py
+++ b/ludwig/utils/config_utils.py
@@ -1,7 +1,20 @@
-from typing import Set
+from typing import Any, Dict, Set, Union
 
 from ludwig.api_annotations import DeveloperAPI
-from ludwig.constants import DECODER, ENCODER, IMAGE, PREPROCESSING, SEQUENCE, TEXT, TIMESERIES, TYPE
+from ludwig.constants import (
+    DECODER,
+    ENCODER,
+    IMAGE,
+    INPUT_FEATURES,
+    MODEL_ECD,
+    MODEL_LLM,
+    MODEL_TYPE,
+    PREPROCESSING,
+    SEQUENCE,
+    TEXT,
+    TIMESERIES,
+    TYPE,
+)
 from ludwig.features.feature_registries import get_input_type_registry
 from ludwig.schema.model_config import ModelConfig
 from ludwig.types import FeatureConfigDict, FeatureTypeDefaultsDict, PreprocessingConfigDict
@@ -90,3 +103,42 @@ def has_pretrained_encoder(config: ModelConfig) -> bool:
         if feature.encoder.is_pretrained():
             return True
     return False
+
+
+def is_or_uses_llm(config: Union[Dict[str, Any], ModelConfig]) -> bool:
+    """Determine if a config uses an LLM.
+
+    Args:
+        config: Ludwig config object or dictionary
+
+    Returns:
+        True if the model type is LLM or if the model uses and LLM encoder, otherwise False.
+    """
+    uses_llm = False
+
+    # For a valid config, model_type LLM is automatically True
+    # ECD or GBM models need to be checked for at least one LLM text encoder
+    if isinstance(config, ModelConfig):
+        if config.model_type == MODEL_LLM:
+            uses_llm = True
+        else:
+            for feature in config.input_features:
+                if feature.encoder and feature.encoder.type == MODEL_LLM:
+                    uses_llm = True
+                    break
+    elif isinstance(config, dict) and config:
+        if config.get(MODEL_TYPE, MODEL_ECD) == MODEL_LLM:
+            uses_llm = True
+        elif INPUT_FEATURES in config:
+            for feature in config.get(INPUT_FEATURES, []):
+                if feature.get(ENCODER, {}).get(TYPE) == MODEL_LLM:
+                    uses_llm = True
+                    break
+        else:
+            raise ValueError(
+                "Invalid config cannot be checked for LLM usage because it has no input features." f"Config: {config}"
+            )
+    else:
+        raise ValueError(f"Invalid config cannot be checked for LLM usage. Config: {config}")
+
+    return uses_llm

--- a/tests/ludwig/utils/test_config_utils.py
+++ b/tests/ludwig/utils/test_config_utils.py
@@ -2,10 +2,25 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from ludwig.constants import MODEL_ECD, TEXT, TYPE
+from ludwig.constants import (
+    BASE_MODEL,
+    BINARY,
+    ENCODER,
+    INPUT_FEATURES,
+    MODEL_ECD,
+    MODEL_GBM,
+    MODEL_LLM,
+    MODEL_TYPE,
+    NAME,
+    OUTPUT_FEATURES,
+    TEXT,
+    TYPE,
+)
 from ludwig.schema.encoders.text_encoders import BERTConfig
 from ludwig.schema.encoders.utils import get_encoder_cls
 from ludwig.schema.features.preprocessing.text import TextPreprocessingConfig
+from ludwig.schema.model_config import ModelConfig
+from ludwig.utils.config_utils import is_or_uses_llm
 
 
 @pytest.mark.parametrize(
@@ -57,3 +72,129 @@ def test_set_fixed_preprocessing_params_cache_embeddings(encoder_params: Dict[st
     encoder = get_encoder_cls(MODEL_ECD, TEXT, encoder_params[TYPE]).from_dict(encoder_params)
     encoder.set_fixed_preprocessing_params(MODEL_ECD, preprocessing)
     assert preprocessing.cache_encoder_embeddings == expected
+
+
+@pytest.fixture()
+def llm_config_dict():
+    return {
+        MODEL_TYPE: MODEL_LLM,
+        BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+        INPUT_FEATURES: [{TYPE: TEXT, NAME: "in1"}],
+        OUTPUT_FEATURES: [{TYPE: TEXT, NAME: "out1"}],
+    }
+
+
+@pytest.fixture()
+def llm_config_object(llm_config_dict):
+    return ModelConfig.from_dict(llm_config_dict)
+
+
+@pytest.fixture()
+def ecd_config_dict_llm_encoder():
+    return {
+        MODEL_TYPE: MODEL_ECD,
+        INPUT_FEATURES: [
+            {
+                TYPE: TEXT,
+                NAME: "in1",
+                ENCODER: {TYPE: MODEL_LLM, BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM"},
+            }
+        ],
+        OUTPUT_FEATURES: [{TYPE: BINARY, NAME: "out1"}],
+    }
+
+
+@pytest.fixture()
+def ecd_config_object_llm_encoder(ecd_config_dict_llm_encoder):
+    return ModelConfig.from_dict(ecd_config_dict_llm_encoder)
+
+
+@pytest.fixture()
+def ecd_config_dict_llm_encoder_multiple_features():
+    return {
+        MODEL_TYPE: MODEL_ECD,
+        INPUT_FEATURES: [
+            {TYPE: BINARY, NAME: "in1"},
+            {
+                TYPE: TEXT,
+                NAME: "in2",
+                ENCODER: {TYPE: MODEL_LLM, BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM"},
+            },
+        ],
+        OUTPUT_FEATURES: [{TYPE: BINARY, NAME: "out1"}],
+    }
+
+
+@pytest.fixture()
+def ecd_config_object_llm_encoder_multiple_features(ecd_config_dict_llm_encoder_multiple_features):
+    return ModelConfig.from_dict(ecd_config_dict_llm_encoder_multiple_features)
+
+
+@pytest.fixture()
+def ecd_config_dict_no_llm_encoder():
+    return {
+        MODEL_TYPE: MODEL_ECD,
+        INPUT_FEATURES: [{TYPE: TEXT, NAME: "in1", ENCODER: {TYPE: "parallel_cnn"}}],
+        OUTPUT_FEATURES: [{TYPE: BINARY, NAME: "out1"}],
+    }
+
+
+@pytest.fixture()
+def ecd_config_object_no_llm_encoder(ecd_config_dict_no_llm_encoder):
+    return ModelConfig.from_dict(ecd_config_dict_no_llm_encoder)
+
+
+@pytest.fixture()
+def ecd_config_dict_no_text_features():
+    return {
+        MODEL_TYPE: MODEL_ECD,
+        INPUT_FEATURES: [{TYPE: BINARY, NAME: "in1"}],
+        OUTPUT_FEATURES: [{TYPE: BINARY, NAME: "out1"}],
+    }
+
+
+@pytest.fixture()
+def ecd_config_object_no_text_features(ecd_config_dict_no_text_features):
+    return ModelConfig.from_dict(ecd_config_dict_no_text_features)
+
+
+@pytest.fixture()
+def gbm_config_dict_llm_encoder():
+    return {
+        MODEL_TYPE: MODEL_GBM,
+        INPUT_FEATURES: [{TYPE: TEXT, NAME: "in1", ENCODER: {TYPE: "tf_idf"}}],
+        OUTPUT_FEATURES: [{TYPE: BINARY, NAME: "out1"}],
+    }
+
+
+@pytest.fixture()
+def gbm_config_object_llm_encoder(gbm_config_dict_llm_encoder):
+    return ModelConfig.from_dict(gbm_config_dict_llm_encoder)
+
+
+@pytest.mark.parametrize(
+    "config,expectation",
+    [
+        # LLM configurations
+        ("llm_config_dict", True),
+        ("llm_config_object", True),
+        # LLM encoder configurations
+        ("ecd_config_dict_llm_encoder", True),
+        ("ecd_config_object_llm_encoder", True),
+        # LLM encoder configurations, multiple features
+        ("ecd_config_dict_llm_encoder_multiple_features", True),
+        ("ecd_config_object_llm_encoder_multiple_features", True),
+        # ECD configuration with text feature and non-LLM encoder
+        ("ecd_config_dict_no_llm_encoder", False),
+        ("ecd_config_object_no_llm_encoder", False),
+        # ECD configuration with no text features
+        ("ecd_config_dict_no_text_features", False),
+        ("ecd_config_object_no_text_features", False),
+        # GBM configuration. "tf_idf" is the only valid text encoder
+        ("gbm_config_dict_llm_encoder", False),
+        ("gbm_config_object_llm_encoder", False),
+    ],
+)
+def test_is_or_uses_llm(config, expectation, request):
+    config = request.getfixturevalue(config)
+    assert is_or_uses_llm(config) == expectation

--- a/tests/ludwig/utils/test_config_utils.py
+++ b/tests/ludwig/utils/test_config_utils.py
@@ -20,7 +20,7 @@ from ludwig.schema.encoders.text_encoders import BERTConfig
 from ludwig.schema.encoders.utils import get_encoder_cls
 from ludwig.schema.features.preprocessing.text import TextPreprocessingConfig
 from ludwig.schema.model_config import ModelConfig
-from ludwig.utils.config_utils import is_or_uses_llm
+from ludwig.utils.config_utils import config_uses_llm
 
 
 @pytest.mark.parametrize(
@@ -207,7 +207,7 @@ def test_is_or_uses_llm(config, expectation, request):
         request: pytest `request` fixture
     """
     config = request.getfixturevalue(config)
-    assert is_or_uses_llm(config) == expectation
+    assert config_uses_llm(config) == expectation
 
 
 @pytest.mark.parametrize("invalid_config", [1, 1.0, "foo", True, False, None, [], {}, {"foo": "bar"}])
@@ -217,4 +217,4 @@ def test_is_or_uses_llm_invalid_input(invalid_config):
     These should all raise an exception.
     """
     with pytest.raises(ValueError):
-        is_or_uses_llm(invalid_config)
+        config_uses_llm(invalid_config)

--- a/tests/ludwig/utils/test_config_utils.py
+++ b/tests/ludwig/utils/test_config_utils.py
@@ -75,7 +75,7 @@ def test_set_fixed_preprocessing_params_cache_embeddings(encoder_params: Dict[st
 
 
 @pytest.fixture()
-def llm_config_dict():
+def llm_config_dict() -> Dict[str, Any]:
     return {
         MODEL_TYPE: MODEL_LLM,
         BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
@@ -85,12 +85,12 @@ def llm_config_dict():
 
 
 @pytest.fixture()
-def llm_config_object(llm_config_dict):
+def llm_config_object(llm_config_dict: Dict[str, Any]) -> ModelConfig:
     return ModelConfig.from_dict(llm_config_dict)
 
 
 @pytest.fixture()
-def ecd_config_dict_llm_encoder():
+def ecd_config_dict_llm_encoder() -> Dict[str, Any]:
     return {
         MODEL_TYPE: MODEL_ECD,
         INPUT_FEATURES: [
@@ -105,12 +105,12 @@ def ecd_config_dict_llm_encoder():
 
 
 @pytest.fixture()
-def ecd_config_object_llm_encoder(ecd_config_dict_llm_encoder):
+def ecd_config_object_llm_encoder(ecd_config_dict_llm_encoder: Dict[str, Any]) -> ModelConfig:
     return ModelConfig.from_dict(ecd_config_dict_llm_encoder)
 
 
 @pytest.fixture()
-def ecd_config_dict_llm_encoder_multiple_features():
+def ecd_config_dict_llm_encoder_multiple_features() -> Dict[str, Any]:
     return {
         MODEL_TYPE: MODEL_ECD,
         INPUT_FEATURES: [
@@ -126,12 +126,14 @@ def ecd_config_dict_llm_encoder_multiple_features():
 
 
 @pytest.fixture()
-def ecd_config_object_llm_encoder_multiple_features(ecd_config_dict_llm_encoder_multiple_features):
+def ecd_config_object_llm_encoder_multiple_features(
+    ecd_config_dict_llm_encoder_multiple_features: Dict[str, Any]
+) -> ModelConfig:
     return ModelConfig.from_dict(ecd_config_dict_llm_encoder_multiple_features)
 
 
 @pytest.fixture()
-def ecd_config_dict_no_llm_encoder():
+def ecd_config_dict_no_llm_encoder() -> Dict[str, Any]:
     return {
         MODEL_TYPE: MODEL_ECD,
         INPUT_FEATURES: [{TYPE: TEXT, NAME: "in1", ENCODER: {TYPE: "parallel_cnn"}}],
@@ -140,12 +142,12 @@ def ecd_config_dict_no_llm_encoder():
 
 
 @pytest.fixture()
-def ecd_config_object_no_llm_encoder(ecd_config_dict_no_llm_encoder):
+def ecd_config_object_no_llm_encoder(ecd_config_dict_no_llm_encoder: Dict[str, Any]) -> ModelConfig:
     return ModelConfig.from_dict(ecd_config_dict_no_llm_encoder)
 
 
 @pytest.fixture()
-def ecd_config_dict_no_text_features():
+def ecd_config_dict_no_text_features() -> Dict[str, Any]:
     return {
         MODEL_TYPE: MODEL_ECD,
         INPUT_FEATURES: [{TYPE: BINARY, NAME: "in1"}],
@@ -154,12 +156,12 @@ def ecd_config_dict_no_text_features():
 
 
 @pytest.fixture()
-def ecd_config_object_no_text_features(ecd_config_dict_no_text_features):
+def ecd_config_object_no_text_features(ecd_config_dict_no_text_features: Dict[str, Any]) -> ModelConfig:
     return ModelConfig.from_dict(ecd_config_dict_no_text_features)
 
 
 @pytest.fixture()
-def gbm_config_dict_llm_encoder():
+def gbm_config_dict_llm_encoder() -> Dict[str, Any]:
     return {
         MODEL_TYPE: MODEL_GBM,
         INPUT_FEATURES: [{TYPE: TEXT, NAME: "in1", ENCODER: {TYPE: "tf_idf"}}],
@@ -168,7 +170,7 @@ def gbm_config_dict_llm_encoder():
 
 
 @pytest.fixture()
-def gbm_config_object_llm_encoder(gbm_config_dict_llm_encoder):
+def gbm_config_object_llm_encoder(gbm_config_dict_llm_encoder: Dict[str, Any]) -> ModelConfig:
     return ModelConfig.from_dict(gbm_config_dict_llm_encoder)
 
 
@@ -196,5 +198,13 @@ def gbm_config_object_llm_encoder(gbm_config_dict_llm_encoder):
     ],
 )
 def test_is_or_uses_llm(config, expectation, request):
+    """Test LLM detection on a variety of configs. Configs that use an LLM anywhere should return True, otherwise
+    False.
+
+    Args:
+        config: The name of the config fixture to test
+        expectation: The expected result
+        request: pytest `request` fixture
+    """
     config = request.getfixturevalue(config)
     assert is_or_uses_llm(config) == expectation

--- a/tests/ludwig/utils/test_config_utils.py
+++ b/tests/ludwig/utils/test_config_utils.py
@@ -208,3 +208,13 @@ def test_is_or_uses_llm(config, expectation, request):
     """
     config = request.getfixturevalue(config)
     assert is_or_uses_llm(config) == expectation
+
+
+@pytest.mark.parametrize("invalid_config", [1, 1.0, "foo", True, False, None, [], {}, {"foo": "bar"}])
+def test_is_or_uses_llm_invalid_input(invalid_config):
+    """Sanity checks for invalid config handling.
+
+    These should all raise an exception.
+    """
+    with pytest.raises(ValueError):
+        is_or_uses_llm(invalid_config)


### PR DESCRIPTION
The LLM encoder in ECD needs to share large parts of the code base with the LLM model type, but branching currently inspects configs for model type only. This adds a utility that detects LLM model type or the usage of LLM encoder in text features for ECD models (LLM encoder is not currently valid for GBM). This can be used as a replacement for expressions like `if config.model_type =="llm":`.