### PR TITLE
Release v0.14.0

### DIFF
--- a/ludwig/globals.py
+++ b/ludwig/globals.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-LUDWIG_VERSION = "0.13.0"
+LUDWIG_VERSION = "0.14.0"
 
 MODEL_FILE_NAME = "model"
 MODEL_WEIGHTS_FILE_NAME = "model_weights"  # legacy pickle format


### PR DESCRIPTION
## Release v0.14.0

Bumps `LUDWIG_VERSION` from `0.13.0` to `0.14.0` in `ludwig/globals.py`.

## Release checklist

- [x] Version bumped in `ludwig/globals.py`
- [ ] `README.md` updated (if needed)
- [ ] `ludwig-docs` updated
- [ ] Commit tagged `v0.14.0` with a meaningful message
- [ ] Pushed with `--tags`
- [ ] Release notes edited on GitHub after merge
- [ ] PyPI upload triggered via GitHub Actions on publish

> **Do not merge until the release checklist above is complete.**