### PR TITLE
fix: Update imdb_genre_prediction dataset yaml to match dataset

### DIFF
--- a/ludwig/datasets/configs/imdb_genre_prediction.yaml
+++ b/ludwig/datasets/configs/imdb_genre_prediction.yaml
@@ -27,7 +27,9 @@ columns:
     type: category
   - name: Runtime (Minutes)
     type: number
-  - name: Rating Votes
+  - name: Rating
+    type: Number
+  - name: Votes
     type: number
   - name: Revenue (Millions)
     type: number


### PR DESCRIPTION
Pulled the dataset file manually from the download link, and here are the columns:

```Rank,Title,Description,Director,Actors,Year,Runtime (Minutes),Rating,Votes,Revenue (Millions),Metascore,Genre_is_Drama```