### PR TITLE
Add batch size tuning for LLMs

### DIFF
--- a/ludwig/models/embedder.py
+++ b/ludwig/models/embedder.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -73,7 +73,7 @@ def create_embed_batch_size_evaluator(
             self.embedder = embedder.to(self.device)
             self.embedder.eval()
 
-        def step(self, batch_size: int):
+        def step(self, batch_size: int, global_max_sequence_length: Optional[int] = None):
             inputs = {
                 input_feature_name: input_feature.create_sample_input(batch_size=batch_size).to(self.device)
                 for input_feature_name, input_feature in self.embedder.input_features.items()

--- a/ludwig/models/retrieval.py
+++ b/ludwig/models/retrieval.py
@@ -186,7 +186,7 @@ def create_semantic_retrieval_model_evaluator(
             self.model = model.to(get_torch_device())
             self.samples = samples
 
-        def step(self, batch_size: int):
+        def step(self, batch_size: int, global_max_sequence_length: Optional[int] = None):
             self.model.encode(self.samples[:batch_size], batch_size=batch_size, show_progress_bar=False)
 
     return _RetrievalModelEvaluator

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -552,6 +552,7 @@ class Trainer(BaseTrainer):
         snapshot_weights: bool = True,
         on_best_batch_size_updated: Optional[Callable[[int, float, int], None]] = None,
         tune_for_training: bool = True,
+        max_sequence_length: Optional[int] = None,
     ) -> int:
         logger.info("Tuning batch size...")
         skip_save_model = self.skip_save_model
@@ -592,7 +593,7 @@ class Trainer(BaseTrainer):
                 checkpoint.save(os.path.join(tmpdir, "latest.ckpt"), global_step=0)
             try:
                 best_batch_size = evaluator.select_best_batch_size(
-                    len(training_set), max_batch_size, max_trials, self.is_coordinator()
+                    len(training_set), max_batch_size, max_trials, self.is_coordinator(), max_sequence_length
                 )
                 best_batch_size = self.distributed.broadcast_object(best_batch_size)
 
@@ -626,7 +627,7 @@ class Trainer(BaseTrainer):
                 trainer.model.reset_metrics()
                 trainer.optimizer.zero_grad()
 
-            def step(self, batch_size: int):
+            def step(self, batch_size: int, max_sequence_length: Optional[int] = None):
                 trainer.distributed.set_batch_size(trainer.dist_model, batch_size)
                 inputs = {
                     input_feature_name: input_feature.create_sample_input(batch_size=batch_size).to(trainer.device)
@@ -648,7 +649,7 @@ class Trainer(BaseTrainer):
                 trainer.model.reset_metrics()
                 trainer.optimizer.zero_grad()
 
-            def step(self, batch_size: int):
+            def step(self, batch_size: int, max_sequence_length: Optional[int] = None):
                 trainer.distributed.set_batch_size(trainer.dist_model, batch_size)
                 inputs = {
                     input_feature_name: input_feature.create_sample_input(batch_size=batch_size).to(trainer.device)

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -552,7 +552,7 @@ class Trainer(BaseTrainer):
         snapshot_weights: bool = True,
         on_best_batch_size_updated: Optional[Callable[[int, float, int], None]] = None,
         tune_for_training: bool = True,
-        max_sequence_length: Optional[int] = None,
+        global_max_sequence_length: Optional[int] = None,
     ) -> int:
         logger.info("Tuning batch size...")
         skip_save_model = self.skip_save_model
@@ -593,7 +593,7 @@ class Trainer(BaseTrainer):
                 checkpoint.save(os.path.join(tmpdir, "latest.ckpt"), global_step=0)
             try:
                 best_batch_size = evaluator.select_best_batch_size(
-                    len(training_set), max_batch_size, max_trials, self.is_coordinator(), max_sequence_length
+                    len(training_set), max_batch_size, max_trials, self.is_coordinator(), global_max_sequence_length
                 )
                 best_batch_size = self.distributed.broadcast_object(best_batch_size)
 
@@ -627,7 +627,7 @@ class Trainer(BaseTrainer):
                 trainer.model.reset_metrics()
                 trainer.optimizer.zero_grad()
 
-            def step(self, batch_size: int, max_sequence_length: Optional[int] = None):
+            def step(self, batch_size: int, global_max_sequence_length: Optional[int] = None):
                 trainer.distributed.set_batch_size(trainer.dist_model, batch_size)
                 inputs = {
                     input_feature_name: input_feature.create_sample_input(batch_size=batch_size).to(trainer.device)
@@ -649,7 +649,7 @@ class Trainer(BaseTrainer):
                 trainer.model.reset_metrics()
                 trainer.optimizer.zero_grad()
 
-            def step(self, batch_size: int, max_sequence_length: Optional[int] = None):
+            def step(self, batch_size: int, global_max_sequence_length: Optional[int] = None):
                 trainer.distributed.set_batch_size(trainer.dist_model, batch_size)
                 inputs = {
                     input_feature_name: input_feature.create_sample_input(batch_size=batch_size).to(trainer.device)

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -492,7 +492,7 @@ class FineTuneTrainer(Trainer):
                 input_feature_name, input_feature = trainer.model.input_features.items()[0]
                 output_feature_name, output_feature = trainer.model.output_features.items()[0]
                 input_msl = input_feature.input_shape[0]
-                output_msl = output_feature.output_shape[0]
+                output_msl = trainer.model.config_obj.output_features[0].preprocessing.max_sequence_length
                 if global_max_sequence_length is not None and input_msl + output_msl > global_max_sequence_length:
                     # In this case, we just need to make sure that the length of the synthetic data exceeds max_sequence_length
                     input_msl = global_max_sequence_length/2 + 1

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -511,10 +511,14 @@ class FineTuneTrainer(Trainer):
                 self.input_msl = self.input_feature.input_shape[0]
                 # Get the length of the longest output sequence from the training data
                 self.output_msl = self.output_feature.output_shape[0]
+                # max_sequence_length here is the smaller value between the global max sequence length of the model
+                # and the model's context length
+                if trainer.model.config_obj.output_features[0].preprocessing.max_sequence_length:
+                    self.output_msl = trainer.model.config_obj.output_features[0].preprocessing.max_sequence_length
 
                 # This is useful to create the synthetic input and target data which will be a
                 # random sequence of integers between 0 and vocab_size
-                self.vocab_size = None
+                self.vocab_size = len(trainer.model.config_obj.input_features[0].encoder.vocab)
 
             def reset(self):
                 trainer.model.reset_metrics()
@@ -523,22 +527,13 @@ class FineTuneTrainer(Trainer):
             def step(self, batch_size: int, global_max_sequence_length: int):
                 trainer.distributed.set_batch_size(trainer.dist_model, batch_size)
 
-                if not self.vocab_size:
-                    self.vocab_size = len(trainer.model.config_obj.input_features[0].encoder.vocab)
-
-                # max_sequence_length here is the smaller value between the global max sequence length of the model
-                # and the model's context length
-                if trainer.model.config_obj.output_features[0].preprocessing.max_sequence_length:
-                    self.output_msl = trainer.model.config_obj.output_features[0].preprocessing.max_sequence_length
-
+                input_msl = self.input_msl
+                output_msl = self.output_msl
                 if self.input_msl + self.output_msl > global_max_sequence_length:
                     # In this case, we just need to make sure that the length of the synthetic data exceeds
                     # max_sequence_length by at most a small amount
                     input_msl = global_max_sequence_length // 2 + 1
                     output_msl = global_max_sequence_length // 2 + 1
-                else:
-                    input_msl = self.input_msl
-                    output_msl = self.output_msl
 
                 inputs = {
                     self.input_feature_name: torch.randint(0, self.vocab_size, size=(batch_size, input_msl))

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+import torch
 from typing import Callable, Dict, List, Optional, Union
 
 from torch.utils.tensorboard import SummaryWriter
@@ -18,6 +19,7 @@ from ludwig.trainers.registry import register_llm_ray_trainer, register_llm_trai
 from ludwig.trainers.trainer import Trainer
 from ludwig.types import ModelConfigDict
 from ludwig.utils import time_utils
+from ludwig.utils.batch_size_tuner import BatchSizeEvaluator
 from ludwig.utils.defaults import default_random_seed
 from ludwig.utils.metric_utils import TrainerMetric
 from ludwig.utils.metrics_printed_table import print_metrics_table
@@ -470,7 +472,40 @@ class FineTuneTrainer(Trainer):
 
         progress_tracker.llm_eval_examples = llm_eval_examples
         return append_metrics(self.model, dataset_name, metrics, metrics_log, progress_tracker)
+    
+    def tune_batch_size(self, config: ModelConfigDict, training_set: Dataset, random_seed: int = default_random_seed, max_trials: int = 20, halving_limit: int = 3, snapshot_weights: bool = True, on_best_batch_size_updated: Optional[Callable[[int, float, int], None]] = None, tune_for_training: bool = True, max_sequence_length: Optional[int] = None) -> int:
+        if max_sequence_length is None:
+            max_sequence_length = self.model.global_max_sequence_length
+        return super().tune_batch_size(config, training_set, random_seed, max_trials, halving_limit, snapshot_weights, on_best_batch_size_updated, tune_for_training, max_sequence_length)
 
+    def _create_batch_size_evaluator(self) -> BatchSizeEvaluator:
+        trainer = self
+
+        class _TrainerBatchSizeEvaluator(BatchSizeEvaluator):
+            def reset(self):
+                trainer.model.reset_metrics()
+                trainer.optimizer.zero_grad()
+
+            def step(self, batch_size: int, max_sequence_length: Optional[int] = None):
+                # max_sequence_length here is the smaller value between the global max sequence length of the model and the model's context length
+                trainer.distributed.set_batch_size(trainer.dist_model, batch_size)
+                input_feature_name, input_feature = trainer.model.input_features.items()[0]
+                output_feature_name, output_feature = trainer.model.output_features.items()[0]
+                input_msl = input_feature.input_shape[0]
+                output_msl = output_feature.output_shape[0]
+                if max_sequence_length is not None and input_msl + output_msl > max_sequence_length:
+                    # In this case, we just need to make sure that the length of the synthetic data exceeds max_sequence_length
+                    input_msl = max_sequence_length/2 + 1
+                    output_msl = max_sequence_length/2 + 1
+                inputs = {
+                    input_feature_name: torch.rand([batch_size, input_msl]).to(input_feature.input_dtype).to(trainer.device)
+                }
+                targets = {
+                    output_feature_name: torch.rand([batch_size, output_msl]).to(output_feature.get_output_dtype()).to(trainer.device)
+                }
+                trainer.train_step(inputs, targets)
+
+        return _TrainerBatchSizeEvaluator()
 
 class RemoteLLMTrainer(NoneTrainer):
     def __init__(self, gpus=None, gpu_memory_limit=None, allow_parallel_threads=True, **kwargs):

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -495,11 +495,11 @@ class FineTuneTrainer(Trainer):
                 if trainer.model.config_obj.output_features[0].preprocessing.max_sequence_length:
                     output_msl = trainer.model.config_obj.output_features[0].preprocessing.max_sequence_length
                 else:
-                    output_msl = global_max_sequence_length/2 + 1
+                    output_msl = global_max_sequence_length//2 + 1
                 if input_msl + output_msl > global_max_sequence_length:
                     # In this case, we just need to make sure that the length of the synthetic data exceeds max_sequence_length
-                    input_msl = global_max_sequence_length/2 + 1
-                    output_msl = global_max_sequence_length/2 + 1
+                    input_msl = global_max_sequence_length//2 + 1
+                    output_msl = global_max_sequence_length//2 + 1
                 inputs = {
                     input_feature_name: torch.rand([batch_size, input_msl]).to(input_feature.input_dtype).to(trainer.device)
                 }

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -491,7 +491,7 @@ class FineTuneTrainer(Trainer):
                 trainer.distributed.set_batch_size(trainer.dist_model, batch_size)
                 input_feature_name, input_feature = trainer.model.input_features.items()[0]
                 output_feature_name, output_feature = trainer.model.output_features.items()[0]
-                input_msl = input_feature.input_shape[0]
+                input_msl = input_feature.input_shape[0] # Based on input_shape in text_feature.py, this should provide a tighter bound than the max_sequence_length in the config
                 output_msl = trainer.model.config_obj.output_features[0].preprocessing.max_sequence_length
                 if global_max_sequence_length is not None and input_msl + output_msl > global_max_sequence_length:
                     # In this case, we just need to make sure that the length of the synthetic data exceeds max_sequence_length

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -495,9 +495,9 @@ class FineTuneTrainer(Trainer):
                 if trainer.model.config_obj.output_features[0].preprocessing.max_sequence_length:
                     output_msl = trainer.model.config_obj.output_features[0].preprocessing.max_sequence_length
                 else:
-                    output_msl = global_max_sequence_length//2 + 1
+                    output_msl = global_max_sequence_length - input_msl
                 if input_msl + output_msl > global_max_sequence_length:
-                    # In this case, we just need to make sure that the length of the synthetic data exceeds max_sequence_length
+                    # In this case, we just need to make sure that the length of the synthetic data exceeds max_sequence_length by at most a small amount
                     input_msl = global_max_sequence_length//2 + 1
                     output_msl = global_max_sequence_length//2 + 1
                 inputs = {

--- a/ludwig/utils/batch_size_tuner.py
+++ b/ludwig/utils/batch_size_tuner.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 TOTAL_STEPS = 5
 
+
 @DeveloperAPI
 class BatchSizeEvaluator(ABC):
     def select_best_batch_size(

--- a/ludwig/utils/batch_size_tuner.py
+++ b/ludwig/utils/batch_size_tuner.py
@@ -21,7 +21,7 @@ class BatchSizeEvaluator(ABC):
         max_batch_size: Optional[int] = None,
         max_trials: int = 20,
         is_coordinator: Optional[bool] = True,
-        max_sequence_length: Optional[int] = None,
+        global_max_sequence_length: Optional[int] = None,
     ) -> int:
         """Returns optimal batch size as measured by throughput (samples / sec)."""
         logger.info("Tuning batch size...")
@@ -52,7 +52,7 @@ class BatchSizeEvaluator(ABC):
             gc.collect()
 
             try:
-                samples_per_sec = self.evaluate(batch_size, total_steps=5, max_sequence_length=max_sequence_length)
+                samples_per_sec = self.evaluate(batch_size, total_steps=5, global_max_sequence_length=global_max_sequence_length)
                 if is_coordinator:
                     logger.info(f"Throughput at batch_size={batch_size}: {samples_per_sec:.5f} samples/s")
                 if samples_per_sec < best_samples_per_sec:
@@ -89,7 +89,7 @@ class BatchSizeEvaluator(ABC):
             logger.info(f"Selected batch_size={best_batch_size}")
         return best_batch_size
 
-    def evaluate(self, batch_size: int, total_steps: int = 5, max_sequence_length: Optional[int] = None) -> float:
+    def evaluate(self, batch_size: int, total_steps: int = 5, global_max_sequence_length: Optional[int] = None) -> float:
         """Evaluates throughput of the given batch size.
 
         Return:
@@ -112,6 +112,6 @@ class BatchSizeEvaluator(ABC):
         """Called at the beginning of each evaluation step."""
         pass
 
-    def step(self, batch_size: int, max_sequence_length: Optional[int] = None):
+    def step(self, batch_size: int, global_max_sequence_length: Optional[int] = None):
         """Called each step to evaluate the given batch size."""
         raise NotImplementedError("`step` must be implemented by concrete evaluator.")

--- a/ludwig/utils/batch_size_tuner.py
+++ b/ludwig/utils/batch_size_tuner.py
@@ -12,6 +12,7 @@ from ludwig.constants import MAX_BATCH_SIZE_DATASET_FRACTION, MIN_POSSIBLE_BATCH
 
 logger = logging.getLogger(__name__)
 
+TOTAL_STEPS = 5
 
 @DeveloperAPI
 class BatchSizeEvaluator(ABC):
@@ -53,7 +54,7 @@ class BatchSizeEvaluator(ABC):
 
             try:
                 samples_per_sec = self.evaluate(
-                    batch_size, total_steps=5, global_max_sequence_length=global_max_sequence_length
+                    batch_size, total_steps=TOTAL_STEPS, global_max_sequence_length=global_max_sequence_length
                 )
                 if is_coordinator:
                     logger.info(f"Throughput at batch_size={batch_size}: {samples_per_sec:.5f} samples/s")

--- a/ludwig/utils/batch_size_tuner.py
+++ b/ludwig/utils/batch_size_tuner.py
@@ -52,7 +52,9 @@ class BatchSizeEvaluator(ABC):
             gc.collect()
 
             try:
-                samples_per_sec = self.evaluate(batch_size, total_steps=5, global_max_sequence_length=global_max_sequence_length)
+                samples_per_sec = self.evaluate(
+                    batch_size, total_steps=5, global_max_sequence_length=global_max_sequence_length
+                )
                 if is_coordinator:
                     logger.info(f"Throughput at batch_size={batch_size}: {samples_per_sec:.5f} samples/s")
                 if samples_per_sec < best_samples_per_sec:
@@ -89,7 +91,9 @@ class BatchSizeEvaluator(ABC):
             logger.info(f"Selected batch_size={best_batch_size}")
         return best_batch_size
 
-    def evaluate(self, batch_size: int, total_steps: int = 5, global_max_sequence_length: Optional[int] = None) -> float:
+    def evaluate(
+        self, batch_size: int, total_steps: int = 5, global_max_sequence_length: Optional[int] = None
+    ) -> float:
         """Evaluates throughput of the given batch size.
 
         Return:

--- a/ludwig/utils/batch_size_tuner.py
+++ b/ludwig/utils/batch_size_tuner.py
@@ -99,7 +99,7 @@ class BatchSizeEvaluator(ABC):
         for _ in range(total_steps):
             self.reset()
             start_ts = time.time()
-            self.step(batch_size, max_sequence_length=max_sequence_length)
+            self.step(batch_size, global_max_sequence_length=global_max_sequence_length)
             durations.append(time.time() - start_ts)
 
         med_duration_s = statistics.median(durations)

--- a/ludwig/utils/batch_size_tuner.py
+++ b/ludwig/utils/batch_size_tuner.py
@@ -21,6 +21,7 @@ class BatchSizeEvaluator(ABC):
         max_batch_size: Optional[int] = None,
         max_trials: int = 20,
         is_coordinator: Optional[bool] = True,
+        max_sequence_length: Optional[int] = None,
     ) -> int:
         """Returns optimal batch size as measured by throughput (samples / sec)."""
         logger.info("Tuning batch size...")
@@ -51,7 +52,7 @@ class BatchSizeEvaluator(ABC):
             gc.collect()
 
             try:
-                samples_per_sec = self.evaluate(batch_size, total_steps=5)
+                samples_per_sec = self.evaluate(batch_size, total_steps=5, max_sequence_length=max_sequence_length)
                 if is_coordinator:
                     logger.info(f"Throughput at batch_size={batch_size}: {samples_per_sec:.5f} samples/s")
                 if samples_per_sec < best_samples_per_sec:
@@ -88,7 +89,7 @@ class BatchSizeEvaluator(ABC):
             logger.info(f"Selected batch_size={best_batch_size}")
         return best_batch_size
 
-    def evaluate(self, batch_size: int, total_steps: int = 5) -> float:
+    def evaluate(self, batch_size: int, total_steps: int = 5, max_sequence_length: Optional[int] = None) -> float:
         """Evaluates throughput of the given batch size.
 
         Return:
@@ -98,7 +99,7 @@ class BatchSizeEvaluator(ABC):
         for _ in range(total_steps):
             self.reset()
             start_ts = time.time()
-            self.step(batch_size)
+            self.step(batch_size, max_sequence_length=max_sequence_length)
             durations.append(time.time() - start_ts)
 
         med_duration_s = statistics.median(durations)
@@ -111,6 +112,6 @@ class BatchSizeEvaluator(ABC):
         """Called at the beginning of each evaluation step."""
         pass
 
-    def step(self, batch_size: int):
+    def step(self, batch_size: int, max_sequence_length: Optional[int] = None):
         """Called each step to evaluate the given batch size."""
         raise NotImplementedError("`step` must be implemented by concrete evaluator.")

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -1255,7 +1255,7 @@ def test_llm_encoding(llm_encoder_config, adapter, quantization, tmpdir):
     model.train(dataset=dataset_path, output_directory=str(tmpdir))
 
 def test_llm_batch_size_tuning():
-    dataset = pd.DataFrame({"instruction": ["a"] * 10, "output": ["a"] * 10})
+    dataset = pd.DataFrame({"instruction": ["a"] * 100, "output": ["a"] * 100})
     config = yaml.safe_load(
         """
     model_type: llm

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -1254,6 +1254,7 @@ def test_llm_encoding(llm_encoder_config, adapter, quantization, tmpdir):
     model = LudwigModel(config)
     model.train(dataset=dataset_path, output_directory=str(tmpdir))
 
+
 def test_llm_batch_size_tuning():
     dataset = pd.DataFrame({"instruction": ["a"] * 100, "output": ["a"] * 100})
     config = yaml.safe_load(

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -1342,35 +1342,3 @@ def test_llm_used_tokens(tmpdir):
         "5": 204,
         "6": 0,
     }
-
-
-def test_llm_batch_size_tuning():
-    dataset = pd.DataFrame({"instruction": ["a"]*10, "output": ["a"]*10})
-    config = yaml.safe_load(
-        '''
-    model_type: llm
-    input_features:
-        - name: instruction
-          type: text
-    output_features:
-        - name: output
-          type: text
-    prompt:
-        template: >-
-            {instruction}
-    adapter:
-        type: lora
-    trainer:
-        type: finetune
-        optimizer:
-            type: adam
-        train_steps: 1
-        learning_rate: 0.0002
-        eval_batch_size: 2
-    backend:
-        type: local
-    base_model: HuggingFaceH4/tiny-random-LlamaForCausalLM
-        ''')
-    model = LudwigModel(config=config)
-    model.train(dataset=dataset)
-    assert model.config_obj.trainer.batch_size > 1

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+import yaml
 
 import ludwig.error as ludwig_error
 from ludwig.api import LudwigModel
@@ -1309,3 +1310,33 @@ def test_llm_used_tokens(tmpdir):
         "5": 204,
         "6": 0,
     }
+def test_llm_batch_size_tuning():
+    dataset = pd.DataFrame({"instruction": ["a"]*10, "output": ["a"]*10})
+    config = yaml.safe_load(
+        '''
+    model_type: llm
+    input_features:
+        - name: instruction
+          type: text
+    output_features:
+        - name: output
+          type: text
+    prompt:
+        template: >-
+            {instruction}
+    adapter:
+        type: lora
+    trainer:
+        type: finetune
+        optimizer:
+            type: adam
+        train_steps: 1
+        learning_rate: 0.0002
+        eval_batch_size: 2
+    backend:
+        type: local
+    base_model: HuggingFaceH4/tiny-random-LlamaForCausalLM
+        ''')
+    model = LudwigModel(config=config)
+    model.train(dataset=dataset)
+    assert model.config_obj.trainer.batch_size > 1

--- a/tests/integration_tests/test_trainer.py
+++ b/tests/integration_tests/test_trainer.py
@@ -417,4 +417,3 @@ def test_enable_gradient_checkpointing(tmpdir, caplog):
     # Check that the warning is emitted when the model does not support gradient checkpointing
     # but does not prevent training from starting.
     assert "Gradient checkpointing is currently only supported for model_type: llm. Skipping..." in caplog.text
-    

--- a/tests/integration_tests/test_trainer.py
+++ b/tests/integration_tests/test_trainer.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import yaml
 import shutil
 from unittest import mock
 
@@ -23,7 +22,6 @@ from ludwig.constants import (
     TRAINER,
 )
 from ludwig.distributed import init_dist_strategy
-from ludwig.trainers.trainer_llm import FineTuneTrainer, FineTuneTrainerConfig
 from tests.integration_tests.utils import (
     binary_feature,
     category_feature,
@@ -419,57 +417,4 @@ def test_enable_gradient_checkpointing(tmpdir, caplog):
     # Check that the warning is emitted when the model does not support gradient checkpointing
     # but does not prevent training from starting.
     assert "Gradient checkpointing is currently only supported for model_type: llm. Skipping..." in caplog.text
-
-def test_llm_batch_size_tuning():
-    config = yaml.safe_load(
-        '''
-    model_type: llm
-    input_features:
-        - name: instruction
-          type: text
-    output_features:
-        - name: output
-          type: text
-    prompt:
-        template: >-
-            Below is an instruction that describes a task, paired with an input that
-            provides further context. Write a response that appropriately completes the
-            request.
-
-            ### Instruction: {instruction}
-
-            ### Input: {input}
-
-            ### Response:
-    preprocessing:
-        split:
-            type: random
-            probabilities:
-            - 0.95
-            - 0
-            - 0.05
-        global_max_sequence_length: 512
-    adapter:
-        type: lora
-    trainer:
-        type: finetune
-        optimizer:
-            type: adam
-        epochs: 1
-        #batch_size: 1
-        learning_rate: 0.0002
-        eval_batch_size: 2
-        learning_rate_scheduler:
-            decay: cosine
-            warmup_fraction: 0.03
-        gradient_accumulation_steps: 16
-    backend:
-        type: local
-    base_model: HuggingFaceH4/tiny-random-LlamaForCausalLM
-    ludwig_version: 0.9.dev
-        ''')
-    model = LudwigModel(config=config)
-    model = LudwigModel.create_model(model.config_obj)
-    trainer = FineTuneTrainer(model.config_obj.trainer, model)
-    evaluator = trainer._create_batch_size_evaluator()
-    print(evaluator.input_feature_name) #TEST IS NOT DONE YET
+    


### PR DESCRIPTION
This PR extends Ludwig's batch size tuning functionality to LLMs.

For each batch size, we generate synthetic data in the following way:
We consider three values:
(1) The sum of the max_sequence_lengths of the input feature and the output feature
(2) The global_max_sequence_length
(3) The model's context length

If (1) is the smallest, then we generate synthetic inputs and outputs with the corresponding max_sequence_lengths.
If (2) is the smallest, then we generate synthetic inputs and outputs with length global_max_sequence_length/2 + 1.
If (3) is the smallest, then we generate synthetic inputs and outputs with length context_len/2 + 1.