### PR TITLE
Cast `LLMEncoder` output to `torch.float32`, freeze final layer at init.

### DIFF
--- a/tests/ludwig/encoders/test_llm_encoders.py
+++ b/tests/ludwig/encoders/test_llm_encoders.py
@@ -68,6 +68,10 @@ class TestLLMEncoder:
         assert encoder.input_shape == torch.Size([encoder_config.max_sequence_length])
         assert encoder.output_shape == torch.Size([encoder_config.max_sequence_length, model_config.hidden_size])
 
+        # The final layer must not be trainable because it is not used
+        last_module = list(encoder.model.modules())[-1]
+        assert all(not p.requires_grad for p in last_module.parameters())
+
         # Test that max sequence length falls back to the context length when too large
         context_len = get_context_len(model_config)
         cl_config = copy.deepcopy(encoder_config)
@@ -80,6 +84,10 @@ class TestLLMEncoder:
         assert all(map(lambda k: "lora_" not in k, encoder.state_dict().keys()))  # Check adapter was not initialized
         assert encoder.input_shape == torch.Size([context_len])
         assert encoder.output_shape == torch.Size([context_len, model_config.hidden_size])
+
+        # The final layer must not be trainable because it is not used
+        last_module = list(encoder.model.modules())[-1]
+        assert all(not p.requires_grad for p in last_module.parameters())
 
     @pytest.mark.parametrize("adapter", list(ADAPTER_CONFIG_MAP.keys()))
     def test_init_with_adapter(self, encoder_config: LLMEncoderConfig, adapter: str, model_config):
@@ -95,6 +103,10 @@ class TestLLMEncoder:
         assert encoder.model_name == encoder_config.base_model
         assert encoder.input_shape == torch.Size([encoder_config.max_sequence_length])
         assert encoder.output_shape == torch.Size([encoder_config.max_sequence_length, model_config.hidden_size])
+
+        # The final layer must not be trainable because it is not used
+        last_module = list(encoder.model.modules())[-1]
+        assert all(not p.requires_grad for p in last_module.parameters())
 
     @pytest.mark.parametrize("adapter", list(ADAPTER_CONFIG_MAP.keys()))
     def test_prepare_for_training(self, encoder_config: LLMEncoderConfig, adapter: str):


### PR DESCRIPTION
`LLMEncoder` fine-tuning is currently blocked by two issues:

- `RuntimeError: mat1 and mat2 must have the same dtype, but got Half and Float.`
- As a result of #3874, the final layer of the base model is no longer frozen until training time, potentially leading to an "unused parameters" error

This PR adds fixes for both issues:

- `LLMEncoder` output is now explicitly cast to `torch.float32`
- The final layer of the base model is always frozen in `LLMEncoder.__init__`