### PR TITLE
cleanup: remove deprecated text encoders and fix quantized checkpoint resumption

### DIFF
--- a/ludwig/encoders/text_encoders.py
+++ b/ludwig/encoders/text_encoders.py
@@ -2516,6 +2516,12 @@ class LLMEncoder(Encoder):
         3. Re-initialize the PEFT adapter on top of the quantized base.
         4. Load only the adapter weights from the checkpoint.
 
+        When resuming a quantized model without an adapter, the quantized base weights cannot be
+        restored from a standard state dict (bitsandbytes quantization is applied at load time).
+        The model is already correctly quantized from __init__; we only need to prepare it for
+        training. No weights need loading from the checkpoint because the base model weights are
+        always re-quantized from the pretrained HuggingFace checkpoint.
+
         For non-quantized models, standard state_dict loading works via Ludwig's default mechanism.
         """
         import os
@@ -2523,7 +2529,8 @@ class LLMEncoder(Encoder):
         if self.config.quantization and self.config.adapter:
             logger.info("Resuming quantized adapter model from checkpoint.")
 
-            # Step 1: Prepare quantized base model for training (freeze + cast)
+            # Step 1: Prepare quantized base model for training (freeze + cast).
+            # prepare_for_quantized_training is idempotent, so safe to call on every resume.
             if not self.adapter_is_initialized:
                 self.prepare_for_quantized_training()
 
@@ -2549,6 +2556,16 @@ class LLMEncoder(Encoder):
                     )
             else:
                 logger.warning(f"Checkpoint file not found at {checkpoint_file}. Starting with fresh adapter weights.")
+        elif self.config.quantization and not self.config.adapter:
+            # Quantized model without adapter: bitsandbytes quantization is applied at load time
+            # in __init__, so the base weights cannot be restored from a standard state dict.
+            # The model is already correctly quantized; we only need to prepare it for training.
+            logger.info(
+                "Resuming quantized model (no adapter) from checkpoint. "
+                "Base model weights are always loaded fresh from the pretrained HuggingFace checkpoint; "
+                "no weight restoration from Ludwig checkpoint is needed."
+            )
+            self.prepare_for_quantized_training()
         else:
             # Non-quantized case: standard state_dict loading is handled by Ludwig's trainer
             logger.info("Resuming from checkpoint (non-quantized path).")

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -54,6 +54,7 @@ class LLM(BaseModel):
 
         self.config_obj = config_obj
         self._random_seed = random_seed
+        self._adapter_initialized = False
 
         self.model_name = self.config_obj.base_model
         self.model_config = AutoConfig.from_pretrained(
@@ -161,8 +162,12 @@ class LLM(BaseModel):
         return self._output_feature_decoder.module
 
     def initialize_adapter(self):
-        """If an adapter config is provided, we want to wrap the model with a PEFT model for fine-tuning."""
-        if self.config_obj.adapter:
+        """If an adapter config is provided, wrap the model with a PEFT model for fine-tuning.
+
+        Guarded by _adapter_initialized to prevent double-wrapping when called multiple times (e.g. prepare_for_training
+        is called on every Trainer construction, including on resume).
+        """
+        if self.config_obj.adapter and not self._adapter_initialized:
             if self.config_obj.trainer.type != "finetune" and not self.config_obj.adapter.pretrained_adapter_weights:
                 raise ValueError(
                     "Adapter config was provided, but trainer type is not set to `finetune`. Either set the trainer to "
@@ -177,8 +182,17 @@ class LLM(BaseModel):
             self.model.print_trainable_parameters()
             logger.info("==================================================")
 
+            self._adapter_initialized = True
+
     def prepare_for_training(self):
-        # TODO: this implementation will not work if resuming from a previous checkpoint. Need to fix this.
+        """Prepare the model for training by setting up quantization and adapters.
+
+        Safe to call multiple times (e.g. when resuming from a checkpoint). Quantization is applied at model-load time
+        in __init__ via load_pretrained_from_config, so prepare_model_for_kbit_training only needs to cast non-quantized
+        layers to float32 and freeze the quantized base — both operations are idempotent. Adapter initialization is
+        guarded by _adapter_initialized so the PEFT wrapper is only created once; on resume the saved adapter weights
+        are subsequently loaded by the trainer via load_state_dict.
+        """
         if self.config_obj.quantization:
             self.prepare_for_quantized_training()
         self.initialize_adapter()

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -861,3 +861,40 @@ def _update_old_image_preprocessing(feature_config: FeatureConfigDict):
     if not preprocessing:
         return
     preprocessing["standardize_image"] = preprocessing.get("standardize_image")
+
+
+@register_config_transformation("0.11", ["input_features"])
+def _upgrade_removed_text_encoders(feature: FeatureConfigDict) -> FeatureConfigDict:
+    """Upgrade configs that reference removed text encoder types.
+
+    TransformerXL, CTRL, and FlauBERT encoders have been removed from Ludwig because they are
+    discontinued or superseded by other models (HuggingFace deprecated TransformerXL; CTRL has
+    no active community use; FlauBERT is superseded by CamemBERT and multilingual models like
+    XLM-RoBERTa). Configs using these types are automatically remapped to `auto_transformer`.
+
+    Note: the `pretrained_model_name_or_path` field must be set explicitly since `auto_transformer`
+    has no built-in default model name.
+    """
+    if feature.get(TYPE) != TEXT:
+        return feature
+
+    encoder = feature.get(ENCODER, {})
+    encoder_type = encoder.get(TYPE)
+
+    removed_encoder_mapping = {
+        "transformer_xl": "auto_transformer",
+        "ctrl": "auto_transformer",
+        "flaubert": "auto_transformer",
+    }
+
+    if encoder_type in removed_encoder_mapping:
+        replacement = removed_encoder_mapping[encoder_type]
+        warnings.warn(
+            f"Text encoder type '{encoder_type}' has been removed and is no longer supported. "
+            f"Remapping to '{replacement}'. You may need to set `pretrained_model_name_or_path` "
+            f"explicitly in the encoder config to specify the model to use.",
+            DeprecationWarning,
+        )
+        encoder[TYPE] = replacement
+
+    return feature


### PR DESCRIPTION
## Summary

- **Backward compatibility**: Add a v0.11 config transformation that remaps the old text encoder types `transformer_xl`, `ctrl`, and `flaubert` to `auto_transformer` with a `DeprecationWarning`. These encoder classes were already removed from the source; this transformation handles configs saved before their removal so they can still be loaded.

- **Fix `LLM.prepare_for_training` double-wrap bug** (`ludwig/models/llm.py`): Add an `_adapter_initialized` flag so the PEFT adapter wrapper is only created once. Previously, calling `prepare_for_training()` more than once (e.g. `Trainer.__init__` on fresh training + a second call on resume) would double-wrap the model with PEFT layers. The flag prevents this. Removes the stale TODO comment and replaces it with a proper docstring.

- **Fix `LLMEncoder.resume_from_checkpoint`** (`ludwig/encoders/text_encoders.py`): Add explicit handling for the quantized-without-adapter case. bitsandbytes 4/8-bit quantization is applied at model-load time in `__init__` via `load_pretrained_from_config`, so quantized base weights cannot be restored from a Ludwig checkpoint state dict. The model is already correctly quantized from the HuggingFace checkpoint; only `prepare_for_quantized_training()` needs to be called on resume. Previously this case fell into the non-quantized `else` branch which would call `prepare_for_training()` (not just `prepare_for_quantized_training()`), incorrectly attempting to also initialize a new adapter.

## Test plan

- [ ] Verify that loading a config with `encoder.type: transformer_xl` (or `ctrl`/`flaubert`) triggers a `DeprecationWarning` and is remapped to `auto_transformer`
- [ ] Verify that training an LLM with quantization + adapter from scratch and then resuming from checkpoint does not double-wrap the model
- [ ] Verify that resuming a quantized LLM encoder (no adapter) from checkpoint logs the correct message and calls `prepare_for_quantized_training()` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)