### PR TITLE
chore(pre-commit): pin docformatter to v1.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: pyupgrade
         args: [--py36-plus]
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.5.1
+    rev: v1.2.0
     hooks:
       - id: docformatter
         args: [--in-place, --wrap-summaries=115, --wrap-descriptions=120]


### PR DESCRIPTION
Fix CI InvalidManifestError by using docformatter v1.2.0 (earliest tag without python_venv / docformatter-venv language). v1.5.x introduces 'python_venv' language unsupported by pre-commit runner image. Only adjusts hook rev; arguments unchanged.