### PR TITLE
[BUGFIX] Guard against UnicodeEncodeError when saving validation results in Google Colab environment

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -699,26 +699,46 @@ class Trainer(BaseTrainer):
             dict_save_dir = os.path.join(os.path.dirname(checkpoint_manager.directory), "llm_eval_examples")
             os.makedirs(dict_save_dir, exist_ok=True)
             dict_save_path = os.path.join(dict_save_dir, f"{progress_tracker.checkpoint_number}.csv")
-            logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-DICT_SAVE_PATH:\n{dict_save_path} ; TYPE: {str(type(dict_save_path))}')
+            if self.is_coordinator():
+                logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-DICT_SAVE_PATH:\n{dict_save_path} ; TYPE: {str(type(dict_save_path))}')
             llm_eval_examples = pd.DataFrame(llm_eval_examples).to_dict(orient="records")
-            logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-LLM_EVAL_EXAMPLES:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+            if self.is_coordinator():
+                logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-LLM_EVAL_EXAMPLES:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
             # TODO: <Alex>ALEX</Alex>
-            # with open(dict_save_path, "w") as outfile:
+            # with open(dict_save_path, "w", encoding="utf-8") as outfile:
             #     writer = csv.DictWriter(outfile, fieldnames=["inputs", "targets", "outputs"])
-            #     logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-0:\n{writer} ; TYPE: {str(type(writer))}')
+            #     # TODO: <Alex>ALEX</Alex>
+            #     if self.is_coordinator():
+            #         logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-0:\n{writer} ; TYPE: {str(type(writer))}')
+            #     # TODO: <Alex>ALEX</Alex>
             #     writer.writeheader()
-            #     logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-1:\n{writer} ; TYPE: {str(type(writer))}')
+            #     # TODO: <Alex>ALEX</Alex>
+            #     if self.is_coordinator():
+            #         logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-1:\n{writer} ; TYPE: {str(type(writer))}')
+            #     # TODO: <Alex>ALEX</Alex>
             #     writer.writerows(llm_eval_examples)
-            #     logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-2:\n{writer} ; TYPE: {str(type(writer))}')
+            #     # TODO: <Alex>ALEX</Alex>
+            #     if self.is_coordinator():
+            #         logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-2:\n{writer} ; TYPE: {str(type(writer))}')
+            #     # TODO: <Alex>ALEX</Alex>
             # TODO: <Alex>ALEX</Alex>
             # TODO: <Alex>ALEX</Alex>
             with open(dict_save_path, "w", encoding="utf-8") as outfile:
                 writer = csv.DictWriter(outfile, fieldnames=["inputs", "targets", "outputs"])
-                logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-0:\n{writer} ; TYPE: {str(type(writer))}')
+                # TODO: <Alex>ALEX</Alex>
+                if self.is_coordinator():
+                    logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-0:\n{writer} ; TYPE: {str(type(writer))}')
+                # TODO: <Alex>ALEX</Alex>
                 writer.writeheader()
-                logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-1:\n{writer} ; TYPE: {str(type(writer))}')
+                # TODO: <Alex>ALEX</Alex>
+                if self.is_coordinator():
+                    logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-1:\n{writer} ; TYPE: {str(type(writer))}')
+                # TODO: <Alex>ALEX</Alex>
                 writer.writerows(llm_eval_examples)
-                logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-2:\n{writer} ; TYPE: {str(type(writer))}')
+                # TODO: <Alex>ALEX</Alex>
+                if self.is_coordinator():
+                    logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-2:\n{writer} ; TYPE: {str(type(writer))}')
+                # TODO: <Alex>ALEX</Alex>
             # TODO: <Alex>ALEX</Alex>
 
             self.write_eval_summary(

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -698,11 +698,16 @@ class Trainer(BaseTrainer):
             dict_save_dir = os.path.join(os.path.dirname(checkpoint_manager.directory), "llm_eval_examples")
             os.makedirs(dict_save_dir, exist_ok=True)
             dict_save_path = os.path.join(dict_save_dir, f"{progress_tracker.checkpoint_number}.csv")
+            logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-dict_save_path:\n{DICT_SAVE_PATH} ; TYPE: {str(type(dict_save_path))}')
             llm_eval_examples = pd.DataFrame(llm_eval_examples).to_dict(orient="records")
+            logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-LLM_EVAL_EXAMPLES:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
             with open(dict_save_path, "w") as outfile:
                 writer = csv.DictWriter(outfile, fieldnames=["inputs", "targets", "outputs"])
+                logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-0:\n{writer} ; TYPE: {str(type(writer))}')
                 writer.writeheader()
+                logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-1:\n{writer} ; TYPE: {str(type(writer))}')
                 writer.writerows(llm_eval_examples)
+                logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-2:\n{writer} ; TYPE: {str(type(writer))}')
 
             self.write_eval_summary(
                 summary_writer=validation_summary_writer,

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -698,7 +698,7 @@ class Trainer(BaseTrainer):
             dict_save_dir = os.path.join(os.path.dirname(checkpoint_manager.directory), "llm_eval_examples")
             os.makedirs(dict_save_dir, exist_ok=True)
             dict_save_path = os.path.join(dict_save_dir, f"{progress_tracker.checkpoint_number}.csv")
-            logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-dict_save_path:\n{DICT_SAVE_PATH} ; TYPE: {str(type(dict_save_path))}')
+            logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-DICT_SAVE_PATH:\n{dict_save_path} ; TYPE: {str(type(dict_save_path))}')
             llm_eval_examples = pd.DataFrame(llm_eval_examples).to_dict(orient="records")
             logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-LLM_EVAL_EXAMPLES:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
             with open(dict_save_path, "w") as outfile:

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -699,47 +699,11 @@ class Trainer(BaseTrainer):
             dict_save_dir = os.path.join(os.path.dirname(checkpoint_manager.directory), "llm_eval_examples")
             os.makedirs(dict_save_dir, exist_ok=True)
             dict_save_path = os.path.join(dict_save_dir, f"{progress_tracker.checkpoint_number}.csv")
-            if self.is_coordinator():
-                logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-DICT_SAVE_PATH:\n{dict_save_path} ; TYPE: {str(type(dict_save_path))}')
             llm_eval_examples = pd.DataFrame(llm_eval_examples).to_dict(orient="records")
-            if self.is_coordinator():
-                logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-LLM_EVAL_EXAMPLES:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
-            # TODO: <Alex>ALEX</Alex>
-            # with open(dict_save_path, "w", encoding="utf-8") as outfile:
-            #     writer = csv.DictWriter(outfile, fieldnames=["inputs", "targets", "outputs"])
-            #     # TODO: <Alex>ALEX</Alex>
-            #     if self.is_coordinator():
-            #         logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-0:\n{writer} ; TYPE: {str(type(writer))}')
-            #     # TODO: <Alex>ALEX</Alex>
-            #     writer.writeheader()
-            #     # TODO: <Alex>ALEX</Alex>
-            #     if self.is_coordinator():
-            #         logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-1:\n{writer} ; TYPE: {str(type(writer))}')
-            #     # TODO: <Alex>ALEX</Alex>
-            #     writer.writerows(llm_eval_examples)
-            #     # TODO: <Alex>ALEX</Alex>
-            #     if self.is_coordinator():
-            #         logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-2:\n{writer} ; TYPE: {str(type(writer))}')
-            #     # TODO: <Alex>ALEX</Alex>
-            # TODO: <Alex>ALEX</Alex>
-            # TODO: <Alex>ALEX</Alex>
             with open(dict_save_path, "w", encoding="utf-8") as outfile:
                 writer = csv.DictWriter(outfile, fieldnames=["inputs", "targets", "outputs"])
-                # TODO: <Alex>ALEX</Alex>
-                if self.is_coordinator():
-                    logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-0:\n{writer} ; TYPE: {str(type(writer))}')
-                # TODO: <Alex>ALEX</Alex>
                 writer.writeheader()
-                # TODO: <Alex>ALEX</Alex>
-                if self.is_coordinator():
-                    logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-1:\n{writer} ; TYPE: {str(type(writer))}')
-                # TODO: <Alex>ALEX</Alex>
                 writer.writerows(llm_eval_examples)
-                # TODO: <Alex>ALEX</Alex>
-                if self.is_coordinator():
-                    logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-2:\n{writer} ; TYPE: {str(type(writer))}')
-                # TODO: <Alex>ALEX</Alex>
-            # TODO: <Alex>ALEX</Alex>
 
             self.write_eval_summary(
                 summary_writer=validation_summary_writer,

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -701,13 +701,24 @@ class Trainer(BaseTrainer):
             logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-DICT_SAVE_PATH:\n{dict_save_path} ; TYPE: {str(type(dict_save_path))}')
             llm_eval_examples = pd.DataFrame(llm_eval_examples).to_dict(orient="records")
             logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-LLM_EVAL_EXAMPLES:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
-            with open(dict_save_path, "w") as outfile:
+            # TODO: <Alex>ALEX</Alex>
+            # with open(dict_save_path, "w") as outfile:
+            #     writer = csv.DictWriter(outfile, fieldnames=["inputs", "targets", "outputs"])
+            #     logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-0:\n{writer} ; TYPE: {str(type(writer))}')
+            #     writer.writeheader()
+            #     logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-1:\n{writer} ; TYPE: {str(type(writer))}')
+            #     writer.writerows(llm_eval_examples)
+            #     logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-2:\n{writer} ; TYPE: {str(type(writer))}')
+            # TODO: <Alex>ALEX</Alex>
+            # TODO: <Alex>ALEX</Alex>
+            with open(dict_save_path, "w", encoding="utf-8") as outfile:
                 writer = csv.DictWriter(outfile, fieldnames=["inputs", "targets", "outputs"])
                 logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-0:\n{writer} ; TYPE: {str(type(writer))}')
                 writer.writeheader()
                 logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-1:\n{writer} ; TYPE: {str(type(writer))}')
                 writer.writerows(llm_eval_examples)
                 logger.info(f'\n[ALEX_TEST] [TuneTrainer.run_evaluation()] <SELF.EVALUATION(VALIDATION_SET)_COMPLETED>-WRITER-2:\n{writer} ; TYPE: {str(type(writer))}')
+            # TODO: <Alex>ALEX</Alex>
 
             self.write_eval_summary(
                 summary_writer=validation_summary_writer,

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -438,11 +438,11 @@ class FineTuneTrainer(Trainer):
         predictor = LlmFineTunePredictor(
             self.model, batch_size=batch_size, distributed=self.distributed, report_tqdm_to_ray=self.report_tqdm_to_ray
         )
-        # logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] PREDICTOR:\n{predictor} ; TYPE: {str(type(predictor))}')
+        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] PREDICTOR:\n{predictor} ; TYPE: {str(type(predictor))}')
         metrics, _, input_target_output_dict = predictor.batch_evaluation(
             dataset, collect_predictions=False, dataset_name=dataset_name
         )
-        # logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] METRICS:\n{metrics} ; TYPE: {str(type(metrics))}')
+        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] METRICS:\n{metrics} ; TYPE: {str(type(metrics))}')
         # Setting collect_predictions=True currently causes an error when doing batch evaluation because the outputs
         # can be of variable sizes but we try to concatenate them into a single tensor.
 
@@ -453,23 +453,23 @@ class FineTuneTrainer(Trainer):
         num_examples = min(len(input_target_output_dict["inputs"][input_key]), MAX_EVALUATION_EXAMPLES)
 
         llm_eval_examples = {"inputs": [], "targets": [], "outputs": []}
-        # logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-0:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-0:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["inputs"]:
             for inp in input_target_output_dict["inputs"][key][:num_examples]:
                 llm_eval_examples["inputs"].append(tokenizer.decode(inp, skip_special_tokens=True))
 
-        # logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-1:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-1:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["targets"]:
             for tar in input_target_output_dict["targets"][key][:num_examples]:
                 llm_eval_examples["targets"].append(tokenizer.decode(tar, skip_special_tokens=True))
 
-        # logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-2:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-2:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["outputs"]:
             for out in input_target_output_dict["outputs"][key][:num_examples]:
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
         num_examples_shown = min(len(llm_eval_examples["inputs"]), MAX_EVALUATION_EXAMPLES_SHOWN)
-        # logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
+        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
         for i in range(num_examples_shown):
             logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")
             logger.info(f"Output: {llm_eval_examples['outputs'][i].strip()}")

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -438,11 +438,11 @@ class FineTuneTrainer(Trainer):
         predictor = LlmFineTunePredictor(
             self.model, batch_size=batch_size, distributed=self.distributed, report_tqdm_to_ray=self.report_tqdm_to_ray
         )
-        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] PREDICTOR:\n{predictor} ; TYPE: {str(type(predictor))}')
+        # logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] PREDICTOR:\n{predictor} ; TYPE: {str(type(predictor))}')
         metrics, _, input_target_output_dict = predictor.batch_evaluation(
             dataset, collect_predictions=False, dataset_name=dataset_name
         )
-        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] METRICS:\n{metrics} ; TYPE: {str(type(metrics))}')
+        # logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] METRICS:\n{metrics} ; TYPE: {str(type(metrics))}')
         # Setting collect_predictions=True currently causes an error when doing batch evaluation because the outputs
         # can be of variable sizes but we try to concatenate them into a single tensor.
 
@@ -453,23 +453,23 @@ class FineTuneTrainer(Trainer):
         num_examples = min(len(input_target_output_dict["inputs"][input_key]), MAX_EVALUATION_EXAMPLES)
 
         llm_eval_examples = {"inputs": [], "targets": [], "outputs": []}
-        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-0:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        # logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-0:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["inputs"]:
             for inp in input_target_output_dict["inputs"][key][:num_examples]:
                 llm_eval_examples["inputs"].append(tokenizer.decode(inp, skip_special_tokens=True))
 
-        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-1:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        # logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-1:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["targets"]:
             for tar in input_target_output_dict["targets"][key][:num_examples]:
                 llm_eval_examples["targets"].append(tokenizer.decode(tar, skip_special_tokens=True))
 
-        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-2:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        # logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-2:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["outputs"]:
             for out in input_target_output_dict["outputs"][key][:num_examples]:
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
         num_examples_shown = min(len(llm_eval_examples["inputs"]), MAX_EVALUATION_EXAMPLES_SHOWN)
-        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
+        # logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
         for i in range(num_examples_shown):
             logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")
             logger.info(f"Output: {llm_eval_examples['outputs'][i].strip()}")

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -438,11 +438,11 @@ class FineTuneTrainer(Trainer):
         predictor = LlmFineTunePredictor(
             self.model, batch_size=batch_size, distributed=self.distributed, report_tqdm_to_ray=self.report_tqdm_to_ray
         )
-        # print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] PREDICTOR:\n{predictor} ; TYPE: {str(type(predictor))}')
+        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] PREDICTOR:\n{predictor} ; TYPE: {str(type(predictor))}')
         metrics, _, input_target_output_dict = predictor.batch_evaluation(
             dataset, collect_predictions=False, dataset_name=dataset_name
         )
-        # print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] METRICS:\n{metrics} ; TYPE: {str(type(metrics))}')
+        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] METRICS:\n{metrics} ; TYPE: {str(type(metrics))}')
         # Setting collect_predictions=True currently causes an error when doing batch evaluation because the outputs
         # can be of variable sizes but we try to concatenate them into a single tensor.
 
@@ -453,23 +453,23 @@ class FineTuneTrainer(Trainer):
         num_examples = min(len(input_target_output_dict["inputs"][input_key]), MAX_EVALUATION_EXAMPLES)
 
         llm_eval_examples = {"inputs": [], "targets": [], "outputs": []}
-        # print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-0:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-0:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["inputs"]:
             for inp in input_target_output_dict["inputs"][key][:num_examples]:
                 llm_eval_examples["inputs"].append(tokenizer.decode(inp, skip_special_tokens=True))
 
-        # print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-1:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-1:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["targets"]:
             for tar in input_target_output_dict["targets"][key][:num_examples]:
                 llm_eval_examples["targets"].append(tokenizer.decode(tar, skip_special_tokens=True))
 
-        # print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-2:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-2:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["outputs"]:
             for out in input_target_output_dict["outputs"][key][:num_examples]:
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
         num_examples_shown = min(len(llm_eval_examples["inputs"]), MAX_EVALUATION_EXAMPLES_SHOWN)
-        # print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
+        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
         for i in range(num_examples_shown):
             logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")
             logger.info(f"Output: {llm_eval_examples['outputs'][i].strip()}")

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -23,7 +23,6 @@ from ludwig.utils.metric_utils import TrainerMetric
 from ludwig.utils.metrics_printed_table import print_metrics_table
 from ludwig.utils.misc_utils import set_random_seed
 from ludwig.utils.torch_utils import get_torch_device
-
 from ludwig.utils.trainer_utils import append_metrics, get_new_progress_tracker, ProgressTracker
 
 logger = logging.getLogger(__name__)
@@ -438,17 +437,9 @@ class FineTuneTrainer(Trainer):
         predictor = LlmFineTunePredictor(
             self.model, batch_size=batch_size, distributed=self.distributed, report_tqdm_to_ray=self.report_tqdm_to_ray
         )
-        # TODO: <Alex>ALEX</Alex>
-        if self.is_coordinator():
-            logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] PREDICTOR:\n{predictor} ; TYPE: {str(type(predictor))}')
-        # TODO: <Alex>ALEX</Alex>
         metrics, _, input_target_output_dict = predictor.batch_evaluation(
             dataset, collect_predictions=False, dataset_name=dataset_name
         )
-        # TODO: <Alex>ALEX</Alex>
-        if self.is_coordinator():
-            logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] METRICS:\n{metrics} ; TYPE: {str(type(metrics))}')
-        # TODO: <Alex>ALEX</Alex>
         # Setting collect_predictions=True currently causes an error when doing batch evaluation because the outputs
         # can be of variable sizes but we try to concatenate them into a single tensor.
 
@@ -459,47 +450,23 @@ class FineTuneTrainer(Trainer):
         num_examples = min(len(input_target_output_dict["inputs"][input_key]), MAX_EVALUATION_EXAMPLES)
 
         llm_eval_examples = {"inputs": [], "targets": [], "outputs": []}
-        # TODO: <Alex>ALEX</Alex>
-        if self.is_coordinator():
-            logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-0:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
-        # TODO: <Alex>ALEX</Alex>
         for key in input_target_output_dict["inputs"]:
             for inp in input_target_output_dict["inputs"][key][:num_examples]:
                 llm_eval_examples["inputs"].append(tokenizer.decode(inp, skip_special_tokens=True))
 
-        # TODO: <Alex>ALEX</Alex>
-        if self.is_coordinator():
-            logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-1:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
-        # TODO: <Alex>ALEX</Alex>
         for key in input_target_output_dict["targets"]:
             for tar in input_target_output_dict["targets"][key][:num_examples]:
                 llm_eval_examples["targets"].append(tokenizer.decode(tar, skip_special_tokens=True))
 
-        # TODO: <Alex>ALEX</Alex>
-        if self.is_coordinator():
-            logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-2:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
-        # TODO: <Alex>ALEX</Alex>
         for key in input_target_output_dict["outputs"]:
             for out in input_target_output_dict["outputs"][key][:num_examples]:
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
         num_examples_shown = min(len(llm_eval_examples["inputs"]), MAX_EVALUATION_EXAMPLES_SHOWN)
-        # TODO: <Alex>ALEX</Alex>
-        if self.is_coordinator():
-            logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
-        # TODO: <Alex>ALEX</Alex>
-        # TODO: <Alex>ALEX</Alex>
-        # for i in range(num_examples_shown):
-        #     logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")
-        #     logger.info(f"Output: {llm_eval_examples['outputs'][i].strip()}")
-        #     logger.info("--------------------")
-        # TODO: <Alex>ALEX</Alex>
-        # TODO: <Alex>ALEX</Alex>
         for i in range(num_examples_shown):
-            logger.info(f"[ALEX_TEST] Input: {llm_eval_examples['inputs'][i].strip()}")
-            logger.info(f"[ALEX_TEST] Output: {llm_eval_examples['outputs'][i].strip()}")
-            logger.info("[ALEX_TEST] --------------------")
-        # TODO: <Alex>ALEX</Alex>
+            logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")
+            logger.info(f"Output: {llm_eval_examples['outputs'][i].strip()}")
+            logger.info("--------------------")
 
         progress_tracker.llm_eval_examples = llm_eval_examples
         return append_metrics(self.model, dataset_name, metrics, metrics_log, progress_tracker)

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -438,11 +438,17 @@ class FineTuneTrainer(Trainer):
         predictor = LlmFineTunePredictor(
             self.model, batch_size=batch_size, distributed=self.distributed, report_tqdm_to_ray=self.report_tqdm_to_ray
         )
-        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] PREDICTOR:\n{predictor} ; TYPE: {str(type(predictor))}')
+        # TODO: <Alex>ALEX</Alex>
+        if self.is_coordinator():
+            logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] PREDICTOR:\n{predictor} ; TYPE: {str(type(predictor))}')
+        # TODO: <Alex>ALEX</Alex>
         metrics, _, input_target_output_dict = predictor.batch_evaluation(
             dataset, collect_predictions=False, dataset_name=dataset_name
         )
-        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] METRICS:\n{metrics} ; TYPE: {str(type(metrics))}')
+        # TODO: <Alex>ALEX</Alex>
+        if self.is_coordinator():
+            logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] METRICS:\n{metrics} ; TYPE: {str(type(metrics))}')
+        # TODO: <Alex>ALEX</Alex>
         # Setting collect_predictions=True currently causes an error when doing batch evaluation because the outputs
         # can be of variable sizes but we try to concatenate them into a single tensor.
 
@@ -453,23 +459,35 @@ class FineTuneTrainer(Trainer):
         num_examples = min(len(input_target_output_dict["inputs"][input_key]), MAX_EVALUATION_EXAMPLES)
 
         llm_eval_examples = {"inputs": [], "targets": [], "outputs": []}
-        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-0:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        # TODO: <Alex>ALEX</Alex>
+        if self.is_coordinator():
+            logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-0:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        # TODO: <Alex>ALEX</Alex>
         for key in input_target_output_dict["inputs"]:
             for inp in input_target_output_dict["inputs"][key][:num_examples]:
                 llm_eval_examples["inputs"].append(tokenizer.decode(inp, skip_special_tokens=True))
 
-        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-1:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        # TODO: <Alex>ALEX</Alex>
+        if self.is_coordinator():
+            logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-1:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        # TODO: <Alex>ALEX</Alex>
         for key in input_target_output_dict["targets"]:
             for tar in input_target_output_dict["targets"][key][:num_examples]:
                 llm_eval_examples["targets"].append(tokenizer.decode(tar, skip_special_tokens=True))
 
-        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-2:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        # TODO: <Alex>ALEX</Alex>
+        if self.is_coordinator():
+            logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-2:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        # TODO: <Alex>ALEX</Alex>
         for key in input_target_output_dict["outputs"]:
             for out in input_target_output_dict["outputs"][key][:num_examples]:
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
         num_examples_shown = min(len(llm_eval_examples["inputs"]), MAX_EVALUATION_EXAMPLES_SHOWN)
-        logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
+        # TODO: <Alex>ALEX</Alex>
+        if self.is_coordinator():
+            logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
+        # TODO: <Alex>ALEX</Alex>
         # TODO: <Alex>ALEX</Alex>
         # for i in range(num_examples_shown):
         #     logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -470,10 +470,18 @@ class FineTuneTrainer(Trainer):
 
         num_examples_shown = min(len(llm_eval_examples["inputs"]), MAX_EVALUATION_EXAMPLES_SHOWN)
         logger.info(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
+        # TODO: <Alex>ALEX</Alex>
+        # for i in range(num_examples_shown):
+        #     logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")
+        #     logger.info(f"Output: {llm_eval_examples['outputs'][i].strip()}")
+        #     logger.info("--------------------")
+        # TODO: <Alex>ALEX</Alex>
+        # TODO: <Alex>ALEX</Alex>
         for i in range(num_examples_shown):
-            logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")
-            logger.info(f"Output: {llm_eval_examples['outputs'][i].strip()}")
-            logger.info("--------------------")
+            logger.info(f"[ALEX_TEST] Input: {llm_eval_examples['inputs'][i].strip()}")
+            logger.info(f"[ALEX_TEST] Output: {llm_eval_examples['outputs'][i].strip()}")
+            logger.info("[ALEX_TEST] --------------------")
+        # TODO: <Alex>ALEX</Alex>
 
         progress_tracker.llm_eval_examples = llm_eval_examples
         return append_metrics(self.model, dataset_name, metrics, metrics_log, progress_tracker)

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -438,11 +438,11 @@ class FineTuneTrainer(Trainer):
         predictor = LlmFineTunePredictor(
             self.model, batch_size=batch_size, distributed=self.distributed, report_tqdm_to_ray=self.report_tqdm_to_ray
         )
-        print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] PREDICTOR:\n{predictor} ; TYPE: {str(type(predictor))}')
+        # print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] PREDICTOR:\n{predictor} ; TYPE: {str(type(predictor))}')
         metrics, _, input_target_output_dict = predictor.batch_evaluation(
             dataset, collect_predictions=False, dataset_name=dataset_name
         )
-        print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] METRICS:\n{metrics} ; TYPE: {str(type(metrics))}')
+        # print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] METRICS:\n{metrics} ; TYPE: {str(type(metrics))}')
         # Setting collect_predictions=True currently causes an error when doing batch evaluation because the outputs
         # can be of variable sizes but we try to concatenate them into a single tensor.
 
@@ -453,23 +453,23 @@ class FineTuneTrainer(Trainer):
         num_examples = min(len(input_target_output_dict["inputs"][input_key]), MAX_EVALUATION_EXAMPLES)
 
         llm_eval_examples = {"inputs": [], "targets": [], "outputs": []}
-        print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-0:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        # print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-0:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["inputs"]:
             for inp in input_target_output_dict["inputs"][key][:num_examples]:
                 llm_eval_examples["inputs"].append(tokenizer.decode(inp, skip_special_tokens=True))
 
-        print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-1:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        # print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-1:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["targets"]:
             for tar in input_target_output_dict["targets"][key][:num_examples]:
                 llm_eval_examples["targets"].append(tokenizer.decode(tar, skip_special_tokens=True))
 
-        print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-2:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
+        # print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-2:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["outputs"]:
             for out in input_target_output_dict["outputs"][key][:num_examples]:
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
         num_examples_shown = min(len(llm_eval_examples["inputs"]), MAX_EVALUATION_EXAMPLES_SHOWN)
-        print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
+        # print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
         for i in range(num_examples_shown):
             logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")
             logger.info(f"Output: {llm_eval_examples['outputs'][i].strip()}")

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -23,6 +23,7 @@ from ludwig.utils.metric_utils import TrainerMetric
 from ludwig.utils.metrics_printed_table import print_metrics_table
 from ludwig.utils.misc_utils import set_random_seed
 from ludwig.utils.torch_utils import get_torch_device
+
 from ludwig.utils.trainer_utils import append_metrics, get_new_progress_tracker, ProgressTracker
 
 logger = logging.getLogger(__name__)
@@ -437,9 +438,11 @@ class FineTuneTrainer(Trainer):
         predictor = LlmFineTunePredictor(
             self.model, batch_size=batch_size, distributed=self.distributed, report_tqdm_to_ray=self.report_tqdm_to_ray
         )
+        print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] PREDICTOR:\n{predictor} ; TYPE: {str(type(predictor))}')
         metrics, _, input_target_output_dict = predictor.batch_evaluation(
             dataset, collect_predictions=False, dataset_name=dataset_name
         )
+        print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] METRICS:\n{metrics} ; TYPE: {str(type(metrics))}')
         # Setting collect_predictions=True currently causes an error when doing batch evaluation because the outputs
         # can be of variable sizes but we try to concatenate them into a single tensor.
 
@@ -450,19 +453,23 @@ class FineTuneTrainer(Trainer):
         num_examples = min(len(input_target_output_dict["inputs"][input_key]), MAX_EVALUATION_EXAMPLES)
 
         llm_eval_examples = {"inputs": [], "targets": [], "outputs": []}
+        print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-0:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["inputs"]:
             for inp in input_target_output_dict["inputs"][key][:num_examples]:
                 llm_eval_examples["inputs"].append(tokenizer.decode(inp, skip_special_tokens=True))
 
+        print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-1:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["targets"]:
             for tar in input_target_output_dict["targets"][key][:num_examples]:
                 llm_eval_examples["targets"].append(tokenizer.decode(tar, skip_special_tokens=True))
 
+        print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] LLM_EVAL_EXAMPLES-2:\n{llm_eval_examples} ; TYPE: {str(type(llm_eval_examples))}')
         for key in input_target_output_dict["outputs"]:
             for out in input_target_output_dict["outputs"][key][:num_examples]:
                 llm_eval_examples["outputs"].append(tokenizer.decode(out, skip_special_tokens=True))
 
         num_examples_shown = min(len(llm_eval_examples["inputs"]), MAX_EVALUATION_EXAMPLES_SHOWN)
+        print(f'\n[ALEX_TEST] [FineTuneTrainer.evaluation()] NUM_EXAMPLES_SHOWN:\n{num_examples_shown} ; TYPE: {str(type(num_examples_shown))}')
         for i in range(num_examples_shown):
             logger.info(f"Input: {llm_eval_examples['inputs'][i].strip()}")
             logger.info(f"Output: {llm_eval_examples['outputs'][i].strip()}")


### PR DESCRIPTION
### Scope
If the textual data in the validation dataset contains non-ASCII characters, saving the results to storage may encounter errors, such as:
```
UnicodeEncodeError: 'ascii' codec can't encode character '\u2260' in position 2699: ordinal not in range(128)
```

The fix consists of defensively converting the contents to the `UTF-8` format.

### Remark

This error was not observed in isolated GPU environments such as while using EC2 outside of Colab, but this change assure stable behavior in all environments.