### PR TITLE
feat: add JSON Schema export for SchemaStore integration

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -31,9 +31,35 @@ jobs:
       - name: Export schemas
         run: |
           mkdir -p schema-out
-          python -m ludwig.schema.export_schema --model-type combined -o schema-out/ludwig-config.json
-          python -m ludwig.schema.export_schema --model-type ecd -o schema-out/ludwig-config-ecd.json
-          python -m ludwig.schema.export_schema --model-type llm -o schema-out/ludwig-config-llm.json
+          ludwig export_schema --model-type combined -o schema-out/ludwig-config.json
+          ludwig export_schema --model-type ecd -o schema-out/ludwig-config-ecd.json
+          ludwig export_schema --model-type llm -o schema-out/ludwig-config-llm.json
+
+      - name: Generate index.html
+        run: |
+          cat > schema-out/index.html << 'HTMLEOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <title>Ludwig JSON Schema</title>
+            <style>body{font-family:system-ui,sans-serif;max-width:640px;margin:2rem auto;padding:0 1rem}a{color:#0066cc}</style>
+          </head>
+          <body>
+            <h1>Ludwig JSON Schema</h1>
+            <p>JSON Schema files for <a href="https://github.com/ludwig-ai/ludwig">Ludwig</a> config validation and IDE auto-complete.</p>
+            <ul>
+              <li><a href="ludwig-config.json">ludwig-config.json</a> — Combined (ECD + LLM)</li>
+              <li><a href="ludwig-config-ecd.json">ludwig-config-ecd.json</a> — ECD only</li>
+              <li><a href="ludwig-config-llm.json">ludwig-config-llm.json</a> — LLM only</li>
+            </ul>
+            <h2>Usage</h2>
+            <p>Add to your Ludwig YAML config:</p>
+            <pre># yaml-language-server: $schema=https://ludwig-ai.github.io/schema/ludwig-config.json</pre>
+            <p>Or see <a href="https://www.schemastore.org/json/">SchemaStore</a> for automatic IDE integration.</p>
+          </body>
+          </html>
+          HTMLEOF
 
       - name: Publish to ludwig-ai/schema
         uses: cpina/github-action-push-to-another-repository@v1.7.2

--- a/ludwig/cli.py
+++ b/ludwig/cli.py
@@ -50,6 +50,7 @@ Available sub-commands:
    export_torchscript    Exports Ludwig models to Torchscript
    export_triton         Exports Ludwig models to Triton
    export_mlflow         Exports Ludwig models to MLflow
+   export_schema         Exports the Ludwig config JSON schema
    preprocess            Preprocess data and saves it into HDF5 and JSON format
    synthesize_dataset    Creates synthetic data for testing purposes
    init_config           Initialize a user config from a dataset and targets
@@ -143,6 +144,11 @@ Available sub-commands:
         from ludwig import export
 
         export.cli_export_mlflow(sys.argv[2:])
+
+    def export_schema(self):
+        from ludwig.schema.export_schema import main as export_schema_main
+
+        export_schema_main(sys.argv[2:])
 
     def preprocess(self):
         from ludwig import preprocess

--- a/ludwig/schema/export_schema.py
+++ b/ludwig/schema/export_schema.py
@@ -1,7 +1,8 @@
 """Export Ludwig config JSON schema.
 
 Usage:
-    python -m ludwig.schema.export_schema [--model-type ecd|llm] [--output FILE]
+    python -m ludwig.schema.export_schema [--model-type ecd|llm|combined] [--output FILE]
+    ludwig export_schema [--model-type ecd|llm|combined] [--output FILE]
 
 Generates a JSON Schema (Draft 7) for Ludwig config validation.
 """
@@ -13,18 +14,37 @@ from ludwig.config_validation.validation import get_schema
 from ludwig.constants import MODEL_ECD, MODEL_LLM
 from ludwig.globals import LUDWIG_VERSION
 
+SCHEMA_BASE_URL = "https://ludwig-ai.github.io/schema"
 
-def export_schema(model_type: str = MODEL_ECD) -> dict:
+
+def _strip_parameter_metadata(obj):
+    """Recursively remove ``parameter_metadata`` keys from a schema dict.
+
+    The Ludwig schema generator attaches ``parameter_metadata`` objects to
+    every field (UI display hints, suggested values, etc.).  These are useful
+    internally but add significant bloat to the published JSON Schema and are
+    not relevant for validation or IDE auto-complete.
+    """
+    if isinstance(obj, dict):
+        return {k: _strip_parameter_metadata(v) for k, v in obj.items() if k != "parameter_metadata"}
+    if isinstance(obj, list):
+        return [_strip_parameter_metadata(item) for item in obj]
+    return obj
+
+
+def export_schema(model_type: str = MODEL_ECD, *, strip_metadata: bool = True) -> dict:
     """Export the full Ludwig config JSON schema for a given model type."""
     schema = get_schema(model_type)
     schema["$schema"] = "http://json-schema.org/draft-07/schema#"
-    schema["$id"] = f"https://ludwig-ai.github.io/schema/ludwig-config-{model_type}.json"
+    schema["$id"] = f"{SCHEMA_BASE_URL}/ludwig-config-{model_type}.json"
     schema["title"] = f"Ludwig {model_type.upper()} Configuration"
     schema["description"] = f"Configuration schema for Ludwig {model_type.upper()} models (v{LUDWIG_VERSION})"
+    if strip_metadata:
+        schema = _strip_parameter_metadata(schema)
     return schema
 
 
-def export_combined_schema() -> dict:
+def export_combined_schema(*, strip_metadata: bool = True) -> dict:
     """Export a combined schema that covers both ECD and LLM model types."""
     ecd_schema = get_schema(MODEL_ECD)
     llm_schema = get_schema(MODEL_LLM)
@@ -34,9 +54,9 @@ def export_combined_schema() -> dict:
     all_properties.update(ecd_schema.get("properties", {}))
     all_properties.update(llm_schema.get("properties", {}))
 
-    return {
+    combined = {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "$id": "https://ludwig-ai.github.io/schema/ludwig-config.json",
+        "$id": f"{SCHEMA_BASE_URL}/ludwig-config.json",
         "title": "Ludwig Configuration",
         "description": f"Configuration schema for Ludwig models (v{LUDWIG_VERSION})",
         "type": "object",
@@ -44,9 +64,12 @@ def export_combined_schema() -> dict:
         "required": ["input_features", "output_features"],
         "additionalProperties": True,
     }
+    if strip_metadata:
+        combined = _strip_parameter_metadata(combined)
+    return combined
 
 
-def main():
+def main(sys_argv=None):
     parser = argparse.ArgumentParser(description="Export Ludwig config JSON schema")
     parser.add_argument(
         "--model-type",
@@ -55,12 +78,19 @@ def main():
         help="Model type to export schema for (default: combined)",
     )
     parser.add_argument("--output", "-o", type=str, default=None, help="Output file (default: stdout)")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Include parameter_metadata in the output (default: stripped)",
+    )
+    args = parser.parse_args(sys_argv)
+
+    strip_metadata = not args.full
 
     if args.model_type == "combined":
-        schema = export_combined_schema()
+        schema = export_combined_schema(strip_metadata=strip_metadata)
     else:
-        schema = export_schema(args.model_type)
+        schema = export_schema(args.model_type, strip_metadata=strip_metadata)
 
     output = json.dumps(schema, indent=2, sort_keys=False)
 

--- a/schemastore/README.md
+++ b/schemastore/README.md
@@ -1,0 +1,21 @@
+# SchemaStore Submission Materials
+
+This directory contains materials for submitting Ludwig's JSON Schema to
+the [JSON Schema Store](https://www.schemastore.org/json/).
+
+## Catalog Entry
+
+The file `catalog-entry.json` contains the entry to add to SchemaStore's
+`src/api/json/catalog.json`.
+
+## Test Configs
+
+The `test/` directory contains example Ludwig config files that validate
+against the schema. These are used as positive test cases in the SchemaStore PR.
+
+## How to Submit
+
+1. Fork [SchemaStore/schemastore](https://github.com/SchemaStore/schemastore)
+1. Add the catalog entry from `catalog-entry.json` to `src/api/json/catalog.json`
+1. Copy test configs from `test/` to `src/test/ludwig/`
+1. Submit a PR referencing Ludwig issue #1343

--- a/schemastore/catalog-entry.json
+++ b/schemastore/catalog-entry.json
@@ -1,0 +1,15 @@
+{
+  "name": "Ludwig",
+  "description": "Ludwig declarative deep learning framework configuration",
+  "fileMatch": [
+    "ludwig.yaml",
+    "ludwig.yml",
+    "ludwig.json",
+    "ludwig_config.yaml",
+    "ludwig_config.yml",
+    "ludwig_config.json",
+    "**/ludwig/**/config.yaml",
+    "**/ludwig/**/config.yml"
+  ],
+  "url": "https://ludwig-ai.github.io/schema/ludwig-config.json"
+}

--- a/schemastore/test/ludwig.yaml
+++ b/schemastore/test/ludwig.yaml
@@ -1,0 +1,23 @@
+# Rotten Tomatoes review classification - multimodal Ludwig config
+input_features:
+  - name: genres
+    type: set
+    preprocessing:
+      tokenizer: comma
+  - name: content_rating
+    type: category
+  - name: top_critic
+    type: binary
+  - name: runtime
+    type: number
+  - name: review_content
+    type: text
+    encoder:
+      type: embed
+
+output_features:
+  - name: recommended
+    type: binary
+
+trainer:
+  epochs: 3

--- a/schemastore/test/ludwig_config.yaml
+++ b/schemastore/test/ludwig_config.yaml
@@ -1,0 +1,24 @@
+# Titanic survival prediction - basic Ludwig config
+input_features:
+  - name: Pclass
+    type: category
+  - name: Sex
+    type: category
+  - name: Age
+    type: number
+    preprocessing:
+      missing_value_strategy: fill_with_mean
+  - name: SibSp
+    type: number
+  - name: Parch
+    type: number
+  - name: Fare
+    type: number
+    preprocessing:
+      missing_value_strategy: fill_with_mean
+  - name: Embarked
+    type: category
+
+output_features:
+  - name: Survived
+    type: binary


### PR DESCRIPTION
## Summary
- Strip `parameter_metadata` bloat from exported JSON Schema (170K → 8K lines) via recursive `_strip_parameter_metadata()` helper
- Add `ludwig export_schema` CLI command (lazy import, delegates to `export_schema.main()`)
- Update CI workflow to use the new CLI command and generate `index.html` for GitHub Pages
- Add SchemaStore submission materials (catalog entry + positive test configs)

Closes #1343

## Test plan
- [x] Verified `ludwig export_schema --model-type combined` produces clean JSON Schema (8,227 lines, 0 `parameter_metadata` keys)
- [x] Verified ECD schema (59,836 lines) and LLM schema (4,269 lines) also stripped clean
- [x] Verified CLI command output matches `python -m` invocation exactly
- [x] All pre-commit hooks pass