### PR TITLE
feat: Entropic Open-Set and Objectosphere losses (Dhamija et al. NeurIPS 2018)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,13 +3,13 @@
 ## Release procedure
 
 1. Update version number in `ludwig/globals.py`
-2. Update the `README.md` file
-3. Update `ludwig-docs`
-4. Commit
-5. Tag the commit with the version number `vX.Y.Z` with a meaningful message
-6. Push with `--tags`
-7. If a non-patch release, edit the release notes
-8. The PyPI upload is automated via GitHub Actions (`.github/workflows/upload-pypi.yml`) when a release is published
+1. Update the `README.md` file
+1. Update `ludwig-docs`
+1. Commit
+1. Tag the commit with the version number `vX.Y.Z` with a meaningful message
+1. Push with `--tags`
+1. If a non-patch release, edit the release notes
+1. The PyPI upload is automated via GitHub Actions (`.github/workflows/upload-pypi.yml`) when a release is published
 
 ## Release policy
 

--- a/examples/open_set_recognition/README.md
+++ b/examples/open_set_recognition/README.md
@@ -1,0 +1,90 @@
+# Open-Set Recognition with Agnostophobia Losses
+
+This example reproduces the key findings from:
+
+> Dhamija, A. R., Günther, M., & Boult, T. (2018).
+> **Reducing Network Agnostophobia.**
+> *NeurIPS 2018.* https://arxiv.org/abs/1811.04110
+
+Standard classifiers are trained to output high-confidence predictions for every input — even inputs
+from classes never seen during training. This is called *network agnostophobia*: the network is
+incapable of expressing "I don't know."
+
+The paper proposes two loss functions that address this:
+
+| Loss                  | Description                                                                |
+| --------------------- | -------------------------------------------------------------------------- |
+| **Entropic Open-Set** | CE on known samples + entropy maximisation on background samples           |
+| **Objectosphere**     | CE + logit-norm push for known + entropy + norm suppression for background |
+
+Both are available in Ludwig's category and binary output features.
+
+## Quick start
+
+```bash
+pip install ludwig
+python train_open_set.py
+```
+
+The script generates a synthetic two-class-family dataset (four known Gaussian clusters + two unknown
+clusters), trains three classifiers, and prints a comparison table showing mean max probability on
+unknowns — lower is better for open-set recognition.
+
+Expected output (approximate):
+
+```
+Model                  | Max-prob (known) | Max-prob (unknown) | Norm known | Norm unknown
+-----------------------|-----------------|-------------------|------------|-------------
+CE Baseline            |           0.998  |              0.741 |      8.828 |        5.375
+Entropic Open-Set      |           0.974  |              0.273 |      6.254 |        0.637
+Objectosphere          |           0.874  |              0.363 |     13.843 |        2.361
+```
+
+## Ludwig configuration
+
+### Entropic Open-Set Loss
+
+```yaml
+output_features:
+  - name: label
+    type: category
+    loss:
+      type: entropic_open_set
+      background_class: 4   # integer index of the background/unknown class
+```
+
+### Objectosphere Loss
+
+```yaml
+output_features:
+  - name: label
+    type: category
+    loss:
+      type: objectosphere
+      background_class: 4
+      xi: 10.0   # minimum logit norm for known-class samples
+      zeta: 0.1  # weight for unknown-class magnitude suppression
+```
+
+`background_class` is the **integer index** of the background/unknown class in Ludwig's
+vocabulary for that feature. You can discover it by inspecting the saved model's
+`training_set_metadata.json` file after a training run — look for the `str2idx` field of the
+relevant output feature.
+
+## Inference-time unknown detection
+
+For **Objectosphere** models, unknown inputs can be detected using a simple threshold on the logit
+L2 norm:
+
+```python
+predictions = model.predict(dataset=df)
+
+# Retrieve raw logits via the API (requires model.collect_activations)
+import torch
+
+norms = logit_tensor.norm(dim=-1)
+is_unknown = norms < threshold  # choose threshold from validation set
+```
+
+For both loss types, you can also use the **maximum softmax probability** as a simpler threshold:
+samples with max-prob below some value (e.g. 0.5) are flagged as unknown.

--- a/examples/open_set_recognition/config_baseline.yaml
+++ b/examples/open_set_recognition/config_baseline.yaml
@@ -1,0 +1,20 @@
+# Baseline: standard softmax cross-entropy classifier.
+# Trained only on known classes; will assign high confidence to unknown inputs.
+
+model_type: ecd
+
+input_features:
+  - name: feature_1
+    type: number
+  - name: feature_2
+    type: number
+
+output_features:
+  - name: label
+    type: category
+    loss:
+      type: softmax_cross_entropy
+
+trainer:
+  epochs: 50
+  learning_rate: 0.001

--- a/examples/open_set_recognition/config_entropic.yaml
+++ b/examples/open_set_recognition/config_entropic.yaml
@@ -1,0 +1,28 @@
+# Entropic Open-Set classifier (Dhamija et al., NeurIPS 2018).
+#
+# Training set must include background/unknown samples labelled with the
+# background class.  For known samples the loss is standard cross-entropy;
+# for background samples the loss maximises output entropy (reduces max-prob).
+#
+# background_class: integer index of the background class in Ludwig's
+# vocabulary for this feature.  Inspect training_set_metadata.json after
+# a first training run to find the correct index for your dataset.
+
+model_type: ecd
+
+input_features:
+  - name: feature_1
+    type: number
+  - name: feature_2
+    type: number
+
+output_features:
+  - name: label
+    type: category
+    loss:
+      type: entropic_open_set
+      background_class: 4   # adjust to match your vocabulary index
+
+trainer:
+  epochs: 50
+  learning_rate: 0.001

--- a/examples/open_set_recognition/config_objectosphere.yaml
+++ b/examples/open_set_recognition/config_objectosphere.yaml
@@ -1,0 +1,31 @@
+# Objectosphere classifier (Dhamija et al., NeurIPS 2018).
+#
+# Extends the Entropic Open-Set loss with a logit-norm objective:
+#   - Known samples: CE + hinge pushing ||logits|| >= xi
+#   - Background samples: entropy maximisation + magnitude suppression (zeta * ||logits||^2)
+#
+# At inference time, flag unknown inputs with a norm threshold:
+#   is_unknown = logit_norm < threshold
+# Choose the threshold from the validation set (e.g. 5th percentile of
+# known-class norms).
+
+model_type: ecd
+
+input_features:
+  - name: feature_1
+    type: number
+  - name: feature_2
+    type: number
+
+output_features:
+  - name: label
+    type: category
+    loss:
+      type: objectosphere
+      background_class: 4   # adjust to match your vocabulary index
+      xi: 10.0              # minimum logit norm for known-class samples
+      zeta: 0.1             # weight for unknown-class magnitude suppression
+
+trainer:
+  epochs: 50
+  learning_rate: 0.001

--- a/examples/open_set_recognition/train_open_set.py
+++ b/examples/open_set_recognition/train_open_set.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Reproduce Dhamija et al. NeurIPS 2018 "Reducing Network Agnostophobia".
+
+Trains three classifiers on a synthetic Gaussian dataset:
+  - CE Baseline (SoftmaxCrossEntropy)
+  - Entropic Open-Set Loss
+  - Objectosphere Loss
+
+then reports the mean max-probability on held-out background/unknown
+samples.  Lower max-prob = better open-set recognition.
+
+Usage:
+    python train_open_set.py
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+EPSILON = 1e-10
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data
+# ---------------------------------------------------------------------------
+
+
+def make_dataset(seed: int = 42):
+    """Four known Gaussian clusters + two unknown clusters in 2D."""
+    rng = torch.Generator()
+    rng.manual_seed(seed)
+
+    known_centers = torch.tensor([[3.0, 3.0], [-3.0, 3.0], [-3.0, -3.0], [3.0, -3.0]])
+    unknown_centers = torch.tensor([[0.0, 0.0], [6.0, 0.0]])
+    std = 0.8
+
+    n_known = 200  # per class
+    n_unknown = 100  # per class (background)
+
+    known_x, known_y = [], []
+    for cls_idx, center in enumerate(known_centers):
+        pts = center + std * torch.randn(n_known, 2, generator=rng)
+        known_x.append(pts)
+        known_y.append(torch.full((n_known,), cls_idx, dtype=torch.long))
+
+    unknown_x = []
+    for center in unknown_centers:
+        pts = center + std * torch.randn(n_unknown, 2, generator=rng)
+        unknown_x.append(pts)
+
+    # Background class index = 4
+    BG = 4
+    unknown_y_bg = torch.full((n_unknown * 2,), BG, dtype=torch.long)
+
+    X_known = torch.cat(known_x)
+    y_known = torch.cat(known_y)
+    X_unknown = torch.cat(unknown_x)
+
+    # Training set: all known + all unknown (for agnostophobia models)
+    X_train = torch.cat([X_known, X_unknown])
+    y_train = torch.cat([y_known, unknown_y_bg])
+
+    # Test set: fresh samples from known and unknown distributions
+    test_known_x, test_known_y = [], []
+    for cls_idx, center in enumerate(known_centers):
+        pts = center + std * torch.randn(50, 2, generator=rng)
+        test_known_x.append(pts)
+        test_known_y.append(torch.full((50,), cls_idx, dtype=torch.long))
+
+    test_unknown_x = []
+    for center in unknown_centers:
+        pts = center + std * torch.randn(50, 2, generator=rng)
+        test_unknown_x.append(pts)
+
+    X_test_known = torch.cat(test_known_x)
+    y_test_known = torch.cat(test_known_y)
+    X_test_unknown = torch.cat(test_unknown_x)
+
+    return X_train, y_train, X_test_known, y_test_known, X_test_unknown, BG
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+class MLP(nn.Module):
+    def __init__(self, in_dim: int = 2, hidden: int = 64, n_classes: int = 5):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, n_classes),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+# ---------------------------------------------------------------------------
+# Loss functions  (mirrors the Ludwig module implementations)
+# ---------------------------------------------------------------------------
+
+
+class EntropicOpenSetLoss(nn.Module):
+    def __init__(self, background_class: int):
+        super().__init__()
+        self.bg = background_class
+
+    def forward(self, logits: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        known_mask = target != self.bg
+        unknown_mask = ~known_mask
+        loss = logits.new_tensor(0.0)
+        if known_mask.any():
+            loss = loss + F.cross_entropy(logits[known_mask], target[known_mask])
+        if unknown_mask.any():
+            probs = torch.softmax(logits[unknown_mask], dim=-1)
+            loss = loss + (probs * torch.log(probs + EPSILON)).sum(dim=-1).mean()
+        return loss
+
+
+class ObjectosphereLoss(nn.Module):
+    def __init__(self, background_class: int, xi: float = 10.0, zeta: float = 0.1):
+        super().__init__()
+        self.bg = background_class
+        self.xi = xi
+        self.zeta = zeta
+
+    def forward(self, logits: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        known_mask = target != self.bg
+        unknown_mask = ~known_mask
+        loss = logits.new_tensor(0.0)
+        if known_mask.any():
+            kl = logits[known_mask]
+            ce = F.cross_entropy(kl, target[known_mask])
+            hinge = torch.clamp(self.xi - kl.norm(dim=-1), min=0.0).pow(2).mean()
+            loss = loss + ce + hinge
+        if unknown_mask.any():
+            ul = logits[unknown_mask]
+            probs = torch.softmax(ul, dim=-1)
+            neg_entropy = (probs * torch.log(probs + EPSILON)).sum(dim=-1).mean()
+            loss = loss + neg_entropy + self.zeta * ul.norm(dim=-1).pow(2).mean()
+        return loss
+
+
+# ---------------------------------------------------------------------------
+# Training loop
+# ---------------------------------------------------------------------------
+
+
+def train(
+    model: nn.Module, loss_fn: nn.Module, X: torch.Tensor, y: torch.Tensor, epochs: int = 200, lr: float = 1e-3
+) -> None:
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    for epoch in range(epochs):
+        model.train()
+        optimizer.zero_grad()
+        logits = model(X)
+        loss = loss_fn(logits, y)
+        loss.backward()
+        optimizer.step()
+
+
+# ---------------------------------------------------------------------------
+# Evaluation helpers
+# ---------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def mean_max_prob(model: nn.Module, X: torch.Tensor) -> float:
+    model.eval()
+    logits = model(X)
+    return torch.softmax(logits, dim=-1).max(dim=-1).values.mean().item()
+
+
+@torch.no_grad()
+def mean_norm(model: nn.Module, X: torch.Tensor) -> float:
+    model.eval()
+    return model(X).norm(dim=-1).mean().item()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    torch.manual_seed(0)
+    X_train, y_train, X_test_known, y_test_known, X_test_unknown, BG = make_dataset()
+
+    # Baseline: train only on known samples with standard CE
+    X_known_train = X_train[y_train != BG]
+    y_known_train = y_train[y_train != BG]
+
+    configs = [
+        (
+            "CE Baseline",
+            MLP(n_classes=4),  # no background class in output
+            nn.CrossEntropyLoss(),
+            X_known_train,
+            y_known_train,
+        ),
+        (
+            "Entropic Open-Set",
+            MLP(n_classes=5),  # includes background class output node
+            EntropicOpenSetLoss(background_class=BG),
+            X_train,
+            y_train,
+        ),
+        (
+            "Objectosphere",
+            MLP(n_classes=5),
+            ObjectosphereLoss(background_class=BG, xi=10.0, zeta=0.1),
+            X_train,
+            y_train,
+        ),
+    ]
+
+    results = []
+    for name, model, loss_fn, X, y in configs:
+        torch.manual_seed(0)
+        train(model, loss_fn, X, y, epochs=300)
+        mmp_known = mean_max_prob(model, X_test_known)
+        mmp_unknown = mean_max_prob(model, X_test_unknown)
+        norm_known = mean_norm(model, X_test_known)
+        norm_unknown = mean_norm(model, X_test_unknown)
+        results.append((name, mmp_known, mmp_unknown, norm_known, norm_unknown))
+
+    cols = ("Model", "Max-prob (known)", "Max-prob (unknown)", "Norm known", "Norm unknown")
+    header = f"{cols[0]:<22} | {cols[1]:>16} | {cols[2]:>18} | {cols[3]:>10} | {cols[4]:>12}"
+    sep = "-" * len(header)
+    print(sep)
+    print(header)
+    print(sep)
+    for name, mpk, mpu, nk, nu in results:
+        print(f"{name:<22} | {mpk:>16.3f} | {mpu:>18.3f} | {nk:>10.3f} | {nu:>12.3f}")
+    print(sep)
+    print()
+    print("Expected behaviour from the paper:")
+    print("  - CE Baseline:        high max-prob on unknowns (≈0.7-0.9)")
+    print("  - Entropic Open-Set:  lower max-prob on unknowns (≈0.2-0.3, near uniform)")
+    print("  - Objectosphere:      similar to entropic, plus norm(known) >> norm(unknown)")
+
+    # --- Assertions so this script can double as a smoke test ---
+    ce_unknown = results[0][2]
+    eos_unknown = results[1][2]
+    obj_unknown = results[2][2]
+
+    assert (
+        eos_unknown < ce_unknown
+    ), f"Entropic loss should reduce unknown confidence: {eos_unknown:.3f} < {ce_unknown:.3f}"
+    assert (
+        obj_unknown < ce_unknown
+    ), f"Objectosphere loss should reduce unknown confidence: {obj_unknown:.3f} < {ce_unknown:.3f}"
+
+    obj_norm_known = results[2][3]
+    obj_norm_unknown = results[2][4]
+    assert (
+        obj_norm_known > obj_norm_unknown * 1.5
+    ), f"Objectosphere should create norm gap: known={obj_norm_known:.3f} unknown={obj_norm_unknown:.3f}"
+
+    print("\nAll assertions passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -334,6 +334,10 @@ SPARSEMAX_LOSS = "sparsemax"
 ENTMAX15_LOSS = "entmax15"
 
 
+# Open-set recognition constants
+ENTROPIC_OPEN_SET = "entropic_open_set"
+OBJECTOSPHERE = "objectosphere"
+
 # Anomaly detection constants
 ANOMALY = "anomaly"
 ANOMALY_SCORE = "anomaly_score"

--- a/ludwig/modules/loss_modules.py
+++ b/ludwig/modules/loss_modules.py
@@ -33,6 +33,7 @@ from ludwig.schema.features.loss.loss import (
     DiceLossConfig,
     DROCCLossConfig,
     Entmax15LossConfig,
+    EntropicOpenSetLossConfig,
     FocalLossConfig,
     HuberLossConfig,
     LovaszSoftmaxLossConfig,
@@ -41,6 +42,7 @@ from ludwig.schema.features.loss.loss import (
     MSELossConfig,
     NextTokenSoftmaxCrossEntropyLossConfig,
     NTXentLossConfig,
+    ObjectosphereLossConfig,
     PolyLossConfig,
     RMSELossConfig,
     RMSPELossConfig,
@@ -360,6 +362,105 @@ class DROCCLoss(nn.Module, AnomalyScoreInputsMixin):
             perturbed = dist_sq.detach() + noise_scale * torch.randn_like(dist_sq)
         hinge = torch.mean(torch.clamp(dist_sq - perturbed, min=0.0))
         return svdd_loss + self.perturbation_strength * hinge
+
+
+@register_loss(EntropicOpenSetLossConfig)
+class EntropicOpenSetLoss(nn.Module, LogitsInputsMixin):
+    """Entropic Open-Set Loss from Dhamija et al., NeurIPS 2018.
+
+    For known-class samples (target != background_class):
+        L = CrossEntropy(logits, target)
+
+    For unknown/background samples (target == background_class):
+        L = sum_i( p_i * log(p_i) )   # negative entropy → maximise entropy
+
+    Without a background_class this reduces to standard cross-entropy.
+
+    Reference: https://arxiv.org/abs/1811.04110
+    """
+
+    def __init__(self, config: EntropicOpenSetLossConfig):
+        super().__init__()
+        self.background_class = config.background_class
+
+    def forward(self, preds: Tensor, target: Tensor) -> Tensor:
+        logits = preds[LOGITS] if isinstance(preds, dict) else preds
+
+        if self.background_class is None:
+            return F.cross_entropy(logits, target)
+
+        known_mask = target != self.background_class
+        unknown_mask = ~known_mask
+
+        loss = logits.new_tensor(0.0)
+
+        if known_mask.any():
+            loss = loss + F.cross_entropy(logits[known_mask], target[known_mask])
+
+        if unknown_mask.any():
+            probs = torch.softmax(logits[unknown_mask], dim=-1)
+            # Negative entropy: p * log(p). Minimising this maximises H(p).
+            loss = loss + (probs * torch.log(probs + EPSILON)).sum(dim=-1).mean()
+
+        return loss
+
+
+@register_loss(ObjectosphereLossConfig)
+class ObjectosphereLoss(nn.Module, LogitsInputsMixin):
+    """Objectosphere Loss from Dhamija et al., NeurIPS 2018.
+
+    For known-class samples:
+        L = CrossEntropy(logits, target) + hinge(||logits|| - xi)
+
+    For unknown/background samples:
+        L = NegEntropy(logits) + zeta * ||logits||^2
+
+    The hinge term for known samples is max(0, xi - ||z||)^2, pushing logit
+    norms above xi. The magnitude term for unknowns pulls norms toward zero,
+    so out-of-distribution inputs produce near-uniform, low-magnitude outputs
+    that are easy to detect with a simple norm threshold at inference time.
+
+    Without a background_class this reduces to CE + known-class hinge only.
+
+    Reference: https://arxiv.org/abs/1811.04110
+    """
+
+    def __init__(self, config: ObjectosphereLossConfig):
+        super().__init__()
+        self.background_class = config.background_class
+        self.xi = config.xi
+        self.zeta = config.zeta
+
+    def forward(self, preds: Tensor, target: Tensor) -> Tensor:
+        logits = preds[LOGITS] if isinstance(preds, dict) else preds
+
+        if self.background_class is None:
+            # No unknowns: CE + magnitude push for all samples.
+            ce = F.cross_entropy(logits, target)
+            mag = logits.norm(dim=-1)
+            hinge = torch.clamp(self.xi - mag, min=0.0).pow(2).mean()
+            return ce + hinge
+
+        known_mask = target != self.background_class
+        unknown_mask = ~known_mask
+
+        loss = logits.new_tensor(0.0)
+
+        if known_mask.any():
+            known_logits = logits[known_mask]
+            ce = F.cross_entropy(known_logits, target[known_mask])
+            mag = known_logits.norm(dim=-1)
+            hinge = torch.clamp(self.xi - mag, min=0.0).pow(2).mean()
+            loss = loss + ce + hinge
+
+        if unknown_mask.any():
+            unknown_logits = logits[unknown_mask]
+            probs = torch.softmax(unknown_logits, dim=-1)
+            neg_entropy = (probs * torch.log(probs + EPSILON)).sum(dim=-1).mean()
+            mag_penalty = unknown_logits.norm(dim=-1).pow(2).mean()
+            loss = loss + neg_entropy + self.zeta * mag_penalty
+
+        return loss
 
 
 @register_loss(FocalLossConfig)

--- a/ludwig/schema/features/loss/loss.py
+++ b/ludwig/schema/features/loss/loss.py
@@ -10,6 +10,7 @@ from ludwig.constants import (
     DICE_LOSS,
     DROCC,
     ENTMAX15_LOSS,
+    ENTROPIC_OPEN_SET,
     FOCAL_LOSS,
     HUBER,
     IMAGE,
@@ -20,6 +21,7 @@ from ludwig.constants import (
     NEXT_TOKEN_SOFTMAX_CROSS_ENTROPY,
     NT_XENT_LOSS,
     NUMBER,
+    OBJECTOSPHERE,
     POLY_LOSS,
     ROOT_MEAN_SQUARED_ERROR,
     ROOT_MEAN_SQUARED_PERCENTAGE_ERROR,
@@ -579,6 +581,123 @@ class DROCCLossConfig(BaseLossConfig):
     @classmethod
     def name(cls) -> str:
         return "DROCC"
+
+
+@DeveloperAPI
+@register_loss([BINARY, CATEGORY])
+class EntropicOpenSetLossConfig(BaseLossConfig):
+    """Entropic Open-Set Loss for open-set recognition.
+
+    Combines standard cross-entropy for known-class samples with an entropy
+    maximisation term for background/unknown samples. This discourages the
+    network from making confident predictions on out-of-distribution inputs,
+    "curing" network agnostophobia.
+
+    The background class (identified by ``background_class``) is treated as the
+    catch-all unknown category. Samples with that label contribute only the
+    entropic term; all other samples contribute cross-entropy as normal.
+    If ``background_class`` is None the loss reduces to standard cross-entropy.
+
+    Reference:
+        Dhamija et al., "Reducing Network Agnostophobia", NeurIPS 2018.
+        https://arxiv.org/abs/1811.04110
+    """
+
+    type: str = schema_utils.ProtectedString(
+        ENTROPIC_OPEN_SET,
+        description=(
+            "Entropic open-set loss — cross-entropy for known classes + entropy "
+            "maximisation for the background/unknown class."
+        ),
+    )
+
+    background_class: int = schema_utils.Integer(
+        default=None,
+        allow_none=True,
+        description=(
+            "Class index that represents 'unknown' or background samples. "
+            "Samples with this label receive the entropic penalty instead of "
+            "cross-entropy. Set to None to disable open-set behaviour and fall "
+            "back to standard cross-entropy."
+        ),
+    )
+
+    weight: float = schema_utils.NonNegativeFloat(
+        default=1.0,
+        description="Weight of the loss.",
+    )
+
+    @classmethod
+    def name(cls) -> str:
+        return "Entropic Open-Set"
+
+
+@DeveloperAPI
+@register_loss([BINARY, CATEGORY])
+class ObjectosphereLossConfig(BaseLossConfig):
+    """Objectosphere Loss for open-set recognition.
+
+    Extends the Entropic Open-Set Loss with a feature-magnitude constraint:
+
+    * **Known samples**: standard cross-entropy + hinge term that pushes the
+      logit L2 norm above ``xi`` (large magnitude → confident, well-separated
+      representations).
+    * **Unknown/background samples**: entropy maximisation + magnitude
+      minimisation weighted by ``zeta`` (small magnitude → low-confidence,
+      "don't know" responses).
+
+    The combined objective makes it easy to threshold on logit magnitude at
+    inference time: known-class inputs will have large norms; truly unknown
+    inputs will have small norms regardless of the argmax prediction.
+
+    Reference:
+        Dhamija et al., "Reducing Network Agnostophobia", NeurIPS 2018.
+        https://arxiv.org/abs/1811.04110
+    """
+
+    type: str = schema_utils.ProtectedString(
+        OBJECTOSPHERE,
+        description=(
+            "Objectosphere loss — cross-entropy + magnitude push for known classes, "
+            "entropy maximisation + magnitude suppression for unknowns."
+        ),
+    )
+
+    background_class: int = schema_utils.Integer(
+        default=None,
+        allow_none=True,
+        description=(
+            "Class index that represents 'unknown' or background samples. "
+            "Samples with this label receive the entropic + magnitude-suppression "
+            "penalty. Set to None to fall back to standard cross-entropy."
+        ),
+    )
+
+    xi: float = schema_utils.NonNegativeFloat(
+        default=10.0,
+        description=(
+            "Minimum desired logit L2 norm for known-class samples. "
+            "A hinge term max(0, xi - ||z||)² is added to push representations "
+            "of known inputs above this threshold. Typical values: 1–50."
+        ),
+    )
+
+    zeta: float = schema_utils.NonNegativeFloat(
+        default=0.1,
+        description=(
+            "Weight applied to the magnitude-suppression term for unknown samples. "
+            "Higher values more aggressively shrink logit norms for background inputs."
+        ),
+    )
+
+    weight: float = schema_utils.NonNegativeFloat(
+        default=1.0,
+        description="Weight of the loss.",
+    )
+
+    @classmethod
+    def name(cls) -> str:
+        return "Objectosphere"
 
 
 @DeveloperAPI

--- a/tests/ludwig/modules/test_loss_modules.py
+++ b/tests/ludwig/modules/test_loss_modules.py
@@ -2,6 +2,7 @@ import contextlib
 
 import pytest
 import torch
+import torch.nn.functional as F
 from pydantic import ValidationError
 
 from ludwig.features.category_feature import CategoryOutputFeature
@@ -11,10 +12,12 @@ from ludwig.modules import loss_modules
 from ludwig.schema.features.loss.loss import (
     BWCEWLossConfig,
     CORNLossConfig,
+    EntropicOpenSetLossConfig,
     HuberLossConfig,
     MAELossConfig,
     MAPELossConfig,
     MSELossConfig,
+    ObjectosphereLossConfig,
     RMSELossConfig,
     RMSPELossConfig,
     SigmoidCrossEntropyLossConfig,
@@ -294,3 +297,143 @@ def test_dict_class_weights_set():
     )
 
     assert model_config.output_features[0].loss.class_weights == [0.1, 0.2, 0.3, 0]
+
+
+# ---------------------------------------------------------------------------
+# Entropic Open-Set Loss (Dhamija et al., NeurIPS 2018)
+# ---------------------------------------------------------------------------
+
+EPSILON = 1e-10
+
+
+def test_entropic_open_set_no_background_equals_ce():
+    """Without background_class, EntropicOpenSetLoss is identical to cross-entropy."""
+    logits = torch.tensor([[2.0, 1.0, 0.0], [0.0, 1.0, 2.0], [1.0, 2.0, 0.0]])
+    target = torch.tensor([0, 2, 1])
+
+    loss = loss_modules.EntropicOpenSetLoss(EntropicOpenSetLossConfig())
+    expected = F.cross_entropy(logits, target)
+    assert torch.isclose(loss(logits, target), expected)
+
+
+def test_entropic_open_set_decomposes_into_known_and_unknown():
+    """With background_class, loss = CE(known) + neg_entropy(unknown)."""
+    bg = 2
+    logits = torch.tensor(
+        [
+            [2.0, 1.0, 0.0],  # known: class 0
+            [0.0, 2.0, 1.0],  # known: class 1
+            [0.5, 0.5, 0.5],  # unknown: background class
+        ]
+    )
+    target = torch.tensor([0, 1, bg])
+
+    loss_fn = loss_modules.EntropicOpenSetLoss(EntropicOpenSetLossConfig(background_class=bg))
+    actual = loss_fn(logits, target)
+
+    known_ce = F.cross_entropy(logits[:2], target[:2])
+    probs = torch.softmax(logits[2:], dim=-1)
+    neg_entropy = (probs * torch.log(probs + EPSILON)).sum(dim=-1).mean()
+    expected = known_ce + neg_entropy
+
+    assert torch.isclose(actual, expected, rtol=1e-4)
+
+
+def test_entropic_loss_reduces_max_prob_on_background():
+    """Optimising the entropic loss on background samples should drive max probability toward 1/C."""
+    torch.manual_seed(0)
+    bg = 4
+    logits = torch.nn.Parameter(torch.randn(20, 5))  # 20 background samples, 5 classes
+    target = torch.full((20,), bg)
+
+    loss_fn = loss_modules.EntropicOpenSetLoss(EntropicOpenSetLossConfig(background_class=bg))
+    optimizer = torch.optim.Adam([logits], lr=0.5)
+
+    for _ in range(150):
+        optimizer.zero_grad()
+        loss_fn(logits, target).backward()
+        optimizer.step()
+
+    max_probs = torch.softmax(logits.detach(), dim=-1).max(dim=-1).values
+    # After entropy maximisation, mean max-prob should be close to uniform (1/5 = 0.2)
+    assert max_probs.mean().item() < 0.25
+
+
+# ---------------------------------------------------------------------------
+# Objectosphere Loss (Dhamija et al., NeurIPS 2018)
+# ---------------------------------------------------------------------------
+
+
+def test_objectosphere_no_background_equals_ce_plus_hinge():
+    """Without background_class, loss = CE + mean(clamp(xi - ||z||, 0)^2)."""
+    xi = 3.0
+    logits = torch.tensor([[1.0, 0.5, -0.5], [0.2, 1.0, 0.8]])
+    target = torch.tensor([0, 1])
+
+    loss_fn = loss_modules.ObjectosphereLoss(ObjectosphereLossConfig(xi=xi))
+    actual = loss_fn(logits, target)
+
+    ce = F.cross_entropy(logits, target)
+    norms = logits.norm(dim=-1)
+    hinge = torch.clamp(xi - norms, min=0.0).pow(2).mean()
+    expected = ce + hinge
+
+    assert torch.isclose(actual, expected, rtol=1e-4)
+
+
+def test_objectosphere_decomposes_into_known_and_unknown():
+    """With background_class, loss splits into CE+hinge (known) and neg_entropy+mag (unknown)."""
+    bg = 3
+    xi = 2.0
+    zeta = 0.5
+    logits = torch.tensor(
+        [
+            [2.0, 1.0, 0.5, 0.0],  # known: class 0
+            [0.0, 2.0, 0.5, 0.0],  # known: class 1
+            [0.3, 0.3, 0.2, 0.2],  # background
+        ]
+    )
+    target = torch.tensor([0, 1, bg])
+
+    loss_fn = loss_modules.ObjectosphereLoss(ObjectosphereLossConfig(background_class=bg, xi=xi, zeta=zeta))
+    actual = loss_fn(logits, target)
+
+    # Known part
+    kl = logits[:2]
+    ce = F.cross_entropy(kl, target[:2])
+    hinge = torch.clamp(xi - kl.norm(dim=-1), min=0.0).pow(2).mean()
+
+    # Unknown part
+    ul = logits[2:]
+    probs = torch.softmax(ul, dim=-1)
+    neg_entropy = (probs * torch.log(probs + EPSILON)).sum(dim=-1).mean()
+    mag = ul.norm(dim=-1).pow(2).mean()
+    expected = ce + hinge + neg_entropy + zeta * mag
+
+    assert torch.isclose(actual, expected, rtol=1e-4)
+
+
+def test_objectosphere_creates_norm_separation():
+    """Training with objectosphere loss pushes known logit norms above xi and unknown toward zero."""
+    torch.manual_seed(0)
+    bg = 3
+    xi = 5.0
+    # 3 known samples (classes 0,1,2) + 3 background samples
+    logits = torch.nn.Parameter(torch.zeros(6, 4))
+    target = torch.tensor([0, 1, 2, bg, bg, bg])
+
+    loss_fn = loss_modules.ObjectosphereLoss(ObjectosphereLossConfig(background_class=bg, xi=xi, zeta=1.0))
+    optimizer = torch.optim.Adam([logits], lr=0.3)
+
+    for _ in range(400):
+        optimizer.zero_grad()
+        loss_fn(logits, target).backward()
+        optimizer.step()
+
+    known_norm = logits[:3].detach().norm(dim=-1).mean().item()
+    unknown_norm = logits[3:].detach().norm(dim=-1).mean().item()
+
+    # Known norms should be substantially larger than unknown norms
+    assert known_norm > unknown_norm * 2, f"Known norm {known_norm:.3f} should be > 2x unknown norm {unknown_norm:.3f}"
+    # Unknown norms should be pulled toward zero (well below xi)
+    assert unknown_norm < xi / 2, f"Unknown norm {unknown_norm:.3f} should be well below xi={xi}"


### PR DESCRIPTION
## Summary

Implements the two open-set recognition losses from **Dhamija, Günther & Boult, NeurIPS 2018 — "Reducing Network Agnostophobia"** (https://arxiv.org/abs/1811.04110).

Standard classifiers assign high-confidence predictions even to inputs from classes never seen during training (*network agnostophobia*). These losses fix that by training the model to be *uncertain* on designated background/unknown inputs.

### New loss functions

| Loss | Type string | Available on |
|------|-------------|--------------|
| Entropic Open-Set | `entropic_open_set` | `category`, `binary` |
| Objectosphere | `objectosphere` | `category`, `binary` |

**Entropic Open-Set Loss**: cross-entropy on known-class samples + entropy maximisation on background samples.

**Objectosphere Loss**: CE + logit-norm hinge for known (pushes `‖z‖ ≥ ξ`) + entropy + magnitude suppression for background (pulls `‖z‖ → 0`). Creates a clean norm threshold for unknown detection at inference time.

### Changes

- `ludwig/constants.py` — `ENTROPIC_OPEN_SET`, `OBJECTOSPHERE` constants
- `ludwig/schema/features/loss/loss.py` — `EntropicOpenSetLossConfig`, `ObjectosphereLossConfig` (registered for `[BINARY, CATEGORY]`)
- `ludwig/modules/loss_modules.py` — `EntropicOpenSetLoss`, `ObjectosphereLoss` implementations
- `examples/open_set_recognition/` — self-contained reproduction script (synthetic Gaussian data, no downloads); asserts the paper's key claims at runtime
- `tests/ludwig/modules/test_loss_modules.py` — 6 unit tests: exact loss decomposition, entropy maximisation convergence, norm-separation convergence

## Test plan

- [ ] `pytest tests/ludwig/modules/test_loss_modules.py` — all 27 tests pass including the 6 new ones
- [ ] `python examples/open_set_recognition/train_open_set.py` — prints comparison table and passes all assertions
- [ ] Entropic loss reduces mean max-probability on unknown samples from ~0.74 (CE baseline) to ~0.27
- [ ] Objectosphere creates a ~6× logit-norm gap between known (13.8) and unknown (2.4) samples