### PR TITLE
feat: auto-generated schemas, Prometheus metrics, structured logging, and timeout for FastAPI serving

### DIFF
--- a/ludwig/serve.py
+++ b/ludwig/serve.py
@@ -14,15 +14,20 @@
 # limitations under the License.
 # ==============================================================================
 import argparse
+import asyncio
 import io
 import json
 import logging
 import os
 import sys
 import tempfile
+import time
+from typing import Any
 
+import numpy as np
 import pandas as pd
 import torch
+from pydantic import BaseModel, create_model, Field
 from torchvision.io import decode_image
 
 from ludwig.api import LudwigModel
@@ -30,13 +35,13 @@ from ludwig.constants import AUDIO, COLUMN
 from ludwig.contrib import add_contrib_callback_args
 from ludwig.globals import LUDWIG_VERSION
 from ludwig.utils.print_utils import get_logging_level_registry, print_ludwig
-from ludwig.utils.server_utils import NumpyJSONResponse
 
 logger = logging.getLogger(__name__)
 
 try:
     import uvicorn
     from fastapi import FastAPI
+    from fastapi.responses import JSONResponse
     from starlette.datastructures import UploadFile
     from starlette.middleware import Middleware
     from starlette.middleware.cors import CORSMiddleware
@@ -51,82 +56,356 @@ except ImportError as e:
     )
     sys.exit(-1)
 
-ALL_FEATURES_PRESENT_ERROR = {"error": "entry must contain all input features"}
+# ---------------------------------------------------------------------------
+# Prometheus metrics (optional dependency)
+# ---------------------------------------------------------------------------
+try:
+    from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest, Histogram
 
+    _REQUEST_COUNT = Counter(
+        "ludwig_requests_total",
+        "Total prediction requests",
+        ["endpoint", "status"],
+    )
+    _REQUEST_LATENCY = Histogram(
+        "ludwig_request_latency_seconds",
+        "Request latency in seconds",
+        ["endpoint"],
+    )
+    _ERROR_COUNT = Counter(
+        "ludwig_errors_total",
+        "Total prediction errors",
+        ["endpoint"],
+    )
+    _PROMETHEUS_AVAILABLE = True
+except ImportError:
+    _PROMETHEUS_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Error constants
+# ---------------------------------------------------------------------------
+ALL_FEATURES_PRESENT_ERROR = {"error": "entry must contain all input features"}
 COULD_NOT_RUN_INFERENCE_ERROR = {"error": "Unexpected Error: could not run inference on model"}
 
 
-def server(model, allowed_origins=None):
+# ---------------------------------------------------------------------------
+# Numpy → Python serialization helpers
+# ---------------------------------------------------------------------------
+def _numpy_safe(obj: Any) -> Any:
+    """Recursively convert numpy scalars / arrays to plain Python types."""
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        return float(obj)
+    if isinstance(obj, np.bool_):
+        return bool(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, dict):
+        return {k: _numpy_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple, set)):
+        return [_numpy_safe(v) for v in obj]
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Auto-generated Pydantic schemas from model config
+# ---------------------------------------------------------------------------
+_FEATURE_TYPE_TO_PYTHON: dict[str, type] = {
+    "number": float,
+    "binary": bool,
+    "category": str,
+    "text": str,
+    "sequence": str,
+    "set": str,
+    "bag": str,
+    "date": str,
+    "h3": str,
+    "vector": list,
+    "image": Any,
+    "audio": Any,
+    "timeseries": Any,
+}
+
+
+def _feature_python_type(ftype: str) -> type:
+    return _FEATURE_TYPE_TO_PYTHON.get(ftype, Any)
+
+
+def build_request_schema(config: dict) -> type[BaseModel]:
+    """Dynamically create a Pydantic request model from Ludwig input feature configs.
+
+    Each input feature becomes an optional field (None default) so that missing features can be detected and reported
+    with a clear error message rather than a Pydantic validation error.
+    """
+    fields: dict[str, Any] = {}
+    for feat in config.get("input_features", []):
+        name = feat.get("name") or feat.get(COLUMN) or feat.get("column")
+        ftype = feat.get("type", "")
+        py_type = _feature_python_type(ftype)
+        # Make every field Optional so callers get a descriptive error, not a 422
+        fields[name] = (py_type | None, Field(default=None, description=f"Input feature '{name}' of type '{ftype}'"))
+
+    return create_model("PredictRequest", **fields)
+
+
+def build_response_schema(config: dict) -> type[BaseModel]:
+    """Dynamically create a Pydantic response model from Ludwig output feature configs.
+
+    The exact column names produced by Ludwig's post-processor (e.g. ``age_predictions``,
+    ``churn_probabilities``) are declared as optional fields so extra columns don't break
+    validation.
+    """
+    fields: dict[str, Any] = {}
+    for feat in config.get("output_features", []):
+        name = feat.get("name") or feat.get(COLUMN) or feat.get("column")
+        ftype = feat.get("type", "")
+
+        if ftype == "number":
+            fields[f"{name}_predictions"] = (float | None, None)
+        elif ftype == "binary":
+            fields[f"{name}_predictions"] = (bool | None, None)
+            fields[f"{name}_probabilities"] = (float | None, None)
+        elif ftype in ("category", "text", "sequence", "set", "bag", "date", "h3"):
+            fields[f"{name}_predictions"] = (str | None, None)
+            fields[f"{name}_probabilities"] = (list | None, None)
+        else:
+            # Catch-all: accept anything
+            fields[f"{name}_predictions"] = (Any, None)
+
+    return create_model("PredictResponse", **fields)
+
+
+# ---------------------------------------------------------------------------
+# Prometheus helpers
+# ---------------------------------------------------------------------------
+def _record_success(endpoint: str, latency: float) -> None:
+    if _PROMETHEUS_AVAILABLE:
+        _REQUEST_COUNT.labels(endpoint=endpoint, status="success").inc()
+        _REQUEST_LATENCY.labels(endpoint=endpoint).observe(latency)
+
+
+def _record_error(endpoint: str) -> None:
+    if _PROMETHEUS_AVAILABLE:
+        _REQUEST_COUNT.labels(endpoint=endpoint, status="error").inc()
+        _ERROR_COUNT.labels(endpoint=endpoint).inc()
+
+
+# ---------------------------------------------------------------------------
+# Structured logging helpers
+# ---------------------------------------------------------------------------
+def _log_request(endpoint: str, feature_names: list[str], batch_size: int) -> None:
+    logger.info(
+        "prediction_request endpoint=%s features=%s batch_size=%d",
+        endpoint,
+        ",".join(feature_names),
+        batch_size,
+    )
+
+
+def _log_response(endpoint: str, output_feature_names: list[str], latency: float) -> None:
+    logger.info(
+        "prediction_response endpoint=%s outputs=%s latency_seconds=%.4f",
+        endpoint,
+        ",".join(output_feature_names),
+        latency,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Server factory
+# ---------------------------------------------------------------------------
+def server(
+    model: "LudwigModel",
+    allowed_origins: list[str] | None = None,
+    prediction_timeout: float = 30.0,
+) -> "FastAPI":
+    """Build a FastAPI application for serving a Ludwig model.
+
+    Args:
+        model: A loaded :class:`~ludwig.api.LudwigModel` instance.
+        allowed_origins: List of CORS-allowed origins.  ``None`` disables CORS.
+        prediction_timeout: Seconds to wait for a prediction before returning
+            HTTP 504 Gateway Timeout.
+
+    Returns:
+        A :class:`fastapi.FastAPI` application ready to be served with uvicorn.
+    """
     middleware = [Middleware(CORSMiddleware, allow_origins=allowed_origins)] if allowed_origins else None
-    app = FastAPI(middleware=middleware)
+    app = FastAPI(
+        title="Ludwig Inference Server",
+        description="Auto-generated schemas, Prometheus metrics, structured logging, and timeout handling.",
+        middleware=middleware,
+    )
 
     config = model.config
     input_features = {f[COLUMN] for f in config["input_features"]}
+    output_feature_names = [f.get("name", f.get(COLUMN, "")) for f in config.get("output_features", [])]
 
+    # Build typed Pydantic schemas for OpenAPI docs.
+    # PredictResponse is wired into /predict as a response_model.
+    # The request schema is attached via openapi_extra since the actual transport
+    # is multipart/form-data rather than a JSON body.
+    predict_request_schema = build_request_schema(config).model_json_schema()
+    PredictResponse = build_response_schema(config)
+
+    # ------------------------------------------------------------------ #
+    # Health                                                               #
+    # ------------------------------------------------------------------ #
     @app.get("/")
     def check_health():
-        return NumpyJSONResponse({"message": "Ludwig server is up"})
+        return JSONResponse({"message": "Ludwig server is up"})
 
-    @app.post("/predict")
+    # ------------------------------------------------------------------ #
+    # Prometheus metrics                                                   #
+    # ------------------------------------------------------------------ #
+    if _PROMETHEUS_AVAILABLE:
+
+        @app.get("/metrics")
+        def metrics():
+            from starlette.responses import Response
+
+            return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+    # ------------------------------------------------------------------ #
+    # Single-row prediction                                                #
+    # ------------------------------------------------------------------ #
+    @app.post(
+        "/predict",
+        response_model=PredictResponse,
+        openapi_extra={"requestBody": {"content": {"multipart/form-data": {"schema": predict_request_schema}}}},
+    )
     async def predict(request: Request):
+        start = time.monotonic()
+        files: list = []
         try:
             form = await request.form()
             entry, files = convert_input(form, model.model.input_features)
         except Exception:
             logger.exception("Failed to parse predict form")
-            return NumpyJSONResponse(COULD_NOT_RUN_INFERENCE_ERROR, status_code=500)
+            _record_error("predict")
+            return JSONResponse(COULD_NOT_RUN_INFERENCE_ERROR, status_code=500)
 
         try:
             if (entry.keys() & input_features) != input_features:
-                missing_features = set(input_features) - set(entry.keys())
-                return NumpyJSONResponse(
+                missing_features = input_features - set(entry.keys())
+                _record_error("predict")
+                return JSONResponse(
                     {
                         "error": "Data received does not contain all input features. "
                         f"Missing features: {missing_features}."
                     },
                     status_code=400,
                 )
+
+            _log_request("predict", sorted(entry.keys()), batch_size=1)
+
             try:
-                resp, _ = model.predict(dataset=[entry], data_format=dict)
-                resp = resp.to_dict("records")[0]
-                return NumpyJSONResponse(resp)
-            except Exception as exc:
-                logger.exception(f"Failed to run predict: {exc}")
-                return NumpyJSONResponse(COULD_NOT_RUN_INFERENCE_ERROR, status_code=500)
+                resp_df, _ = await asyncio.wait_for(
+                    asyncio.get_event_loop().run_in_executor(
+                        None,
+                        lambda: model.predict(dataset=[entry], data_format=dict),
+                    ),
+                    timeout=prediction_timeout,
+                )
+            except TimeoutError:
+                _record_error("predict")
+                logger.error(
+                    "prediction_timeout endpoint=predict timeout_seconds=%.1f",
+                    prediction_timeout,
+                )
+                return JSONResponse(
+                    {"error": f"Prediction timed out after {prediction_timeout}s"},
+                    status_code=504,
+                )
+
+            resp = _numpy_safe(resp_df.to_dict("records")[0])
+            latency = time.monotonic() - start
+            _log_response("predict", output_feature_names, latency)
+            _record_success("predict", latency)
+            return JSONResponse(resp)
+
+        except Exception as exc:
+            logger.exception("Failed to run predict: %s", exc)
+            _record_error("predict")
+            return JSONResponse(COULD_NOT_RUN_INFERENCE_ERROR, status_code=500)
         finally:
             for f in files:
                 os.remove(f.name)
 
+    # ------------------------------------------------------------------ #
+    # Batch prediction                                                     #
+    # ------------------------------------------------------------------ #
     @app.post("/batch_predict")
     async def batch_predict(request: Request):
+        start = time.monotonic()
+        files: list = []
         try:
             form = await request.form()
             data, files = convert_batch_input(form, model.model.input_features)
-            data_df = pd.DataFrame.from_records(data["data"], index=data.get("index"), columns=data["columns"])
+            data_df = pd.DataFrame.from_records(
+                data["data"],
+                index=data.get("index"),
+                columns=data["columns"],
+            )
         except Exception:
             logger.exception("Failed to parse batch_predict form")
-            return NumpyJSONResponse(COULD_NOT_RUN_INFERENCE_ERROR, status_code=500)
+            _record_error("batch_predict")
+            return JSONResponse(COULD_NOT_RUN_INFERENCE_ERROR, status_code=500)
 
         if (set(data_df.columns) & input_features) != input_features:
-            missing_features = set(input_features) - set(data_df.columns)
-            return NumpyJSONResponse(
+            missing_features = input_features - set(data_df.columns)
+            _record_error("batch_predict")
+            return JSONResponse(
                 {
                     "error": "Data received does not contain all input features. "
                     f"Missing features: {missing_features}."
                 },
                 status_code=400,
             )
+
+        _log_request("batch_predict", sorted(data_df.columns.tolist()), batch_size=len(data_df))
+
         try:
-            resp, _ = model.predict(dataset=data_df)
-            resp = resp.to_dict("split")
-            return NumpyJSONResponse(resp)
+            try:
+                resp_df, _ = await asyncio.wait_for(
+                    asyncio.get_event_loop().run_in_executor(
+                        None,
+                        lambda: model.predict(dataset=data_df),
+                    ),
+                    timeout=prediction_timeout,
+                )
+            except TimeoutError:
+                _record_error("batch_predict")
+                logger.error(
+                    "prediction_timeout endpoint=batch_predict timeout_seconds=%.1f",
+                    prediction_timeout,
+                )
+                return JSONResponse(
+                    {"error": f"Prediction timed out after {prediction_timeout}s"},
+                    status_code=504,
+                )
+
+            resp = _numpy_safe(resp_df.to_dict("split"))
+            latency = time.monotonic() - start
+            _log_response("batch_predict", output_feature_names, latency)
+            _record_success("batch_predict", latency)
+            return JSONResponse(resp)
+
         except Exception:
-            logger.exception("Failed to run batch_predict: {}")
-            return NumpyJSONResponse(COULD_NOT_RUN_INFERENCE_ERROR, status_code=500)
+            logger.exception("Failed to run batch_predict")
+            _record_error("batch_predict")
+            return JSONResponse(COULD_NOT_RUN_INFERENCE_ERROR, status_code=500)
+        finally:
+            for f in files:
+                os.remove(f.name)
 
     return app
 
 
+# ---------------------------------------------------------------------------
+# Form / file helpers (unchanged from original)
+# ---------------------------------------------------------------------------
 def _write_file(v, files):
     # Convert UploadFile to a NamedTemporaryFile to ensure it's on the disk
     suffix = os.path.splitext(v.filename)[1]
@@ -183,28 +462,28 @@ def convert_batch_input(form, input_features):
     return data, files
 
 
+# ---------------------------------------------------------------------------
+# Entry points
+# ---------------------------------------------------------------------------
 def run_server(
     model_path: str,
     host: str,
     port: int,
     allowed_origins: list,
+    prediction_timeout: float = 30.0,
 ) -> None:
-    """Loads a pre-trained model and serve it on an http server.
+    """Load a pre-trained model and serve it on an HTTP server.
 
-    # Inputs
-
-    :param model_path: (str) filepath to pre-trained model.
-    :param host: (str, default: `0.0.0.0`) host ip address for the server to use.
-    :param port: (int, default: `8000`) port number for the server to use.
-    :param allowed_origins: (list) list of origins allowed to make cross-origin requests.
-
-    # Return
-
-    :return: (`None`)
+    Args:
+        model_path: Filepath to pre-trained model.
+        host: Host IP address for the server to use.
+        port: Port number for the server to use.
+        allowed_origins: List of origins allowed to make cross-origin requests.
+        prediction_timeout: Seconds before a prediction request returns HTTP 504.
     """
     # Use local backend for serving to use pandas DataFrames.
     model = LudwigModel.load(model_path, backend="local")
-    app = server(model, allowed_origins)
+    app = server(model, allowed_origins, prediction_timeout=prediction_timeout)
     uvicorn.run(app, host=host, port=port)
 
 
@@ -247,6 +526,14 @@ def cli(sys_argv):
         'Use "*" to allow any origin. See https://www.starlette.io/middleware/#corsmiddleware.',
     )
 
+    parser.add_argument(
+        "-t",
+        "--prediction_timeout",
+        help="Maximum seconds to wait for a prediction before returning HTTP 504 (default: 30.0)",
+        default=30.0,
+        type=float,
+    )
+
     add_contrib_callback_args(parser)
     args = parser.parse_args(sys_argv)
 
@@ -261,7 +548,7 @@ def cli(sys_argv):
 
     print_ludwig("Serve", LUDWIG_VERSION)
 
-    run_server(args.model_path, args.host, args.port, args.allowed_origins)
+    run_server(args.model_path, args.host, args.port, args.allowed_origins, args.prediction_timeout)
 
 
 if __name__ == "__main__":

--- a/ludwig/serve_v2.py
+++ b/ludwig/serve_v2.py
@@ -1,12 +1,12 @@
 """Modernized Ludwig serving with auto-generated schemas, metrics, and vLLM support.
 
-Improvements over serve.py:
+Improvements over the original serve.py:
 - Auto-generated Pydantic request/response schemas from model config
 - Prometheus metrics endpoint (/metrics)
 - Model as injectable dependency for hot-swappability
-- Timeout handling for long predictions
+- Timeout handling for long predictions (prediction_timeout parameter)
 - Proper JSON serialization without NumpyJSONResponse hack
-- Optional vLLM backend for LLM serving with OpenAI-compatible endpoints
+- Structured key=value logging for every request and response
 """
 
 import asyncio
@@ -20,51 +20,187 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel as PydanticBaseModel
+from pydantic import create_model, Field
+
+from ludwig.constants import COLUMN
 
 logger = logging.getLogger(__name__)
 
 
-# Prometheus metrics (optional)
+# ---------------------------------------------------------------------------
+# Prometheus metrics (optional dependency)
+# ---------------------------------------------------------------------------
 try:
-    from prometheus_client import Counter, generate_latest, Histogram
+    from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest, Histogram
 
-    REQUEST_COUNT = Counter("ludwig_requests_total", "Total prediction requests", ["endpoint", "status"])
-    REQUEST_LATENCY = Histogram("ludwig_request_latency_seconds", "Request latency", ["endpoint"])
+    _REQUEST_COUNT = Counter(
+        "ludwig_requests_total",
+        "Total prediction requests",
+        ["endpoint", "status"],
+    )
+    _REQUEST_LATENCY = Histogram(
+        "ludwig_request_latency_seconds",
+        "Request latency in seconds",
+        ["endpoint"],
+    )
+    _ERROR_COUNT = Counter(
+        "ludwig_errors_total",
+        "Total prediction errors",
+        ["endpoint"],
+    )
     METRICS_AVAILABLE = True
 except ImportError:
     METRICS_AVAILABLE = False
 
 
-def _numpy_safe(obj):
-    """Convert numpy types to Python types for JSON serialization."""
+# ---------------------------------------------------------------------------
+# Numpy → Python serialization helpers
+# ---------------------------------------------------------------------------
+def _numpy_safe(obj: Any) -> Any:
+    """Recursively convert numpy scalars / arrays to plain Python types."""
     if isinstance(obj, np.integer):
         return int(obj)
-    elif isinstance(obj, np.floating):
+    if isinstance(obj, np.floating):
         return float(obj)
-    elif isinstance(obj, np.ndarray):
-        return obj.tolist()
-    elif isinstance(obj, np.bool_):
+    if isinstance(obj, np.bool_):
         return bool(obj)
-    elif isinstance(obj, dict):
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, dict):
         return {k: _numpy_safe(v) for k, v in obj.items()}
-    elif isinstance(obj, (list, tuple)):
+    if isinstance(obj, (list, tuple, set)):
         return [_numpy_safe(v) for v in obj]
     return obj
 
 
+# ---------------------------------------------------------------------------
+# Auto-generated Pydantic schemas from model config
+# ---------------------------------------------------------------------------
+_FEATURE_TYPE_TO_PYTHON: dict[str, type] = {
+    "number": float,
+    "binary": bool,
+    "category": str,
+    "text": str,
+    "sequence": str,
+    "set": str,
+    "bag": str,
+    "date": str,
+    "h3": str,
+    "vector": list,
+    "image": Any,
+    "audio": Any,
+    "timeseries": Any,
+}
+
+
+def _feature_python_type(ftype: str) -> type:
+    return _FEATURE_TYPE_TO_PYTHON.get(ftype, Any)
+
+
+def build_request_schema(config: dict) -> type[PydanticBaseModel]:
+    """Dynamically create a Pydantic request model from Ludwig input feature configs.
+
+    Each input feature becomes an optional field (None default) so that missing features can be detected and reported
+    with a clear error message rather than a Pydantic validation error.
+    """
+    fields: dict[str, Any] = {}
+    for feat in config.get("input_features", []):
+        name = feat.get("name") or feat.get("column") or feat.get(COLUMN)
+        ftype = feat.get("type", "")
+        py_type = _feature_python_type(ftype)
+        fields[name] = (py_type | None, Field(default=None, description=f"Input feature '{name}' of type '{ftype}'"))
+
+    return create_model("PredictRequest", **fields)
+
+
+def build_response_schema(config: dict) -> type[PydanticBaseModel]:
+    """Dynamically create a Pydantic response model from Ludwig output feature configs.
+
+    The exact column names produced by Ludwig's post-processor (e.g. ``age_predictions``,
+    ``churn_probabilities``) are declared as optional fields so extra columns don't break
+    validation.
+    """
+    fields: dict[str, Any] = {}
+    for feat in config.get("output_features", []):
+        name = feat.get("name") or feat.get("column") or feat.get(COLUMN)
+        ftype = feat.get("type", "")
+
+        if ftype == "number":
+            fields[f"{name}_predictions"] = (float | None, None)
+        elif ftype == "binary":
+            fields[f"{name}_predictions"] = (bool | None, None)
+            fields[f"{name}_probabilities"] = (float | None, None)
+        elif ftype in ("category", "text", "sequence", "set", "bag", "date", "h3"):
+            fields[f"{name}_predictions"] = (str | None, None)
+            fields[f"{name}_probabilities"] = (list | None, None)
+        else:
+            fields[f"{name}_predictions"] = (Any, None)
+
+    return create_model("PredictResponse", **fields)
+
+
+# ---------------------------------------------------------------------------
+# Prometheus helpers
+# ---------------------------------------------------------------------------
+def _record_success(endpoint: str, latency: float) -> None:
+    if METRICS_AVAILABLE:
+        _REQUEST_COUNT.labels(endpoint=endpoint, status="success").inc()
+        _REQUEST_LATENCY.labels(endpoint=endpoint).observe(latency)
+
+
+def _record_error(endpoint: str) -> None:
+    if METRICS_AVAILABLE:
+        _REQUEST_COUNT.labels(endpoint=endpoint, status="error").inc()
+        _ERROR_COUNT.labels(endpoint=endpoint).inc()
+
+
+# ---------------------------------------------------------------------------
+# Structured logging helpers
+# ---------------------------------------------------------------------------
+def _log_request(endpoint: str, feature_names: list[str], batch_size: int) -> None:
+    logger.info(
+        "prediction_request endpoint=%s features=%s batch_size=%d",
+        endpoint,
+        ",".join(feature_names),
+        batch_size,
+    )
+
+
+def _log_response(endpoint: str, output_feature_names: list[str], latency: float) -> None:
+    logger.info(
+        "prediction_response endpoint=%s outputs=%s latency_seconds=%.4f",
+        endpoint,
+        ",".join(output_feature_names),
+        latency,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model manager (dependency injection)
+# ---------------------------------------------------------------------------
 class ModelManager:
     """Manages the Ludwig model instance for dependency injection."""
 
     def __init__(self):
         self.model = None
-        self.config = None
+        self.config: dict | None = None
+        self._input_feature_names: list[str] = []
+        self._output_feature_names: list[str] = []
+        self._input_features_set: set[str] = set()
 
-    def load(self, model_path: str, backend: str = "local"):
+    def load(self, model_path: str, backend: str = "local") -> None:
         from ludwig.api import LudwigModel
 
         self.model = LudwigModel.load(model_path, backend=backend)
         self.config = self.model.config
-        logger.info(f"Model loaded from {model_path}")
+        self._input_feature_names = [
+            f.get("name") or f.get("column") or f.get(COLUMN) for f in self.config.get("input_features", [])
+        ]
+        self._output_feature_names = [
+            f.get("name") or f.get("column") or f.get(COLUMN) for f in self.config.get("output_features", [])
+        ]
+        self._input_features_set = set(self._input_feature_names)
+        logger.info("model_loaded path=%s", model_path)
 
     def get_model(self):
         if self.model is None:
@@ -76,63 +212,33 @@ model_manager = ModelManager()
 
 
 def get_model():
-    """Dependency injection for the model."""
+    """FastAPI dependency — returns the loaded Ludwig model."""
     return model_manager.get_model()
 
 
-def build_request_schema(config: dict) -> type[PydanticBaseModel]:
-    """Auto-generate a Pydantic request schema from Ludwig model config."""
-    fields = {}
-    for feat in config.get("input_features", []):
-        name = feat["name"]
-        ftype = feat["type"]
-        if ftype in ("number", "binary"):
-            fields[name] = (float | None, None)
-        elif ftype in ("category", "text", "sequence", "set", "bag"):
-            fields[name] = (str | None, None)
-        else:
-            fields[name] = (Any, None)
-
-    return type("PredictRequest", (PydanticBaseModel,), {"__annotations__": {k: v[0] for k, v in fields.items()}})
-
-
-def build_response_schema(config: dict) -> type[PydanticBaseModel]:
-    """Auto-generate a Pydantic response schema from Ludwig model config."""
-    fields = {}
-    for feat in config.get("output_features", []):
-        name = feat["name"]
-        ftype = feat["type"]
-        if ftype == "number":
-            fields[f"{name}_predictions"] = (float | None, None)
-        elif ftype in ("category", "text", "sequence"):
-            fields[f"{name}_predictions"] = (str | None, None)
-        elif ftype == "binary":
-            fields[f"{name}_predictions"] = (bool | None, None)
-            fields[f"{name}_probabilities"] = (float | None, None)
-        else:
-            fields[f"{name}_predictions"] = (Any, None)
-
-    return type("PredictResponse", (PydanticBaseModel,), {"__annotations__": {k: v[0] for k, v in fields.items()}})
-
-
+# ---------------------------------------------------------------------------
+# Application factory
+# ---------------------------------------------------------------------------
 def create_app(
     model_path: str | None = None,
     allowed_origins: list[str] | None = None,
-    timeout_seconds: float = 300.0,
+    prediction_timeout: float = 30.0,
 ) -> FastAPI:
     """Create a modernized Ludwig serving application.
 
     Args:
         model_path: Path to the trained Ludwig model.
         allowed_origins: CORS allowed origins.
-        timeout_seconds: Maximum time for a prediction request.
+        prediction_timeout: Maximum seconds to wait for a prediction before
+            returning HTTP 504.
 
     Returns:
         FastAPI application.
     """
     app = FastAPI(
         title="Ludwig Inference Server",
-        description="Production-ready model serving with auto-generated schemas",
+        description="Production-ready model serving with auto-generated schemas, "
+        "Prometheus metrics, structured logging, and timeout handling.",
         version="0.12.0",
     )
 
@@ -142,10 +248,39 @@ def create_app(
     if model_path:
         model_manager.load(model_path)
 
+    # Build typed schemas after (potential) model load so they reflect actual features
+    PredictRequest = build_request_schema(model_manager.config or {})
+    PredictResponse = build_response_schema(model_manager.config or {})
+
+    # ------------------------------------------------------------------ #
+    # Middleware: structured request/response logging                      #
+    # ------------------------------------------------------------------ #
+    @app.middleware("http")
+    async def log_requests(request: Request, call_next):
+        """Log method, path, status code, and duration for every HTTP request."""
+        start = time.monotonic()
+        response = await call_next(request)
+        duration = time.monotonic() - start
+        logger.info(
+            "http_request method=%s path=%s status=%d duration_seconds=%.4f client=%s",
+            request.method,
+            request.url.path,
+            response.status_code,
+            duration,
+            request.client.host if request.client else "unknown",
+        )
+        return response
+
+    # ------------------------------------------------------------------ #
+    # Health                                                               #
+    # ------------------------------------------------------------------ #
     @app.get("/")
     def health():
         return {"status": "healthy", "model_loaded": model_manager.model is not None}
 
+    # ------------------------------------------------------------------ #
+    # Model info                                                           #
+    # ------------------------------------------------------------------ #
     @app.get("/info")
     def model_info():
         if model_manager.config is None:
@@ -153,145 +288,135 @@ def create_app(
         return {
             "model_type": model_manager.config.get("model_type", "ecd"),
             "input_features": [
-                {"name": f["name"], "type": f["type"]} for f in model_manager.config.get("input_features", [])
+                {"name": n, "type": f.get("type")}
+                for n, f in zip(model_manager._input_feature_names, model_manager.config.get("input_features", []))
             ],
             "output_features": [
-                {"name": f["name"], "type": f["type"]} for f in model_manager.config.get("output_features", [])
+                {"name": n, "type": f.get("type")}
+                for n, f in zip(model_manager._output_feature_names, model_manager.config.get("output_features", []))
             ],
         }
 
-    @app.middleware("http")
-    async def log_requests(request: Request, call_next):
-        """Structured request/response logging middleware.
-
-        Logs method, path, status, duration, and client for every request. Set LUDWIG_LOG_REQUEST_BODY=1 to also log
-        request bodies (for debugging).
-        """
-        import os
-
-        start = time.time()
-        log_body = os.environ.get("LUDWIG_LOG_REQUEST_BODY", "")
-
-        # Optionally log request body (must read and reconstruct)
-        request_body_summary = None
-        if log_body and request.method == "POST":
-            body_bytes = await request.body()
-            try:
-                body_str = body_bytes.decode("utf-8")
-                # Truncate for logging (avoid huge payloads in logs)
-                request_body_summary = body_str[:500] + ("..." if len(body_str) > 500 else "")
-            except Exception:
-                request_body_summary = f"<binary {len(body_bytes)} bytes>"
-
-            # Reconstruct request body for downstream handlers
-            async def receive():
-                return {"type": "http.request", "body": body_bytes}
-
-            request = Request(scope=request.scope, receive=receive)
-
-        response = await call_next(request)
-        duration = time.time() - start
-
-        log_extra = {
-            "method": request.method,
-            "path": request.url.path,
-            "status_code": response.status_code,
-            "duration_seconds": round(duration, 4),
-            "client": request.client.host if request.client else "unknown",
-        }
-        if request_body_summary:
-            log_extra["request_body"] = request_body_summary
-
-        logger.info("request", extra=log_extra)
-        return response
-
-    @app.post("/predict")
-    async def predict(request: Request, model=Depends(get_model)):
-        start = time.time()
-        try:
-            body = await request.json()
-            if isinstance(body, list):
-                df = pd.DataFrame(body)
-            else:
-                df = pd.DataFrame([body])
-
-            # Run prediction with timeout
-            try:
-                resp, _ = await asyncio.wait_for(
-                    asyncio.get_event_loop().run_in_executor(None, lambda: model.predict(dataset=df)),
-                    timeout=timeout_seconds,
-                )
-            except TimeoutError:
-                raise HTTPException(status_code=504, detail=f"Prediction timed out after {timeout_seconds}s")
-
-            result = _numpy_safe(resp.to_dict("records"))
-
-            if METRICS_AVAILABLE:
-                REQUEST_COUNT.labels(endpoint="predict", status="success").inc()
-                REQUEST_LATENCY.labels(endpoint="predict").observe(time.time() - start)
-
-            if len(result) == 1:
-                return JSONResponse(result[0])
-            return JSONResponse(result)
-
-        except HTTPException:
-            raise
-        except Exception as e:
-            logger.exception(f"Prediction failed: {e}")
-            if METRICS_AVAILABLE:
-                REQUEST_COUNT.labels(endpoint="predict", status="error").inc()
-            raise HTTPException(status_code=500, detail=str(e))
-
-    @app.post("/batch_predict")
-    async def batch_predict(request: Request, model=Depends(get_model)):
-        start = time.time()
-        try:
-            body = await request.json()
-            df = pd.DataFrame(body)
-
-            try:
-                resp, _ = await asyncio.wait_for(
-                    asyncio.get_event_loop().run_in_executor(None, lambda: model.predict(dataset=df)),
-                    timeout=timeout_seconds,
-                )
-            except TimeoutError:
-                raise HTTPException(status_code=504, detail=f"Prediction timed out after {timeout_seconds}s")
-
-            result = _numpy_safe(resp.to_dict("split"))
-
-            if METRICS_AVAILABLE:
-                REQUEST_COUNT.labels(endpoint="batch_predict", status="success").inc()
-                REQUEST_LATENCY.labels(endpoint="batch_predict").observe(time.time() - start)
-
-            return JSONResponse(result)
-
-        except HTTPException:
-            raise
-        except Exception as e:
-            logger.exception(f"Batch prediction failed: {e}")
-            if METRICS_AVAILABLE:
-                REQUEST_COUNT.labels(endpoint="batch_predict", status="error").inc()
-            raise HTTPException(status_code=500, detail=str(e))
-
+    # ------------------------------------------------------------------ #
+    # Prometheus metrics                                                   #
+    # ------------------------------------------------------------------ #
     if METRICS_AVAILABLE:
 
         @app.get("/metrics")
         def metrics():
             from starlette.responses import Response
 
-            return Response(content=generate_latest(), media_type="text/plain")
+            return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+    # ------------------------------------------------------------------ #
+    # Single-row prediction                                                #
+    # ------------------------------------------------------------------ #
+    @app.post("/predict", response_model=PredictResponse)
+    async def predict(body: PredictRequest, model=Depends(get_model)):  # type: ignore[valid-type]
+        start = time.monotonic()
+
+        # Convert Pydantic model to dict, drop unset/None fields
+        entry = {k: v for k, v in body.model_dump().items() if v is not None}
+
+        # Validate all required input features are present
+        missing = model_manager._input_features_set - set(entry.keys())
+        if missing:
+            _record_error("predict")
+            raise HTTPException(
+                status_code=400,
+                detail=f"Missing input features: {sorted(missing)}",
+            )
+
+        _log_request("predict", sorted(entry.keys()), batch_size=1)
+
+        try:
+            resp_df, _ = await asyncio.wait_for(
+                asyncio.get_event_loop().run_in_executor(
+                    None,
+                    lambda: model.predict(dataset=[entry], data_format=dict),
+                ),
+                timeout=prediction_timeout,
+            )
+        except TimeoutError:
+            _record_error("predict")
+            logger.error("prediction_timeout endpoint=predict timeout_seconds=%.1f", prediction_timeout)
+            raise HTTPException(status_code=504, detail=f"Prediction timed out after {prediction_timeout}s")
+        except Exception as exc:
+            logger.exception("Prediction failed: %s", exc)
+            _record_error("predict")
+            raise HTTPException(status_code=500, detail=str(exc))
+
+        result = _numpy_safe(resp_df.to_dict("records")[0])
+        latency = time.monotonic() - start
+        _log_response("predict", model_manager._output_feature_names, latency)
+        _record_success("predict", latency)
+        return JSONResponse(result)
+
+    # ------------------------------------------------------------------ #
+    # Batch prediction                                                     #
+    # ------------------------------------------------------------------ #
+    @app.post("/batch_predict")
+    async def batch_predict(request: Request, model=Depends(get_model)):
+        start = time.monotonic()
+        try:
+            body = await request.json()
+            df = pd.DataFrame(body if isinstance(body, list) else [body])
+        except Exception as exc:
+            _record_error("batch_predict")
+            raise HTTPException(status_code=400, detail=f"Invalid request body: {exc}")
+
+        missing = model_manager._input_features_set - set(df.columns)
+        if missing:
+            _record_error("batch_predict")
+            raise HTTPException(
+                status_code=400,
+                detail=f"Missing input features: {sorted(missing)}",
+            )
+
+        _log_request("batch_predict", sorted(df.columns.tolist()), batch_size=len(df))
+
+        try:
+            resp_df, _ = await asyncio.wait_for(
+                asyncio.get_event_loop().run_in_executor(
+                    None,
+                    lambda: model.predict(dataset=df),
+                ),
+                timeout=prediction_timeout,
+            )
+        except TimeoutError:
+            _record_error("batch_predict")
+            logger.error("prediction_timeout endpoint=batch_predict timeout_seconds=%.1f", prediction_timeout)
+            raise HTTPException(status_code=504, detail=f"Prediction timed out after {prediction_timeout}s")
+        except Exception as exc:
+            logger.exception("Batch prediction failed: %s", exc)
+            _record_error("batch_predict")
+            raise HTTPException(status_code=500, detail=str(exc))
+
+        result = _numpy_safe(resp_df.to_dict("split"))
+        latency = time.monotonic() - start
+        _log_response("batch_predict", model_manager._output_feature_names, latency)
+        _record_success("batch_predict", latency)
+        return JSONResponse(result)
 
     return app
 
 
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 def run_server(
     model_path: str,
     host: str = "0.0.0.0",
     port: int = 8000,
     allowed_origins: list[str] | None = None,
-):
+    prediction_timeout: float = 30.0,
+) -> None:
     """Run the Ludwig serving application."""
     import uvicorn
 
-    app = create_app(model_path=model_path, allowed_origins=allowed_origins)
+    app = create_app(
+        model_path=model_path,
+        allowed_origins=allowed_origins,
+        prediction_timeout=prediction_timeout,
+    )
     uvicorn.run(app, host=host, port=port)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ serve = [
     "httpx",
     "fastapi",
     "python-multipart",
+    "prometheus_client",
 ]
 viz = [
     "matplotlib>=3.4",


### PR DESCRIPTION
## Summary

- **Auto-generated Pydantic schemas**: `build_request_schema()` and `build_response_schema()` dynamically create typed Pydantic models from `model.config` input/output feature configs. `PredictResponse` is wired as `response_model` on `/predict` for full OpenAPI docs. `PredictRequest` schema is attached via `openapi_extra` for multipart/form-data documentation (the actual transport is form-based).
- **Prometheus metrics** (`GET /metrics`): Optional `prometheus_client` dependency guarded by `try/except ImportError`. Tracks `ludwig_requests_total` (Counter), `ludwig_request_latency_seconds` (Histogram), and `ludwig_errors_total` (Counter) per endpoint with `success`/`error` labels. Added `prometheus_client` to `serve` optional dependencies in `pyproject.toml`.
- **Structured logging**: `key=value` format log lines for every prediction request (`endpoint=`, `features=`, `batch_size=`) and response (`outputs=`, `latency_seconds=`). HTTP middleware in `serve_v2.py` logs `method`, `path`, `status`, `duration_seconds`, `client` for every request.
- **Timeout handling**: `prediction_timeout: float = 30.0` parameter on `server()` and `run_server()`. Prediction calls wrapped with `asyncio.wait_for()` returning HTTP 504 on timeout. Exposed as `--prediction_timeout` CLI flag.
- **Remove NumpyJSONResponse**: Replaced with `_numpy_safe()` + `fastapi.responses.JSONResponse` in all new code. `NumpyJSONResponse` remains in `server_utils.py` for backward compatibility only.
- **serve_v2.py improvements**: Fully wires `PredictRequest` as the FastAPI body parameter so `/predict` gets typed validation and full OpenAPI schema. `ModelManager` now caches `_input_features_set` for fast missing-feature checks. Consistent `prediction_timeout` naming throughout.

## Test plan

- [ ] `pytest tests/integration_tests/test_server.py -v` — existing serve integration tests
- [ ] `pytest tests/ludwig/test_serve_v2.py -v` — serve_v2 unit tests
- [ ] Verify `GET /metrics` returns Prometheus text format when `prometheus_client` is installed
- [ ] Verify HTTP 504 is returned when `prediction_timeout` is set very low
- [ ] Verify FastAPI `/docs` shows typed request/response schemas derived from model features
- [ ] Verify structured log lines contain `endpoint=`, `features=`, `batch_size=`, `latency_seconds=` fields