### PR TITLE
fix: use eos token in target tensor for instruction-tuning

### DIFF
--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -471,14 +471,14 @@ def generate_merged_ids(
     merged_input_and_targets = []
     lengths = []
 
-    pad_tensor = torch.tensor([tokenizer.pad_token_id]).to(target_ids[0].device)
+    eos_tensor = torch.tensor([tokenizer.eos_token_id]).to(target_ids[0].device)
 
     # Merge input_ids and target_ids by concatenating them together.
     # We remove the left padding from both input_ids and target_ids before concatenating them.
     for input_id_sample, target_id_sample in zip(input_ids, target_ids):
         input_id_sample_no_padding = remove_left_padding(input_id_sample, tokenizer)[0]
         target_id_sample_no_padding = remove_left_padding(target_id_sample, tokenizer)[0]
-        target_id_sample_no_padding = torch.cat((target_id_sample_no_padding, pad_tensor), dim=-1)
+        target_id_sample_no_padding = torch.cat((target_id_sample_no_padding, eos_tensor), dim=-1)
 
         merged_sample_ids = torch.cat((input_id_sample_no_padding, target_id_sample_no_padding), dim=-1)
         # If the merged tensor is longer than the maximum sequence length, we truncate it.

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -1339,7 +1339,9 @@ def test_llm_used_tokens(tmpdir):
     ) as f:
         progress_tracker = json.load(f)
 
-    assert progress_tracker["cumulative_step_token_usage"]["11"] == progress_tracker["total_tokens_used"] == 612
+    print("progress_tracker['cumulative_step_token_usage']", progress_tracker["cumulative_step_token_usage"])
+    print("progress_tracker['total_tokens_used']", progress_tracker["total_tokens_used"])
+    assert progress_tracker["cumulative_step_token_usage"]["11"] == progress_tracker["total_tokens_used"] == 621
     assert progress_tracker["checkpoint_to_epoch"] == {"1": 1, "2": 1, "3": 2, "4": 2, "5": 3, "6": 3}
     assert progress_tracker["checkpoint_to_step"] == {"1": 4, "2": 4, "3": 8, "4": 8, "5": 12, "6": 12}
     assert progress_tracker["cumulative_checkpoint_token_usage"] == {

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -1343,18 +1343,18 @@ def test_llm_used_tokens(tmpdir):
     assert progress_tracker["checkpoint_to_epoch"] == {"1": 1, "2": 1, "3": 2, "4": 2, "5": 3, "6": 3}
     assert progress_tracker["checkpoint_to_step"] == {"1": 4, "2": 4, "3": 8, "4": 8, "5": 12, "6": 12}
     assert progress_tracker["cumulative_checkpoint_token_usage"] == {
-        "1": 204,
-        "2": 204,
-        "3": 408,
-        "4": 408,
-        "5": 612,
-        "6": 612,
+        "1": 207,
+        "2": 207,
+        "3": 414,
+        "4": 414,
+        "5": 621,
+        "6": 621,
     }
     assert progress_tracker["incremental_checkpoint_token_usage"] == {
-        "1": 204,
+        "1": 207,
         "2": 0,
-        "3": 204,
+        "3": 207,
         "4": 0,
-        "5": 204,
+        "5": 207,
         "6": 0,
     }

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -1339,8 +1339,6 @@ def test_llm_used_tokens(tmpdir):
     ) as f:
         progress_tracker = json.load(f)
 
-    print("progress_tracker['cumulative_step_token_usage']", progress_tracker["cumulative_step_token_usage"])
-    print("progress_tracker['total_tokens_used']", progress_tracker["total_tokens_used"])
     assert progress_tracker["cumulative_step_token_usage"]["11"] == progress_tracker["total_tokens_used"] == 621
     assert progress_tracker["checkpoint_to_epoch"] == {"1": 1, "2": 1, "3": 2, "4": 2, "5": 3, "6": 3}
     assert progress_tracker["checkpoint_to_step"] == {"1": 4, "2": 4, "3": 8, "4": 8, "5": 12, "6": 12}

--- a/tests/ludwig/utils/test_llm_utils.py
+++ b/tests/ludwig/utils/test_llm_utils.py
@@ -156,7 +156,7 @@ def test_find_last_matching_index(tensor_a, tensor_b, expected_index):
 def test_generate_merged_ids_with_target(tokenizer, input_ids, target_ids):
     # Test case when target_ids is not None
     merged_ids, attention_masks = generate_merged_ids(input_ids, target_ids, tokenizer)
-    assert torch.equal(merged_ids, torch.tensor([[3, 4, 5, 9, 10, 11, 1], [6, 7, 8, 12, 13, 14, 1]]))
+    assert torch.equal(merged_ids, torch.tensor([[3, 4, 5, 9, 10, 11, 2], [6, 7, 8, 12, 13, 14, 2]]))
     assert merged_ids.shape == (2, 7)  # Check the shape of merged_ids
     assert attention_masks.shape == (2, 7)  # Check the shape of attention_masks
 
@@ -186,7 +186,7 @@ def test_generate_merged_ids_padding_removal(tokenizer, input_ids, target_ids):
 
     assert torch.equal(merged_ids[0][:3], input_ids[0])  # Check the input_ids part without padding
     assert torch.equal(merged_ids[0][3:-1], target_ids[0])  # Check the target_ids part without padding
-    assert torch.equal(merged_ids[0][-1], torch.tensor(tokenizer.pad_token_id))  # Check the padding tokens
+    assert torch.equal(merged_ids[0][-1], torch.tensor(tokenizer.eos_token_id))  # Check the padding tokens
 
     assert torch.all(attention_masks == 1)
 


### PR DESCRIPTION
Prior to this change, we used pad token at the end of target tensor. This was okay because many of the new LLMs trained with pad token == eos token. With Gemma, there is a separate eos token. The issue now is that, during generation, Gemma cannot produce an eos token, so generation never stops. We now use eos token during fine-tuning so that LLMs are guaranteed to learn how to stop during the generation step.