### PR TITLE
feat: add trust_remote_code support for custom HuggingFace models

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -95,7 +95,10 @@ class LLM(BaseModel):
         self._random_seed = random_seed
 
         self.model_name = self.config_obj.base_model
-        self.model_config = AutoConfig.from_pretrained(self.config_obj.base_model)
+        self.model_config = AutoConfig.from_pretrained(
+            self.config_obj.base_model,
+            trust_remote_code=self.config_obj.trust_remote_code,
+        )
 
         self.model = load_pretrained_from_config(self.config_obj, model_config=self.model_config)
         self.curr_device = next(self.model.parameters()).device
@@ -116,7 +119,10 @@ class LLM(BaseModel):
             self.global_max_sequence_length = self.context_len
 
         # Initialize tokenizer
-        self.tokenizer = HFTokenizer(self.config_obj.base_model).tokenizer
+        self.tokenizer = HFTokenizer(
+            self.config_obj.base_model,
+            trust_remote_code=self.config_obj.trust_remote_code,
+        ).tokenizer
 
         self._set_generation_config(self.config_obj.generation.to_dict())
 

--- a/ludwig/schema/llms/base_model.py
+++ b/ludwig/schema/llms/base_model.py
@@ -83,7 +83,7 @@ def BaseModelDataclassField():
             if os.path.isdir(model_name):
                 return model_name
             try:
-                AutoConfig.from_pretrained(model_name)
+                AutoConfig.from_pretrained(model_name, trust_remote_code=True)
                 return model_name
             except OSError:
                 raise ConfigValidationError(

--- a/ludwig/schema/model_types/llm.py
+++ b/ludwig/schema/model_types/llm.py
@@ -50,3 +50,12 @@ class LLMModelConfig(ModelConfig):
     adapter: BaseAdapterConfig | None = AdapterDataclassField()
     quantization: QuantizationConfig | None = QuantizationConfigField().get_default_field()
     model_parameters: ModelParametersConfig | None = ModelParametersConfigField().get_default_field()
+
+    trust_remote_code: bool = schema_utils.Boolean(
+        default=False,
+        description=(
+            "Whether to trust and execute remote code from the HuggingFace model repository. "
+            "Required for some models (e.g. Phi-2, Qwen) that use custom architectures. "
+            "Only enable this for models you trust."
+        ),
+    )

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -82,7 +82,10 @@ def load_pretrained_from_config(
 
     logger.info("Loading large language model...")
     pretrained_model_name_or_path = weights_save_path or config_obj.base_model
-    model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path, **load_kwargs)
+    trust_remote_code = getattr(config_obj, "trust_remote_code", False)
+    model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
+        pretrained_model_name_or_path, trust_remote_code=trust_remote_code, **load_kwargs
+    )
     return model
 
 
@@ -138,6 +141,7 @@ def to_device(
             if config_obj.adapter:
                 model = AutoModelForCausalLM.from_pretrained(
                     config_obj.base_model,
+                    trust_remote_code=getattr(config_obj, "trust_remote_code", False),
                     **model_kwargs,
                 )
 
@@ -152,6 +156,7 @@ def to_device(
             else:
                 model = AutoModelForCausalLM.from_pretrained(
                     tmpdir,
+                    trust_remote_code=getattr(config_obj, "trust_remote_code", False),
                     **model_kwargs,
                 )
     else:

--- a/ludwig/utils/tokenizers.py
+++ b/ludwig/utils/tokenizers.py
@@ -796,6 +796,7 @@ class HFTokenizer(BaseTokenizer):
 
         self.tokenizer = AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path,
+            trust_remote_code=kwargs.get("trust_remote_code", False),
         )
         # Some models (e.g. LLaMA) don't have a pad_token by default.
         # Set it to eos_token to avoid NoneType errors in preprocessing.


### PR DESCRIPTION
## Summary
- Add `trust_remote_code` config option to `LLMModelConfig` (default: `False`)
- Thread it through all `AutoConfig`, `AutoModelForCausalLM`, and `AutoTokenizer` loading calls
- Required for models like Phi-2, Qwen, and other custom HuggingFace architectures

**Files changed:**
- `ludwig/schema/model_types/llm.py` — new `trust_remote_code: bool` field
- `ludwig/models/llm.py` — pass to `AutoConfig.from_pretrained()` and `HFTokenizer()`
- `ludwig/utils/llm_utils.py` — pass to all `AutoModelForCausalLM.from_pretrained()` calls (load + to_device)
- `ludwig/utils/tokenizers.py` — `HFTokenizer` passes kwargs to `AutoTokenizer.from_pretrained()`
- `ludwig/schema/llms/base_model.py` — validation uses `trust_remote_code=True` so custom models can be validated

**Usage:**
```yaml
model_type: llm
base_model: microsoft/phi-2
trust_remote_code: true
```

## Manual test results

```
=== PR #4065: trust_remote_code support ===
Test 1: HFTokenizer with trust_remote_code=False (standard model)
  HFTokenizer.__init__ has **kwargs: True
  Tokenizer loaded with trust_remote_code=False, vocab size: 30522

Test 2: HFTokenizer with trust_remote_code=True (standard model)
  Tokenizer loaded with trust_remote_code=True, vocab size: 30522

Test 3: AutoConfig.from_pretrained with trust_remote_code
  Config loaded: model_type=gpt2
  Config loaded: model_type=gpt2

All PR #4065 tests PASSED
```

## Test plan
- [x] Manual test: HFTokenizer loads with trust_remote_code=False (no regression)
- [x] Manual test: HFTokenizer loads with trust_remote_code=True
- [x] Manual test: AutoConfig works with both True and False
- [x] CI: All tests pass

Closes #3894