### PR TITLE
fix: Always return a list of quantization bits values from `get_quantization`

### DIFF
--- a/ludwig/utils/config_utils.py
+++ b/ludwig/utils/config_utils.py
@@ -144,7 +144,7 @@ def config_uses_llm(config: Union[Dict[str, Any], ModelConfig]) -> bool:
     return uses_llm
 
 
-def get_quantization(config: Union[Dict[str, Any], ModelConfig]) -> Union[int, List[int], None]:
+def get_quantization(config: Union[Dict[str, Any], ModelConfig]) -> Union[List[int], None]:
     """Get the quantization specified in a config at any level.
 
     Args:
@@ -157,7 +157,7 @@ def get_quantization(config: Union[Dict[str, Any], ModelConfig]) -> Union[int, L
     """
     if isinstance(config, ModelConfig):
         if config.model_type == MODEL_LLM:
-            return config.quantization.bits if config.quantization else None
+            return [config.quantization.bits] if config.quantization else None
         else:
             quantization_bits = []
             for feature in config.input_features:
@@ -169,7 +169,8 @@ def get_quantization(config: Union[Dict[str, Any], ModelConfig]) -> Union[int, L
             return quantization_bits
     elif isinstance(config, dict) and config:
         if config.get(MODEL_TYPE, MODEL_ECD) == MODEL_LLM:
-            return config.get("quantization", {}).get("bits")
+            quantization = config.get("quantization", {}).get("bits")
+            return [quantization] if quantization is not None else quantization_bits
         elif INPUT_FEATURES in config:
             quantization_bits = []
             for feature in config.get(INPUT_FEATURES, []):

--- a/ludwig/utils/config_utils.py
+++ b/ludwig/utils/config_utils.py
@@ -144,7 +144,7 @@ def config_uses_llm(config: Union[Dict[str, Any], ModelConfig]) -> bool:
     return uses_llm
 
 
-def get_quantization(config: Union[Dict[str, Any], ModelConfig]) -> Union[List[int], None]:
+def get_quantization(config: Union[Dict[str, Any], ModelConfig]) -> List[Union[int, None]]:
     """Get the quantization specified in a config at any level.
 
     Args:
@@ -157,7 +157,7 @@ def get_quantization(config: Union[Dict[str, Any], ModelConfig]) -> Union[List[i
     """
     if isinstance(config, ModelConfig):
         if config.model_type == MODEL_LLM:
-            return [config.quantization.bits] if config.quantization else None
+            return [config.quantization.bits] if config.quantization else [None]
         else:
             quantization_bits = []
             for feature in config.input_features:
@@ -169,8 +169,7 @@ def get_quantization(config: Union[Dict[str, Any], ModelConfig]) -> Union[List[i
             return quantization_bits
     elif isinstance(config, dict) and config:
         if config.get(MODEL_TYPE, MODEL_ECD) == MODEL_LLM:
-            quantization = config.get("quantization", {}).get("bits")
-            return [quantization] if quantization is not None else quantization_bits
+            return [config.get("quantization", {}).get("bits")]
         elif INPUT_FEATURES in config:
             quantization_bits = []
             for feature in config.get(INPUT_FEATURES, []):

--- a/tests/ludwig/utils/test_config_utils.py
+++ b/tests/ludwig/utils/test_config_utils.py
@@ -246,9 +246,9 @@ def ecd_config_dict_llm_encoder_8bit(
     "config,expectation",
     [
         # LLM configurations
-        ("llm_config_dict", None),
-        ("llm_config_dict_4bit", 4),
-        ("llm_config_dict_8bit", 8),
+        ("llm_config_dict", [None]),
+        ("llm_config_dict_4bit", [4]),
+        ("llm_config_dict_8bit", [8]),
         # LLM encoder configurations with one feature
         ("ecd_config_dict_llm_encoder", [None]),
         ("ecd_config_dict_llm_encoder_4bit", [4]),


### PR DESCRIPTION
`ludwig.utils.config_utils.get_quantization` returns the value of `quantization.bits` for LLM model types (either `int` or `None` type), but for ECD it returns a list of values to account for multiple LLM encoders. To simplify checking the quantization, `get_quantization` now returns a list in every case.