### PR TITLE
Rename the argument of dense encoder from layers to fc_layers

### DIFF
--- a/ludwig/encoders/generic_encoders.py
+++ b/ludwig/encoders/generic_encoders.py
@@ -65,7 +65,7 @@ class DenseEncoder(Encoder):
     def __init__(
         self,
         input_size,
-        layers=None,
+        fc_layers=None,
         num_layers=1,
         output_size=256,
         use_bias=True,
@@ -87,7 +87,7 @@ class DenseEncoder(Encoder):
         logger.debug("  FCStack")
         self.fc_stack = FCStack(
             first_layer_input_size=input_size,
-            layers=layers,
+            layers=fc_layers,
             num_layers=num_layers,
             default_output_size=output_size,
             default_use_bias=use_bias,


### PR DESCRIPTION
# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does: fc_layers setting not working for the dense encoder for the input feature. To fix this, layers in the DenseEncoder class has been renamed to fc_layers.
- if applicable, a reference to an issue: I posted a question on Slack, but haven't received an answer yet. https://ludwig-ai.slack.com/archives/C01PN6M2RSM/p1707631595275339
- a reproducible test for your PR (code, config and data sample): 
https://gist.github.com/metamath1/0dc3893e11a887cdd2544372d9e46852
