### PR TITLE
Docker image fixes part 2: pin to torch==2.1.0, add dependency for urllib<2

### DIFF
--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -44,7 +44,7 @@ RUN pip install -U pip
 
 WORKDIR /ludwig
 
-RUN pip install --no-cache-dir torch==2.1.1 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu118
+RUN pip install --no-cache-dir torch==2.1.0 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu118
 
 COPY . .
 RUN pip install --no-cache-dir '.[full]' --extra-index-url https://download.pytorch.org/whl/cu118

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -31,7 +31,7 @@ RUN pip install -U pip
 
 WORKDIR /ludwig
 
-RUN pip install --no-cache-dir torch==2.1.1 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache-dir torch==2.1.0 torchtext torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
 
 COPY . .
 RUN pip install --no-cache-dir '.[full]' --extra-index-url https://download.pytorch.org/whl/cpu

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,6 @@ html5lib            # html
 
 # requirement for loading hugging face datasets
 datasets
+
+# pin required for torch 2.1.0
+urllib3<2


### PR DESCRIPTION
Fixes an issue with the previous docker image build where torchdata 0.7.1 doesn't seem to play nicely when installed with cuda118 because of libssl errors. 

Torch 2.1.0 ships with torchdata 0.7 