### PR TITLE
perf: optimize slow tests to reduce CI runtime

### DIFF
--- a/tests/integration_tests/test_automl.py
+++ b/tests/integration_tests/test_automl.py
@@ -282,7 +282,7 @@ def test_autoconfig_preprocessing_text_image(tmpdir):
 
 @pytest.mark.slow
 @pytest.mark.distributed
-@pytest.mark.parametrize("time_budget", [200, 1], ids=["high", "low"])
+@pytest.mark.parametrize("time_budget", [30, 1], ids=["high", "low"])
 def test_train_with_config(time_budget, test_data_tabular_large, ray_cluster_2cpu, tmpdir):
     _run_train_with_config(time_budget, test_data_tabular_large, tmpdir)
 

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -281,7 +281,7 @@ def _run_hyperopt_run_hyperopt(csv_filename, search_space, tmpdir, backend, ray_
         INPUT_FEATURES: input_features,
         OUTPUT_FEATURES: output_features,
         COMBINER: {TYPE: "concat"},
-        TRAINER: {"epochs": 2, "learning_rate": 0.001, BATCH_SIZE: 128},
+        TRAINER: {"epochs": 1, "learning_rate": 0.001, BATCH_SIZE: 128},
         "backend": backend,
     }
 
@@ -610,12 +610,13 @@ def test_hyperopt_without_config_defaults(csv_filename, tmpdir, ray_cluster_7cpu
             "goal": "minimize",
             "output_feature": output_features[0]["name"],
             "metric": "loss",
+            "executor": {"type": "ray", "num_samples": 2},
         },
     }
 
     experiment_name = f"test_hyperopt_{uuid.uuid4().hex}"
     hyperopt_results = hyperopt(config, dataset=rel_path, output_directory=tmpdir, experiment_name=experiment_name)
-    assert hyperopt_results.experiment_analysis.results_df.shape[0] == 10
+    assert hyperopt_results.experiment_analysis.results_df.shape[0] == 2
 
 
 @pytest.mark.slow

--- a/tests/integration_tests/test_model_save_and_load.py
+++ b/tests/integration_tests/test_model_save_and_load.py
@@ -382,7 +382,7 @@ def test_model_save_reload_hf_model(tmpdir, csv_filename, tmp_path):
     config = {
         "input_features": input_features,
         "output_features": output_features,
-        TRAINER: {"epochs": 2, BATCH_SIZE: 128},
+        TRAINER: {"train_steps": 1, BATCH_SIZE: 128},
     }
 
     data_df = read_csv(data_csv_path)

--- a/tests/integration_tests/test_remote.py
+++ b/tests/integration_tests/test_remote.py
@@ -53,7 +53,7 @@ def test_remote_training_set(csv_filename, fs_protocol, bucket, creds, backend, 
                 "input_features": input_features,
                 "output_features": output_features,
                 "combiner": {"type": "concat", "output_size": 14},
-                TRAINER: {"epochs": 2, BATCH_SIZE: 128},
+                TRAINER: {"train_steps": 1, BATCH_SIZE: 128},
             }
 
             config_path = os.path.join(tmpdir, "config.yaml")

--- a/tests/integration_tests/test_sequence_decoders.py
+++ b/tests/integration_tests/test_sequence_decoders.py
@@ -6,7 +6,6 @@ from ludwig.constants import (
     BATCH_SIZE,
     DECODER,
     ENCODER,
-    EPOCHS,
     INPUT_FEATURES,
     OUTPUT_FEATURES,
     SEQUENCE,
@@ -45,7 +44,7 @@ def test_sequence_decoder_predictions(tmpdir, csv_filename, ray_cluster_2cpu, fe
     )
     dataset_path = create_data_set_to_use("csv", dataset_path)
 
-    config = {INPUT_FEATURES: [input_feature], TRAINER: {EPOCHS: 1, BATCH_SIZE: 4}}
+    config = {INPUT_FEATURES: [input_feature], TRAINER: {"train_steps": 1, BATCH_SIZE: 4}}
 
     # Ensure that the decoder outputs the correct predictions through both the default and feature-specific configs.
     config[OUTPUT_FEATURES] = [output_feature]

--- a/tests/ludwig/data/dataframe/test_dask.py
+++ b/tests/ludwig/data/dataframe/test_dask.py
@@ -5,7 +5,6 @@ from ludwig.api import LudwigModel
 from tests.integration_tests.utils import generate_data_as_dataframe
 
 
-@pytest.mark.slow
 @pytest.mark.distributed
 def test_from_ray_dataset_empty(tmpdir, ray_cluster_2cpu):
     import dask.dataframe as dd

--- a/tests/ludwig/datasets/test_dataset_links.py
+++ b/tests/ludwig/datasets/test_dataset_links.py
@@ -3,6 +3,7 @@
 # Checks all dataset download links (just those with URLs, not including kaggle datasets)."""
 #
 import logging
+from concurrent.futures import as_completed, ThreadPoolExecutor
 
 import pytest
 import requests
@@ -18,10 +19,31 @@ def test_links():
     # Iterate through all datasets, ensure links are valid and reachable.
     all_datasets = ludwig.datasets.list_datasets()
 
-    for dataset_name in all_datasets:
-        config = ludwig.datasets._get_dataset_config(dataset_name)
-        download_urls = [config.download_urls] if isinstance(config.download_urls, str) else config.download_urls
-        for url in download_urls:
-            logger.info(f"Checking {dataset_name}: {url}")
-            response = requests.head(url)
-            assert response.ok, f"Failed to download {dataset_name} from {url}"
+    tasks = {}
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        for dataset_name in all_datasets:
+            config = ludwig.datasets._get_dataset_config(dataset_name)
+            download_urls = [config.download_urls] if isinstance(config.download_urls, str) else config.download_urls
+            for url in download_urls:
+                future = executor.submit(_check_url, dataset_name, url)
+                tasks[future] = (dataset_name, url)
+
+        failures = []
+        for future in as_completed(tasks):
+            dataset_name, url = tasks[future]
+            error = future.result()
+            if error:
+                failures.append(error)
+
+    assert not failures, "Failed URLs:\n" + "\n".join(failures)
+
+
+def _check_url(dataset_name, url):
+    logger.info(f"Checking {dataset_name}: {url}")
+    try:
+        response = requests.head(url, timeout=30)
+        if not response.ok:
+            return f"Failed to download {dataset_name} from {url} (status {response.status_code})"
+    except requests.RequestException as e:
+        return f"Failed to download {dataset_name} from {url} ({e})"
+    return None


### PR DESCRIPTION
## Summary
- Replace `epochs: 2` with `train_steps: 1` in pipeline-verification tests that only check end-to-end execution (test_ray, test_remote, test_model_save_and_load, test_sequence_decoders, test_cached_preprocessing)
- Reduce hyperopt epochs from 2 → 1 and BOHB `max_t` from 81 → 2
- Reduce hyperopt trial count from 10 → 2 in `test_hyperopt_without_config_defaults`
- Split local/ray parameterized tests so local variants run without `@slow` (test_cached_preprocessing, test_postprocessing)
- Remove `@slow` from fast tests (`test_onehot_encoding_preprocessing`, `test_from_ray_dataset_empty`)
- Merge duplicate `test_ray_distributed_predict` and `test_ray_preprocessing_placement_group` into one parameterized test
- Parallelize URL checks in `test_dataset_links` with `ThreadPoolExecutor`
- Reduce AutoML `time_budget` from 200 → 30

## Test plan
- [ ] Verify split local tests pass without `@slow` marker: `pytest -x -v tests/integration_tests/test_cached_preprocessing.py::test_onehot_encoding tests/integration_tests/test_postprocessing.py::test_binary_predictions`
- [ ] Verify `@slow` ray tests still pass: `pytest -x -v -m "slow" tests/integration_tests/test_ray.py tests/integration_tests/test_cached_preprocessing.py`
- [ ] Confirm no regressions in hyperopt tests: `pytest -x -v tests/integration_tests/test_hyperopt.py tests/integration_tests/test_hyperopt_ray.py`