### PR TITLE
feat: add MLPClassifier decoder, temperature scaling calibration, and MC Dropout uncertainty (Phase 1.7.4)

### DIFF
--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -323,3 +323,13 @@ IMAGENET1K = "imagenet1k"
 AUGMENTATION = "augmentation"
 
 LUDWIG_SCHEMA_VALIDATION_POLICY = "LUDWIG_SCHEMA_VALIDATION_POLICY"
+
+# Anomaly detection constants
+ANOMALY = "anomaly"
+ANOMALY_SCORE = "anomaly_score"
+DEEP_SVDD = "deep_svdd"
+DEEP_SAD = "deep_sad"
+DROCC = "drocc"
+F1_MAX = "f1_max"
+ANOMALY_AUROC = "anomaly_auroc"
+UNCERTAINTY = "uncertainty"  # MC Dropout uncertainty output key

--- a/ludwig/decoders/generic_decoders.py
+++ b/ludwig/decoders/generic_decoders.py
@@ -19,7 +19,18 @@ from functools import partial
 import torch
 
 from ludwig.api_annotations import DeveloperAPI
-from ludwig.constants import BINARY, CATEGORY, CATEGORY_DISTRIBUTION, LOSS, NUMBER, SET, TIMESERIES, TYPE, VECTOR
+from ludwig.constants import (
+    ANOMALY,
+    BINARY,
+    CATEGORY,
+    CATEGORY_DISTRIBUTION,
+    LOSS,
+    NUMBER,
+    SET,
+    TIMESERIES,
+    TYPE,
+    VECTOR,
+)
 from ludwig.decoders.base import Decoder
 from ludwig.decoders.registry import register_decoder
 from ludwig.schema.decoders.base import ClassifierConfig, PassthroughDecoderConfig, ProjectorConfig, RegressorConfig
@@ -196,3 +207,228 @@ class Classifier(Decoder):
 
     def forward(self, inputs, **kwargs):
         return self.dense(inputs)
+
+
+@DeveloperAPI
+@register_decoder("anomaly", [ANOMALY])
+class AnomalyDecoder(Decoder):
+    """AnomalyDecoder: computes ||z - c||^2 as the anomaly score.
+
+    The center c is initialized after the first training epoch by calling
+    initialize_center(center_tensor), where center = mean(encoder_outputs).
+    Until initialization, the center is zeros.
+
+    Args:
+        input_size: Latent space dimensionality.
+        decoder_config: AnomalyDecoderConfig instance.
+    """
+
+    def __init__(self, input_size: int = None, decoder_config=None, **kwargs):
+        super().__init__()
+        self.config = decoder_config
+        self.input_size = input_size or 1
+        logger.debug(f" {self.name}")
+        self.register_buffer("center", torch.zeros(self.input_size))
+        self._center_initialized = False
+
+    def initialize_center(self, center: torch.Tensor) -> None:
+        """Set the hypersphere center from the mean of first-epoch encoder outputs.
+
+        Args:
+            center: Tensor of shape [input_size].
+        """
+        if center.shape != self.center.shape:
+            raise ValueError(f"Center shape mismatch: expected {self.center.shape}, got {center.shape}.")
+        self.center.copy_(center)
+        self._center_initialized = True
+
+    def forward(self, inputs: torch.Tensor, **kwargs) -> torch.Tensor:
+        """Compute anomaly scores as squared distance to hypersphere center.
+
+        Args:
+            inputs: Encoder output, shape [batch, input_size].
+
+        Returns:
+            Anomaly scores, shape [batch] (higher = more anomalous).
+        """
+        diff = inputs - self.center.unsqueeze(0)
+        return (diff * diff).sum(dim=-1)
+
+    @staticmethod
+    def get_schema_cls():
+        from ludwig.schema.decoders.base import AnomalyDecoderConfig
+
+        return AnomalyDecoderConfig
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size([self.input_size])
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size([1])
+
+
+@DeveloperAPI
+@register_decoder("mlp_classifier", [CATEGORY, BINARY])
+class MLPClassifier(Decoder):
+    """Multi-layer perceptron classifier decoder.
+
+    Stacks ``num_fc_layers`` fully-connected hidden layers (each of size ``output_size``, with
+    configurable ``activation`` and ``dropout``) before a final linear projection to ``num_classes``
+    logits.  When ``num_fc_layers=0`` this is equivalent to the standard ``Classifier`` decoder.
+    Use this decoder when the combiner output benefits from additional non-linear transformation
+    before the classification head -- for example, when using a simple concatenation combiner with
+    heterogeneous input features.
+
+    Supports two optional inference-time extensions:
+
+    * **Temperature scaling** (``calibration='temperature_scaling'`` on the decoder config):
+      After training, a single scalar *T* is learned on the validation set so that
+      ``calibrated_logits = logits / T`` minimises negative log-likelihood.  This reliably
+      reduces overconfidence without changing argmax predictions.
+      See: Guo et al., "On Calibration of Modern Neural Networks", ICML 2017.
+
+    * **MC Dropout uncertainty** (``mc_dropout_samples > 0``):
+      At inference time the decoder is run ``mc_dropout_samples`` times with dropout layers kept
+      in training mode.  The mean of the resulting probability distributions is returned as the
+      prediction, and the per-class variance is reported as an ``uncertainty`` tensor.
+      See: Gal & Ghahramani, "Dropout as a Bayesian Approximation: Representing Model
+      Uncertainty in Deep Learning", ICML 2016.
+    """
+
+    def __init__(
+        self,
+        input_size: int,
+        num_classes: int = None,
+        num_fc_layers: int = 1,
+        output_size: int = 256,
+        activation: str = "relu",
+        dropout: float = 0.0,
+        use_bias: bool = True,
+        weights_initializer: str = "xavier_uniform",
+        bias_initializer: str = "zeros",
+        mc_dropout_samples: int = 0,
+        decoder_config=None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.config = decoder_config
+
+        logger.debug(f" {self.name}")
+
+        # For binary features num_classes is not set by the caller; default to 1 (single logit).
+        effective_num_classes = num_classes if num_classes is not None else 1
+        self.num_classes = effective_num_classes
+        self.mc_dropout_samples = mc_dropout_samples
+        self._input_size = input_size
+
+        # Build hidden FC layers.  FCLayer is imported here to avoid circular imports at
+        # module load time (fully_connected_modules imports from torch_utils which imports Decoder).
+        from ludwig.modules.fully_connected_modules import FCLayer
+
+        self.fc_layers = torch.nn.ModuleList()
+        current_size = input_size
+        for i in range(num_fc_layers):
+            logger.debug(f"  FCLayer {i}")
+            layer = FCLayer(
+                input_size=current_size,
+                output_size=output_size,
+                use_bias=use_bias,
+                weights_initializer=weights_initializer,
+                bias_initializer=bias_initializer,
+                activation=activation,
+                dropout=dropout,
+            )
+            self.fc_layers.append(layer)
+            current_size = output_size
+
+        # Final linear projection to logits.
+        logger.debug("  Linear (classification head)")
+        self.output_layer = torch.nn.Linear(current_size, effective_num_classes, bias=use_bias)
+        if use_bias:
+            torch.nn.init.zeros_(self.output_layer.bias)
+        _init_fns = {
+            "xavier_uniform": torch.nn.init.xavier_uniform_,
+            "xavier_normal": torch.nn.init.xavier_normal_,
+            "zeros": torch.nn.init.zeros_,
+        }
+        _init_fns.get(weights_initializer, torch.nn.init.xavier_uniform_)(self.output_layer.weight)
+
+        self._hidden_size = current_size
+
+    @staticmethod
+    def get_schema_cls():
+        from ludwig.schema.decoders.base import MLPClassifierConfig
+
+        return MLPClassifierConfig
+
+    @property
+    def input_shape(self) -> torch.Size:
+        return torch.Size([self._input_size])
+
+    @property
+    def output_shape(self) -> torch.Size:
+        return torch.Size([self.num_classes])
+
+    def _single_forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        """Run one forward pass through hidden layers + classification head."""
+        hidden = inputs
+        for layer in self.fc_layers:
+            hidden = layer(hidden)
+        logits = self.output_layer(hidden)
+        # For binary (num_classes=1), squeeze to match the expected 1-D logit shape.
+        if self.num_classes == 1:
+            logits = logits.squeeze(-1)
+        return logits
+
+    def forward(self, inputs: torch.Tensor, **kwargs) -> torch.Tensor:
+        """Run the forward pass and return raw logits.
+
+        Returns logits of shape ``[batch, num_classes]`` for category features,
+        or ``[batch]`` for binary features.
+        MC Dropout inference is available via :meth:`mc_forward`.
+        """
+        return self._single_forward(inputs)
+
+    def mc_forward(self, inputs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """MC Dropout inference: run ``mc_dropout_samples`` stochastic passes.
+
+        Keeps dropout layers in training mode so each pass samples a different sub-network,
+        then averages the resulting probability distributions.
+
+        For category features returns (mean_probs [batch, num_classes], variance [batch, num_classes]).
+        For binary features returns (mean_probs [batch, 2], variance [batch, 2]).
+
+        Args:
+            inputs: Float tensor of shape ``[batch, input_size]``.
+
+        Returns:
+            mean_probs: Averaged softmax/sigmoid probabilities over MC samples.
+            uncertainty: Per-class variance across MC samples.
+
+        References:
+            Gal & Ghahramani, "Dropout as a Bayesian Approximation: Representing Model
+            Uncertainty in Deep Learning", ICML 2016.
+        """
+        was_training = self.training
+        # Enable dropout (train mode) while keeping BN in eval mode if present.
+        self.train()
+        with torch.no_grad():
+            probs_list = []
+            for _ in range(self.mc_dropout_samples):
+                logits = self._single_forward(inputs)
+                if self.num_classes == 1:
+                    # Binary: convert scalar logit to 2-class probability pair for consistent output.
+                    pos_prob = torch.sigmoid(logits)
+                    probs = torch.stack([1 - pos_prob, pos_prob], dim=-1)
+                else:
+                    probs = torch.softmax(logits, dim=-1)
+                probs_list.append(probs)
+        if not was_training:
+            self.eval()
+        # Stack to [num_samples, batch, 2_or_num_classes]
+        probs_stack = torch.stack(probs_list, dim=0)
+        mean_probs = probs_stack.mean(dim=0)
+        uncertainty = probs_stack.var(dim=0)
+        return mean_probs, uncertainty

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -18,7 +18,18 @@ import logging
 import numpy as np
 import torch
 
-from ludwig.constants import BINARY, COLUMN, HIDDEN, LOGITS, NAME, PREDICTIONS, PROBABILITIES, PROBABILITY, PROC_COLUMN
+from ludwig.constants import (
+    BINARY,
+    COLUMN,
+    HIDDEN,
+    LOGITS,
+    NAME,
+    PREDICTIONS,
+    PROBABILITIES,
+    PROBABILITY,
+    PROC_COLUMN,
+    UNCERTAINTY,
+)
 from ludwig.error import InputDataError
 from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
 from ludwig.schema.features.binary_feature import BinaryInputFeatureConfig, BinaryOutputFeatureConfig
@@ -96,9 +107,13 @@ class _BinaryPredict(PredictModule):
         super().__init__()
         self.threshold = threshold
         self.calibration_module = calibration_module
+        self.uncertainty_key = UNCERTAINTY
 
     def forward(self, inputs: dict[str, torch.Tensor], feature_name: str) -> dict[str, torch.Tensor]:
         logits = output_feature_utils.get_output_feature_tensor(inputs, feature_name, self.logits_key)
+
+        uncertainty_tensor_key = f"{feature_name}::{self.uncertainty_key}"
+        mc_uncertainty = inputs.get(uncertainty_tensor_key, None)
 
         if self.calibration_module is not None:
             probabilities = self.calibration_module(logits)
@@ -106,11 +121,14 @@ class _BinaryPredict(PredictModule):
             probabilities = torch.sigmoid(logits)
 
         predictions = probabilities >= self.threshold
-        return {
+        result = {
             self.probabilities_key: probabilities,
             self.predictions_key: predictions,
             self.logits_key: logits,
         }
+        if mc_uncertainty is not None:
+            result[self.uncertainty_key] = mc_uncertainty
+        return result
 
 
 class BinaryFeatureMixin(BaseFeatureMixin):
@@ -275,6 +293,15 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
 
     def logits(self, inputs, **kwargs):
         hidden = inputs[HIDDEN]
+        mc_samples = getattr(self.decoder_obj, "mc_dropout_samples", 0)
+        if mc_samples > 0 and hasattr(self.decoder_obj, "mc_forward"):
+            # MC Dropout inference for binary features.
+            # See: Gal & Ghahramani, "Dropout as a Bayesian Approximation", ICML 2016.
+            mean_probs, uncertainty = self.decoder_obj.mc_forward(hidden)
+            pos_prob = mean_probs[:, 1].clamp(min=1e-10, max=1 - 1e-10)
+            pseudo_logit = torch.log(pos_prob / (1 - pos_prob))
+            scalar_uncertainty = uncertainty.sum(dim=-1)
+            return {LOGITS: pseudo_logit, UNCERTAINTY: scalar_uncertainty}
         return self.decoder_obj(hidden)
 
     def create_calibration_module(self, feature: BinaryOutputFeatureConfig) -> torch.nn.Module:
@@ -286,6 +313,10 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
         if feature.calibration:
             calibration_cls = calibration.get_calibration_cls(BINARY, "temperature_scaling")
             return calibration_cls(binary=True)
+        decoder_calibration = getattr(feature.decoder, "calibration", None)
+        if decoder_calibration:
+            calibration_cls = calibration.get_calibration_cls(BINARY, decoder_calibration)
+            return calibration_cls(binary=True)
         return None
 
     def create_predict_module(self) -> PredictModule:
@@ -295,7 +326,10 @@ class BinaryOutputFeature(BinaryFeatureMixin, OutputFeature):
         return _BinaryPredict(threshold, calibration_module=self.calibration_module)
 
     def get_prediction_set(self):
-        return {PREDICTIONS, PROBABILITIES, LOGITS}
+        prediction_set = {PREDICTIONS, PROBABILITIES, LOGITS}
+        if getattr(self.decoder_obj, "mc_dropout_samples", 0) > 0:
+            prediction_set = prediction_set | {UNCERTAINTY}
+        return prediction_set
 
     @classmethod
     def get_output_dtype(cls):

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -32,6 +32,7 @@ from ludwig.constants import (
     PROBABILITY,
     PROC_COLUMN,
     PROJECTION_INPUT,
+    UNCERTAINTY,
 )
 from ludwig.error import InputDataError
 from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
@@ -106,6 +107,7 @@ class _CategoryPredict(PredictModule):
         # Taken from CORN loss implementation:
         # https://github.com/Raschka-research-group/coral-pytorch/blob/main/coral_pytorch/dataset.py#L123
         self.use_cumulative_probs = use_cumulative_probs
+        self.uncertainty_key = UNCERTAINTY
 
     def forward(self, inputs: dict[str, torch.Tensor], feature_name: str) -> dict[str, torch.Tensor]:
         logits = output_feature_utils.get_output_feature_tensor(inputs, feature_name, self.logits_key)
@@ -132,7 +134,13 @@ class _CategoryPredict(PredictModule):
         # predictions: [batch_size]
         # probabilities: [batch_size, num_classes]
         # logits: [batch_size, num_classes]
-        return {self.predictions_key: predictions, self.probabilities_key: probabilities, self.logits_key: logits}
+        # uncertainty (optional): [batch_size, num_classes] when mc_dropout_samples > 0
+        result = {self.predictions_key: predictions, self.probabilities_key: probabilities, self.logits_key: logits}
+        uncertainty_tensor_key = f"{feature_name}::{self.uncertainty_key}"
+        mc_uncertainty = inputs.get(uncertainty_tensor_key, None)
+        if mc_uncertainty is not None:
+            result[self.uncertainty_key] = mc_uncertainty
+        return result
 
 
 class CategoryFeatureMixin(BaseFeatureMixin):
@@ -347,6 +355,13 @@ class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):
         # EXPECTED SHAPES FOR RETURNED TENSORS
         # logits: shape [batch_size, num_classes]
         # hidden: shape [batch_size, size of final fully connected layer]
+        mc_samples = getattr(self.decoder_obj, "mc_dropout_samples", 0)
+        if mc_samples > 0 and hasattr(self.decoder_obj, "mc_forward"):
+            # MC Dropout: run mc_samples stochastic forward passes, average probabilities, report variance.
+            # See: Gal & Ghahramani, "Dropout as a Bayesian Approximation", ICML 2016.
+            mean_probs, uncertainty = self.decoder_obj.mc_forward(hidden)
+            pseudo_logits = torch.log(mean_probs.clamp(min=1e-10))
+            return {LOGITS: pseudo_logits, PROJECTION_INPUT: hidden, UNCERTAINTY: uncertainty}
         return {LOGITS: self.decoder_obj(hidden), PROJECTION_INPUT: hidden}
 
     def create_calibration_module(self, feature: CategoryOutputFeatureConfig) -> torch.nn.Module:
@@ -358,6 +373,11 @@ class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):
         if feature.calibration:
             calibration_cls = calibration.get_calibration_cls(CATEGORY, "temperature_scaling")
             return calibration_cls(num_classes=self.num_classes)
+        # Decoder-level calibration field (MLPClassifierConfig / ClassifierConfig)
+        decoder_calibration = getattr(feature.decoder, "calibration", None)
+        if decoder_calibration:
+            calibration_cls = calibration.get_calibration_cls(CATEGORY, decoder_calibration)
+            return calibration_cls(num_classes=self.num_classes)
         return None
 
     def create_predict_module(self) -> PredictModule:
@@ -366,7 +386,10 @@ class CategoryOutputFeature(CategoryFeatureMixin, OutputFeature):
         )
 
     def get_prediction_set(self):
-        return {PREDICTIONS, PROBABILITIES, LOGITS}
+        prediction_set = {PREDICTIONS, PROBABILITIES, LOGITS}
+        if getattr(self.decoder_obj, "mc_dropout_samples", 0) > 0:
+            prediction_set = prediction_set | {UNCERTAINTY}
+        return prediction_set
 
     @property
     def input_shape(self) -> torch.Size:

--- a/ludwig/schema/decoders/base.py
+++ b/ludwig/schema/decoders/base.py
@@ -1,7 +1,7 @@
 from abc import ABC
 
 from ludwig.api_annotations import DeveloperAPI
-from ludwig.constants import BINARY, CATEGORY, MODEL_ECD, MODEL_LLM, NUMBER, SET, TIMESERIES, VECTOR
+from ludwig.constants import ANOMALY, BINARY, CATEGORY, MODEL_ECD, MODEL_LLM, NUMBER, SET, TIMESERIES, VECTOR
 from ludwig.schema import common_fields
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.decoders.utils import register_decoder_config
@@ -258,4 +258,167 @@ class ClassifierConfig(BaseDecoderConfig):
         default="zeros",
         description="Initializer for the bias vector.",
         parameter_metadata=DECODER_METADATA["Classifier"]["bias_initializer"],
+    )
+
+    calibration: str | None = schema_utils.StringOptions(
+        options=["temperature_scaling"],
+        default=None,
+        allow_none=True,
+        description=(
+            "Post-training calibration method to apply to the decoder logits. "
+            "'temperature_scaling' learns a single scalar T that divides logits "
+            "(calibrated_logits = logits / T) using NLL minimisation on the validation set. "
+            "It never changes argmax predictions but improves probability reliability. "
+            "See: Guo et al., 'On Calibration of Modern Neural Networks', ICML 2017. "
+            "Set to null (default) to disable calibration."
+        ),
+    )
+
+    mc_dropout_samples: int = schema_utils.NonNegativeInteger(
+        default=0,
+        description=(
+            "Number of Monte Carlo forward passes to run at inference time with dropout enabled. "
+            "When > 0, the decoder is run mc_dropout_samples times and the mean of the resulting "
+            "probability distributions is used as the prediction; the variance across runs is reported "
+            "as an 'uncertainty' tensor alongside 'predictions' and 'probabilities'. "
+            "Setting this to 0 (default) disables MC Dropout. "
+            "See: Gal & Ghahramani, 'Dropout as a Bayesian Approximation', ICML 2016."
+        ),
+    )
+
+
+@DeveloperAPI
+@register_decoder_config("mlp_classifier", [CATEGORY, BINARY], model_types=[MODEL_ECD])
+class MLPClassifierConfig(BaseDecoderConfig):
+    """Configuration for the MLPClassifier decoder.
+
+    MLPClassifier stacks one or more fully-connected hidden layers (with configurable size,
+    activation, and dropout) before the final linear projection to class logits. This is useful
+    when the combiner output is too raw for a single-layer linear projection.
+
+    When num_fc_layers=1 (the default), it applies a single hidden layer of size output_size
+    before projecting to class logits. When num_fc_layers=0 the behaviour is equivalent to the
+    standard Classifier. Increase num_fc_layers for more expressive capacity on harder
+    classification problems.
+
+    References:
+        - Guo et al., "On Calibration of Modern Neural Networks", ICML 2017
+          (for the calibration field).
+        - Gal & Ghahramani, "Dropout as a Bayesian Approximation: Representing
+          Model Uncertainty in Deep Learning", ICML 2016 (for mc_dropout_samples).
+    """
+
+    @classmethod
+    def module_name(cls):
+        return "MLPClassifier"
+
+    type: str = schema_utils.ProtectedString(
+        "mlp_classifier",
+        description=(
+            "Multi-layer perceptron classifier decoder. Stacks num_fc_layers fully-connected "
+            "layers (each of size output_size) with activation and dropout, followed "
+            "by a final linear projection to num_classes logits. "
+            "Use this instead of the standard classifier when the combiner output benefits "
+            "from additional non-linear transformation before the classification head."
+        ),
+    )
+
+    input_size: int = schema_utils.PositiveInteger(
+        default=None,
+        allow_none=True,
+        description="Size of the input to the decoder. Set automatically from the combiner output size.",
+    )
+
+    num_classes: int = schema_utils.PositiveInteger(
+        default=None,
+        allow_none=True,
+        description="Number of classes to predict. Set automatically from the feature vocabulary size.",
+    )
+
+    num_fc_layers: int = schema_utils.NonNegativeInteger(
+        default=1,
+        description=(
+            "Number of fully-connected hidden layers to stack before the classification head. "
+            "When set to 1 (default) a single hidden layer of size output_size is applied. "
+            "Set to 0 to make this decoder equivalent to the standard single-layer Classifier."
+        ),
+    )
+
+    output_size: int = schema_utils.PositiveInteger(
+        default=256,
+        description="Size of each hidden fully-connected layer. Only used when num_fc_layers > 0.",
+    )
+
+    activation: str = schema_utils.ActivationOptions(
+        default="relu",
+        description="Activation function applied after each hidden fully-connected layer.",
+    )
+
+    dropout: float = common_fields.DropoutField()
+
+    use_bias: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether each fully-connected layer (and the final projection) uses a bias vector.",
+    )
+
+    weights_initializer: str = schema_utils.InitializerOptions(
+        description="Initializer for the weight matrices.",
+        parameter_metadata=DECODER_METADATA["Classifier"]["weights_initializer"],
+    )
+
+    bias_initializer: str = schema_utils.InitializerOptions(
+        default="zeros",
+        description="Initializer for the bias vectors.",
+        parameter_metadata=DECODER_METADATA["Classifier"]["bias_initializer"],
+    )
+
+    calibration: str | None = schema_utils.StringOptions(
+        options=["temperature_scaling"],
+        default=None,
+        allow_none=True,
+        description=(
+            "Post-training calibration method to apply to the decoder logits. "
+            "'temperature_scaling' learns a single scalar T that divides logits "
+            "(calibrated_logits = logits / T) using NLL minimisation on the validation set. "
+            "It never changes argmax predictions but improves probability reliability. "
+            "See: Guo et al., 'On Calibration of Modern Neural Networks', ICML 2017. "
+            "Set to null (default) to disable calibration."
+        ),
+    )
+
+    mc_dropout_samples: int = schema_utils.NonNegativeInteger(
+        default=0,
+        description=(
+            "Number of Monte Carlo forward passes to run at inference time with dropout enabled. "
+            "When > 0, the decoder is run mc_dropout_samples times and the mean of the resulting "
+            "probability distributions is used as the prediction; the variance across runs is reported "
+            "as an 'uncertainty' tensor alongside 'predictions' and 'probabilities'. "
+            "Setting this to 0 (default) disables MC Dropout. "
+            "See: Gal & Ghahramani, 'Dropout as a Bayesian Approximation', ICML 2016."
+        ),
+    )
+
+
+@DeveloperAPI
+@register_decoder_config("anomaly", [ANOMALY], model_types=[MODEL_ECD])
+class AnomalyDecoderConfig(BaseDecoderConfig):
+    """AnomalyDecoderConfig configures the anomaly decoder.
+
+    The anomaly decoder computes ||z - c||^2 as the anomaly score, where z is the
+    encoder output and c is the hypersphere center initialized after the first epoch.
+    """
+
+    @classmethod
+    def module_name(cls):
+        return "AnomalyDecoder"
+
+    type: str = schema_utils.ProtectedString(
+        "anomaly",
+        description="Computes ||z - c||^2 as the anomaly score.",
+    )
+
+    input_size: int = schema_utils.PositiveInteger(
+        default=None,
+        allow_none=True,
+        description="Size of the encoder output. Set automatically.",
     )

--- a/ludwig/schema/metadata/configs/decoders.yaml
+++ b/ludwig/schema/metadata/configs/decoders.yaml
@@ -118,6 +118,56 @@ Classifier:
             The default choice (`xavier_uniform`) is a suitable starting point for
             most tasks.
         ui_display_name: Layer Weights Initializer
+MLPClassifier:
+    type:
+        short_description:
+            Multi-layer perceptron classifier decoder.
+        long_description:
+            The MLPClassifier decoder stacks one or more fully-connected hidden layers
+            (each of configurable size, activation, and dropout) before a final linear
+            projection to class logits. Use this when the combiner output benefits from
+            additional non-linear transformation before the classification head. When
+            num_fc_layers=0 it is equivalent to the standard Classifier decoder. Supports
+            optional temperature-scaling calibration (Guo et al., ICML 2017) and MC Dropout
+            uncertainty estimation (Gal & Ghahramani, ICML 2016).
+        expected_impact: 2
+    num_fc_layers:
+        expected_impact: 3
+        ui_display_name: Number of Hidden Layers
+    output_size:
+        expected_impact: 3
+        ui_display_name: Hidden Layer Size
+    activation:
+        expected_impact: 2
+        ui_display_name: Activation
+    dropout:
+        expected_impact: 3
+        ui_display_name: Dropout
+    input_size:
+        other_information: Internal Only
+        internal_only: true
+        related_parameters:
+            - "No"
+        ui_display_name: Not Displayed
+    num_classes:
+        other_information: Internal Only
+        internal_only: true
+        ui_display_name: Not Displayed
+    use_bias:
+        expected_impact: 1
+        ui_display_name: Use Bias
+    weights_initializer:
+        expected_impact: 1
+        ui_display_name: Layer Weights Initializer
+    bias_initializer:
+        expected_impact: 1
+        ui_display_name: Bias Initializer
+    calibration:
+        expected_impact: 2
+        ui_display_name: Calibration Method
+    mc_dropout_samples:
+        expected_impact: 2
+        ui_display_name: MC Dropout Samples
 Projector:
     type:
         short_description:


### PR DESCRIPTION
## Summary

- **MLPClassifier decoder** (`type: mlp_classifier`) registered for `CATEGORY` and `BINARY` output features. Stacks `num_fc_layers` fully-connected hidden layers (configurable `output_size`, `activation`, `dropout`) before the final linear classification head. `num_fc_layers=0` is equivalent to the existing `Classifier` decoder. Use when the combiner output benefits from additional non-linear transformation before classification.

- **Temperature scaling calibration** (`calibration: str | None` on `ClassifierConfig` and `MLPClassifierConfig`): setting `calibration='temperature_scaling'` post-training learns a single scalar *T* on the validation set (NLL loss) so `calibrated_logits = logits / T`. Wired through `create_calibration_module()` in both `CategoryOutputFeature` and `BinaryOutputFeature` alongside the legacy output-feature-level bool flag. Ref: Guo et al., "On Calibration of Modern Neural Networks", ICML 2017.

- **MC Dropout uncertainty** (`mc_dropout_samples: int` on both decoder configs, default 0): when `> 0`, `MLPClassifier.mc_forward()` runs `mc_dropout_samples` stochastic passes with dropout active, averages probabilities, and returns per-class variance. `CategoryOutputFeature.logits()` and `BinaryOutputFeature.logits()` call `mc_forward()` when available, embedding the `UNCERTAINTY` tensor alongside `LOGITS`. `_CategoryPredict` and `_BinaryPredict` pass it through to the output dict, and `get_prediction_set()` includes `UNCERTAINTY` when MC Dropout is enabled. Ref: Gal & Ghahramani, "Dropout as a Bayesian Approximation", ICML 2016.

- Added `UNCERTAINTY = "uncertainty"` to `ludwig/constants.py`.
- Added `MLPClassifier` metadata to `schema/metadata/configs/decoders.yaml`.
- Fixed pre-existing `AnomalyDecoder.get_schema_cls()` to use a local import (was referencing `AnomalyDecoderConfig` without importing it).

## Changed files

| File | Purpose |
|------|---------|
| `ludwig/constants.py` | Add `UNCERTAINTY` constant |
| `ludwig/decoders/generic_decoders.py` | Add `MLPClassifier` class; fix `AnomalyDecoder` import |
| `ludwig/schema/decoders/base.py` | Add `MLPClassifierConfig`; add `calibration` + `mc_dropout_samples` fields to `ClassifierConfig` |
| `ludwig/features/category_feature.py` | Wire MC Dropout + decoder-level calibration into `CategoryOutputFeature` |
| `ludwig/features/binary_feature.py` | Wire MC Dropout + decoder-level calibration into `BinaryOutputFeature` |
| `ludwig/schema/metadata/configs/decoders.yaml` | `MLPClassifier` metadata entry |

## Test plan

- [ ] `MLPClassifier` with `num_fc_layers=0` produces same outputs as `Classifier` for a simple dataset
- [ ] `MLPClassifier` with `num_fc_layers=2` trains and predicts on a multi-class task
- [ ] `calibration='temperature_scaling'` on `MLPClassifierConfig` → `create_calibration_module()` returns `TemperatureScaling`; calibration reduces ECE on hold-out set
- [ ] `mc_dropout_samples=10` on an `MLPClassifier` with `dropout=0.3` → `uncertainty` tensor present in output dict with shape `[batch, num_classes]`
- [ ] Binary feature with `MLPClassifier` + MC Dropout → `uncertainty` scalar (sum over 2-class variance) in output dict
- [ ] Existing `Classifier` decoder with no new fields set → no behaviour change