### PR TITLE
Add custom `prepare_for_trianing` logic to ECD model for LLM encoder adapter initialization

### DIFF
--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch
 
 from ludwig.combiners.combiners import create_combiner
-from ludwig.constants import MODEL_ECD
+from ludwig.constants import MODEL_ECD, MODEL_LLM
 from ludwig.globals import MODEL_WEIGHTS_FILE_NAME
 from ludwig.models.base import BaseModel
 from ludwig.schema.model_types.ecd import ECDModelConfig
@@ -55,6 +55,18 @@ class ECD(BaseModel):
 
         # After constructing all layers, clear the cache to free up memory
         clear_data_cache()
+
+    def prepare_for_training(self):
+        # 1/10/23: For parity with how the LLM model type sets up adapters and quantization, LLM encoders should call
+        # `prepare_for_training` at training time rather than at initialization. This loop searches for input features
+        # using the LLM encoder and calls `prepare_for_training` on those encoders only. No other changes should be
+        # made to the ECD model itself or any other encoders.
+        for feature in self.config_obj.input_features:
+            encoder_type = feature.encoder.type
+            if encoder_type == MODEL_LLM:
+                feature_name = feature.name
+                encoder = self.input_features.get(feature_name)
+                encoder.prepare_for_training(feature)
 
     def encode(
         self,

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -66,7 +66,7 @@ class ECD(BaseModel):
             if encoder_type == MODEL_LLM:
                 feature_name = feature.name
                 encoder = self.input_features.get(feature_name)
-                encoder.prepare_for_training(feature)
+                encoder.prepare_for_training()
 
     def encode(
         self,


### PR DESCRIPTION
The LLM model type initializes the adapter weights and quantization at training time using `LLM.prepare_for_training`. When `LLMEncoder` was added, ECD model did not have a corresponding `prepare_for_training` method, so adapter initialization occurred at encoder initialization. This PR adds `ECD.prepare_for_training`, which brings `LLMEncoder` adapter initialization to parity with LLM models.