### PR TITLE
Add california_housing dataset to ludwig.datasets

### DIFF
--- a/ludwig/datasets/configs/california_housing.yaml
+++ b/ludwig/datasets/configs/california_housing.yaml
@@ -1,0 +1,32 @@
+version: 1.0
+name: california_housing
+loader: california_housing.CaliforniaHousingLoader
+description: |
+  California Housing dataset from the 1990 US Census. Predict median house value
+  for California districts from 8 numerical features (median income, house age,
+  average rooms, etc.). Standard ML regression benchmark used in the FT-Transformer
+  paper (Gorishniy et al., NeurIPS 2021).
+
+  Originally from StatLib, available via sklearn.datasets.fetch_california_housing.
+columns:
+  - name: MedInc
+    type: number
+  - name: HouseAge
+    type: number
+  - name: AveRooms
+    type: number
+  - name: AveBedrms
+    type: number
+  - name: Population
+    type: number
+  - name: AveOccup
+    type: number
+  - name: Latitude
+    type: number
+  - name: Longitude
+    type: number
+  - name: target
+    type: number
+output_features:
+  - name: target
+    type: number

--- a/ludwig/datasets/loaders/california_housing.py
+++ b/ludwig/datasets/loaders/california_housing.py
@@ -1,0 +1,33 @@
+"""California Housing dataset loader.
+
+Wraps sklearn.datasets.fetch_california_housing to provide the standard ML regression benchmark through Ludwig's dataset
+infrastructure.
+"""
+
+import numpy as np
+import pandas as pd
+
+from ludwig.datasets.loaders.dataset_loader import DatasetLoader
+
+
+class CaliforniaHousingLoader(DatasetLoader):
+    def load(self, kaggle_username=None, kaggle_key=None, split=False):
+        """Load California Housing directly from sklearn."""
+        from sklearn.datasets import fetch_california_housing
+
+        data = fetch_california_housing()
+        df = pd.DataFrame(data.data, columns=data.feature_names)
+        df["target"] = data.target
+
+        # Add deterministic split column (70/15/15)
+        n = len(df)
+        rng = np.random.RandomState(42)
+        indices = rng.permutation(n)
+        splits = np.zeros(n, dtype=int)
+        splits[indices[int(n * 0.7) : int(n * 0.85)]] = 1
+        splits[indices[int(n * 0.85) :]] = 2
+        df["split"] = splits
+
+        if split:
+            return self.split(df)
+        return df


### PR DESCRIPTION
## Summary

Adds the California Housing dataset (sklearn) to `ludwig.datasets` so all experiment benchmark datasets are fully reproducible through Ludwig's dataset infrastructure.

This is the standard ML regression benchmark from the 1990 US Census, used in the FT-Transformer paper (Gorishniy et al., NeurIPS 2021) and the numerical embeddings paper (Gorishniy et al., NeurIPS 2022). 8 numerical input features, 1 regression target (median house value).

### Changes
- `ludwig/datasets/configs/california_housing.yaml` — dataset config with column definitions
- `ludwig/datasets/loaders/california_housing.py` — custom loader wrapping `sklearn.datasets.fetch_california_housing` with deterministic 70/15/15 train/val/test split (fixed seed=42)

### Usage
```python
from ludwig.datasets import california_housing
df = california_housing.load()  # 20,640 rows, 9 columns + split
```

## Test plan
- [x] `ludwig.datasets.get_dataset('california_housing').load()` returns 20,640 rows with correct columns
- [x] Split column has deterministic 70/15/15 distribution