### PR TITLE
fix: rewrite devcontainer config for modern setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,24 +1,24 @@
-FROM ludwigai/ludwig-ray:master
+FROM python:3.12-slim
 
-USER root
-# Copy library scripts to execute
-RUN curl -o /tmp/common-debian.sh https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/common-debian.sh
-
-# [Option] Install zsh
-ARG INSTALL_ZSH="false"
-# [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="false"
-# Install needed packages and use existing non-root user (ray).
-ARG USERNAME=automatic
-ARG USER_UID=1000
-ARG USER_GID=102
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
-    && apt-get purge -y imagemagick imagemagick-6-common \
-    # Install common packages, non-root user
-    && bash /tmp/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
-    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends \
+        git \
+        build-essential \
+        curl \
+        libsndfile1 \
+        ffmpeg \
+        sox \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN pip install pre-commit black pylint flake8 mypy
+# Create non-root user
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
 
-USER ${USER_UID}
+USER $USERNAME
+ENV PATH="/home/$USERNAME/.local/bin:$PATH"
+
+# Pre-install pip tools so editable install is fast
+RUN pip install --user --no-cache-dir --upgrade pip setuptools wheel

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "Python 3",
+	"name": "Ludwig Dev",
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": ".."
@@ -7,23 +7,18 @@
 	"customizations": {
 		"vscode": {
 			"settings": {
-				"python.defaultInterpreterPath": "/home/ray/anaconda3/bin/python"
+				"python.defaultInterpreterPath": "/usr/local/bin/python"
 			},
 			"extensions": [
 				"ms-python.python",
-				"ms-python.vscode-pylance"
+				"ms-python.vscode-pylance",
+				"charliermarsh.ruff"
 			]
 		}
 	},
-	"postCreateCommand": "pip install .[test]",
-	"runArgs": [
-		"--network=host",
-		"--shm-size=3.55gb"
-	],
-	"remoteUser": "ray",
+	"postCreateCommand": "pip install --user -e '.[test]'",
+	"remoteUser": "vscode",
 	"features": {
-		"docker-in-docker": "latest",
-		"git": "latest",
-		"aws-cli": "latest"
+		"ghcr.io/devcontainers/features/git:1": {}
 	}
 }


### PR DESCRIPTION
## Summary
- Rewrote the devcontainer from scratch -- the old one was from 2022 and completely broken
- Uses `python:3.12-slim` base image instead of the nonexistent `ludwigai/ludwig-ray:master`
- Includes system deps for audio processing (libsndfile1, ffmpeg, sox)
- Standard vscode non-root user instead of the old `ray` user
- Simple `pip install -e '.[test]'` postCreateCommand
- Modern devcontainer features format (`ghcr.io/devcontainers/features/git:1`)

**Old setup (broken):**
- Base image `ludwigai/ludwig-ray:master` doesn't exist
- Downloaded scripts from deprecated `microsoft/vscode-dev-containers` repo
- Referenced `ray` user/anaconda paths that don't exist

Closes #4017