### PR TITLE
[MAINTENANCE] Refactor and clean up.

### DIFF
--- a/ludwig/encoders/image/base.py
+++ b/ludwig/encoders/image/base.py
@@ -382,16 +382,17 @@ class ViTEncoder(ImageEncoder):
             raise ValueError("img_height and img_width should be identical.")
         self._input_shape = (in_channels, img_height, img_width)
 
+        config_dict: dict
         if use_pretrained and not saved_weights_in_checkpoint:
+            config_dict = {
+                "pretrained_model_name_or_path": pretrained_model,
+            }
             if output_attentions:
-                transformer = ViTModel.from_pretrained(
-                    pretrained_model_name_or_path=pretrained_model,
-                    attn_implementation="eager",
-                )
-            else:
-                transformer = ViTModel.from_pretrained(pretrained_model_name_or_path=pretrained_model)
+                config_dict["attn_implementation"] = "eager"
+
+            transformer = ViTModel.from_pretrained(**config_dict)
         else:
-            config_dict: dict = {
+            config_dict = {
                 "image_size": img_height,
                 "num_channels": in_channels,
                 "patch_size": patch_size,

--- a/ludwig/encoders/image/base.py
+++ b/ludwig/encoders/image/base.py
@@ -391,39 +391,23 @@ class ViTEncoder(ImageEncoder):
             else:
                 transformer = ViTModel.from_pretrained(pretrained_model_name_or_path=pretrained_model)
         else:
-            if output_attentions:
-                config = ViTConfig(
-                    image_size=img_height,
-                    num_channels=in_channels,
-                    patch_size=patch_size,
-                    hidden_size=hidden_size,
-                    num_hidden_layers=num_hidden_layers,
-                    num_attention_heads=num_attention_heads,
-                    intermediate_size=intermediate_size,
-                    hidden_act=hidden_act,
-                    hidden_dropout_prob=hidden_dropout_prob,
-                    attention_probs_dropout_prob=attention_probs_dropout_prob,
-                    initializer_range=initializer_range,
-                    layer_norm_eps=layer_norm_eps,
-                    gradient_checkpointing=gradient_checkpointing,
-                    attn_implementation="eager",
-                )
-            else:
-                config = ViTConfig(
-                    image_size=img_height,
-                    num_channels=in_channels,
-                    patch_size=patch_size,
-                    hidden_size=hidden_size,
-                    num_hidden_layers=num_hidden_layers,
-                    num_attention_heads=num_attention_heads,
-                    intermediate_size=intermediate_size,
-                    hidden_act=hidden_act,
-                    hidden_dropout_prob=hidden_dropout_prob,
-                    attention_probs_dropout_prob=attention_probs_dropout_prob,
-                    initializer_range=initializer_range,
-                    layer_norm_eps=layer_norm_eps,
-                    gradient_checkpointing=gradient_checkpointing,
-                )
+            config_dict: dict = {
+                "image_size": img_height,
+                "num_channels": in_channels,
+                "patch_size": patch_size,
+                "hidden_size": hidden_size,
+                "num_hidden_layers": num_hidden_layers,
+                "num_attention_heads": num_attention_heads,
+                "intermediate_size": intermediate_size,
+                "hidden_act": hidden_act,
+                "hidden_dropout_prob": hidden_dropout_prob,
+                "attention_probs_dropout_prob": attention_probs_dropout_prob,
+                "initializer_range": initializer_range,
+                "layer_norm_eps": layer_norm_eps,
+                "gradient_checkpointing": gradient_checkpointing,
+            }
+            config_dict["attn_implementation"] = "eager"
+            config = ViTConfig(**config_dict)
             transformer = ViTModel(config)
 
         self.transformer = FreezeModule(transformer, frozen=not trainable)

--- a/ludwig/encoders/image/base.py
+++ b/ludwig/encoders/image/base.py
@@ -406,7 +406,9 @@ class ViTEncoder(ImageEncoder):
                 "layer_norm_eps": layer_norm_eps,
                 "gradient_checkpointing": gradient_checkpointing,
             }
-            config_dict["attn_implementation"] = "eager"
+            if output_attentions:
+                config_dict["attn_implementation"] = "eager"
+
             config = ViTConfig(**config_dict)
             transformer = ViTModel(config)
 

--- a/ludwig/encoders/image/base.py
+++ b/ludwig/encoders/image/base.py
@@ -383,30 +383,48 @@ class ViTEncoder(ImageEncoder):
         self._input_shape = (in_channels, img_height, img_width)
 
         if use_pretrained and not saved_weights_in_checkpoint:
-            transformer = ViTModel.from_pretrained(pretrained_model)
+            if output_attentions:
+                transformer = ViTModel.from_pretrained(
+                    pretrained_model_name_or_path=pretrained_model,
+                    attn_implementation="eager",
+                )
+            else:
+                transformer = ViTModel.from_pretrained(pretrained_model)
         else:
-            config = ViTConfig(
-                image_size=img_height,
-                num_channels=in_channels,
-                patch_size=patch_size,
-                hidden_size=hidden_size,
-                num_hidden_layers=num_hidden_layers,
-                num_attention_heads=num_attention_heads,
-                intermediate_size=intermediate_size,
-                hidden_act=hidden_act,
-                hidden_dropout_prob=hidden_dropout_prob,
-                attention_probs_dropout_prob=attention_probs_dropout_prob,
-                initializer_range=initializer_range,
-                layer_norm_eps=layer_norm_eps,
-                gradient_checkpointing=gradient_checkpointing,
-            )
+            if output_attentions:
+                config = ViTConfig(
+                    image_size=img_height,
+                    num_channels=in_channels,
+                    patch_size=patch_size,
+                    hidden_size=hidden_size,
+                    num_hidden_layers=num_hidden_layers,
+                    num_attention_heads=num_attention_heads,
+                    intermediate_size=intermediate_size,
+                    hidden_act=hidden_act,
+                    hidden_dropout_prob=hidden_dropout_prob,
+                    attention_probs_dropout_prob=attention_probs_dropout_prob,
+                    initializer_range=initializer_range,
+                    layer_norm_eps=layer_norm_eps,
+                    gradient_checkpointing=gradient_checkpointing,
+                    attn_implementation="eager",
+                )
+            else:
+                config = ViTConfig(
+                    image_size=img_height,
+                    num_channels=in_channels,
+                    patch_size=patch_size,
+                    hidden_size=hidden_size,
+                    num_hidden_layers=num_hidden_layers,
+                    num_attention_heads=num_attention_heads,
+                    intermediate_size=intermediate_size,
+                    hidden_act=hidden_act,
+                    hidden_dropout_prob=hidden_dropout_prob,
+                    attention_probs_dropout_prob=attention_probs_dropout_prob,
+                    initializer_range=initializer_range,
+                    layer_norm_eps=layer_norm_eps,
+                    gradient_checkpointing=gradient_checkpointing,
+                )
             transformer = ViTModel(config)
-
-        if output_attentions:
-            config_dict: dict = transformer.config.to_dict()
-            updated_config: ViTConfig = ViTConfig(**config_dict)
-            updated_config._attn_implementation = "eager"
-            transformer = ViTModel(updated_config)
 
         self.transformer = FreezeModule(transformer, frozen=not trainable)
 

--- a/ludwig/encoders/image/base.py
+++ b/ludwig/encoders/image/base.py
@@ -389,7 +389,7 @@ class ViTEncoder(ImageEncoder):
                     attn_implementation="eager",
                 )
             else:
-                transformer = ViTModel.from_pretrained(pretrained_model)
+                transformer = ViTModel.from_pretrained(pretrained_model_name_or_path=pretrained_model)
         else:
             if output_attentions:
                 config = ViTConfig(


### PR DESCRIPTION
### Scope
* Make the implementation for the fix of the `ViTEncoder` to ensure that the `transformers.ViTModel` returns the `output_attentions` more elegant (and cuts on the amount of code).

# Code Pull Requests

Please provide the following:

- a clear explanation of what your code does
- if applicable, a reference to an issue
- a reproducible test for your PR (code, config and data sample)

# Documentation Pull Requests

Note that the documentation HTML files are in `docs/` while the Markdown sources are in `mkdocs/docs`.

If you are proposing a modification to the documentation you should change only the Markdown files.

`api.md` is automatically generated from the docstrings in the code, so if you want to change something in that file, first modify `ludwig/api.py` docstring, then run `mkdocs/code_docs_autogen.py`, which will create `mkdocs/docs/api.md` .
