### PR TITLE
Fix for issue 4013

### DIFF
--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -19,6 +19,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import torch
 import torchtext
+import torchtext.utils
+import torchtext.transforms
 
 from ludwig.constants import PADDING_SYMBOL, UNKNOWN_SYMBOL
 from ludwig.utils.data_utils import load_json

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -19,8 +19,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import torch
 import torchtext
-import torchtext.utils
 import torchtext.transforms
+import torchtext.utils
 
 from ludwig.constants import PADDING_SYMBOL, UNKNOWN_SYMBOL
 from ludwig.utils.data_utils import load_json


### PR DESCRIPTION
Added two imports to fix issue 4013, "module torchtext has no attribute util" by importing necessary elements.

# Code Pull Requests

Updated code imports modules necessary to get rid of the error.

# Documentation Pull Requests
