### PR TITLE
fix: set `use_reentrant` to `True` to fix `Mixtral-7b` bug

### DIFF
--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -262,7 +262,7 @@ class Trainer(BaseTrainer):
                     # https://pytorch.org/docs/stable/checkpoint.html
                     # https://github.com/huggingface/transformers/blob/02f8738ef8c674300c314d004ba436cb5aaca165/src/transformers/modeling_utils.py#L2094 # noqa: E501
                     self.compiled_model.model.gradient_checkpointing_enable(
-                        gradient_checkpointing_kwargs={"use_reentrant": False}
+                        gradient_checkpointing_kwargs={"use_reentrant": True}
                     )
                 else:
                     self.compiled_model.model.gradient_checkpointing_enable()


### PR DESCRIPTION
Got the following error when training Mixstral-7b in a multi-GPU setting:

```
tensor at position 96:
saved metadata: {'shape': torch.Size([142]), 'dtype': torch.int64, 'device': device(type='cuda', index=1)}
recomputed metadata: {'shape': torch.Size([143]), 'dtype': torch.int64, 'device': device(type='cuda', index=1)}
tensor at position 97:
saved metadata: {'shape': torch.Size([142]), 'dtype': torch.int64, 'device': device(type='cuda', index=1)}
recomputed metadata: {'shape': torch.Size([143]), 'dtype': torch.int64, 'device': device(type='cuda', index=1)}
...
```

This can be resolved by setting reentrant to True ensures
> Reentrant checkpoint always recomputes function in its entirety during the backward pass.
Source: https://pytorch.org/docs/stable/checkpoint.html

So shape mismatches should be prevented.