### PR TITLE
enh: add batch size tuning memory limit option to hedge against OOMs

### DIFF
--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -114,6 +114,11 @@ class BaseTrainerConfig(schema_utils.BaseMarshmallowConfig, ABC):
         default={},
     )
 
+    batch_size_tuning_gpu_memory_limit: int = schema_utils.NonNegativeFloat(
+        default=1.0,
+        description="The maximum amount of GPU memory to use for batch size tuning.",
+    )
+
     def can_tune_batch_size(self) -> bool:
         return True
 

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -527,8 +527,7 @@ class Trainer(BaseTrainer):
                 # Total memory used.
                 train_summary_writer.add_scalar(
                     f"cuda/device{i}/total_memory_used_gb",
-                    (torch.cuda.mem_get_info(device=device)[1] - torch.cuda.mem_get_info(device=device)[0])
-                    / (1000**3),
+                    (torch.cuda.mem_get_info(device=device)[1] - torch.cuda.mem_get_info(device=device)[0]) / (1000**3),
                     global_step=step,
                 )
 
@@ -595,7 +594,12 @@ class Trainer(BaseTrainer):
                 checkpoint.save(os.path.join(tmpdir, "latest.ckpt"), global_step=0)
             try:
                 best_batch_size = evaluator.select_best_batch_size(
-                    len(training_set), max_batch_size, max_trials, self.is_coordinator(), global_max_sequence_length
+                    len(training_set),
+                    max_batch_size,
+                    max_trials,
+                    self.is_coordinator(),
+                    global_max_sequence_length,
+                    gpu_memory_fraction=self.config.batch_size_tuning_gpu_memory_limit,
                 )
                 best_batch_size = self.distributed.broadcast_object(best_batch_size)
 

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -527,7 +527,8 @@ class Trainer(BaseTrainer):
                 # Total memory used.
                 train_summary_writer.add_scalar(
                     f"cuda/device{i}/total_memory_used_gb",
-                    (torch.cuda.mem_get_info(device=device)[1] - torch.cuda.mem_get_info(device=device)[0]) / (1000**3),
+                    (torch.cuda.mem_get_info(device=device)[1] - torch.cuda.mem_get_info(device=device)[0])
+                    / (1000**3),
                     global_step=step,
                 )
 

--- a/ludwig/utils/batch_size_tuner.py
+++ b/ludwig/utils/batch_size_tuner.py
@@ -6,13 +6,32 @@ from abc import ABC
 from typing import Optional
 
 import torch
+from contextlib import contextmanager
+
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import MAX_BATCH_SIZE_DATASET_FRACTION, MIN_POSSIBLE_BATCH_SIZE
+from ludwig.utils.torch_utils import get_torch_init_params
 
 logger = logging.getLogger(__name__)
 
 TOTAL_STEPS = 5
+
+
+@contextmanager
+def use_gpu_memory_fraction(fraction):
+    """Temporarily sets the GPU memory fraction for the current process."""
+    _, original_fraction, _, _, _ = get_torch_init_params()
+    if original_fraction is None:
+        original_fraction = 1.0
+
+    try:
+        logger.info("Using GPU memory fraction for batch size tuning: %.2f", fraction)
+        torch.cuda.set_per_process_memory_fraction(fraction)
+        yield
+    finally:
+        logger.info("Resetting GPU memory fraction to: %.2f", original_fraction)
+        torch.cuda.set_per_process_memory_fraction(original_fraction)
 
 
 @DeveloperAPI
@@ -24,74 +43,76 @@ class BatchSizeEvaluator(ABC):
         max_trials: int = 20,
         is_coordinator: Optional[bool] = True,
         global_max_sequence_length: Optional[int] = None,
+        gpu_memory_fraction: int = 1.0,  # optionally set a ceiling to hedge against OOMs
     ) -> int:
         """Returns optimal batch size as measured by throughput (samples / sec)."""
         logger.info("Tuning batch size...")
 
-        max_batch_size = max_batch_size or dataset_len
+        with use_gpu_memory_fraction(gpu_memory_fraction):
+            max_batch_size = max_batch_size or dataset_len
 
-        def _is_valid_batch_size(batch_size):
-            # make sure that batch size is valid (e.g. less than 20% of ds size and max_batch_size)
-            is_smaller_than_training_set = batch_size <= MAX_BATCH_SIZE_DATASET_FRACTION * dataset_len
-            is_under_max_batch_size = batch_size <= max_batch_size
-            is_valid = is_smaller_than_training_set and is_under_max_batch_size
-            if not is_valid and is_coordinator:
-                logger.info(
-                    f"Batch size {batch_size} is invalid, must be less than or equal to "
-                    f"{MAX_BATCH_SIZE_DATASET_FRACTION * 100}% dataset size "
-                    f"({int(MAX_BATCH_SIZE_DATASET_FRACTION * dataset_len)} samples "
-                    f"of {dataset_len}) and less than or equal to max batch size {max_batch_size}"
-                )
-            return is_valid
+            def _is_valid_batch_size(batch_size):
+                # make sure that batch size is valid (e.g. less than 20% of ds size and max_batch_size)
+                is_smaller_than_training_set = batch_size <= MAX_BATCH_SIZE_DATASET_FRACTION * dataset_len
+                is_under_max_batch_size = batch_size <= max_batch_size
+                is_valid = is_smaller_than_training_set and is_under_max_batch_size
+                if not is_valid and is_coordinator:
+                    logger.info(
+                        f"Batch size {batch_size} is invalid, must be less than or equal to "
+                        f"{MAX_BATCH_SIZE_DATASET_FRACTION * 100}% dataset size "
+                        f"({int(MAX_BATCH_SIZE_DATASET_FRACTION * dataset_len)} samples "
+                        f"of {dataset_len}) and less than or equal to max batch size {max_batch_size}"
+                    )
+                return is_valid
 
-        batch_size = MIN_POSSIBLE_BATCH_SIZE
-        best_samples_per_sec = 0
-        best_batch_size = None
-        count = 0
-        while count < max_trials and _is_valid_batch_size(batch_size):
-            if is_coordinator:
-                logger.info(f"Exploring batch_size={batch_size}")
-            gc.collect()
-
-            try:
-                samples_per_sec = self.evaluate(
-                    batch_size, total_steps=TOTAL_STEPS, global_max_sequence_length=global_max_sequence_length
-                )
+            batch_size = MIN_POSSIBLE_BATCH_SIZE
+            best_samples_per_sec = 0
+            best_batch_size = None
+            count = 0
+            while count < max_trials and _is_valid_batch_size(batch_size):
                 if is_coordinator:
-                    logger.info(f"Throughput at batch_size={batch_size}: {samples_per_sec:.5f} samples/s")
-                if samples_per_sec < best_samples_per_sec:
-                    # We assume that once the throughput starts degrading, it won't go up again
+                    logger.info(f"Exploring batch_size={batch_size}")
+                gc.collect()
+
+                try:
+                    samples_per_sec = self.evaluate(
+                        batch_size, total_steps=TOTAL_STEPS, global_max_sequence_length=global_max_sequence_length
+                    )
                     if is_coordinator:
-                        logger.info(f"Throughput decrease at batch_size={batch_size}")
+                        logger.info(f"Throughput at batch_size={batch_size}: {samples_per_sec:.5f} samples/s")
+                    if samples_per_sec < best_samples_per_sec:
+                        # We assume that once the throughput starts degrading, it won't go up again
+                        if is_coordinator:
+                            logger.info(f"Throughput decrease at batch_size={batch_size}")
+                        break
+
+                    best_samples_per_sec = samples_per_sec
+                    best_batch_size = batch_size
+                    count += 1
+
+                    # double batch size
+                    batch_size *= 2
+                except RuntimeError as e:
+                    # PyTorch only generates Runtime errors for CUDA OOM.
+                    gc.collect()
+                    if "CUDA out of memory" in str(e) or isinstance(e, torch.cuda.OutOfMemoryError):
+                        if is_coordinator:
+                            logger.info(f"OOM at batch_size={batch_size}")
+                    else:
+                        # Not a CUDA error
+                        raise
                     break
 
-                best_samples_per_sec = samples_per_sec
-                best_batch_size = batch_size
-                count += 1
+            # Ensure that some batch size is found.
+            # `best_batch_size` can be None if the first batch size is invalid.
+            if best_batch_size is None:
+                if is_coordinator:
+                    logger.info(f"Could not tune batch size, using minimum batch size of {MIN_POSSIBLE_BATCH_SIZE}")
+                best_batch_size = MIN_POSSIBLE_BATCH_SIZE
 
-                # double batch size
-                batch_size *= 2
-            except RuntimeError as e:
-                # PyTorch only generates Runtime errors for CUDA OOM.
-                gc.collect()
-                if "CUDA out of memory" in str(e) or isinstance(e, torch.cuda.OutOfMemoryError):
-                    if is_coordinator:
-                        logger.info(f"OOM at batch_size={batch_size}")
-                else:
-                    # Not a CUDA error
-                    raise
-                break
-
-        # Ensure that some batch size is found.
-        # `best_batch_size` can be None if the first batch size is invalid.
-        if best_batch_size is None:
             if is_coordinator:
-                logger.info(f"Could not tune batch size, using minimum batch size of {MIN_POSSIBLE_BATCH_SIZE}")
-            best_batch_size = MIN_POSSIBLE_BATCH_SIZE
-
-        if is_coordinator:
-            logger.info(f"Selected batch_size={best_batch_size}")
-        return best_batch_size
+                logger.info(f"Selected batch_size={best_batch_size}")
+            return best_batch_size
 
     def evaluate(
         self, batch_size: int, total_steps: int = 5, global_max_sequence_length: Optional[int] = None

--- a/ludwig/utils/batch_size_tuner.py
+++ b/ludwig/utils/batch_size_tuner.py
@@ -3,11 +3,10 @@ import logging
 import statistics
 import time
 from abc import ABC
+from contextlib import contextmanager
 from typing import Optional
 
 import torch
-from contextlib import contextmanager
-
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.constants import MAX_BATCH_SIZE_DATASET_FRACTION, MIN_POSSIBLE_BATCH_SIZE

--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -356,15 +356,15 @@ def initialize_pytorch(
             for gpu in gpus or range(gpu_device_count):
                 torch.cuda.memory.set_per_process_memory_fraction(gpu_memory_limit, gpu)
 
-    _set_torch_init_params(param_tuple)
+    set_torch_init_params(param_tuple)
 
 
-def _set_torch_init_params(params: Optional[Tuple]):
+def set_torch_init_params(params: Optional[Tuple]):
     global _TORCH_INIT_PARAMS
     _TORCH_INIT_PARAMS = params
 
 
-def _get_torch_init_params() -> Optional[Tuple]:
+def get_torch_init_params() -> Optional[Tuple]:
     return _TORCH_INIT_PARAMS
 
 

--- a/tests/ludwig/utils/test_torch_utils.py
+++ b/tests/ludwig/utils/test_torch_utils.py
@@ -8,10 +8,10 @@ import torch
 
 from ludwig.utils.torch_utils import (
     get_torch_init_params,
-    set_torch_init_params,
     initialize_pytorch,
     sequence_length_2D,
     sequence_length_3D,
+    set_torch_init_params,
 )
 
 

--- a/tests/ludwig/utils/test_torch_utils.py
+++ b/tests/ludwig/utils/test_torch_utils.py
@@ -7,8 +7,8 @@ import pytest
 import torch
 
 from ludwig.utils.torch_utils import (
-    _get_torch_init_params,
-    _set_torch_init_params,
+    get_torch_init_params,
+    set_torch_init_params,
     initialize_pytorch,
     sequence_length_2D,
     sequence_length_3D,
@@ -33,14 +33,14 @@ def test_sequence_length_3D(input_sequence: List[List[List[int]]], expected_outp
 
 @contextlib.contextmanager
 def clean_params():
-    prev = _get_torch_init_params()
+    prev = get_torch_init_params()
     try:
-        _set_torch_init_params(None)
+        set_torch_init_params(None)
         if "CUDA_VISIBLE_DEVICES" in os.environ:
             del os.environ["CUDA_VISIBLE_DEVICES"]
         yield
     finally:
-        _set_torch_init_params(prev)
+        set_torch_init_params(prev)
 
 
 @patch("ludwig.utils.torch_utils.torch")


### PR DESCRIPTION
Batch size tuning attempts to find the maximum batch size possible for training. However, sometimes this causes GPU utilization can spike and cause OOMs during training regardless. The new `trainer.batch_size_tuning_gpu_memory_limit` param allows the user to set a temporary ceiling on GPU memory usage for batch size tuning to hedge against CUDA OOMs during training.