### PR TITLE
Ensure correct padding token for Phi and Pythia models

### DIFF
--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -845,11 +845,16 @@ class HFTokenizer(BaseTokenizer):
     def _set_pad_token(self) -> None:
         """Sets the pad token and pad token ID for the tokenizer."""
 
+        # CodeGenTokenizer Used by Phi-2
+        # GPTNeoXTokenizerFast Used by Pythia
         from transformers import (
+            CodeGenTokenizer,
+            CodeGenTokenizerFast,
             CodeLlamaTokenizer,
             CodeLlamaTokenizerFast,
             GPT2Tokenizer,
             GPT2TokenizerFast,
+            GPTNeoXTokenizerFast,
             LlamaTokenizer,
             LlamaTokenizerFast,
         )
@@ -865,12 +870,15 @@ class HFTokenizer(BaseTokenizer):
         if any(
             isinstance(self.tokenizer, t)
             for t in [
-                GPT2Tokenizer,
-                GPT2TokenizerFast,
-                LlamaTokenizer,
-                LlamaTokenizerFast,
+                CodeGenTokenizer,
+                CodeGenTokenizerFast,
                 CodeLlamaTokenizer,
                 CodeLlamaTokenizerFast,
+                GPT2Tokenizer,
+                GPT2TokenizerFast,
+                GPTNeoXTokenizerFast,
+                LlamaTokenizer,
+                LlamaTokenizerFast,
             ]
         ):
             if hasattr(self.tokenizer, "eos_token") and self.tokenizer.eos_token is not None:


### PR DESCRIPTION
Follow up from https://github.com/ludwig-ai/ludwig/commit/9eb113b7b407ab5dd0e7c1f69f715fb8af8ca85e 

Ensures that all of the tokenizers for the models listed in https://github.com/ludwig-ai/ludwig/blob/master/ludwig/schema/llms/base_model.py#L20 have the correct initialization.