### PR TITLE
Fix TensorArrayElement not subscriptable in sequence postprocessing

### DIFF
--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -469,7 +469,7 @@ class SequenceOutputFeature(SequenceFeatureMixin, OutputFeature):
             if "idx2str" in metadata:
 
                 def idx2str(row):
-                    pred = row[predictions_col]
+                    pred = np.asarray(row[predictions_col])
                     length = metadata["max_sequence_length"]
                     return [
                         metadata["idx2str"][token] if token < len(metadata["idx2str"]) else UNKNOWN_SYMBOL


### PR DESCRIPTION
Ray Data wraps tensor columns as `TensorArrayElement` objects which don't support integer indexing (`pred[i]`). This causes a `TypeError` during postprocessing of sequence predictions when running via Ray.

## Fix

Convert `pred` to a numpy array with `np.asarray()` before indexing in the `idx2str` closure inside `SequenceOutputFeature.postprocess_predictions`.

## Test

Fixes `test_sequence_decoder_predictions[generator-sequence-sequence_feature]` in the slow test suite.