### PR TITLE
Enable IA3 adapters in `LLMEncoder`

### DIFF
--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -2387,7 +2387,11 @@ class TfIdfEncoder(Encoder):
 class LLMEncoder(Encoder):
     # Per-adapter type prefixes for parameter names in the state dict, taken from
     # https://github.com/huggingface/peft/blob/0f1e9091cc975eb5458cc163bf1843a34fb42b76/src/peft/utils/save_and_load.py#L173C9-L180
-    ADAPTER_PARAM_NAME_PREFIX = {"lora": "lora_", "adalora": "lora_"}
+    ADAPTER_PARAM_NAME_PREFIX = {
+        "adalora": "lora_",
+        "ia3": "ia3_",
+        "lora": "lora_",
+    }
 
     def __init__(self, encoder_config: LLMEncoderConfig = None, **kwargs):
         super().__init__()

--- a/tests/ludwig/encoders/test_llm_encoders.py
+++ b/tests/ludwig/encoders/test_llm_encoders.py
@@ -7,13 +7,14 @@ from transformers import AutoConfig, PreTrainedModel
 
 from ludwig.encoders.text_encoders import LLMEncoder
 from ludwig.schema.encoders.text_encoders import LLMEncoderConfig
-from ludwig.schema.llms.peft import AdaloraConfig, BaseAdapterConfig, LoraConfig
+from ludwig.schema.llms.peft import AdaloraConfig, BaseAdapterConfig, IA3Config, LoraConfig
 from ludwig.utils.llm_utils import get_context_len
 
 # Mapping of adapter types to test against and their respective config objects.
 ADAPTER_CONFIG_MAP = {
-    "lora": LoraConfig,
     "adalora": AdaloraConfig,
+    "ia3": IA3Config,
+    "lora": LoraConfig,
 }
 
 


### PR DESCRIPTION
This adds support for IA3 adapters to `LLMEncoder` and updates the `LLMEncoder` tests to cover it.