### PR TITLE
Add unit tests for image utils unet functions

### DIFF
--- a/ludwig/schema/decoders/image_decoders.py
+++ b/ludwig/schema/decoders/image_decoders.py
@@ -71,4 +71,5 @@ class UNetDecoderConfig(ImageDecoderConfig):
         default=None,
         allow_none=True,
         description="Number of classes to predict in the output. ",
+        parameter_metadata=DECODER_METADATA["UNetDecoder"]["num_classes"],
     )

--- a/ludwig/schema/features/preprocessing/image.py
+++ b/ludwig/schema/features/preprocessing/image.py
@@ -144,7 +144,7 @@ class ImagePreprocessingConfig(BasePreprocessingConfig):
         default=None,
         allow_none=True,
         description="Number of channel classes in the images. If specified, this value will be validated "
-        "against the inferred number of classes. ",
+        "against the inferred number of classes. Use 2 to convert grayscale images to binary images.",
         parameter_metadata=FEATURE_METADATA[IMAGE][PREPROCESSING]["num_classes"],
     )
 

--- a/ludwig/schema/metadata/configs/encoders.yaml
+++ b/ludwig/schema/metadata/configs/encoders.yaml
@@ -9593,6 +9593,7 @@ UNetEncoder:
         default_value_reasoning:
             Computed internally, automatically, based on image
             data preprocessing.
+        internal_only: true
         ui_display_name: NOT DISPLAYED
     width:
         default_value_reasoning:


### PR DESCRIPTION
This is a follow up to PR 3913. 
It adds unit tests for the image utils functions added by that PR.