### PR TITLE
feat: add CLIP, DINOv2, SigLIP image encoders

### DIFF
--- a/ludwig/encoders/image/pretrained.py
+++ b/ludwig/encoders/image/pretrained.py
@@ -41,7 +41,7 @@ class CLIPImageEncoder(ImageEncoder):
         super().__init__()
         self.config = encoder_config
 
-        from transformers import CLIPImageProcessor, CLIPVisionConfig, CLIPVisionModel
+        from transformers import CLIPVisionConfig, CLIPVisionModel
 
         if use_pretrained and not saved_weights_in_checkpoint:
             logger.info(f"Loading pretrained CLIP vision model: {pretrained_model_name_or_path}")
@@ -50,7 +50,6 @@ class CLIPImageEncoder(ImageEncoder):
             logger.info("Instantiating CLIP vision model without pretrained weights.")
             self.model = CLIPVisionModel(CLIPVisionConfig())
 
-        self.processor = CLIPImageProcessor.from_pretrained(pretrained_model_name_or_path)
         self._output_dim = self.model.config.hidden_size
 
         for p in self.model.parameters():


### PR DESCRIPTION
## Summary

- Adds `CLIPImageEncoder` (type `clip`) using `transformers.CLIPVisionModel` — zero-shot and multimodal tasks (Radford et al., ICML 2021)
- Adds `DINOv2ImageEncoder` (type `dinov2`) using `transformers.Dinov2Model` — self-supervised frozen backbone for dense prediction (Oquab et al., TMLR 2024)
- Adds `SigLIPImageEncoder` (type `siglip`) using `transformers.SiglipVisionModel` — sigmoid-loss image-text pretraining with better scaling than CLIP (Zhai et al., ICCV 2023)

All three encoders:
- Follow the same HuggingFace-wrapping pattern as `Wav2Vec2Encoder` in `audio_encoders.py`
- Support `pretrained_model_name_or_path`, `trainable`, `use_pretrained`, and `adapter` (PEFT, inherited from `BaseEncoderConfig`)
- Are registered in the encoder registry for the `image` feature type
- Include class-level docstrings with paper citations and guidance on when to use each

Also removes an unused `CLIPImageProcessor` object that was being instantiated in `CLIPImageEncoder.__init__` but never used (Ludwig handles image preprocessing in the feature pipeline).

## Default checkpoints

| Encoder | Default model |
|---------|--------------|
| `clip` | `openai/clip-vit-base-patch32` |
| `dinov2` | `facebook/dinov2-base` |
| `siglip` | `google/siglip-base-patch16-224` |

## Test plan

- [ ] Verify encoder registration: `get_encoder_cls("image", "clip")`, `"dinov2"`, `"siglip"` resolve correctly
- [ ] Instantiate each encoder without pretrained weights (`use_pretrained=False`) to avoid download dependency
- [ ] Confirm `forward()` returns `{ENCODER_OUTPUT: tensor}` with shape `[batch, hidden_size]`
- [ ] Confirm `output_shape` and `input_shape` properties return correct `torch.Size` values
- [ ] Confirm `trainable=False` freezes all model parameters