### PR TITLE
Add support for official `microsoft/phi-2`

### DIFF
--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -33,11 +33,10 @@ transformers_436 = version.parse(transformers.__version__) >= version.parse("4.3
 _PHI_BASE_MODEL_MAPPING = {
     "microsoft/phi-1": "susnato/phi-1_dev",
     "microsoft/phi-1.5": "susnato/phi-1_5_dev",
-    "microsoft/phi-2": "susnato/phi-2",
 }
 
 # The susnato Phi models as of Transformers 4.36.1 don't support "device_map='auto'" at model load time.
-_MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION = {"susnato/phi-1_dev", "susnato/phi-1_5_dev", "susnato/phi-2"}
+_MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION = {"susnato/phi-1_dev", "susnato/phi-1_5_dev"}
 
 
 @default_retry(tries=8)

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -35,8 +35,13 @@ _PHI_BASE_MODEL_MAPPING = {
     "microsoft/phi-1.5": "susnato/phi-1_5_dev",
 }
 
-# The susnato Phi models as of Transformers 4.36.1 don't support "device_map='auto'" at model load time.
-_MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION = {"susnato/phi-1_dev", "susnato/phi-1_5_dev"}
+# The susnato Phi models as of Transformers 4.36.2 don't support "device_map='auto'" at model load time.
+_MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION = {
+    "susnato/phi-1_dev",
+    "susnato/phi-1_5_dev",
+    "susnato/phi-2_dev",
+    "microsoft/phi-2",
+}
 
 
 @default_retry(tries=8)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
-transformers==55090585619d7ab880d9a7d7c8b327a746f7cc40 # For official microsoft/phi-2 support
+git+https://github.com/huggingface/transformers.git@55090585619d7ab880d9a7d7c8b327a746f7cc40 # For official microsoft/phi-2 support
 tifffile
 imagecodecs
 tokenizers>=0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
-transformers>=4.36.2
+transformers==55090585619d7ab880d9a7d7c8b327a746f7cc40 # For official microsoft/phi-2 support
 tifffile
 imagecodecs
 tokenizers>=0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ torchtext
 torchvision
 pydantic<2.0
 # For official microsoft/phi-2 support
-git + https://github.com/huggingface/transformers.git@55090585619d7ab880d9a7d7c8b327a746f7cc40
+transformers@git+https://github.com/huggingface/transformers.git@55090585619d7ab880d9a7d7c8b327a746f7cc40
 tifffile
 imagecodecs
 tokenizers>=0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ torchaudio
 torchtext
 torchvision
 pydantic<2.0
-git+https://github.com/huggingface/transformers.git@55090585619d7ab880d9a7d7c8b327a746f7cc40 # For official microsoft/phi-2 support
+# For official microsoft/phi-2 support
+git + https://github.com/huggingface/transformers.git@55090585619d7ab880d9a7d7c8b327a746f7cc40
 tifffile
 imagecodecs
 tokenizers>=0.15


### PR DESCRIPTION
It works nicely, no need to use the `susnato` version, but we need to pin transformers to the commit that introduce the GQA implementation in transformers: https://github.com/huggingface/transformers/commit/55090585619d7ab880d9a7d7c8b327a746f7cc40 