### PR TITLE
Fixed options dublicate in documentation for EmbeddingInitializerField

### DIFF
--- a/ludwig/schema/common_fields.py
+++ b/ludwig/schema/common_fields.py
@@ -139,15 +139,13 @@ def WeightsInitializerField(
 def EmbeddingInitializerField(
     default: Optional[str] = None, description: str = None, parameter_metadata: ParameterMetadata = None
 ) -> Field:
-    initializers_str = ", ".join([f"`{i}`" for i in initializer_registry.keys()])
     description = description or "Initializer for the embedding matrix."
-    full_description = f"{description} Options: {initializers_str}."
     parameter_metadata = parameter_metadata or COMMON_METADATA["embedding_initializer"]
     return schema_utils.StringOptions(
         list(initializer_registry.keys()),
         default=default,
         allow_none=True,
-        description=full_description,
+        description=description,
         parameter_metadata=parameter_metadata,
     )
 


### PR DESCRIPTION
The options for the EmbeddingInitializerField are displayed twice in the documentation. 

This is due to the fact that both the field in the Ludwig repro and the build logic in the documentation append the options list to the description string in this particular case.

The problem has been solved by removing this logic from the field. The documentation takes over the task of appending this information.

See issue in [documentation repo](https://github.com/ludwig-ai/ludwig-docs/issues/366).

There should be a discussion about what the right path is. At the moment, different fields handle the task differently. Sometimes the documentation is supposed to assemble the string, sometimes the field does it itself.