### PR TITLE
[MAINTENANCE] Comment Out PyTorch Nightly Test

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -126,11 +126,11 @@ jobs:
 
           if [ "$PYTORCH" == "nightly" ]; then
             index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch torchtext torchvision torchaudio --index-url $extra_index_url
+            pip install --pre torch torchtext torchvision torchaudio --index-url $index_url
 
           else
-            extra_index_url=https://download.pytorch.org/whl/cpu
-            pip install torch==$PYTORCH torchtext torchvision torchaudio --index-url $extra_index_url
+            index_url=https://download.pytorch.org/whl/cpu
+            pip install torch==$PYTORCH torchtext torchvision torchaudio --index-url $index_url
           fi
 
           pip install '.[test]' --index-url $index_url

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -136,7 +136,7 @@ jobs:
           fi
 
           # pip install '.[test]' --extra-index-url $extra_index_url
-          pip install '.[test]'
+          pip install ".[test]"
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -125,15 +125,15 @@ jobs:
           fi
 
           if [ "$PYTORCH" == "nightly" ]; then
-            extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            index_url=https://download.pytorch.org/whl/nightly/cpu
+            pip install --pre torch torchtext torchvision torchaudio --index-url $index_url
 
           else
-            extra_index_url=https://download.pytorch.org/whl/cpu
-            pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            index_url=https://download.pytorch.org/whl/cpu
+            pip install torch==$PYTORCH torchtext torchvision torchaudio --index-url $index_url
           fi
 
-          pip install '.[test]' --extra-index-url $extra_index_url
+          pip install '.[test]' --index-url $index_url
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -136,7 +136,7 @@ jobs:
             pip install torch==$PYTORCH torch torchvision torchaudio --extra-index-url $extra_index_url
           fi
 
-          pip install '.[test]' --extra-index-url $extra_index_url
+          # pip install '.[test]' --extra-index-url $extra_index_url
           # pip install torchtext --extra-index-url $extra_index_url
           pip install torchtext
           pip install '.[test]'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -125,15 +125,17 @@ jobs:
           fi
 
           if [ "$PYTORCH" == "nightly" ]; then
-            index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch torchtext torchvision torchaudio --index-url $index_url
+            extra_index_url=https://download.pytorch.org/whl/nightly/cpu
+            # pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            pip install --pre torch torchvision torchaudio --extra-index-url $extra_index_url
 
           else
-            index_url=https://download.pytorch.org/whl/cpu
-            pip install torch==$PYTORCH torchtext torchvision torchaudio --index-url $index_url
+            extra_index_url=https://download.pytorch.org/whl/cpu
+            # pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            pip install torch==$PYTORCH torch torchvision torchaudio --extra-index-url $extra_index_url
           fi
 
-          pip install '.[test]' --index-url $index_url
+          pip install '.[test]' --extra-index-url $extra_index_url
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -136,7 +136,8 @@ jobs:
           fi
 
           # pip install '.[test]' --extra-index-url $extra_index_url
-          pip install ".[test]"
+          pip install torchtext
+          pip install '.[test]'
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -125,22 +125,16 @@ jobs:
           fi
 
           if [ "$PYTORCH" == "nightly" ]; then
-            # pip install nvidia-cuda-nvrtc-cu12==12.1.105
+            pip install --upgrade bitsandbytes
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            # pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
-            pip install --pre torch torchvision torchaudio --extra-index-url $extra_index_url
+            pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
 
           else
             extra_index_url=https://download.pytorch.org/whl/cpu
-            # pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
-            pip install torch==$PYTORCH torch torchvision torchaudio --extra-index-url $extra_index_url
+            pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
           fi
 
-          # pip install '.[test]' --extra-index-url $extra_index_url
-          # pip install torchtext --extra-index-url $extra_index_url
-          pip install cudatoolkit
-          pip install torchtext
-          pip install '.[test]'
+          pip install '.[test]' --extra-index-url $extra_index_url
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -135,7 +135,8 @@ jobs:
             pip install torch==$PYTORCH torch torchvision torchaudio --extra-index-url $extra_index_url
           fi
 
-          pip install '.[test]' --extra-index-url $extra_index_url
+          # pip install '.[test]' --extra-index-url $extra_index_url
+          pip install '.[test]'
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -126,18 +126,20 @@ jobs:
 
           if [ "$PYTORCH" == "nightly" ]; then
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            # pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
-            pip install --pre torch torchvision torchaudio --extra-index-url $extra_index_url
+            pip install pytorch-cuda
+            pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            # pip install --pre torch torchvision torchaudio --extra-index-url $extra_index_url
 
           else
             extra_index_url=https://download.pytorch.org/whl/cpu
-            # pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
-            pip install torch==$PYTORCH torch torchvision torchaudio --extra-index-url $extra_index_url
+            pip install pytorch-cuda
+            pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            # pip install torch==$PYTORCH torch torchvision torchaudio --extra-index-url $extra_index_url
           fi
 
-          # pip install '.[test]' --extra-index-url $extra_index_url
-          pip install torchtext --extra-index-url $extra_index_url
-          pip install '.[test]'
+          pip install '.[test]' --extra-index-url $extra_index_url
+          # pip install torchtext --extra-index-url $extra_index_url
+          # pip install '.[test]'
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -126,14 +126,14 @@ jobs:
 
           if [ "$PYTORCH" == "nightly" ]; then
             index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
+            pip install --pre wheel torch torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
 
           else
             index_url=https://download.pytorch.org/whl/cpu
-            pip install torch==$PYTORCH torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
+            pip install wheel torch==$PYTORCH torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
           fi
 
-          pip install '.[test]' --no-build-isolation --index-url $index_url
+          pip install wheel '.[test]' --no-build-isolation --index-url $index_url
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -126,11 +126,11 @@ jobs:
 
           if [ "$PYTORCH" == "nightly" ]; then
             index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch torchtext torchvision torchaudio --index-url $index_url
+            pip install --pre torch torchtext torchvision torchaudio --index-url $index_url --find-links
 
           else
             index_url=https://download.pytorch.org/whl/cpu
-            pip install torch==$PYTORCH torchtext torchvision torchaudio --index-url $index_url
+            pip install torch==$PYTORCH torchtext torchvision torchaudio --index-url $index_url --find-links
           fi
 
           pip install '.[test]' --index-url $index_url

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -136,7 +136,7 @@ jobs:
           fi
 
           # pip install '.[test]' --extra-index-url $extra_index_url
-          pip install torchtext
+          pip install torchtext --extra-index-url $extra_index_url
           pip install '.[test]'
           pip list
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -138,6 +138,7 @@ jobs:
 
           # pip install '.[test]' --extra-index-url $extra_index_url
           # pip install torchtext --extra-index-url $extra_index_url
+          pip install cudatoolkit
           pip install torchtext
           pip install '.[test]'
           pip list

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,10 +33,10 @@ jobs:
             pytorch-version: 2.1.1
             torchscript-version: 1.10.2
             ray-version: 2.3.1
-          - python-version: "3.10"
-            pytorch-version: nightly
-            torchscript-version: 1.10.2
-            ray-version: 2.3.1
+          # - python-version: "3.10"
+          #   pytorch-version: nightly
+          #   torchscript-version: 1.10.2
+          #   ray-version: 2.3.1
     env:
       PYTORCH: ${{ matrix.pytorch-version }}
       MARKERS: ${{ matrix.test-markers }}
@@ -125,7 +125,6 @@ jobs:
           fi
 
           if [ "$PYTORCH" == "nightly" ]; then
-            pip install --upgrade bitsandbytes
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
             pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -125,12 +125,16 @@ jobs:
           fi
 
           if [ "$PYTORCH" == "nightly" ]; then
+            pip install wheel
+            python setup.py bdist_wheel
             index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre wheel torch torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
+            pip install --pre torch torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
 
           else
+            pip install wheel
+            python setup.py bdist_wheel
             index_url=https://download.pytorch.org/whl/cpu
-            pip install wheel torch==$PYTORCH torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
+            pip install torch==$PYTORCH torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
           fi
 
           pip install wheel '.[test]' --no-build-isolation --index-url $index_url

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -78,7 +78,14 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev cuda
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
+          sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+          wget https://developer.download.nvidia.com/compute/cuda/11.5.1/local_installers/cuda-repo-ubuntu2004-11-5-local_11.5.1-495.29.05-1_amd64.deb
+          sudo dpkg -i cuda-repo-ubuntu2004-11-5-local_11.5.1-495.29.05-1_amd64.deb
+          sudo apt-key add /var/cuda-repo-ubuntu2004-11-5-local/7fa2af80.pub
+          # sudo apt-get update
+          # sudo apt-get -y install cuda
+          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev
 
       - name: Setup macOS
         if: runner.os == 'macOS'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,7 +42,7 @@ jobs:
       MARKERS: ${{ matrix.test-markers }}
       NEUROPOD_BASE_DIR: "/usr/local/lib/neuropod"
       NEUROPOD_VERISON: "0.3.0-rc6"
-      TORCHSCRIPT_VERISON: ${{ matrix.torchscript-version }}
+      TORCHSCRIPT_VERSION: ${{ matrix.torchscript-version }}
       RAY_VERSION: ${{ matrix.ray-version }}
       AWS_ACCESS_KEY_ID: ${{ secrets.LUDWIG_TESTS_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.LUDWIG_TESTS_AWS_SECRET_ACCESS_KEY }}
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev libhdf5-dev libhdf5-serial-dev
+          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev
 
       - name: Setup macOS
         if: runner.os == 'macOS'
@@ -125,19 +125,16 @@ jobs:
           fi
 
           if [ "$PYTORCH" == "nightly" ]; then
-            pip install wheel Cython h5py
-            python setup.py bdist_wheel
-            index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
+            extra_index_url=https://download.pytorch.org/whl/nightly/cpu
+            pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
 
           else
-            pip install wheel Cython h5py
-            python setup.py bdist_wheel
-            index_url=https://download.pytorch.org/whl/cpu
-            pip install torch==$PYTORCH torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
+            extra_index_url=https://download.pytorch.org/whl/cpu
+            pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
           fi
 
-          pip install '.[test]' --no-build-isolation --index-url $index_url
+          # pip install '.[test]' --extra-index-url $extra_index_url
+          pip install '.[test]' --index-url $extra_index_url
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then
@@ -156,7 +153,7 @@ jobs:
       - name: Install Neuropod backend
         run: |
           sudo mkdir -p "$NEUROPOD_BASE_DIR"
-          curl -L https://github.com/uber/neuropod/releases/download/v${{ env.NEUROPOD_VERISON }}/libneuropod-cpu-linux-v${{ env.NEUROPOD_VERISON }}-torchscript-${{ env.TORCHSCRIPT_VERISON }}-backend.tar.gz | sudo tar -xz -C "$NEUROPOD_BASE_DIR"
+          curl -L https://github.com/uber/neuropod/releases/download/v${{ env.NEUROPOD_VERISON }}/libneuropod-cpu-linux-v${{ env.NEUROPOD_VERISON }}-torchscript-${{ env.TORCHSCRIPT_VERSION }}-backend.tar.gz | sudo tar -xz -C "$NEUROPOD_BASE_DIR"
         shell: bash
 
       - name: Unit Tests
@@ -445,7 +442,7 @@ jobs:
   #     PYTORCH: ${{ matrix.pytorch-version }}
   #     NEUROPOD_BASE_DIR: "/usr/local/lib/neuropod"
   #     NEUROPOD_VERISON: "0.3.0-rc6"
-  #     TORCHSCRIPT_VERISON: ${{ matrix.torchscript-version }}
+  #     TORCHSCRIPT_VERSION: ${{ matrix.torchscript-version }}
 
   #   name: py${{ matrix.python-version  }}, torch-${{ matrix.pytorch-version }}, gpu
 
@@ -507,7 +504,7 @@ jobs:
   #     - name: Install Neuropod backend
   #       run: |
   #         sudo mkdir -p "$NEUROPOD_BASE_DIR"
-  #         curl -L https://github.com/uber/neuropod/releases/download/v${{ env.NEUROPOD_VERISON }}/libneuropod-cpu-linux-v${{ env.NEUROPOD_VERISON }}-torchscript-${{ env.TORCHSCRIPT_VERISON }}-backend.tar.gz | sudo tar -xz -C "$NEUROPOD_BASE_DIR"
+  #         curl -L https://github.com/uber/neuropod/releases/download/v${{ env.NEUROPOD_VERISON }}/libneuropod-cpu-linux-v${{ env.NEUROPOD_VERISON }}-torchscript-${{ env.TORCHSCRIPT_VERSION }}-backend.tar.gz | sudo tar -xz -C "$NEUROPOD_BASE_DIR"
   #       shell: bash
 
   #     - name: Reinstall Horovod if necessary

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev libssl-dev
+          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev
 
       - name: Setup macOS
         if: runner.os == 'macOS'
@@ -125,19 +125,19 @@ jobs:
           fi
 
           if [ "$PYTORCH" == "nightly" ]; then
-            pip install wheel
+            pip install wheel Cython
             python setup.py bdist_wheel
             index_url=https://download.pytorch.org/whl/nightly/cpu
             pip install --pre torch torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
 
           else
-            pip install wheel
+            pip install wheel Cython
             python setup.py bdist_wheel
             index_url=https://download.pytorch.org/whl/cpu
             pip install torch==$PYTORCH torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
           fi
 
-          pip install wheel '.[test]' --no-build-isolation --index-url $index_url
+          pip install '.[test]' --no-build-isolation --index-url $index_url
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev
+          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev libhdf5-dev libhdf5-serial-dev
 
       - name: Setup macOS
         if: runner.os == 'macOS'
@@ -125,13 +125,13 @@ jobs:
           fi
 
           if [ "$PYTORCH" == "nightly" ]; then
-            pip install wheel Cython
+            pip install wheel Cython h5py
             python setup.py bdist_wheel
             index_url=https://download.pytorch.org/whl/nightly/cpu
             pip install --pre torch torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
 
           else
-            pip install wheel Cython
+            pip install wheel Cython h5py
             python setup.py bdist_wheel
             index_url=https://download.pytorch.org/whl/cpu
             pip install torch==$PYTORCH torchtext torchvision torchaudio --no-build-isolation --index-url $index_url

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -85,7 +85,7 @@ jobs:
           sudo apt-key add /var/cuda-repo-ubuntu2004-11-5-local/7fa2af80.pub
           # sudo apt-get update
           # sudo apt-get -y install cuda
-          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev
+          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev cuda
 
       - name: Setup macOS
         if: runner.os == 'macOS'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -125,20 +125,21 @@ jobs:
           fi
 
           if [ "$PYTORCH" == "nightly" ]; then
-            pip install nvidia-cuda-nvrtc-cu12==12.1.105
+            # pip install nvidia-cuda-nvrtc-cu12==12.1.105
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
-            # pip install --pre torch torchvision torchaudio --extra-index-url $extra_index_url
+            # pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            pip install --pre torch torchvision torchaudio --extra-index-url $extra_index_url
 
           else
             extra_index_url=https://download.pytorch.org/whl/cpu
-            pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
-            # pip install torch==$PYTORCH torch torchvision torchaudio --extra-index-url $extra_index_url
+            # pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            pip install torch==$PYTORCH torch torchvision torchaudio --extra-index-url $extra_index_url
           fi
 
           pip install '.[test]' --extra-index-url $extra_index_url
           # pip install torchtext --extra-index-url $extra_index_url
-          # pip install '.[test]'
+          pip install torchtext
+          pip install '.[test]'
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,10 +33,11 @@ jobs:
             pytorch-version: 2.1.1
             torchscript-version: 1.10.2
             ray-version: 2.3.1
-#          - python-version: "3.10"
-#            pytorch-version: nightly
-#            torchscript-version: 1.10.2
-#            ray-version: 2.3.1
+          - python-version: "3.10"
+            # pytorch-version: nightly
+            pytorch-version: 2.2.1
+            torchscript-version: 1.10.2
+            ray-version: 2.3.1
     env:
       PYTORCH: ${{ matrix.pytorch-version }}
       MARKERS: ${{ matrix.test-markers }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -126,14 +126,14 @@ jobs:
 
           if [ "$PYTORCH" == "nightly" ]; then
             index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch torchtext torchvision torchaudio --index-url $index_url --find-links
+            pip install --pre torch torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
 
           else
             index_url=https://download.pytorch.org/whl/cpu
-            pip install torch==$PYTORCH torchtext torchvision torchaudio --index-url $index_url --find-links
+            pip install torch==$PYTORCH torchtext torchvision torchaudio --no-build-isolation --index-url $index_url
           fi
 
-          pip install '.[test]' --index-url $index_url
+          pip install '.[test]' --no-build-isolation --index-url $index_url
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -125,16 +125,15 @@ jobs:
           fi
 
           if [ "$PYTORCH" == "nightly" ]; then
-            extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            index_url=https://download.pytorch.org/whl/nightly/cpu
+            pip install --pre torch torchtext torchvision torchaudio --index-url $extra_index_url
 
           else
             extra_index_url=https://download.pytorch.org/whl/cpu
-            pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
+            pip install torch==$PYTORCH torchtext torchvision torchaudio --index-url $extra_index_url
           fi
 
-          # pip install '.[test]' --extra-index-url $extra_index_url
-          pip install '.[test]' --index-url $extra_index_url
+          pip install '.[test]' --index-url $index_url
           pip list
 
           if [ "$PYTORCH" == "nightly" ]; then

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev
+          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev cuda
 
       - name: Setup macOS
         if: runner.os == 'macOS'
@@ -126,13 +126,11 @@ jobs:
 
           if [ "$PYTORCH" == "nightly" ]; then
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
-            pip install pytorch-cuda
             pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
             # pip install --pre torch torchvision torchaudio --extra-index-url $extra_index_url
 
           else
             extra_index_url=https://download.pytorch.org/whl/cpu
-            pip install pytorch-cuda
             pip install torch==$PYTORCH torchtext torchvision torchaudio --extra-index-url $extra_index_url
             # pip install torch==$PYTORCH torch torchvision torchaudio --extra-index-url $extra_index_url
           fi

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev
+          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev libssl-dev
 
       - name: Setup macOS
         if: runner.os == 'macOS'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -78,14 +78,7 @@ jobs:
       - name: Setup Linux
         if: runner.os == 'linux'
         run: |
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
-          sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-          wget https://developer.download.nvidia.com/compute/cuda/11.5.1/local_installers/cuda-repo-ubuntu2004-11-5-local_11.5.1-495.29.05-1_amd64.deb
-          sudo dpkg -i cuda-repo-ubuntu2004-11-5-local_11.5.1-495.29.05-1_amd64.deb
-          sudo apt-key add /var/cuda-repo-ubuntu2004-11-5-local/7fa2af80.pub
-          # sudo apt-get update
-          # sudo apt-get -y install cuda
-          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev cuda
+          sudo apt-get update && sudo apt-get install -y cmake libsndfile1 wget libsox-dev
 
       - name: Setup macOS
         if: runner.os == 'macOS'
@@ -132,6 +125,7 @@ jobs:
           fi
 
           if [ "$PYTORCH" == "nightly" ]; then
+            pip install nvidia-cuda-nvrtc-cu12==12.1.105
             extra_index_url=https://download.pytorch.org/whl/nightly/cpu
             pip install --pre torch torchtext torchvision torchaudio --extra-index-url $extra_index_url
             # pip install --pre torch torchvision torchaudio --extra-index-url $extra_index_url

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,10 +33,10 @@ jobs:
             pytorch-version: 2.1.1
             torchscript-version: 1.10.2
             ray-version: 2.3.1
-          # - python-version: "3.10"
-          #   pytorch-version: nightly
-          #   torchscript-version: 1.10.2
-          #   ray-version: 2.3.1
+#          - python-version: "3.10"
+#            pytorch-version: nightly
+#            torchscript-version: 1.10.2
+#            ray-version: 2.3.1
     env:
       PYTORCH: ${{ matrix.pytorch-version }}
       MARKERS: ${{ matrix.test-markers }}


### PR DESCRIPTION
### Scope
We get an error while installing PyTorch nightly:
```
ERROR: HTTP error 403 while getting https://download.pytorch.org/whl/nightly/nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (from https://download.pytorch.org/whl/nightly/cpu/nvidia-cuda-nvrtc-cu12/)
2024-02-12T19:11:26.3258455Z ERROR: Could not install requirement nvidia-cuda-nvrtc-cu12==12.1.105 from https://download.pytorch.org/whl/nightly/nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (from torch) because of HTTP error 403 Client Error: Forbidden for url: https://download.pytorch.org/whl/nightly/nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl for URL https://download.pytorch.org/whl/nightly/nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl (from https://download.pytorch.org/whl/nightly/cpu/nvidia-cuda-nvrtc-cu12/)
```

Documentation states to use the following command:
```
pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu
```

But then unit tests fail, because `torchtext` is not found.

Numerous attempts to reconcile these dependencies have not led to success; so we are disabling the PyTorch nightly test.

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
