### PR TITLE
Set use_reentrant to False for gradient checkpointing

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -28,6 +28,7 @@ import time
 from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np
+import packaging
 import pandas as pd
 import psutil
 import torch
@@ -87,6 +88,9 @@ from ludwig.utils.trainer_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+_TORCH210 = packaging.version.parse(torch.__version__) >= packaging.version.parse("2.1.0")
 
 
 @register_trainer(MODEL_ECD, default=True)
@@ -252,7 +256,11 @@ class Trainer(BaseTrainer):
             ):
                 logger.warning("Gradient checkpointing is not supported by this model. Skipping...")
             elif hasattr(self.compiled_model.model, "gradient_checkpointing_enable"):
-                self.compiled_model.model.gradient_checkpointing_enable()
+                if _TORCH210:
+                    # https://pytorch.org/docs/stable/checkpoint.html
+                    self.compiled_model.model.gradient_checkpointing_enable(use_reentrant=False)
+                else:
+                    self.compiled_model.model.gradient_checkpointing_enable()
                 self.compiled_model.model.enable_input_require_grads()
                 logger.info("Gradient checkpointing enabled for training.")
             else:

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -258,6 +258,7 @@ class Trainer(BaseTrainer):
             elif hasattr(self.compiled_model.model, "gradient_checkpointing_enable"):
                 if _TORCH210:
                     # https://pytorch.org/docs/stable/checkpoint.html
+                    # https://github.com/huggingface/transformers/blob/02f8738ef8c674300c314d004ba436cb5aaca165/src/transformers/modeling_utils.py#L2094 # noqa: E501
                     self.compiled_model.model.gradient_checkpointing_enable(
                         gradient_checkpointing_kwargs={"use_reentrant": False}
                     )

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -263,6 +263,8 @@ class Trainer(BaseTrainer):
                     )
                 else:
                     self.compiled_model.model.gradient_checkpointing_enable()
+                # `use_cache=True` is incompatible with gradient checkpointing.
+                self.compiled_model.model.config.use_cache = False
                 self.compiled_model.model.enable_input_require_grads()
                 logger.info("Gradient checkpointing enabled for training.")
             else:

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -258,7 +258,9 @@ class Trainer(BaseTrainer):
             elif hasattr(self.compiled_model.model, "gradient_checkpointing_enable"):
                 if _TORCH210:
                     # https://pytorch.org/docs/stable/checkpoint.html
-                    self.compiled_model.model.gradient_checkpointing_enable(use_reentrant=False)
+                    self.compiled_model.model.gradient_checkpointing_enable(
+                        gradient_checkpointing_kwargs={"use_reentrant": False}
+                    )
                 else:
                     self.compiled_model.model.gradient_checkpointing_enable()
                 self.compiled_model.model.enable_input_require_grads()


### PR DESCRIPTION
Fixes the following warnings in newer versions of Torch (>= 2.1.0)

```
/home/ray/anaconda3/lib/python3.8/site-packages/torch/utils/checkpoint.py:429: UserWarning: torch.utils.checkpoint:
 please pass in use_reentrant=True or use_reentrant=False explicitly. The default value of use_reentrant will be 
updated to be False in the future. To maintain current behavior, pass use_reentrant=True. It is recommended that 
you use use_reentrant=False. Refer to docs for more details on the differences between the two variants.
```

and 

```
`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`...
```