### PR TITLE
fix: clip probabilities before log to prevent -inf in serve endpoint

### DIFF
--- a/ludwig/features/feature_utils.py
+++ b/ludwig/features/feature_utils.py
@@ -98,7 +98,7 @@ def compute_sequence_probability(
     sequence_probabilities = sequence_probabilities[:max_sequence_length]
 
     if return_log_prob:
-        return np.sum(np.log(sequence_probabilities))
+        return np.sum(np.log(np.clip(sequence_probabilities, 1e-10, 1.0)))
     else:
         return np.prod(sequence_probabilities)
 

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -167,7 +167,7 @@ class _SequencePostprocessing(torch.nn.Module):
             predictions.append(sequence_predictions)
 
         probabilities, _ = torch.max(pred_probabilities, dim=-1)
-        probability = torch.sum(torch.log(probabilities), dim=-1)
+        probability = torch.sum(torch.log(probabilities.clamp(min=1e-10)), dim=-1)
 
         return {
             self.predictions_key: predictions,


### PR DESCRIPTION
## Summary
- Clip sequence probabilities to `[1e-10, 1.0]` before taking `log()` in both NumPy and PyTorch code paths
- Prevents `-inf` values that crash `ludwig serve`'s JSON serialization (`allow_nan=False`)

**Root cause:** When a model predicts zero probability for any token in a sequence, `np.log(0)` / `torch.log(0)` produces `-inf`. The serve endpoint uses `json.dumps(..., allow_nan=False)` which rejects infinity values per RFC 8259.

**Files changed:**
- `ludwig/features/feature_utils.py` — `np.clip(sequence_probabilities, 1e-10, 1.0)` before `np.log`
- `ludwig/features/sequence_feature.py` — `probabilities.clamp(min=1e-10)` before `torch.log`

## Manual test results

```
=== PR #4064: Clip probabilities before log ===
Test 1: zero probability in sequence
  Old result: -inf (is -inf: True)
  New result: -23.711029940851223 (is finite: True)
  Old: JSON serialization FAILED as expected: Out of range float values are not JSON compliant: -inf
  New: JSON serialization PASSED

Test 2: torch version (sequence_feature.py)
  Old result: -inf (is -inf: True)
  New result: -23.711027145385742 (is finite: True)

Test 3: normal probabilities (no change expected)
  Old: -1.1960046346767592
  New: -1.1960046346767592

All PR #4064 tests PASSED
```

## Test plan
- [x] Manual test: zero probability produces finite log value (not -inf)
- [x] Manual test: JSON serialization succeeds with allow_nan=False
- [x] Manual test: normal probabilities produce identical results (no regression)
- [x] CI: Unit tests pass
- [x] CI: All integration tests pass (integration_tests_e failure is OOM, unrelated)

Closes #3751