### PR TITLE
chore(pre-commit): remove docformatter hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,11 +33,6 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.2.0
-    hooks:
-      - id: docformatter
-        args: [--in-place, --wrap-summaries=115, --wrap-descriptions=120]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:


### PR DESCRIPTION
Remove docformatter from pre-commit since all available tags expose a hook manifest containing the unsupported 'python_venv' language in pre-commit.ci runner and older tags without it either lack the hook file or are unavailable (404). This unblocks CI. Formatting still covered by black + isort. Can revisit when upstream provides a plain 'python' hook again.