### PR TITLE
Add timm encoder with MetaFormer variants (CAFormer, ConvFormer, PoolFormer)

### DIFF
--- a/ludwig/encoders/image/__init__.py
+++ b/ludwig/encoders/image/__init__.py
@@ -1,2 +1,3 @@
 import ludwig.encoders.image.base
+import ludwig.encoders.image.timm  # noqa
 import ludwig.encoders.image.torchvision  # noqa

--- a/ludwig/encoders/image/timm.py
+++ b/ludwig/encoders/image/timm.py
@@ -1,0 +1,138 @@
+import logging
+
+import torch
+
+from ludwig.api_annotations import DeveloperAPI
+from ludwig.constants import ENCODER_OUTPUT, IMAGE
+from ludwig.encoders.image.base import ImageEncoder
+from ludwig.encoders.registry import register_encoder
+from ludwig.encoders.types import EncoderOutputDict
+from ludwig.schema.encoders.base import BaseEncoderConfig
+from ludwig.schema.encoders.image.timm import (
+    TimmCAFormerEncoderConfig,
+    TimmConvFormerEncoderConfig,
+    TimmEncoderConfig,
+    TimmPoolFormerEncoderConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _get_timm():
+    try:
+        import timm
+    except ImportError:
+        raise ImportError("timm is required for this encoder. Install it with: pip install timm")
+    return timm
+
+
+@DeveloperAPI
+@register_encoder("timm", IMAGE)
+class TimmEncoder(ImageEncoder):
+    """Wraps any model from the timm (pytorch-image-models) library as a Ludwig image encoder.
+
+    This provides access to hundreds of pretrained vision models including MetaFormer variants
+    (CAFormer, ConvFormer, PoolFormer), ConvNeXt V2, EfficientFormer, and many more.
+
+    Usage in Ludwig config:
+        encoder:
+            type: timm
+            model_name: caformer_s18.sail_in22k_ft_in1k
+            use_pretrained: true
+            trainable: true
+    """
+
+    def __init__(
+        self,
+        model_name: str = "caformer_s18",
+        use_pretrained: bool = True,
+        trainable: bool = True,
+        saved_weights_in_checkpoint: bool = False,
+        encoder_config=None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.config = encoder_config
+
+        logger.debug(f" {self.name}")
+
+        timm = _get_timm()
+
+        pretrained = use_pretrained and not saved_weights_in_checkpoint
+        if pretrained:
+            logger.info(f"Instantiating timm image encoder '{model_name}' with pretrained weights.")
+        else:
+            logger.info(f"Instantiating timm image encoder '{model_name}' without pretrained weights.")
+
+        # num_classes=0 removes the classification head, returning pooled features
+        self.model = timm.create_model(model_name, pretrained=pretrained, num_classes=0)
+
+        # Get the model's expected input config for input_shape
+        data_config = timm.data.resolve_model_data_config(self.model)
+        self._input_size = data_config["input_size"]  # (C, H, W)
+
+        # Compute output dim by running a dummy forward
+        with torch.no_grad():
+            dummy = torch.zeros(1, *self._input_size)
+            out = self.model(dummy)
+            self._output_dim = out.shape[-1]
+
+        for p in self.model.parameters():
+            p.requires_grad_(trainable)
+
+    def forward(self, inputs: torch.Tensor) -> EncoderOutputDict:
+        return {ENCODER_OUTPUT: self.model(inputs)}
+
+    @staticmethod
+    def get_schema_cls() -> type[BaseEncoderConfig]:
+        return TimmEncoderConfig
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size([self._output_dim])
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size(self._input_size)
+
+
+@DeveloperAPI
+@register_encoder("caformer", IMAGE)
+class TimmCAFormerEncoder(TimmEncoder):
+    """CAFormer encoder — hybrid Conv+Attention MetaFormer achieving SOTA accuracy on ImageNet.
+
+    Variants: s18 (26M, 83.6%), s36 (39M, 84.5%), m36 (56M, 85.2%), b36 (99M, 85.5%).
+    """
+
+    def __init__(self, model_name: str = "caformer_s18", **kwargs):
+        super().__init__(model_name=model_name, **kwargs)
+
+    @staticmethod
+    def get_schema_cls() -> type[BaseEncoderConfig]:
+        return TimmCAFormerEncoderConfig
+
+
+@DeveloperAPI
+@register_encoder("convformer", IMAGE)
+class TimmConvFormerEncoder(TimmEncoder):
+    """ConvFormer encoder — pure CNN MetaFormer that outperforms ConvNeXt."""
+
+    def __init__(self, model_name: str = "convformer_s18", **kwargs):
+        super().__init__(model_name=model_name, **kwargs)
+
+    @staticmethod
+    def get_schema_cls() -> type[BaseEncoderConfig]:
+        return TimmConvFormerEncoderConfig
+
+
+@DeveloperAPI
+@register_encoder("poolformer", IMAGE)
+class TimmPoolFormerEncoder(TimmEncoder):
+    """PoolFormer encoder — MetaFormer using simple average pooling as token mixer."""
+
+    def __init__(self, model_name: str = "poolformerv2_s12", **kwargs):
+        super().__init__(model_name=model_name, **kwargs)
+
+    @staticmethod
+    def get_schema_cls() -> type[BaseEncoderConfig]:
+        return TimmPoolFormerEncoderConfig

--- a/ludwig/schema/encoders/image/__init__.py
+++ b/ludwig/schema/encoders/image/__init__.py
@@ -1,2 +1,3 @@
 import ludwig.schema.encoders.image.base
+import ludwig.schema.encoders.image.timm  # noqa
 import ludwig.schema.encoders.image.torchvision  # noqa

--- a/ludwig/schema/encoders/image/timm.py
+++ b/ludwig/schema/encoders/image/timm.py
@@ -1,0 +1,148 @@
+from ludwig.api_annotations import DeveloperAPI
+from ludwig.constants import IMAGE
+from ludwig.schema import utils as schema_utils
+from ludwig.schema.encoders.base import BaseEncoderConfig
+from ludwig.schema.encoders.utils import register_encoder_config
+from ludwig.schema.metadata import ENCODER_METADATA
+from ludwig.schema.utils import ludwig_dataclass
+
+
+@ludwig_dataclass
+class TimmBaseConfig(BaseEncoderConfig):
+    use_pretrained: bool = schema_utils.Boolean(
+        default=True,
+        description="Download model weights from pretrained model.",
+        parameter_metadata=ENCODER_METADATA["TimmEncoder"]["use_pretrained"],
+    )
+
+    saved_weights_in_checkpoint: bool = schema_utils.Boolean(
+        default=False,
+        description="Whether to use weights saved in the Ludwig checkpoint instead of pretrained weights.",
+        parameter_metadata=ENCODER_METADATA["TimmEncoder"]["saved_weights_in_checkpoint"],
+    )
+
+    trainable: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether the encoder parameters are trainable.",
+        parameter_metadata=ENCODER_METADATA["TimmEncoder"]["trainable"],
+    )
+
+    def is_pretrained(self) -> bool:
+        return self.use_pretrained
+
+
+@DeveloperAPI
+@register_encoder_config("timm", IMAGE)
+@ludwig_dataclass
+class TimmEncoderConfig(TimmBaseConfig):
+    type: str = schema_utils.ProtectedString("timm", description="Type of encoder.")
+
+    model_name: str = schema_utils.String(
+        default="caformer_s18",
+        description=(
+            "Name of the timm model to use. Any model from the timm library is supported. "
+            "See https://huggingface.co/docs/timm for available models."
+        ),
+        parameter_metadata=ENCODER_METADATA["TimmEncoder"]["model_name"],
+    )
+
+
+# Convenience aliases for MetaFormer variants with curated model_name options
+
+CAFORMER_MODELS = [
+    "caformer_s18",
+    "caformer_s36",
+    "caformer_m36",
+    "caformer_b36",
+    "caformer_s18.sail_in22k_ft_in1k",
+    "caformer_s18.sail_in22k_ft_in1k_384",
+    "caformer_s36.sail_in22k_ft_in1k",
+    "caformer_s36.sail_in22k_ft_in1k_384",
+    "caformer_m36.sail_in22k_ft_in1k",
+    "caformer_m36.sail_in22k_ft_in1k_384",
+    "caformer_b36.sail_in22k_ft_in1k",
+    "caformer_b36.sail_in22k_ft_in1k_384",
+]
+
+CONVFORMER_MODELS = [
+    "convformer_s18",
+    "convformer_s36",
+    "convformer_m36",
+    "convformer_b36",
+    "convformer_s18.sail_in22k_ft_in1k",
+    "convformer_s18.sail_in22k_ft_in1k_384",
+    "convformer_s36.sail_in22k_ft_in1k",
+    "convformer_s36.sail_in22k_ft_in1k_384",
+    "convformer_m36.sail_in22k_ft_in1k",
+    "convformer_m36.sail_in22k_ft_in1k_384",
+    "convformer_b36.sail_in22k_ft_in1k",
+    "convformer_b36.sail_in22k_ft_in1k_384",
+]
+
+POOLFORMER_MODELS = [
+    "poolformerv2_s12",
+    "poolformerv2_s24",
+    "poolformerv2_s36",
+    "poolformerv2_m36",
+    "poolformerv2_m48",
+    "poolformer_s12",
+    "poolformer_s24",
+    "poolformer_s36",
+    "poolformer_m36",
+    "poolformer_m48",
+]
+
+
+@DeveloperAPI
+@register_encoder_config("caformer", IMAGE)
+@ludwig_dataclass
+class TimmCAFormerEncoderConfig(TimmBaseConfig):
+    type: str = schema_utils.ProtectedString("caformer", description="Type of encoder.")
+
+    model_name: str = schema_utils.StringOptions(
+        CAFORMER_MODELS,
+        default="caformer_s18",
+        allow_none=False,
+        description=(
+            "CAFormer model variant. Hybrid Conv+Attention MetaFormer achieving SOTA accuracy. "
+            "Variants with '.sail_in22k_ft_in1k' are pretrained on ImageNet-21K and finetuned on ImageNet-1K. "
+            "Variants with '_384' use 384x384 input resolution."
+        ),
+        parameter_metadata=ENCODER_METADATA["TimmCAFormerEncoder"]["model_name"],
+    )
+
+
+@DeveloperAPI
+@register_encoder_config("convformer", IMAGE)
+@ludwig_dataclass
+class TimmConvFormerEncoderConfig(TimmBaseConfig):
+    type: str = schema_utils.ProtectedString("convformer", description="Type of encoder.")
+
+    model_name: str = schema_utils.StringOptions(
+        CONVFORMER_MODELS,
+        default="convformer_s18",
+        allow_none=False,
+        description=(
+            "ConvFormer model variant. Pure CNN MetaFormer that outperforms ConvNeXt. "
+            "Variants with '.sail_in22k_ft_in1k' are pretrained on ImageNet-21K and finetuned on ImageNet-1K."
+        ),
+        parameter_metadata=ENCODER_METADATA["TimmConvFormerEncoder"]["model_name"],
+    )
+
+
+@DeveloperAPI
+@register_encoder_config("poolformer", IMAGE)
+@ludwig_dataclass
+class TimmPoolFormerEncoderConfig(TimmBaseConfig):
+    type: str = schema_utils.ProtectedString("poolformer", description="Type of encoder.")
+
+    model_name: str = schema_utils.StringOptions(
+        POOLFORMER_MODELS,
+        default="poolformerv2_s12",
+        allow_none=False,
+        description=(
+            "PoolFormer model variant. MetaFormer using simple average pooling as token mixer. "
+            "V2 variants use StarReLU activation and improved training recipe."
+        ),
+        parameter_metadata=ENCODER_METADATA["TimmPoolFormerEncoder"]["model_name"],
+    )

--- a/ludwig/schema/metadata/configs/encoders.yaml
+++ b/ludwig/schema/metadata/configs/encoders.yaml
@@ -9601,3 +9601,22 @@ UNetEncoder:
             data preprocessing.
         internal_only: true
         ui_display_name: NOT DISPLAYED
+TimmEncoder:
+    model_name:
+        ui_display_name: Model Name
+    use_pretrained:
+        ui_display_name: Use Pretrained
+    saved_weights_in_checkpoint:
+        internal_only: true
+        ui_display_name: Saved Weights in Checkpoint
+    trainable:
+        ui_display_name: Trainable
+TimmCAFormerEncoder:
+    model_name:
+        ui_display_name: Model Name
+TimmConvFormerEncoder:
+    model_name:
+        ui_display_name: Model Name
+TimmPoolFormerEncoder:
+    model_name:
+        ui_display_name: Model Name

--- a/tests/ludwig/encoders/test_timm_encoder.py
+++ b/tests/ludwig/encoders/test_timm_encoder.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+
+timm = pytest.importorskip("timm", reason="timm not installed")
+
+from ludwig.encoders.image.timm import (  # noqa: E402
+    TimmCAFormerEncoder,
+    TimmConvFormerEncoder,
+    TimmEncoder,
+    TimmPoolFormerEncoder,
+)
+
+
+@pytest.mark.parametrize(
+    "encoder_cls,model_name",
+    [
+        (TimmEncoder, "resnetv2_50"),
+        (TimmCAFormerEncoder, "caformer_s18"),
+        (TimmConvFormerEncoder, "convformer_s18"),
+        (TimmPoolFormerEncoder, "poolformerv2_s12"),
+    ],
+    ids=["timm_resnet", "caformer", "convformer", "poolformer"],
+)
+def test_timm_encoder_forward(encoder_cls, model_name):
+    encoder = encoder_cls(model_name=model_name, use_pretrained=False, trainable=True)
+
+    # Get the expected input shape from the encoder
+    input_shape = encoder.input_shape  # (C, H, W)
+    batch = torch.randn(2, *input_shape)
+
+    output = encoder(batch)
+    assert "encoder_output" in output
+
+    out_tensor = output["encoder_output"]
+    assert out_tensor.shape[0] == 2
+    assert out_tensor.shape[1:] == encoder.output_shape
+
+
+@pytest.mark.parametrize("trainable", [True, False])
+def test_timm_encoder_trainable(trainable):
+    encoder = TimmCAFormerEncoder(model_name="caformer_s18", use_pretrained=False, trainable=trainable)
+
+    for p in encoder.model.parameters():
+        assert p.requires_grad == trainable
+
+
+def test_timm_encoder_output_shape_property():
+    encoder = TimmEncoder(model_name="caformer_s18", use_pretrained=False)
+    assert len(encoder.output_shape) == 1
+    assert encoder.output_shape[0] > 0


### PR DESCRIPTION
## Summary

- Add a lightweight `timm` (pytorch-image-models) wrapper that exposes any of its 700+ pretrained vision models as Ludwig image encoders
- Register first-class encoder types for the MetaFormer family:
  - **`caformer`** — hybrid Conv+Attention, SOTA on ImageNet (up to 85.5% top-1)
  - **`convformer`** — pure CNN MetaFormer, outperforms ConvNeXt
  - **`poolformer`** — uses simple average pooling as token mixer
- The generic **`timm`** encoder accepts any `timm` model name for maximum flexibility
- `timm` is an optional dependency (`pip install timm`)

### Usage

```yaml
# MetaFormer variants (curated model options)
encoder:
  type: caformer
  model_name: caformer_s18.sail_in22k_ft_in1k

# Or any timm model
encoder:
  type: timm
  model_name: convnextv2_base.fcmae_ft_in22k_in1k
```

### Design

Follows the same pattern as the existing torchvision encoders (`TVBaseEncoder`). Each encoder:
1. Creates a timm model with `num_classes=0` (removes classification head, returns pooled features)
2. Resolves input shape from the model's data config
3. Computes output dimension via a dummy forward pass
4. Registers via `@register_encoder` / `@register_encoder_config`

Inspired by community contributions in #4052 and #4053.

## Test plan

- [x] 7 new tests pass (forward shape, trainable flag, output_shape property)
- [x] All 300 existing image encoder tests still pass
- [x] Pre-commit hooks (flake8, isort, black) pass