### PR TITLE
[BUGFIX] Pinning torch nightly to January 13, 2024 to avoid AttributeError

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -126,7 +126,7 @@ jobs:
 
           if [ "$PYTORCH" == "nightly" ]; then
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch torchdata torchtext torchvision torchaudio --index-url $extra_index_url
+            pip install --pre torch==2.3.0.dev20240113+cpu torchtext torchvision torchaudio --extra-index-url $extra_index_url
 
           else
             extra_index_url=https://download.pytorch.org/whl/cpu

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -126,6 +126,7 @@ jobs:
 
           if [ "$PYTORCH" == "nightly" ]; then
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
+            # This is being tracked as the Issue "https://github.com/ludwig-ai/ludwig/issues/3886" in Ludwig GitHub repository.
             pip install --pre torch==2.3.0.dev20240113+cpu torchtext torchvision torchaudio --extra-index-url $extra_index_url
 
           else

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -127,7 +127,7 @@ jobs:
           if [ "$PYTORCH" == "nightly" ]; then
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
             # This is being tracked as the Issue "https://github.com/ludwig-ai/ludwig/issues/3886" in Ludwig GitHub repository.
-            pip install --pre torch==2.3.0.dev20240113+cpu torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            pip install --pre torch==2.3.0.dev20240111+cpu torchtext torchvision torchaudio --extra-index-url $extra_index_url
 
           else
             extra_index_url=https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
We had a nightly failure: `https://github.com/ludwig-ai/ludwig/actions/runs/7545437935/job/20541040550?pr=3883`.


# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
