### PR TITLE
Add streaming support for zero shot inference

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1037,6 +1037,9 @@ class LudwigModel:
         for i in range(len(input_ids)):
             with torch.no_grad():
                 logger.info(f"Input: {input_strings[i]}\n")
+                # NOTE: self.model.model.generation_config is not used here because it is the default
+                # generation config that the CausalLM was initialized with, rather than the one set within the
+                # context manager.
                 generated_output = self.model.model.generate(
                     input_ids=input_ids[i].unsqueeze(0),
                     attention_mask=attention_mask[i].unsqueeze(0),
@@ -1066,6 +1069,9 @@ class LudwigModel:
             torch.Tensor: Tensor of generated outputs.
         """
         with torch.no_grad():
+            # NOTE: self.model.model.generation_config is not used here because it is the default
+            # generation config that the CausalLM was initialized with, rather than the one set within the
+            # context manager.
             return self.model.model.generate(
                 input_ids=input_ids,
                 attention_mask=attention_mask,

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1002,12 +1002,12 @@ class LudwigModel:
             tokenized_inputs = tokenizer.tokenizer(input_strings, return_tensors="pt", padding=True)
             input_ids = tokenized_inputs["input_ids"].to("cuda")
             attention_mask = tokenized_inputs["attention_mask"].to("cuda")
-            streamer = create_text_streamer(tokenizer.tokenizer) if streaming else None
 
-            if streamer:
+            if streaming:
+                streamer = create_text_streamer(tokenizer.tokenizer)
                 outputs = self._generate_streaming_outputs(input_strings, input_ids, attention_mask, streamer)
             else:
-                outputs = self._generate_non_streaming_outputs(input_strings, input_ids, attention_mask, streamer)
+                outputs = self._generate_non_streaming_outputs(input_strings, input_ids, attention_mask)
 
             decoded_outputs = tokenizer.tokenizer.batch_decode(outputs, skip_special_tokens=True)
             logger.info(f"Finished generating in: {(time.time() - start_time):.2f}s.")
@@ -1019,8 +1019,8 @@ class LudwigModel:
         input_strings: Union[str, List[str]],
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
-        streamer: Union[TextStreamer, None],
-    ):
+        streamer: TextStreamer,
+    ) -> torch.Tensor:
         """Generate streaming outputs for the given input.
 
         Args:
@@ -1055,8 +1055,7 @@ class LudwigModel:
         _input_strings: Union[str, List[str]],
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
-        streamer: Union[TextStreamer, None],
-    ):
+    ) -> torch.Tensor:
         """Generate non-streaming outputs for the given input.
 
         Args:
@@ -1076,7 +1075,6 @@ class LudwigModel:
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 generation_config=self.model.generation,
-                streamer=streamer,
             )
 
     def predict(

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 import transformers
 from bitsandbytes.nn.modules import Embedding
 from packaging import version
-from transformers import AutoConfig, AutoModelForCausalLM, PreTrainedModel, PreTrainedTokenizer
+from transformers import AutoConfig, AutoModelForCausalLM, PreTrainedModel, PreTrainedTokenizer, TextStreamer
 
 from ludwig.constants import IGNORE_INDEX_TOKEN_ID, LOGITS, PREDICTIONS, PROBABILITIES
 from ludwig.schema.trainer import LLMTrainerConfig
@@ -622,3 +622,8 @@ def update_embedding_layer(model: AutoModelForCausalLM, config_obj: LLMTrainerCo
         logger.info("Updated the pretrained embedding layer to use the embedding layer from bitsandbytes.")
 
     return model
+
+
+def create_text_streamer(tokenizer: PreTrainedTokenizer):
+    """Creates a TextStreamer object for streaming text to stdout during generation."""
+    return TextStreamer(tokenizer=tokenizer, skip_prompt=True)

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -624,6 +624,6 @@ def update_embedding_layer(model: AutoModelForCausalLM, config_obj: LLMTrainerCo
     return model
 
 
-def create_text_streamer(tokenizer: PreTrainedTokenizer):
+def create_text_streamer(tokenizer: PreTrainedTokenizer) -> TextStreamer:
     """Creates a TextStreamer object for streaming text to stdout during generation."""
     return TextStreamer(tokenizer=tokenizer, skip_prompt=True)


### PR DESCRIPTION
This PR introduces a new boolean flag called `streaming` to the LudwigModel.generate() API which allows users to see streaming output when performing zero-shot inference on single or multiple samples. 

## Demo

https://github.com/ludwig-ai/ludwig/assets/106701836/50fc01db-837b-4689-8e8a-8da491481da1

## Config to reproduce the demo video

```python
import yaml
import logging
from ludwig.api import LudwigModel

config = yaml.safe_load(
    """
model_type: llm
base_model: meta-llama/Llama-2-7b-chat-hf

quantization:
  bits: 4

input_features:
  - name: instruction
    type: text

output_features:
  - name: output
    type: text

generation:
  max_new_tokens: 64
  temperature: 0.1

trainer:
    type: none

backend:
  type: local
"""
)

model = LudwigModel(config, logging_level=logging.INFO)

# Single sample - Normal generation
output = model.generate("What is the meaning of life?", generation_config={"max_new_tokens": 32})

# Single sample - Streaming generation
output = model.generate("What is the meaning of life?", generation_config={"max_new_tokens": 32}, streaming=True)

# Multi sample - Normal generation
output = model.generate(["What is the meaning of life?", "What is the weather like in Germany around December?"], generation_config={"max_new_tokens": 64})

# Multi sample - Streaming generation
output = model.generate(["What is the meaning of life?", "What is the weather like in Germany around December?"], generation_config={"max_new_tokens": 64}, streaming=True)
```