### PR TITLE
Fix training_progress.json containing invalid JSON (Infinity values)

### DIFF
--- a/ludwig/modules/metric_modules.py
+++ b/ludwig/modules/metric_modules.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 import logging
+import sys
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
@@ -552,10 +553,13 @@ def get_improved_fn(metric: str) -> Callable:
 
 
 def get_initial_validation_value(metric: str) -> float:
+    # Use finite floats instead of inf/-inf so that training_progress.json
+    # is valid JSON (RFC 8259). sys.float_info.max (~1.8e308) is larger than
+    # any real metric value, so comparison semantics are identical.
     if get_metric_objective(metric) == MINIMIZE:
-        return float("inf")
+        return sys.float_info.max
     else:
-        return float("-inf")
+        return -sys.float_info.max
 
 
 def get_best_function(metric: str) -> Callable:

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -182,7 +182,7 @@ class NoneTrainer(BaseTrainer):
             batch_size=self.batch_size,
             learning_rate=self.base_learning_rate,
             best_eval_metric_value=get_initial_validation_value(self.validation_metric),
-            best_increase_batch_size_eval_metric=float("inf"),
+            best_increase_batch_size_eval_metric=get_initial_validation_value(self.validation_metric),
             output_features=output_features,
         )
 

--- a/tests/ludwig/modules/test_lr_scheduler.py
+++ b/tests/ludwig/modules/test_lr_scheduler.py
@@ -1,4 +1,5 @@
 import math
+import sys
 
 import numpy as np
 from torch.optim import SGD
@@ -109,8 +110,8 @@ def test_lr_scheduler_reduce_on_plateau():
 
     progress_tracker = get_new_progress_tracker(
         batch_size=64,
-        best_eval_metric_value=float("inf"),
-        best_increase_batch_size_eval_metric=float("inf"),
+        best_eval_metric_value=sys.float_info.max,
+        best_increase_batch_size_eval_metric=sys.float_info.max,
         learning_rate=base_lr,
         output_features={"output1": output1},
     )
@@ -233,8 +234,8 @@ def test_lr_scheduler_save_load():
 
     progress_tracker = get_new_progress_tracker(
         batch_size=64,
-        best_eval_metric_value=float("inf"),
-        best_increase_batch_size_eval_metric=float("inf"),
+        best_eval_metric_value=sys.float_info.max,
+        best_increase_batch_size_eval_metric=sys.float_info.max,
         learning_rate=base_lr,
         output_features={"output1": output1},
     )

--- a/tests/ludwig/utils/test_trainer_utils.py
+++ b/tests/ludwig/utils/test_trainer_utils.py
@@ -1,3 +1,4 @@
+import sys
 from collections import OrderedDict
 
 import pytest
@@ -180,7 +181,7 @@ def test_full_progress_tracker():
                 "Survived": {"accuracy": 0.719, "loss": 4.396, "roc_auc": 0.667},
                 "combined": {"loss": 4.396},
             },
-            "best_increase_batch_size_eval_metric": float("inf"),
+            "best_increase_batch_size_eval_metric": sys.float_info.max,
             "checkpoint_number": 12,
             "epoch": 12,
             "last_increase_batch_size": 0,


### PR DESCRIPTION
## Summary

- Replace `float("inf")` / `float("-inf")` sentinel values with `sys.float_info.max` / `-sys.float_info.max` in `get_initial_validation_value()`
- These finite floats (~1.8e308) are larger than any real metric value, so comparison semantics are identical
- `training_progress.json` now produces valid JSON per RFC 8259, compatible with `jq` and other standard tools
- Also fix hardcoded `float("inf")` in `NoneTrainer` (LLM trainer) to use `get_initial_validation_value()` consistently

Fixes #4016

## Test plan

- [x] All 45 existing tests in `test_backward_compatibility.py`, `test_trainer_utils.py`, and `test_lr_scheduler.py` pass
- [x] JSON round-trip verified: `save_json` → `load_json` preserves values exactly
- [x] Comparison semantics verified: `x < sys.float_info.max` and `x > -sys.float_info.max` behave identically to `x < inf` / `x > -inf` for all real metric values