### PR TITLE
Revert: Simplify how we set pad token and pad token ID for huggingfac…

### DIFF
--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -843,30 +843,43 @@ class HFTokenizer(BaseTokenizer):
         return self.tokenizer.unk_token
 
     def _set_pad_token(self) -> None:
-        """Sets the pad token and pad token ID for the tokenizer.
+        """Sets the pad token and pad token ID for the tokenizer."""
 
-        If there is no pad token, then set one by default.
-        If there is no pad token index, then set it to 0.
+        from transformers import (
+            CodeLlamaTokenizer,
+            CodeLlamaTokenizerFast,
+            GPT2Tokenizer,
+            GPT2TokenizerFast,
+            LlamaTokenizer,
+            LlamaTokenizerFast,
+        )
 
-        Notes:
-        - (geoffrey): gpt2 has no pad token. Recommendation is to use eos token instead.
-            - https://github.com/huggingface/transformers/issues/2630#issuecomment-1290809338
-            - https://github.com/huggingface/transformers/issues/2648#issuecomment-616177044
-        - (Justin): Using the EOS token in place of the pad token causes an issue with HF model.generate() when
-            there are multiple examples in the batch.
-            - https://github.com/facebookresearch/llama/issues/380#issuecomment-1716832417
-            - Recommendation is to set a separate '[PAD]' or '<pad>' token.
-        """
-        if self.tokenizer.pad_token is None:
-            logger.warning("No padding token found. Using '[PAD]' as the pad token.")
-            self.tokenizer.pad_token = "[PAD]"
+        # Tokenizers might have the pad token id attribute since they tend to use the same base class, but
+        # it can be set to None so we check for this explicitly.
+        if hasattr(self.tokenizer, "pad_token_id") and self.tokenizer.pad_token_id is not None:
+            return
 
-        # NOTE(geoffrey): you can check this condition separately because these are actually @property methods,
-        # which means one's logic is tightly coupled with the other. If one changes, the other will change as well.
-        # On a related note, that means that this below condition should never be called, but leaving it here in case
-        # it was put here for a reason.
-        # https://github.com/huggingface/transformers/blob/4ab5fb8941a38d172b3883c152c34ae2a0b83a68/src/transformers/tokenization_utils_base.py#L1204-L1210
-        # https://github.com/huggingface/transformers/blob/4ab5fb8941a38d172b3883c152c34ae2a0b83a68/src/transformers/tokenization_utils_base.py#L1266-L1267
+        # HACK(geoffrey): gpt2 has no pad token. Recommendation is to use eos token instead.
+        # https://github.com/huggingface/transformers/issues/2630#issuecomment-1290809338
+        # https://github.com/huggingface/transformers/issues/2648#issuecomment-616177044
+        if any(
+            isinstance(self.tokenizer, t)
+            for t in [
+                GPT2Tokenizer,
+                GPT2TokenizerFast,
+                LlamaTokenizer,
+                LlamaTokenizerFast,
+                CodeLlamaTokenizer,
+                CodeLlamaTokenizerFast,
+            ]
+        ):
+            if hasattr(self.tokenizer, "eos_token") and self.tokenizer.eos_token is not None:
+                logger.warning("No padding token id found. Using eos_token as pad_token.")
+                self.tokenizer.pad_token = self.tokenizer.eos_token
+                self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+
+        # Incase any HF tokenizer does not have pad token ID, just default to using 0
+        # as the pad_token_id.
         if self.tokenizer.pad_token_id is None:
             logger.warning("No padding token id found. Using 0 as pad token id.")
             self.tokenizer.pad_token_id = 0


### PR DESCRIPTION
This revert addresses a critical issue introduced in the previous pull request (#3735), where the simplification of pad token configuration inadvertently led to the PAD token being mapped to the same token ID as the UNK (unknown) token. This mapping anomaly resulted in quality degradation during fine-tuning.

The problem surfaced as the model, instead of learning to predict an EOS (end-of-sequence) token to indicate stopping at the end of a sequence, learned to predict an UNK token at the end of sequences. This hindered the model's ability to recognize when to halt during generation, impacting the overall performance and quality of the fine-tuned model.

This reversion aims to restore the previous pad token setup and rectify the unintended mapping issue, ensuring that the model correctly learns to predict EOS tokens for proper sequence termination during fine-tuning.

# Demonstration of the bug that was introduced using Llama-2

Current:

```python
>>> from transformers import AutoTokenizer
>>> tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
>>> tokenizer
LlamaTokenizerFast(name_or_path='meta-llama/Llama-2-7b-hf', vocab_size=32000, model_max_length=1000000000000000019884624838656, is_fast=True, padding_side='right', truncation_side='right', special_tokens={'bos_token': '<s>', 'eos_token': '</s>', 'unk_token': '<unk>'}, clean_up_tokenization_spaces=False),  added_tokens_decoder={
	0: AddedToken("<unk>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
	1: AddedToken("<s>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
	2: AddedToken("</s>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
}
>>> tokenizer.pad_token = "[PAD]"
>>> tokenizer
LlamaTokenizerFast(name_or_path='meta-llama/Llama-2-7b-hf', vocab_size=32000, model_max_length=1000000000000000019884624838656, is_fast=True, padding_side='right', truncation_side='right', special_tokens={'bos_token': '<s>', 'eos_token': '</s>', 'unk_token': '<unk>', 'pad_token': '[PAD]'}, clean_up_tokenization_spaces=False),  added_tokens_decoder={
	0: AddedToken("<unk>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
	1: AddedToken("<s>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
	2: AddedToken("</s>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
}
>>> tokenizer.pad_token_id
0
>>> str2idx = tokenizer.vocab
>>> idx2str = {v: k for k, v in str2idx.items()}
>>> idx2str[0]
'<unk>'
>>> tokenizer.unk_token_id
0
```

The issue here is that we're mapping the new PAD token to the same token ID as the UNK token, which is the last token that's passed into the model's forward pass. 

This is what used to happen before (and what this revert will go back to)
```python
>>> from transformers import AutoTokenizer
>>> tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
>>> tokenizer.pad_token = tokenizer.eos_token
>>> tokenizer.pad_token_id = tokenizer.eos_token_id
>>> tokenizer.pad_token
'</s>'
>>> tokenizer.pad_token_id
2
>>> tokenizer.eos_token
'</s>'
>>> tokenizer.eos_token_id
2
>>> tokenizer.unk_token_id
0
>>> tokenizer.unk_token
'<unk>'
>>> tokenizer
LlamaTokenizerFast(name_or_path='meta-llama/Llama-2-7b-hf', vocab_size=32000, model_max_length=1000000000000000019884624838656, is_fast=True, padding_side='right', truncation_side='right', special_tokens={'bos_token': '<s>', 'eos_token': '</s>', 'unk_token': '<unk>', 'pad_token': '</s>'}, clean_up_tokenization_spaces=False),  added_tokens_decoder={
	0: AddedToken("<unk>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
	1: AddedToken("<s>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
	2: AddedToken("</s>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
}
```


