### PR TITLE
Fix workflows: install setuptools for PyPI, rename master to main

### DIFF
--- a/.github/workflows/cherry-pick-release.yml
+++ b/.github/workflows/cherry-pick-release.yml
@@ -2,7 +2,7 @@ name: Cherry-Pick into Release Branch
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
 
 jobs:
   release_pull_requestk:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 10 * * *" # everyday at 10am
   push:
-    branches: ["master", "release-*"]
+    branches: ["main", "release-*"]
     tags: ["v*.*.*"]
 
 jobs:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,9 +2,9 @@ name: pytest
 
 on:
   push:
-    branches: ["master", "release-*"]
+    branches: ["main", "release-*"]
   pull_request:
-    branches: ["master", "release-*"]
+    branches: ["main", "release-*"]
 
 concurrency:
   group: pytest-${{ github.head_ref || github.sha }}

--- a/.github/workflows/pytest_slow.yml
+++ b/.github/workflows/pytest_slow.yml
@@ -5,7 +5,7 @@ name: pytest (slow)
 
 on:
   push:
-    branches: ["master", "release-*"]
+    branches: ["main", "release-*"]
 
 jobs:
   slow-pytest:

--- a/.github/workflows/upload-pypi.yml
+++ b/.github/workflows/upload-pypi.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Build source distribution
         run: |
+          pip install setuptools
           python setup.py sdist
 
       - name: Publish package distributions to PyPI


### PR DESCRIPTION
## Summary
- **upload-pypi.yml**: Install setuptools before `python setup.py sdist` — Python 3.12 no longer bundles setuptools, which caused the v0.11.0 PyPI upload to fail
- **All workflows**: Update branch triggers from `master` to `main` after branch rename

## Test plan
- [ ] Re-run PyPI upload after merge
- [ ] Verify CI triggers on pushes to `main`