### PR TITLE
[MAINTENANCE] Most Recent Version of matplotlib breaks ptitprince and seaborn method calls.

### DIFF
--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -1224,7 +1224,7 @@ def build_dataset(
         else:
             logger.warning(
                 f"Specified split column {global_preprocessing_parameters['split']['column']} for fixed "
-                f"split strategy was not found in dataset."
+                f"split strategy was not found in dataset."  # noqa: E713
             )
 
     # update input features with prompt configs during preprocessing (as opposed to during the model forward pass)
@@ -1457,7 +1457,7 @@ def cast_columns(dataset_cols, features, backend) -> None:
             )
         except KeyError as e:
             raise KeyError(
-                f"Feature name {e} specified in the config was not found in dataset with columns: "
+                f"Feature name {e} specified in the config was not found in dataset with columns: "  # noqa: E713
                 + f"{list(dataset_cols.keys())}"
             )
 

--- a/ludwig/encoders/image/base.py
+++ b/ludwig/encoders/image/base.py
@@ -402,6 +402,12 @@ class ViTEncoder(ImageEncoder):
             )
             transformer = ViTModel(config)
 
+        if output_attentions:
+            config_dict: dict = transformer.config.to_dict()
+            updated_config: ViTConfig = ViTConfig(**config_dict)
+            updated_config._attn_implementation = "eager"
+            transformer = ViTModel(updated_config)
+
         self.transformer = FreezeModule(transformer, frozen=not trainable)
 
         self._output_shape = (transformer.config.hidden_size,)

--- a/ludwig/models/base.py
+++ b/ludwig/models/base.py
@@ -316,7 +316,7 @@ class BaseModel(LudwigModule, metaclass=ABCMeta):
         weight_names = {name for name, _ in self.named_parameters()}
         for name in tensor_names:
             if name not in weight_names:
-                raise ValueError(f'Requested tensor name filter "{name}" not present in the model graph')
+                raise ValueError(f'Requested tensor name filter "{name}" not present in the model graph')  # noqa: E713
 
         # Apply filter.
         tensor_set = set(tensor_names)

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -563,6 +563,8 @@ class LLM(BaseModel):
         # avoid this hack
         if self.config_obj.trainer.type != "none":
             weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
+            # We initialize the model's generation configuration; otherwise, we get a validation error.
+            self.model.generation_config = self.generation
             self.model.save_pretrained(weights_save_path)
         else:
             logger.info("Skipped saving LLM without weight adjustments.")

--- a/ludwig/utils/automl/utils.py
+++ b/ludwig/utils/automl/utils.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 def avg_num_tokens_decoder(x):
     if x is None:
         return None
-    if type(x) == bytes:
+    if type(x) is bytes:
         return x.decode("utf-8")
     return str(x)
 

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -446,11 +446,11 @@ def to_np_tuple(prop: Union[int, Iterable]) -> np.ndarray:
     height_stride = 2 and width_stride = 3. stride=2 gets converted into
     np.array([2, 2]).
     """
-    if type(prop) == int:
+    if type(prop) is int:
         return np.ones(2).astype(int) * prop
     elif isinstance(prop, Iterable) and len(prop) == 2:
         return np.array(list(prop)).astype(int)
-    elif type(prop) == np.ndarray and prop.size == 2:
+    elif type(prop) is np.ndarray and prop.size == 2:
         return prop.astype(int)
     else:
         raise TypeError(f"prop must be int or iterable of length 2, but is {prop}.")

--- a/ludwig/utils/server_utils.py
+++ b/ludwig/utils/server_utils.py
@@ -134,7 +134,7 @@ def deserialize_request(form) -> tuple:
     files = []
     file_index = {}
     for k, v in form.multi_items():
-        if type(v) == UploadFile:
+        if type(v) is UploadFile:
             file_index[v.filename] = _write_file(v, files)
 
     # reconstruct the dataframe

--- a/ludwig/utils/visualization_utils.py
+++ b/ludwig/utils/visualization_utils.py
@@ -1432,7 +1432,7 @@ def hyperopt_report(hyperparameters, hyperopt_results_df, metric, filename_templ
         else:
             # TODO: more research needed on how to handle RayTune "sample_from" search space
             raise ValueError(
-                f"{hp_params[SPACE]} search space not supported in Ludwig.  "
+                f"{hp_params[SPACE]} search space not supported in Ludwig.  "  # noqa: E713
                 f"Supported values are {RAY_TUNE_FLOAT_SPACES | RAY_TUNE_INT_SPACES | RAY_TUNE_CATEGORY_SPACES}."
             )
 

--- a/requirements_viz.txt
+++ b/requirements_viz.txt
@@ -1,4 +1,4 @@
-matplotlib>=3.4; python_version > '3.6'
+matplotlib>3.4,<3.9.0; python_version > '3.6'
 matplotlib>=3.0,<3.4; python_version <= '3.6'
 seaborn>=0.7,<0.12
 hiplot

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,5 @@ ignore =
     E221
     # Ignore "multiple spaces after ':'"
     E241
+    # Ignore "multiple spaces after keyword"
+    E271

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,9 @@ ignore =
     E203
     # Ignore "missing whitespace after ':'"
     E231
+    # Ignore "multiple spaces after ':'"
+    E241
+    # Ignore "multiple spaces before operator"
+    E221
+    # Ignore "multiple spaces after ':'"
+    E241

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,5 @@ ignore =
     W503
     # Ignore "whitespace before ':'"
     E203
+    # Ignore "missing whitespace after ':'"
+    E231

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,13 @@ ignore =
     E241
     # Ignore "multiple spaces before operator"
     E221
+    # Ignore "whitespace around operator"
+    E225
+    # Ignore "whitespace around arithmetic operator"
+    E226
     # Ignore "multiple spaces after ':'"
     E241
     # Ignore "multiple spaces after keyword"
     E271
+    # Ignore "missing whitespace after keyword"
+    E275


### PR DESCRIPTION
### Scope
* We must pin `matplotlib` to `"<3.9.0"`, because the latter (released on 5/15/2024), cause API incompatibilities:
```
-------- generated xml file: /home/runner/work/ludwig/ludwig/pytest.xml --------
=========================== short test summary info ============================
ERROR tests/integration_tests/test_visualization.py - AttributeError: module 'matplotlib.cm' has no attribute 'register_cmap'
ERROR tests/integration_tests/test_visualization_api.py - AttributeError: module 'matplotlib.cm' has no attribute 'register_cmap'
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
==== 2 skipped, 4[93](https://github.com/ludwig-ai/ludwig/actions/runs/9151376924/job/25157299861?pr=3981#step:7:94)3 deselected, 2 warnings, 2 errors in 357.57s (0:05:57) =====
Error: Process completed with exit code 2.
```

thus breaking the tests collection.  Pinning the version of `matplotlib` fixes this issue.  We will keep an eye on the future `matplotlib` releases, which might render the pinning of its version unnecessary.

* We also fix the `ViTEncoder` to ensure that the `transformers.ViTModel` returns the `output_attentions`.
 
# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
