### PR TITLE
[Maintenance] Docker Image Fix part 3: fix torchaudio 2.1.0 dependencies by installing `libsox-dev` and update API

### DIFF
--- a/docker/ludwig-gpu/Dockerfile
+++ b/docker/ludwig-gpu/Dockerfile
@@ -26,7 +26,8 @@ RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" apt-get -y install \
     libsndfile1 \
     cmake \
     ffmpeg \
-    sox
+    sox \
+    libsox-dev
 RUN pip install -U pip
 
 WORKDIR /ludwig

--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -39,7 +39,8 @@ RUN sudo apt-get update && sudo apt install -y software-properties-common && \
     vim \
     gcc-9 \
     ffmpeg \
-    sox
+    sox \
+    libsox-dev
 RUN pip install -U pip
 
 WORKDIR /ludwig

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -26,7 +26,8 @@ RUN sudo apt-get update && DEBIAN_FRONTEND="noninteractive" sudo apt-get install
 	rsync \
 	vim \
 	ffmpeg \
-	sox
+	sox \
+	libsox-dev
 RUN pip install -U pip
 
 WORKDIR /ludwig

--- a/docker/ludwig/Dockerfile
+++ b/docker/ludwig/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get -y update && apt-get -y install \
     g++ \
     cmake \
     ffmpeg \
-    sox
+    sox \
+    libsox-dev
 RUN pip install -U pip
 
 WORKDIR /ludwig

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -1050,8 +1050,7 @@ class RayBackend(RemoteTrainingMixin, Backend):
                         fs=fs,
                     ),
                 )
-
-            if map_fn is not None:
+            else:
                 df = df.with_column(column.name, df[column.name].apply(map_fn, return_dtype=daft.DataType.python()))
 
             # Executes and convert Daft Dataframe to Dask DataFrame or Pandas Dataframe

--- a/ludwig/data/dataset_synthesizer.py
+++ b/ludwig/data/dataset_synthesizer.py
@@ -27,6 +27,7 @@ import pandas as pd
 import torch
 import torchaudio
 import yaml
+from packaging import version
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import (
@@ -61,6 +62,8 @@ from ludwig.utils.misc_utils import get_from_registry
 from ludwig.utils.print_utils import print_ludwig
 
 logger = logging.getLogger(__name__)
+
+_TORCH_AUDIO_210 = version.parse(torchaudio.__version__) >= version.parse("2.1.0")
 
 letters = string.ascii_letters
 
@@ -355,6 +358,8 @@ def generate_audio(feature, outdir: str) -> str:
     audio_dest_path = os.path.join(destination_folder, audio_filename)
 
     try:
+        if _TORCH_AUDIO_210:
+            torchaudio.save(audio_dest_path, audio_tensor, sample_rate=sampling_rate, backend="sox")
         torchaudio.save(audio_dest_path, audio_tensor, sampling_rate)
 
     except OSError as e:

--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -159,8 +159,8 @@ class AudioFeatureMixin(BaseFeatureMixin):
 
         try:
             default_audio = get_default_audio([audio for audio in raw_audio if is_torch_audio_tuple(audio)])
-        except RuntimeError:
-            logger.info("Unable to process audio files provided")
+        except RuntimeError as e:
+            logger.info(f"Unable to process audio files provided: {e}")
             raise RuntimeError
 
         raw_audio = df_engine.map_objects(raw_audio, lambda row: row if is_torch_audio_tuple(row) else default_audio)

--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -49,6 +49,8 @@ from ludwig.utils.types import TorchscriptPreprocessingInput
 
 logger = logging.getLogger(__name__)
 
+_TORCH_200 = version.parse(torch.__version__) >= version.parse("2.0.0")
+
 
 class _AudioPreprocessing(torch.nn.Module):
     audio_feature_dict: Dict[str, Union[float, int, str]]
@@ -151,8 +153,8 @@ class AudioFeatureMixin(BaseFeatureMixin):
         backend,
     ):
         df_engine = backend.df_engine
-        if version.parse(torch.__version__) > version.parse("2.0.0"):
-            # Read audio from path if the version of torch is > 2.0.0.
+        if _TORCH_200:
+            # Read audio from path if the version of torch is >= 2.0.0.
             raw_audio = backend.read_binary_files(column, map_fn=read_audio_from_path)
         else:
             raw_audio = backend.read_binary_files(column, map_fn=read_audio_from_bytes_obj)

--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -160,8 +160,7 @@ class AudioFeatureMixin(BaseFeatureMixin):
         try:
             default_audio = get_default_audio([audio for audio in raw_audio if is_torch_audio_tuple(audio)])
         except RuntimeError as e:
-            logger.info(f"Unable to process audio files provided: {e}")
-            raise RuntimeError
+            raise RuntimeError(f"Unable to process audio files provided: {e}") from e
 
         raw_audio = df_engine.map_objects(raw_audio, lambda row: row if is_torch_audio_tuple(row) else default_audio)
         processed_audio = df_engine.map_objects(

--- a/ludwig/utils/audio_utils.py
+++ b/ludwig/utils/audio_utils.py
@@ -21,6 +21,7 @@ from typing import Any, List, Optional, Union
 import torch
 import torch.nn.functional as F
 import torchaudio
+from packaging import version
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import DEFAULT_AUDIO_TENSOR_LENGTH
@@ -30,6 +31,9 @@ logger = logging.getLogger(__name__)
 
 # https://github.com/pytorch/audio/blob/main/torchaudio/csrc/sox/types.cpp
 AUDIO_EXTENSIONS = (".wav", ".amb", ".mp3", ".ogg", ".vorbis", ".flac", ".opus", ".sphere")
+
+
+_TORCH_AUDIO_210 = version.parse(torchaudio.__version__) >= version.parse("2.1.0")
 
 
 @DeveloperAPI
@@ -64,7 +68,9 @@ def read_audio_from_path(path: str) -> Optional[TorchAudioTuple]:
     Useful for reading from a small number of paths. For more intensive reads, use backend.read_binary_files instead.
     """
     try:
-        return torchaudio.backend.sox_io_backend.load(path)
+        if _TORCH_AUDIO_210:
+            return torchaudio.load(path, backend="sox")
+        return torchaudio.backend.sox_backend.load(path)
     except Exception as e:
         logger.warning(e)
         return None
@@ -75,7 +81,9 @@ def read_audio_from_path(path: str) -> Optional[TorchAudioTuple]:
 def read_audio_from_bytes_obj(bytes_obj: bytes) -> Optional[TorchAudioTuple]:
     try:
         f = BytesIO(bytes_obj)
-        return torchaudio.backend.sox_io_backend.load(f)
+        if _TORCH_AUDIO_210:
+            return torchaudio.load(f, backend="sox")
+        return torchaudio.backend.sox_backend.load(f)
     except Exception as e:
         logger.warning(e)
         return None

--- a/ludwig/utils/audio_utils.py
+++ b/ludwig/utils/audio_utils.py
@@ -34,6 +34,7 @@ AUDIO_EXTENSIONS = (".wav", ".amb", ".mp3", ".ogg", ".vorbis", ".flac", ".opus",
 
 
 _TORCH_AUDIO_210 = version.parse(torchaudio.__version__) >= version.parse("2.1.0")
+_TORCH_AUDIO_201 = version.parse(torchaudio.__version__) >= version.parse("2.0.1")
 
 
 @DeveloperAPI
@@ -70,7 +71,10 @@ def read_audio_from_path(path: str) -> Optional[TorchAudioTuple]:
     try:
         if _TORCH_AUDIO_210:
             return torchaudio.load(path, backend="sox")
-        return torchaudio.backend.sox_backend.load(path)
+        elif _TORCH_AUDIO_201:
+            return torchaudio.backend.sox_io_backend.load(path)
+        else:
+            return torchaudio.backend.sox_backend.load(path)
     except Exception as e:
         logger.warning(e)
         return None
@@ -83,7 +87,10 @@ def read_audio_from_bytes_obj(bytes_obj: bytes) -> Optional[TorchAudioTuple]:
         f = BytesIO(bytes_obj)
         if _TORCH_AUDIO_210:
             return torchaudio.load(f, backend="sox")
-        return torchaudio.backend.sox_backend.load(f)
+        elif _TORCH_AUDIO_201:
+            return torchaudio.backend.sox_io_backend.load(f)
+        else:
+            return torchaudio.backend.sox_backend.load(f)
     except Exception as e:
         logger.warning(e)
         return None


### PR DESCRIPTION
We need to add `libsox-dev` because it's needed for torchaudio 2.1.0 which ships with torch 2.1.0. It fixes this error:

```
load requires sox extension which is not available. Please refer to the stacktrace above for how to resolve this.
```

This also requires updating the way we use the torchaudio backend, which is now an argument that's passed into the load/save methods as opposed to using an instance of the backend object directly. 