### PR TITLE
api.py: corrected save path in 'LudwigModel.save()'

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1894,14 +1894,16 @@ class LudwigModel:
         """
         self._check_initialization()
 
+        model_save_path: str = os.path.join(save_path, "model")
+
         # save config
-        self.save_config(save_path)
+        self.save_config(model_save_path)
 
         # save model weights
-        self.model.save(save_path)
+        self.model.save(model_save_path)
 
         # save training set metadata
-        training_set_metadata_path = os.path.join(save_path, TRAIN_SET_METADATA_FILE_NAME)
+        training_set_metadata_path = os.path.join(model_save_path, TRAIN_SET_METADATA_FILE_NAME)
         save_json(training_set_metadata_path, self.training_set_metadata)
 
     @staticmethod


### PR DESCRIPTION
This PR is a fix for the issue '[upload_to_hf_hub model path mismatch with model.save](https://github.com/ludwig-ai/ludwig/issues/3925)'.

It corrects the code in [Ludwig.api.LudwigModel.save()](https://github.com/ludwig-ai/ludwig/blob/c09d5dc70139877d381899a81ea68c81e59177bc/ludwig/api.py#L1875), prefixing the value of the supplied argument `save_path` to the literal string `model` to locate the base directory for all saved artifacts. 

The modified code has been unit tested in isolation manually.