### PR TITLE
Update text_encoders.py

### DIFF
--- a/ludwig/schema/encoders/text_encoders.py
+++ b/ludwig/schema/encoders/text_encoders.py
@@ -793,7 +793,7 @@ class DebertaV2Config(HFEncoderImplConfig, DebertaModelParams):
     )
 
     pretrained_model_name_or_path: str = schema_utils.String(
-        default="sileod/deberta-v3-base-tasksource-nli",
+        default="tasksource/deberta-base-long-nli",
         description="Name or path of the pretrained model.",
         parameter_metadata=ENCODER_METADATA["DeBERTa"]["pretrained_model_name_or_path"],
     )


### PR DESCRIPTION
This replaces https://huggingface.co/sileod/deberta-v3-base-tasksource-nli with https://huggingface.co/tasksource/deberta-base-long-nli

The previous model is deprecated, and the newer one has doubled context window and more training data.