### PR TITLE
Disabling AdaptionPrompt till PEFT is fixed.

### DIFF
--- a/ludwig/schema/llms/peft.py
+++ b/ludwig/schema/llms/peft.py
@@ -407,7 +407,9 @@ class AdaloraConfig(LoraConfig):
 
 @DeveloperAPI
 # TODO: <Alex>02/21/2024: Disabling AdaptionPrompt (waiting for PEFT release to fix
-# "TypeError: LlamaRotaryEmbedding.forward() missing 1 required positional argument: 'position_ids')"</Alex>
+# "TypeError: LlamaRotaryEmbedding.forward() missing 1 required positional argument: 'position_ids')"
+# (this is reflected in https://github.com/ludwig-ai/ludwig/issues/3938).
+# </Alex>
 # @register_adapter("adaption_prompt")
 @ludwig_dataclass
 class AdaptionPromptConfig(BaseAdapterConfig):

--- a/ludwig/schema/llms/peft.py
+++ b/ludwig/schema/llms/peft.py
@@ -406,7 +406,9 @@ class AdaloraConfig(LoraConfig):
 
 
 @DeveloperAPI
-@register_adapter("adaption_prompt")
+# TODO: <Alex>02/21/2024: Disabling AdaptionPrompt (waiting for PEFT release to fix
+# "TypeError: LlamaRotaryEmbedding.forward() missing 1 required positional argument: 'position_ids')"</Alex>
+# @register_adapter("adaption_prompt")
 @ludwig_dataclass
 class AdaptionPromptConfig(BaseAdapterConfig):
     """Adapted from https://github.com/huggingface/peft/blob/main/src/peft/tuners/adaption_prompt/config.py."""

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -532,7 +532,9 @@ def _verify_lm_lora_finetuning_layers(
             id="adalora_not_merged",
         ),
         # TODO: <Alex>02/21/2024: Disabling AdaptionPrompt (waiting for PEFT release to fix
-        # "TypeError: LlamaRotaryEmbedding.forward() missing 1 required positional argument: 'position_ids')"</Alex>
+        # "TypeError: LlamaRotaryEmbedding.forward() missing 1 required positional argument: 'position_ids')"
+        # (this is reflected in https://github.com/ludwig-ai/ludwig/issues/3938).
+        # </Alex>
         # pytest.param(
         #     "adaption_prompt",
         #     {},
@@ -1024,7 +1026,9 @@ def test_default_max_sequence_length():
         "lora",
         "adalora",
         # TODO: <Alex>02/21/2024: Disabling AdaptionPrompt (waiting for PEFT release to fix
-        # "TypeError: LlamaRotaryEmbedding.forward() missing 1 required positional argument: 'position_ids')"</Alex>
+        # "TypeError: LlamaRotaryEmbedding.forward() missing 1 required positional argument: 'position_ids')"
+        # (this is reflected in https://github.com/ludwig-ai/ludwig/issues/3938).
+        # </Alex>
         # "adaption_prompt",
     ],
 )

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -1018,7 +1018,16 @@ def test_default_max_sequence_length():
 
 
 @pytest.mark.llm
-@pytest.mark.parametrize("adapter", ["lora", "adalora", "adaption_prompt"])
+@pytest.mark.parametrize(
+    "adapter",
+    [
+        "lora",
+        "adalora",
+        # TODO: <Alex>02/21/2024: Disabling AdaptionPrompt (waiting for PEFT release to fix
+        # "TypeError: LlamaRotaryEmbedding.forward() missing 1 required positional argument: 'position_ids')"</Alex>
+        # "adaption_prompt",
+    ],
+)
 def test_load_pretrained_adapter_weights(adapter):
     from peft import PeftModel
     from transformers import PreTrainedModel

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -531,16 +531,18 @@ def _verify_lm_lora_finetuning_layers(
             {POSTPROCESSOR: {MERGE_ADAPTER_INTO_BASE_MODEL: False}},
             id="adalora_not_merged",
         ),
-        pytest.param(
-            "adaption_prompt",
-            {},
-            id="adaption_prompt-defaults",
-        ),
-        pytest.param(
-            "adaption_prompt",
-            {"adapter_len": 6, "adapter_layers": 1},
-            id="adaption_prompt-modified-defaults",
-        ),
+        # TODO: <Alex>02/21/2024: Disabling AdaptionPrompt (waiting for PEFT release to fix
+        # "TypeError: LlamaRotaryEmbedding.forward() missing 1 required positional argument: 'position_ids')"</Alex>
+        # pytest.param(
+        #     "adaption_prompt",
+        #     {},
+        #     id="adaption_prompt-defaults",
+        # ),
+        # pytest.param(
+        #     "adaption_prompt",
+        #     {"adapter_len": 6, "adapter_layers": 1},
+        #     id="adaption_prompt-modified-defaults",
+        # ),
         pytest.param(
             "ia3",
             {},


### PR DESCRIPTION
### Scope
We are disabling `AdaptionPrompt` temporarily, until incompatibility with the `forward()` signature in HuggingFace PEFT is fixed.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
