### PR TITLE
feat: add OneCycleLR, inverse_sqrt, polynomial, and WSD LR schedulers

### DIFF
--- a/ludwig/modules/lr_scheduler.py
+++ b/ludwig/modules/lr_scheduler.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from typing import Any
 
 from torch.optim import Optimizer
-from torch.optim.lr_scheduler import CosineAnnealingWarmRestarts, LambdaLR, ReduceLROnPlateau, SequentialLR
+from torch.optim.lr_scheduler import CosineAnnealingWarmRestarts, LambdaLR, OneCycleLR, ReduceLROnPlateau, SequentialLR
 
 from ludwig.constants import MINIMIZE, TRAINING, VALIDATION
 from ludwig.modules.metric_registry import get_metric_objective
@@ -16,6 +16,15 @@ logger = logging.getLogger(__name__)
 
 
 class ReduceLROnPLateauCappedDecreases(ReduceLROnPlateau):
+    """ReduceLROnPlateau with a cap on the number of allowed reductions.
+
+    Use when: you want to reduce LR in response to plateaus, but want to prevent the LR
+    from collapsing to zero over a very long training run.
+
+    Trade-offs: Requires a validation metric to be tracked. Does not interact well with
+    schedules that already decay LR aggressively (e.g., one_cycle).
+    """
+
     def __init__(self, optimizer: Optimizer, mode: str, reduce_limit: int, factor: float, patience: int):
         super().__init__(optimizer, mode=mode, factor=factor, patience=patience)
         self.reduce_limit = reduce_limit
@@ -161,10 +170,28 @@ def get_schedule_with_warmup_and_decay(
     step_info: StepInfo,
 ) -> LambdaLR:
     """Creates a learning rate scheduler that updates each training step."""
+    decay = config.decay
+
+    # OneCycleLR manages warmup and decay internally - skip the SequentialLR wrapper.
+    if decay == "one_cycle":
+        if step_info.num_warmup_steps > 0:
+            logger.warning(
+                "decay='one_cycle' includes its own warmup phase controlled by `pct_start`. "
+                "The `warmup_fraction`/`warmup_evaluations` settings will be ignored."
+            )
+        return init_one_cycle(config, optimizer, step_info)
+
+    # WSD manages its own warmup internally via wsd_warmup_fraction.
+    if decay == "wsd" and step_info.num_warmup_steps > 0:
+        logger.warning(
+            "decay='wsd' includes its own warmup phase controlled by `wsd_warmup_fraction`. "
+            "The external `warmup_fraction`/`warmup_evaluations` settings will be ignored for WSD."
+        )
+
     schedulers = []
 
     # Warmup scheduler.
-    if step_info.num_warmup_steps > 0:
+    if step_info.num_warmup_steps > 0 and decay != "wsd":
         warmup_scheduler = LambdaLR(
             optimizer,
             lambda current_step: float(current_step) / float(max(1, step_info.num_warmup_steps)),
@@ -172,7 +199,6 @@ def get_schedule_with_warmup_and_decay(
         schedulers.append(warmup_scheduler)
 
     # Decay scheduler.
-    decay = config.decay
     decay_scheduler = decay_registry[decay](config, optimizer, step_info)
     schedulers.append(decay_scheduler)
 
@@ -185,11 +211,32 @@ def get_schedule_with_warmup_and_decay(
     return SequentialLR(optimizer, schedulers=schedulers, milestones=[step_info.num_warmup_steps])
 
 
+# ---------------------------------------------------------------------------
+# Decay functions (used via wrap_decay_fn -> LambdaLR)
+# ---------------------------------------------------------------------------
+
+
 def no_decay(current_step: int, num_training_steps: int, num_warmup_steps: int, config: LRSchedulerConfig):
+    """No decay: keep LR constant throughout training.
+
+    Use when: you want full control via the optimizer's initial LR, or when using
+    reduce_on_plateau alone.
+
+    Trade-offs: Simple but rarely optimal for long runs; the LR never adapts to the loss
+    landscape.
+    """
     return 1.0
 
 
 def linear_decay(current_step: int, num_training_steps: int, num_warmup_steps: int, config: LRSchedulerConfig):
+    """Linear decay from base LR to 0 over the remaining training steps after warmup.
+
+    Use when: fine-tuning pretrained models (catastrophic forgetting risk), or when a
+    predictable, monotone LR reduction is preferred. Popular for BERT-style fine-tuning.
+
+    Trade-offs: Aggressive and inflexible - once the schedule starts, LR can only decrease.
+    May converge too fast if training is short.
+    """
     return max(
         0.0,
         float(num_training_steps - num_warmup_steps - current_step)
@@ -198,6 +245,15 @@ def linear_decay(current_step: int, num_training_steps: int, num_warmup_steps: i
 
 
 def exponential_decay(current_step: int, num_training_steps: int, num_warmup_steps: int, config: LRSchedulerConfig):
+    """Exponential decay: lr *= decay_rate^(step / decay_steps).
+
+    Use when: training from scratch and a smooth, gradual LR reduction is desired. A good
+    default for most tabular and vision tasks.
+
+    Trade-offs: Never reaches zero, so the optimizer always has a non-trivial step size.
+    Sensitive to the choice of decay_rate and decay_steps - too aggressive and the model
+    under-trains in the later stages; too gentle and the LR barely changes.
+    """
     decay_rate = float(config.decay_rate)
     decay_steps = float(config.decay_steps)
     step = float(current_step)
@@ -224,6 +280,17 @@ def init_cosine_decay(
     optimizer: Optimizer,
     step_info: StepInfo,
 ) -> CosineAnnealingWarmRestarts:
+    """Cosine annealing with warm restarts (Loshchilov & Hutter, 2017).
+
+    The LR follows a cosine curve from base_lr down to eta_min over T_0 steps, then
+    restarts. Each restart can have a longer period controlled by t_mult.
+
+    Use when: you want periodic exploration boosts during training (each restart resets LR
+    upward), which can help escape local minima. Popular for image classification.
+
+    Trade-offs: The periodic restarts add variance to the loss curve. Selecting good T_0
+    and T_mult values requires some tuning. Not well-suited for very short training runs.
+    """
     t_0 = config.t_0
     if not t_0:
         t_0 = step_info.steps_per_checkpoint
@@ -240,9 +307,146 @@ def init_cosine_decay(
     )
 
 
+def init_one_cycle(
+    config: LRSchedulerConfig,
+    optimizer: Optimizer,
+    step_info: StepInfo,
+) -> OneCycleLR:
+    """1cycle policy (Smith & Topin, 2018).
+
+    Three phases: LR rises from initial_lr to max_lr over pct_start of total steps
+    (warmup), then decays to min_lr = initial_lr / final_div_factor via cosine annealing.
+    initial_lr = max_lr / div_factor.
+
+    Use when: you want the fastest convergence in a single training run, especially for
+    image/audio tasks. Works best with a pre-determined total_steps budget.
+
+    Trade-offs: Requires total_steps to be known in advance (cannot restart mid-training
+    without reinitializing). Not composable with an external warmup scheduler (warmup is
+    built in). The LR goes to near-zero at the end, so extending training is ineffective.
+    """
+    total_steps = step_info.num_training_steps
+    if not total_steps:
+        total_steps = 1  # Avoid division-by-zero during dummy init
+
+    # Determine max_lr: use config override or fall back to optimizer's param-group lr.
+    if config.max_lr is not None:
+        max_lr = config.max_lr
+    else:
+        max_lr = max(pg["lr"] for pg in optimizer.param_groups)
+
+    return OneCycleLR(
+        optimizer,
+        max_lr=max_lr,
+        total_steps=total_steps,
+        pct_start=config.pct_start,
+        div_factor=config.div_factor,
+        final_div_factor=config.final_div_factor,
+        anneal_strategy="cos",
+    )
+
+
+def inverse_sqrt_decay(current_step: int, num_training_steps: int, num_warmup_steps: int, config: LRSchedulerConfig):
+    """Inverse square root decay: lr = base_lr / sqrt(max(step, warmup_steps)).
+
+    This is the original Transformer learning rate schedule from Vaswani et al. (2017).
+    The LR warms up linearly for warmup_steps steps (handled externally via SequentialLR),
+    then decays as 1/sqrt(step), which is slow and keeps the LR meaningfully large for a
+    long time.
+
+    The peak step count is anchored to inverse_sqrt_warmup_steps so that the decay
+    transition is predictable regardless of the global warmup setting.
+
+    Use when: training vanilla Transformer models from scratch (NLP, speech). Standard in
+    sequence-to-sequence and language model pretraining baselines.
+
+    Trade-offs: LR never reaches zero, so training can be extended freely. Decays slower
+    than linear or exponential - may be too high for very long runs without tuning
+    warmup_steps.
+    """
+    warmup = float(config.inverse_sqrt_warmup_steps)
+    return 1.0 / math.sqrt(max(float(current_step), warmup))
+
+
+def polynomial_decay(current_step: int, num_training_steps: int, num_warmup_steps: int, config: LRSchedulerConfig):
+    """Polynomial decay with configurable power and end LR.
+
+    lr = (base_lr - end_lr) * (1 - progress)^power + end_lr where progress = (step -
+    warmup_steps) / (total_steps - warmup_steps).
+
+    With power=1.0 this is equivalent to linear decay. Higher powers give more concave
+    curves that stay high for longer and drop sharply near the end.
+
+    Use when: replicating BERT, RoBERTa, or GPT-2 fine-tuning recipes. These models
+    commonly use polynomial (linear) decay with a small warmup fraction.
+
+    Trade-offs: Requires total_steps to be known. end_lr > 0 prevents the LR from
+    collapsing to zero, which can help with very long training. Power > 1 risks a sudden
+    sharp drop near the end of training.
+    """
+    if num_training_steps <= num_warmup_steps:
+        return 1.0
+
+    progress = float(current_step - num_warmup_steps) / float(max(1, num_training_steps - num_warmup_steps))
+    progress = min(progress, 1.0)
+
+    # Compute the scale factor as a fraction of the base LR (base LR = 1.0 in LambdaLR).
+    end_lr_fraction = config.polynomial_end_lr  # relative to base_lr; 0.0 means decay to 0
+    return (1.0 - end_lr_fraction) * math.pow(1.0 - progress, config.polynomial_power) + end_lr_fraction
+
+
+def wsd_decay(current_step: int, num_training_steps: int, num_warmup_steps: int, config: LRSchedulerConfig):
+    """Warmup-Stable-Decay (WSD) schedule.
+
+    Three phases:
+
+    1. Warmup: LR rises linearly from 0 to base_lr over wsd_warmup_fraction * total_steps
+       steps.
+    2. Stable: LR stays constant at base_lr for wsd_stable_fraction * total_steps steps.
+    3. Decay: LR decreases via cosine from base_lr to 0 over wsd_decay_fraction *
+       total_steps steps.
+
+    wsd_warmup_fraction + wsd_stable_fraction + wsd_decay_fraction should sum to 1.
+
+    Popular for LLM pretraining (MiniCPM, DeepSeek-V2). The long stable phase allows easy
+    checkpoint reuse: you can extend training by appending another stable phase and a final
+    decay.
+
+    Use when: pretraining large language models where you want flexibility to extend the
+    training budget without restarting from scratch.
+
+    Trade-offs: The sharp cosine decay at the end can cause instability if decay_fraction
+    is too small. The three fractions must be manually tuned and must sum to 1. Warmup is
+    managed internally - do not also set warmup_fraction or warmup_evaluations.
+    """
+    T = float(num_training_steps)
+    t = float(current_step)
+
+    warmup_end = config.wsd_warmup_fraction * T
+    stable_end = warmup_end + config.wsd_stable_fraction * T
+
+    if t < warmup_end:
+        # Linear warmup phase
+        return t / max(1.0, warmup_end)
+    elif t < stable_end:
+        # Constant LR phase
+        return 1.0
+    else:
+        # Cosine decay phase
+        decay_start = stable_end
+        decay_end = T
+        decay_progress = (t - decay_start) / max(1.0, decay_end - decay_start)
+        decay_progress = min(decay_progress, 1.0)
+        return 0.5 * (1.0 + math.cos(math.pi * decay_progress))
+
+
 decay_registry = {
     None: wrap_decay_fn(no_decay),
     "linear": wrap_decay_fn(linear_decay),
     "exponential": wrap_decay_fn(exponential_decay),
     "cosine": init_cosine_decay,
+    "inverse_sqrt": wrap_decay_fn(inverse_sqrt_decay),
+    "polynomial": wrap_decay_fn(polynomial_decay),
+    "wsd": wrap_decay_fn(wsd_decay),
+    # one_cycle is handled specially in get_schedule_with_warmup_and_decay
 }

--- a/ludwig/schema/lr_scheduler.py
+++ b/ludwig/schema/lr_scheduler.py
@@ -13,10 +13,13 @@ class LRSchedulerConfig(schema_utils.LudwigBaseConfig, ABC):
     """Configuration for learning rate scheduler parameters."""
 
     decay: str = schema_utils.StringOptions(
-        options=["linear", "exponential", "cosine"],
+        options=["linear", "exponential", "cosine", "one_cycle", "inverse_sqrt", "polynomial", "wsd"],
         default=None,
         allow_none=True,
-        description="Turn on decay of the learning rate.",
+        description=(
+            "Learning rate decay schedule. Options: 'linear', 'exponential', 'cosine', 'one_cycle', "
+            "'inverse_sqrt', 'polynomial', 'wsd'."
+        ),
         parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["decay"],
     )
 
@@ -52,7 +55,7 @@ class LRSchedulerConfig(schema_utils.LudwigBaseConfig, ABC):
     reduce_on_plateau_patience: int = schema_utils.NonNegativeInteger(
         default=10,
         description=(
-            "How many evaluation steps have to pass before the learning rate reduces " "when `reduce_on_plateau > 0`."
+            "How many evaluation steps have to pass before the learning rate reduces when `reduce_on_plateau > 0`."
         ),
         parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["reduce_on_plateau_patience"],
     )
@@ -80,18 +83,14 @@ class LRSchedulerConfig(schema_utils.LudwigBaseConfig, ABC):
     reduce_eval_metric: str = schema_utils.String(
         default=LOSS,
         allow_none=False,
-        description=(
-            "Metric plateau used to trigger when we reduce the learning rate " "when `reduce_on_plateau > 0`."
-        ),
+        description=("Metric plateau used to trigger when we reduce the learning rate when `reduce_on_plateau > 0`."),
         parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["reduce_eval_metric"],
     )
 
     reduce_eval_split: str = schema_utils.String(
         default=TRAINING,
         allow_none=False,
-        description=(
-            "Which dataset split to listen on for reducing the learning rate " "when `reduce_on_plateau > 0`."
-        ),
+        description=("Which dataset split to listen on for reducing the learning rate when `reduce_on_plateau > 0`."),
         parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["reduce_eval_split"],
     )
 
@@ -119,6 +118,118 @@ class LRSchedulerConfig(schema_utils.LudwigBaseConfig, ABC):
         max=1,
         description="Minimum learning rate allowed for cosine annealing decay. Default: 0.",
         parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["eta_min"],
+    )
+
+    # Parameters for OneCycleLR scheduler
+
+    max_lr: float = schema_utils.Float(
+        default=None,
+        allow_none=True,
+        description=(
+            "Maximum learning rate for the OneCycleLR scheduler. If None, defaults to the optimizer's base "
+            "learning rate. Used only when decay='one_cycle'."
+        ),
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["max_lr"],
+    )
+
+    pct_start: float = schema_utils.FloatRange(
+        default=0.3,
+        min=0,
+        max=1,
+        description=(
+            "Fraction of training steps spent increasing the learning rate in the OneCycleLR scheduler. "
+            "Used only when decay='one_cycle'."
+        ),
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["pct_start"],
+    )
+
+    div_factor: float = schema_utils.Float(
+        default=25.0,
+        allow_none=False,
+        description=(
+            "Determines the initial learning rate (initial_lr = max_lr / div_factor) for OneCycleLR. "
+            "Used only when decay='one_cycle'."
+        ),
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["div_factor"],
+    )
+
+    final_div_factor: float = schema_utils.Float(
+        default=1e4,
+        allow_none=False,
+        description=(
+            "Determines the minimum learning rate (min_lr = initial_lr / final_div_factor) for OneCycleLR. "
+            "Used only when decay='one_cycle'."
+        ),
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["final_div_factor"],
+    )
+
+    # Parameters for InverseSqrtLR scheduler
+
+    inverse_sqrt_warmup_steps: int = schema_utils.PositiveInteger(
+        default=4000,
+        description=(
+            "Number of warmup steps for the inverse square root scheduler. After warmup, the LR decays as "
+            "1/sqrt(step). This is the classic Transformer schedule from Vaswani et al. (2017). "
+            "Used only when decay='inverse_sqrt'."
+        ),
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["inverse_sqrt_warmup_steps"],
+    )
+
+    # Parameters for Polynomial Decay scheduler
+
+    polynomial_power: float = schema_utils.Float(
+        default=1.0,
+        allow_none=False,
+        description=(
+            "Power of the polynomial decay. power=1.0 gives linear decay; higher values give more concave "
+            "decay curves. Used only when decay='polynomial'."
+        ),
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["polynomial_power"],
+    )
+
+    polynomial_end_lr: float = schema_utils.Float(
+        default=0.0,
+        allow_none=False,
+        description=(
+            "Final (minimum) learning rate at the end of polynomial decay. Used only when decay='polynomial'."
+        ),
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["polynomial_end_lr"],
+    )
+
+    # Parameters for Warmup-Stable-Decay (WSD) scheduler
+
+    wsd_warmup_fraction: float = schema_utils.FloatRange(
+        default=0.1,
+        min=0,
+        max=1,
+        description=(
+            "Fraction of total training steps spent in the linear warmup phase of the WSD scheduler. "
+            "Used only when decay='wsd'."
+        ),
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["wsd_warmup_fraction"],
+    )
+
+    wsd_stable_fraction: float = schema_utils.FloatRange(
+        default=0.8,
+        min=0,
+        max=1,
+        description=(
+            "Fraction of total training steps spent in the constant LR phase of the WSD scheduler. "
+            "Used only when decay='wsd'."
+        ),
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["wsd_stable_fraction"],
+    )
+
+    wsd_decay_fraction: float = schema_utils.FloatRange(
+        default=0.1,
+        min=0,
+        max=1,
+        description=(
+            "Fraction of total training steps spent in the decay phase of the WSD scheduler. "
+            "wsd_warmup_fraction + wsd_stable_fraction + wsd_decay_fraction should sum to 1. "
+            "Used only when decay='wsd'."
+        ),
+        parameter_metadata=TRAINER_METADATA[MODEL_ECD]["learning_rate_scheduler"]["wsd_decay_fraction"],
     )
 
 

--- a/ludwig/schema/metadata/configs/trainer.yaml
+++ b/ludwig/schema/metadata/configs/trainer.yaml
@@ -649,6 +649,36 @@ ecd:
         eta_min:
             expected_impact: 1
             ui_display_name: Eta Min
+        max_lr:
+            expected_impact: 2
+            ui_display_name: Max LR (OneCycleLR)
+        pct_start:
+            expected_impact: 2
+            ui_display_name: Pct Start (OneCycleLR)
+        div_factor:
+            expected_impact: 1
+            ui_display_name: Div Factor (OneCycleLR)
+        final_div_factor:
+            expected_impact: 1
+            ui_display_name: Final Div Factor (OneCycleLR)
+        inverse_sqrt_warmup_steps:
+            expected_impact: 2
+            ui_display_name: Inverse Sqrt Warmup Steps
+        polynomial_power:
+            expected_impact: 2
+            ui_display_name: Polynomial Power
+        polynomial_end_lr:
+            expected_impact: 1
+            ui_display_name: Polynomial End LR
+        wsd_warmup_fraction:
+            expected_impact: 2
+            ui_display_name: WSD Warmup Fraction
+        wsd_stable_fraction:
+            expected_impact: 2
+            ui_display_name: WSD Stable Fraction
+        wsd_decay_fraction:
+            expected_impact: 2
+            ui_display_name: WSD Decay Fraction
 gbm:
     learning_rate:
         commonly_used: true


### PR DESCRIPTION
## Summary

- **OneCycleLR** (`decay='one_cycle'`): Smith & Topin 2018 super-convergence policy. Linear warmup to `max_lr` then cosine decay. Manages warmup internally (bypasses external SequentialLR). Config: `max_lr`, `pct_start` (0.3), `div_factor` (25.0), `final_div_factor` (1e4).
- **Inverse Square Root** (`decay='inverse_sqrt'`): Classic Vaswani et al. 2017 Transformer schedule. `lr = base_lr / sqrt(max(step, warmup_steps))`. Slow, long-tailed decay; good for NLP pretraining. Config: `inverse_sqrt_warmup_steps` (4000).
- **Polynomial Decay** (`decay='polynomial'`): `lr = (base - end_lr) * (1 - progress)^power + end_lr`. `power=1.0` gives BERT/RoBERTa-style linear decay. Config: `polynomial_power` (1.0), `polynomial_end_lr` (0.0).
- **Warmup-Stable-Decay** (`decay='wsd'`): Three-phase schedule popularized by MiniCPM and DeepSeek-V2 for LLM pretraining. Linear warmup → constant LR → cosine decay. Config: `wsd_warmup_fraction` (0.1), `wsd_stable_fraction` (0.8), `wsd_decay_fraction` (0.1).

All schedulers integrate through the existing `LRScheduler.step()` call site with no trainer changes needed. OneCycleLR and WSD emit warnings when `warmup_fraction`/`warmup_evaluations` are also set, since they manage warmup internally.

Docstrings added to all schedulers (existing + new) covering intended use, when to choose, and trade-offs.

## Test plan

- [ ] Verify each new `decay` option can be instantiated via `LRSchedulerConfig(decay='one_cycle')` etc.
- [ ] Check that LR curves are monotone/correct for `inverse_sqrt`, `polynomial`, `wsd` using unit tests or manual inspection
- [ ] Verify `one_cycle` peak LR does not exceed `max_lr`
- [ ] Verify WSD transitions between phases at the correct step fractions
- [ ] Confirm existing schedulers (`linear`, `exponential`, `cosine`, `None`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)