### PR TITLE
[MAINTENANCE] Replace Slack links with Discord links.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ way to help the community. Answering questions, helping others, reaching out and
 documentation are immensely valuable contributions as well.
 
 It also helps us if you spread the word: reference the library from blog posts on the awesome
-projects it made possible, shout out on Twitter every time it has helped you, or simply star the
+projects it made possible, shout out on X every time it has helped you, or simply star the
 repo to say "thank you".
 
 Check out the official [ludwig docs](https://ludwig-ai.github.io/ludwig-docs/) to get oriented

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,7 @@ Work on your self-assigned issue and eventually create a Pull Request.
    To do that, edit the file `requirements_extra.txt` and comment out the line that begins with `horovod`.  After that,
    please execute the long `pip install` command given in the previous step.  With these work-around provisions, your
    installation should run to completion successfully.  If you are still having difficulty, please reach out with the
-   specifics of your environment in the Ludwig Community
-   [Slack](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ).
+   specifics of your environment in the Ludwig Community [Discord](https://discord.gg/CBgdrGnZjy).
 
 1. Develop features on your branch.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 _Declarative deep learning framework built for scale and efficiency._
 
 [![PyPI version](https://badge.fury.io/py/ludwig.svg)](https://badge.fury.io/py/ludwig)
-[![](https://dcbadge.vercel.app/api/server/CBgdrGnZjy?style=flat&theme=discord-inverted)](https://discord.gg/CBgdrGnZjy)
+[![Discord](https://dcbadge.vercel.app/api/server/CBgdrGnZjy?style=flat&theme=discord-inverted)](https://discord.gg/CBgdrGnZjy)
 [![DockerHub](https://img.shields.io/docker/pulls/ludwigai/ludwig.svg)](https://hub.docker.com/r/ludwigai)
 [![Downloads](https://pepy.tech/badge/ludwig)](https://pepy.tech/project/ludwig)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/ludwig-ai/ludwig/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -34,8 +34,13 @@ Ludwig is hosted by the
 
 ![img](https://raw.githubusercontent.com/ludwig-ai/ludwig-docs/master/docs/images/ludwig_legos_unanimated.gif)
 
+`  `
+`  `
+
 > \[!IMPORTANT\]
 > Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
+> `  `
+> `  `
 
 # 💾 Installation
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Ludwig is hosted by the
 > `  `
 > `  `
 >
-> # \[!IMPORTANT\]
+> \[!# IMPORTANT\]
 >
 > Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
 > `  `

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Ludwig is hosted by the
 
 ![img](https://raw.githubusercontent.com/ludwig-ai/ludwig-docs/master/docs/images/ludwig_legos_unanimated.gif)
 
+\[!IMPORTANT\]
+Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
+
 # 💾 Installation
 
 Install from PyPi. Be aware that Ludwig requires Python 3.8+.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ _Declarative deep learning framework built for scale and efficiency._
 
 </div>
 
+> \[!**IMPORTANT**\]
+> Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
+
 # 📖 What is Ludwig?
 
 Ludwig is a **low-code** framework for building **custom** AI models like **LLMs** and other deep neural networks.
@@ -33,10 +36,6 @@ Ludwig is hosted by the
 [Linux Foundation AI & Data](https://lfaidata.foundation/).
 
 ![img](https://raw.githubusercontent.com/ludwig-ai/ludwig-docs/master/docs/images/ludwig_legos_unanimated.gif)
-
-> **IMPORTANT**
->
-> Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
 
 # 💾 Installation
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,9 @@ Ludwig is hosted by the
 
 ![img](https://raw.githubusercontent.com/ludwig-ai/ludwig-docs/master/docs/images/ludwig_legos_unanimated.gif)
 
-> `  `
-> `  `
->
-> \[! # IMPORTANT\]
+> **IMPORTANT**
 >
 > Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
-> `  `
-> `  `
 
 # 💾 Installation
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ Ludwig is hosted by the
 
 ![img](https://raw.githubusercontent.com/ludwig-ai/ludwig-docs/master/docs/images/ludwig_legos_unanimated.gif)
 
-`  `
-`  `
-
-> \[!IMPORTANT\]
+> `  `
+> `  `
+>
+> # \[!IMPORTANT\]
+>
 > Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
 > `  `
 > `  `

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 _Declarative deep learning framework built for scale and efficiency._
 
 [![PyPI version](https://badge.fury.io/py/ludwig.svg)](https://badge.fury.io/py/ludwig)
-[![Slack](https://img.shields.io/badge/slack-chat-green.svg?logo=slack)](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ)
+[![](https://dcbadge.vercel.app/api/server/CBgdrGnZjy?style=flat&theme=discord-inverted)](https://discord.gg/CBgdrGnZjy)
 [![DockerHub](https://img.shields.io/docker/pulls/ludwigai/ludwig.svg)](https://hub.docker.com/r/ludwigai)
 [![Downloads](https://pepy.tech/badge/ludwig)](https://pepy.tech/project/ludwig)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/ludwig-ai/ludwig/blob/master/LICENSE)
@@ -193,7 +193,7 @@ ludwig train --config model.yaml --dataset rotten_tomatoes.csv
 
 **Happy modeling**
 
-Try applying Ludwig to your data. [Reach out](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ)
+Try applying Ludwig to your data. [Reach out on Discord](https://discord.gg/CBgdrGnZjy)
 if you have any questions.
 
 # ❓ Why you should use Ludwig
@@ -313,7 +313,7 @@ Read our publications on [Ludwig](https://arxiv.org/pdf/1909.07930.pdf), [declar
 Learn more about [how Ludwig works](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/how_ludwig_works/), [how to get started](https://ludwig-ai.github.io/ludwig-docs/latest/getting_started/), and work through more [examples](https://ludwig-ai.github.io/ludwig-docs/latest/examples).
 
 If you are interested in [contributing](https://github.com/ludwig-ai/ludwig/blob/master/CONTRIBUTING.md), have questions, comments, or thoughts to share, or if you just want to be in the
-know, please consider [joining the Ludwig Slack](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ) and follow us on [Twitter](https://twitter.com/ludwig_ai)!
+know, please consider [joining our Community Discord](https://discord.gg/CBgdrGnZjy) and follow us on [Twitter](https://twitter.com/ludwig_ai)!
 
 # 🤝 Join the community to build Ludwig with us
 
@@ -331,7 +331,7 @@ more accessible and feature rich framework for everyone to use!
 
 # 👋 Getting Involved
 
-- [Slack](https://join.slack.com/t/ludwig-ai/shared_invite/zt-mrxo87w6-DlX5~73T2B4v_g6jj0pJcQ)
+- [Discord](https://discord.gg/CBgdrGnZjy)
 - [Twitter](https://twitter.com/ludwig_ai)
 - [Medium](https://medium.com/ludwig-ai)
 - [GitHub Issues](https://github.com/ludwig-ai/ludwig/issues)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Declarative deep learning framework built for scale and efficiency._
 </div>
 
 > \[!IMPORTANT\]
-> Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
+> Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us there!
 
 # 📖 What is Ludwig?
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Declarative deep learning framework built for scale and efficiency._
 
 </div>
 
-> \[**!IMPORTANT**\]
+> \[!IMPORTANT\]
 > Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
 
 # 📖 What is Ludwig?

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _Declarative deep learning framework built for scale and efficiency._
 [![DockerHub](https://img.shields.io/docker/pulls/ludwigai/ludwig.svg)](https://hub.docker.com/r/ludwigai)
 [![Downloads](https://pepy.tech/badge/ludwig)](https://pepy.tech/project/ludwig)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/ludwig-ai/ludwig/blob/master/LICENSE)
-[![Twitter](https://img.shields.io/twitter/follow/ludwig_ai.svg?style=social&logo=twitter)](https://twitter.com/ludwig_ai)
+[![X](https://img.shields.io/twitter/follow/ludwig_ai.svg?style=social&logo=twitter)](https://twitter.com/ludwig_ai)
 
 </div>
 
@@ -313,7 +313,7 @@ Read our publications on [Ludwig](https://arxiv.org/pdf/1909.07930.pdf), [declar
 Learn more about [how Ludwig works](https://ludwig-ai.github.io/ludwig-docs/latest/user_guide/how_ludwig_works/), [how to get started](https://ludwig-ai.github.io/ludwig-docs/latest/getting_started/), and work through more [examples](https://ludwig-ai.github.io/ludwig-docs/latest/examples).
 
 If you are interested in [contributing](https://github.com/ludwig-ai/ludwig/blob/master/CONTRIBUTING.md), have questions, comments, or thoughts to share, or if you just want to be in the
-know, please consider [joining our Community Discord](https://discord.gg/CBgdrGnZjy) and follow us on [Twitter](https://twitter.com/ludwig_ai)!
+know, please consider [joining our Community Discord](https://discord.gg/CBgdrGnZjy) and follow us on [X](https://twitter.com/ludwig_ai)!
 
 # 🤝 Join the community to build Ludwig with us
 
@@ -332,6 +332,6 @@ more accessible and feature rich framework for everyone to use!
 # 👋 Getting Involved
 
 - [Discord](https://discord.gg/CBgdrGnZjy)
-- [Twitter](https://twitter.com/ludwig_ai)
+- [X](https://twitter.com/ludwig_ai)
 - [Medium](https://medium.com/ludwig-ai)
 - [GitHub Issues](https://github.com/ludwig-ai/ludwig/issues)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Ludwig is hosted by the
 > `  `
 > `  `
 >
-> \[!# IMPORTANT\]
+> \[! # IMPORTANT\]
 >
 > Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
 > `  `

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Ludwig is hosted by the
 
 ![img](https://raw.githubusercontent.com/ludwig-ai/ludwig-docs/master/docs/images/ludwig_legos_unanimated.gif)
 
-\[!IMPORTANT\]
-Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
+> \[!IMPORTANT\]
+> Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
 
 # 💾 Installation
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Declarative deep learning framework built for scale and efficiency._
 
 </div>
 
-> \[!**IMPORTANT**\]
+> \[**!IMPORTANT**\]
 > Our community has moved to [Discord](https://discord.gg/CBgdrGnZjy) -- please join us!
 
 # 📖 What is Ludwig?


### PR DESCRIPTION
### Scope
* All Slack links are replaced with links referring to the "Predibase / LoRAX / Ludwig" community on Discord.
* There is a sibling [documentation pull request.](https://github.com/ludwig-ai/ludwig-docs/pull/358)

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
