### PR TITLE
Fix test_remote to check for safetensors model weights

### DIFF
--- a/tests/integration_tests/test_remote.py
+++ b/tests/integration_tests/test_remote.py
@@ -6,7 +6,12 @@ import yaml
 from ludwig.api import LudwigModel
 from ludwig.backend import initialize_backend
 from ludwig.constants import BATCH_SIZE, TRAINER
-from ludwig.globals import DESCRIPTION_FILE_NAME, MODEL_FILE_NAME, MODEL_WEIGHTS_FILE_NAME
+from ludwig.globals import (
+    DESCRIPTION_FILE_NAME,
+    MODEL_FILE_NAME,
+    MODEL_WEIGHTS_FILE_NAME,
+    MODEL_WEIGHTS_SAFETENSORS_FILE_NAME,
+)
 from ludwig.utils import fs_utils
 from ludwig.utils.data_utils import use_credentials
 from tests.integration_tests.utils import (
@@ -75,7 +80,10 @@ def test_remote_training_set(csv_filename, fs_protocol, bucket, creds, backend, 
             assert fs_utils.path_exists(os.path.join(output_run_directory, DESCRIPTION_FILE_NAME))
             assert fs_utils.path_exists(os.path.join(output_run_directory, "training_statistics.json"))
             assert fs_utils.path_exists(os.path.join(output_run_directory, MODEL_FILE_NAME))
-            assert fs_utils.path_exists(os.path.join(output_run_directory, MODEL_FILE_NAME, MODEL_WEIGHTS_FILE_NAME))
+            model_dir = os.path.join(output_run_directory, MODEL_FILE_NAME)
+            assert fs_utils.path_exists(
+                os.path.join(model_dir, MODEL_WEIGHTS_SAFETENSORS_FILE_NAME)
+            ) or fs_utils.path_exists(os.path.join(model_dir, MODEL_WEIGHTS_FILE_NAME))
 
             model.predict(dataset=test_csv, output_directory=output_directory)
 


### PR DESCRIPTION
The test was asserting the existence of the legacy `model_weights` file, but ECD models now save as `model_weights.safetensors`. Updated to accept either format.

Fixes the 4 failing tests in pytest_slow CI:
- test_remote_training_set[file-local]
- test_remote_training_set[file-ray]
- test_remote_training_set[s3-local]
- test_remote_training_set[s3-ray]