### PR TITLE
[WIP] Gradual Unfreezing to mitigate catastrophic forgetting

### DIFF
--- a/ludwig/modules/gradual_unfreezer.py
+++ b/ludwig/modules/gradual_unfreezer.py
@@ -1,0 +1,28 @@
+from ludwig.models.ecd import ECD
+from ludwig.schema.gradual_unfreezer import GradualUnfreezerConfig
+
+
+class GradualUnfreezer:
+    def __init__(self, config: GradualUnfreezerConfig, model: ECD):
+        self.config = config
+        self.model = model
+        self.thaw_epochs = self.config.thaw_epochs
+        self.layers_to_thaw = self.config.layers_to_thaw
+        self.freeze_before_training()
+
+        self.layers = dict(zip(self.thaw_epochs, self.layers_to_thaw))
+
+    def freeze_before_training(self):
+        for p in self.model.parameters():
+            p.requires_grad_(False)
+
+    def thaw(self, current_epoch):
+        if current_epoch in self.layers:
+            current_layers = self.layers[current_epoch]
+            for layer in current_layers:
+                self.thawParameter(layer)
+
+    def thawParameter(self, layer):
+        for name, p in self.model.named_parameters():
+            if layer in str(name):
+                p.requires_grad_(True)

--- a/ludwig/modules/gradual_unfreezer.py
+++ b/ludwig/modules/gradual_unfreezer.py
@@ -1,9 +1,8 @@
-from ludwig.models.ecd import ECD
 from ludwig.schema.gradual_unfreezer import GradualUnfreezerConfig
 
 
 class GradualUnfreezer:
-    def __init__(self, config: GradualUnfreezerConfig, model: ECD):
+    def __init__(self, config: GradualUnfreezerConfig, model):
         self.config = config
         self.model = model
         self.thaw_epochs = self.config.thaw_epochs

--- a/ludwig/modules/gradual_unfreezer.py
+++ b/ludwig/modules/gradual_unfreezer.py
@@ -7,21 +7,22 @@ class GradualUnfreezer:
         self.model = model
         self.thaw_epochs = self.config.thaw_epochs
         self.layers_to_thaw = self.config.layers_to_thaw
-        self.freeze_before_training()
 
+        if len(self.thaw_epochs) != len(self.layers_to_thaw):
+            raise ValueError("The length of thaw_epochs and layers_to_thaw must be equal.")
         self.layers = dict(zip(self.thaw_epochs, self.layers_to_thaw))
 
-    def freeze_before_training(self):
-        for p in self.model.parameters():
-            p.requires_grad_(False)
-
-    def thaw(self, current_epoch):
+    def thaw(self, current_epoch: int) -> None:
         if current_epoch in self.layers:
             current_layers = self.layers[current_epoch]
             for layer in current_layers:
                 self.thawParameter(layer)
 
+    # thaw individual layer
     def thawParameter(self, layer):
+        # is there a better way to do this instead of iterating through all parameters?
         for name, p in self.model.named_parameters():
             if layer in str(name):
                 p.requires_grad_(True)
+            else:
+                raise ValueError("Layer type doesn't exist within model architecture")

--- a/ludwig/schema/gradual_unfreezer.py
+++ b/ludwig/schema/gradual_unfreezer.py
@@ -1,4 +1,3 @@
-# schema
 from abc import ABC
 from dataclasses import field
 from typing import Dict
@@ -7,19 +6,30 @@ from marshmallow import fields, ValidationError
 
 import ludwig.schema.utils as schema_utils
 from ludwig.api_annotations import DeveloperAPI
+from ludwig.constants import MODEL_ECD
+from ludwig.schema.metadata import TRAINER_METADATA
 from ludwig.schema.utils import ludwig_dataclass
 
 
 @DeveloperAPI
 @ludwig_dataclass
 class GradualUnfreezerConfig(schema_utils.BaseMarshmallowConfig, ABC):
-    """Configuration for freezing scheduler parameters."""
+    """Configuration for gradual unfreezing parameters."""
 
     thaw_epochs: list = schema_utils.List(
-        default=None, description="Epochs to thaw at. For example, [1, 2, 3, 4] will thaw corresponding layers in "
+        int,
+        default=None,
+        description="Epochs to thaw at. For example, [1, 2, 3, 4] will thaw layers in layers_to_thaw 2D array",
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["gradual_unfreezer"]["thaw_epochs"],
     )
 
-    layers_to_thaw: list = schema_utils.List(default=None, description="placeholder")
+    layers_to_thaw: list = schema_utils.List(
+        list,
+        inner_type=str,
+        default=None,
+        description="Individual layers to thaw at each thaw_epoch. 2D Array",
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["gradual_unfreezer"]["layers_to_thaw"],
+    )
 
 
 @DeveloperAPI
@@ -43,7 +53,7 @@ def GradualUnfreezerDataclassField(description: str, default: Dict = None):
         def _jsonschema_type_mapping(self):
             return {
                 **schema_utils.unload_jsonschema_from_marshmallow_class(GradualUnfreezerConfig),
-                "title": "gradual_unfreezer_options",
+                "title": "gradual_unfreeze_options",
                 "description": description,
             }
 

--- a/ludwig/schema/gradual_unfreezer.py
+++ b/ludwig/schema/gradual_unfreezer.py
@@ -1,0 +1,68 @@
+# schema
+from abc import ABC
+from dataclasses import field
+from typing import Dict
+
+from marshmallow import fields, ValidationError
+
+import ludwig.schema.utils as schema_utils
+from ludwig.api_annotations import DeveloperAPI
+from ludwig.schema.utils import ludwig_dataclass
+
+
+@DeveloperAPI
+@ludwig_dataclass
+class GradualUnfreezerConfig(schema_utils.BaseMarshmallowConfig, ABC):
+    """Configuration for freezing scheduler parameters."""
+
+    thaw_epochs: list = schema_utils.List(
+        default=None, description="Epochs to thaw at. For example, [1, 2, 3, 4] will thaw corresponding layers in "
+    )
+
+    layers_to_thaw: list = schema_utils.List(default=None, description="placeholder")
+
+
+@DeveloperAPI
+def GradualUnfreezerDataclassField(description: str, default: Dict = None):
+    allow_none = True
+    default = default or {}
+
+    class GradualUnfreezerMarshmallowField(fields.Field):
+        def _deserialize(self, value, attr, data, **kwargs):
+            if value is None:
+                return value
+            if isinstance(value, dict):
+                try:
+                    return GradualUnfreezerConfig.Schema().load(value)
+                except (TypeError, ValidationError) as e:
+                    raise ValidationError(
+                        f"Invalid params for gradual unfreezer: {value}, see GradualUnfreezerConfig class. Error: {e}"
+                    )
+            raise ValidationError("Field should be None or dict")
+
+        def _jsonschema_type_mapping(self):
+            return {
+                **schema_utils.unload_jsonschema_from_marshmallow_class(GradualUnfreezerConfig),
+                "title": "gradual_unfreezer_options",
+                "description": description,
+            }
+
+    if not isinstance(default, dict):
+        raise ValidationError(f"Invalid default: `{default}`")
+
+    load_default = lambda: GradualUnfreezerConfig.Schema().load(default)
+    dump_default = GradualUnfreezerConfig.Schema().dump(default)
+
+    return field(
+        metadata={
+            "marshmallow_field": GradualUnfreezerMarshmallowField(
+                allow_none=allow_none,
+                load_default=load_default,
+                dump_default=dump_default,
+                metadata={
+                    "description": description,
+                },
+            )
+        },
+        default_factory=load_default,
+    )

--- a/ludwig/schema/metadata/configs/trainer.yaml
+++ b/ludwig/schema/metadata/configs/trainer.yaml
@@ -640,6 +640,11 @@ ecd:
         eta_min:
             expected_impact: 1
             ui_display_name: Eta Min
+    gradual_unfreezer:
+        thaw_epochs:
+            expected_impact: 1
+        layers_to_thaw:
+            expected_impact: 1
 gbm:
     learning_rate:
         commonly_used: true

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -18,6 +18,7 @@ from ludwig.constants import (
 )
 from ludwig.error import ConfigValidationError
 from ludwig.schema import utils as schema_utils
+from ludwig.schema.gradual_unfreezer import GradualUnfreezerConfig, GradualUnfreezerDataclassField
 from ludwig.schema.lr_scheduler import LRSchedulerConfig, LRSchedulerDataclassField
 from ludwig.schema.metadata import TRAINER_METADATA
 from ludwig.schema.optimizers import (
@@ -175,6 +176,11 @@ class ECDTrainerConfig(BaseTrainerConfig):
             schema_utils.FloatRange(default=0.001, allow_none=False, min=0, max=1),
             schema_utils.StringOptions(options=["auto"], default="auto", allow_none=False),
         ],
+    )
+
+    gradual_unfreezer: GradualUnfreezerConfig = GradualUnfreezerDataclassField(
+        description="Parameter values for gradual unfreezer.",
+        default=None,
     )
 
     learning_rate_scheduler: LRSchedulerConfig = LRSchedulerDataclassField(

--- a/tests/ludwig/modules/test_gradual_unfreezing.py
+++ b/tests/ludwig/modules/test_gradual_unfreezing.py
@@ -6,15 +6,13 @@ from ludwig.utils.misc_utils import set_random_seed
 def test_gradual_unfreezer():
     set_random_seed(13)
 
-    config = GradualUnfreezerConfig(thaw_epochs=[1, 2], layers_to_thaw=[["features.0", "features.1"]])
-
     model = TVSwinTransformerEncoder(
         model_variant="t",
         use_pretrained=False,
         saved_weights_in_checkpoint=True,
         trainable=False,
     )
-    print(model)
+    config = GradualUnfreezerConfig(thaw_epochs=[1, 2], layers_to_thaw=[["features.0", "features.1"], ["features.2"]])
 
     unfreezer = GradualUnfreezer(config=config, model=model)
 
@@ -22,9 +20,8 @@ def test_gradual_unfreezer():
         unfreezer.thaw(epoch)
 
     for name, p in model.named_parameters():
-        if config.layers_to_thaw[0][0] in name:
-            assert p.requires_grad
-        elif config.layers_to_thaw[0][1] in name:
+        layer_to_thaw = any(layer in str(name) for layer_list in config.layers_to_thaw for layer in layer_list)
+        if layer_to_thaw:
             assert p.requires_grad
         else:
             assert not p.requires_grad

--- a/tests/ludwig/modules/test_gradual_unfreezing.py
+++ b/tests/ludwig/modules/test_gradual_unfreezing.py
@@ -1,0 +1,30 @@
+from ludwig.encoders.image.torchvision import TVSwinTransformerEncoder
+from ludwig.modules.gradual_unfreezer import GradualUnfreezer, GradualUnfreezerConfig
+from ludwig.utils.misc_utils import set_random_seed
+
+
+def test_gradual_unfreezer():
+    set_random_seed(13)
+
+    config = GradualUnfreezerConfig(thaw_epochs=[1, 2], layers_to_thaw=[["features.0", "features.1"]])
+
+    model = TVSwinTransformerEncoder(
+        model_variant="t",
+        use_pretrained=False,
+        saved_weights_in_checkpoint=True,
+        trainable=False,
+    )
+    print(model)
+
+    unfreezer = GradualUnfreezer(config=config, model=model)
+
+    for epoch in range(10):
+        unfreezer.thaw(epoch)
+
+    for name, p in model.named_parameters():
+        if config.layers_to_thaw[0][0] in name:
+            assert p.requires_grad
+        elif config.layers_to_thaw[0][1] in name:
+            assert p.requires_grad
+        else:
+            assert not p.requires_grad


### PR DESCRIPTION
Adds the ability to gradually unfreeze or thaw specific layers within a pre-trained model's architecture. Aims to mitigate catastrophic forgetting/improve transfer learning capabilities. Currently works for ECD architecture.

User passes in two things:
thaw_epochs (list of integers) and layers_to_thaw (2D array of layer strings)

thaw_epochs:
    -1
    -2
layers_to_thaw:
   - ["features.0", "features.1"] (thaws these layers (weights+biases) at epoch 1)
   - ["features.2", "features.3"] (epoch 2)
(keep in mind "features.0" will thaw all layers with the prefix "features.0" e.g. "features.0.1/2/3")

TODO/potential issues:
- potentially change config syntax
- users currently need to know the exact strings in architecture for thawing which is inconvenient
- unittest iffy 

test:
[tests/ludwig/modules/test_gradual_unfreezing.py]

Any and all feedback is greatly appreciated. 👍 


