### PR TITLE
Add default LoRA target modules for Phi-2

### DIFF
--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -315,7 +315,13 @@ def set_llm_parameters(config: "ModelConfig") -> None:
 
     # HACK(Arnav): Set Mixtral target modules when using LoRA
     # GitHub issue: https://github.com/ludwig-ai/ludwig/issues/3853
+    # PEFT PR: https://github.com/huggingface/peft/pull/1376
     _set_mixtral_target_modules(config)
+
+    # HACK(Arnav): Set Phi-2 target modules when using LoRA
+    # GitHub issue:
+    # PEFT PR: https://github.com/huggingface/peft/pull/1375
+    _set_phi2_target_modules(config)
 
 
 def _set_llm_tokenizers(config: "ModelConfig") -> None:
@@ -421,9 +427,35 @@ def _set_mixtral_target_modules(config: "ModelConfig") -> None:
     if config.adapter.type != "lora" or config.adapter.target_modules:
         return
 
-    logger.info("Setting adapter target modules to ['q_proj', 'v_proj'] for Mixtral 7x8 base model with LoRA adapter.")
+    target_modules = ["q_proj", "v_proj"]
 
-    config.adapter.target_modules = ["q_proj", "v_proj"]
+    logger.info(f"Setting adapter target modules to {target_modules} for Mixtral 7x8 base model with LoRA adapter.")
+    config.adapter.target_modules = target_modules
+
+
+def _set_phi2_target_modules(config: "ModelConfig") -> None:
+    """If the base model is Phi-2, LoRA is enabled and the target modules are not set, set the target modules to
+    maximize performance."""
+    if config.base_model not in {
+        "susnato/phi-1_dev",
+        "susnato/phi-1_5_dev",
+        "susnato/phi-2",
+        "microsoft/phi-1",
+        "microsoft/phi-1_5",
+        "microsoft/phi-2",
+    }:
+        return
+
+    if not config.adapter:
+        return
+
+    if config.adapter.type != "lora" or config.adapter.target_modules:
+        return
+
+    target_modules = ["q_proj", "k_proj", "v_proj", "dense", "fc1", "fc2"]
+
+    logger.info(f"Setting adapter target modules to {target_modules} for Phi-2 base model with LoRA adapter.")
+    config.adapter.target_modules = target_modules
 
 
 @DeveloperAPI

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -34,7 +34,7 @@ from ludwig.schema.llms.generation import LLMGenerationConfig
 from ludwig.schema.trainer import ECDTrainerConfig
 from ludwig.types import HyperoptConfigDict, ModelConfigDict
 from ludwig.utils.data_utils import get_sanitized_feature_name
-from ludwig.utils.llm_utils import get_context_len
+from ludwig.utils.llm_utils import _PHI_MODELS, get_context_len
 
 if TYPE_CHECKING:
     from ludwig.schema.model_types.base import ModelConfig
@@ -436,14 +436,7 @@ def _set_mixtral_target_modules(config: "ModelConfig") -> None:
 def _set_phi2_target_modules(config: "ModelConfig") -> None:
     """If the base model is Phi-2, LoRA is enabled and the target modules are not set, set the target modules to
     maximize performance."""
-    if config.base_model not in {
-        "susnato/phi-1_dev",
-        "susnato/phi-1_5_dev",
-        "susnato/phi-2",
-        "microsoft/phi-1",
-        "microsoft/phi-1_5",
-        "microsoft/phi-2",
-    }:
+    if config.base_model not in _PHI_MODELS:
         return
 
     if not config.adapter:

--- a/ludwig/schema/model_types/utils.py
+++ b/ludwig/schema/model_types/utils.py
@@ -319,7 +319,7 @@ def set_llm_parameters(config: "ModelConfig") -> None:
     _set_mixtral_target_modules(config)
 
     # HACK(Arnav): Set Phi-2 target modules when using LoRA
-    # GitHub issue:
+    # GitHub issue: https://github.com/ludwig-ai/ludwig/issues/3910
     # PEFT PR: https://github.com/huggingface/peft/pull/1375
     _set_phi2_target_modules(config)
 

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -23,13 +23,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+transformers_436 = version.parse(transformers.__version__) >= version.parse("4.36.0")
 
 FALLBACK_CONTEXT_LEN = 2048
 
-transformers_436 = version.parse(transformers.__version__) >= version.parse("4.36.0")
-
-# Phi models don't support "device_map='auto'" at model load time as of transformers 4.37.0.
-_MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION = {
+_PHI_MODELS = {
     "susnato/phi-1_dev",
     "susnato/phi-1_5_dev",
     "susnato/phi-2",
@@ -37,6 +35,10 @@ _MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION = {
     "microsoft/phi-1_5",
     "microsoft/phi-2",
 }
+
+_MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION = set()
+# Phi models don't support "device_map='auto'" at model load time as of transformers 4.37.0.
+_MODELS_WITH_DEVICE_MAP_AUTO_EXCLUSION.update(_PHI_MODELS)
 
 
 @default_retry(tries=8)


### PR DESCRIPTION
These modules maximize performance, also the current LoRA target modules for Phi-2 are wrong on the PEFT repo.

See #3910 