### PR TITLE
feat: multi-adapter PEFT support with weighted merging (Phase 2.4.2)

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -164,21 +164,43 @@ class LLM(BaseModel):
     def initialize_adapter(self):
         """If an adapter config is provided, wrap the model with a PEFT model for fine-tuning.
 
-        Guarded by _adapter_initialized to prevent double-wrapping when called multiple times (e.g. prepare_for_training
-        is called on every Trainer construction, including on resume).
+        Handles both the singular ``config_obj.adapter`` and the multi-adapter
+        ``config_obj.adapters`` forms — the two fields are schema-level mutually exclusive.
+        Guarded by _adapter_initialized to prevent double-wrapping when called multiple
+        times (e.g. prepare_for_training is called on every Trainer construction,
+        including on resume).
         """
-        if self.config_obj.adapter and not self._adapter_initialized:
-            if self.config_obj.trainer.type != "finetune" and not self.config_obj.adapter.pretrained_adapter_weights:
-                raise ValueError(
-                    "Adapter config was provided, but trainer type is not set to `finetune`. Either set the trainer to "
-                    "`finetune` or remove the adapter config."
-                )
+        has_adapter = bool(self.config_obj.adapter)
+        has_adapters = getattr(self.config_obj, "adapters", None) is not None
+
+        if (has_adapter or has_adapters) and not self._adapter_initialized:
+            # Finetune is required for any adapter path unless we're loading pretrained
+            # adapter weights on the single-adapter fast path.
+            if self.config_obj.trainer.type != "finetune":
+                if has_adapter and self.config_obj.adapter.pretrained_adapter_weights:
+                    pass  # allowed: pretrained adapter inference
+                else:
+                    raise ValueError(
+                        "Adapter config was provided, but trainer type is not set to `finetune`. "
+                        "Either set the trainer to `finetune` or remove the adapter config."
+                    )
 
             self.model = initialize_adapter(self.model, self.config_obj)
 
             logger.info("==================================================")
             logger.info("Trainable Parameter Summary For Fine-Tuning")
-            logger.info(f"Fine-tuning with adapter: {self.config_obj.adapter.type}")
+            if has_adapter:
+                logger.info(f"Fine-tuning with adapter: {self.config_obj.adapter.type}")
+            else:
+                adapter_types = [
+                    cfg.get("type") if isinstance(cfg, dict) else cfg.type
+                    for cfg in self.config_obj.adapters.adapters.values()
+                ]
+                logger.info(
+                    "Fine-tuning with %d named adapters: %s",
+                    len(adapter_types),
+                    list(zip(self.config_obj.adapters.adapters.keys(), adapter_types)),
+                )
             self.model.print_trainable_parameters()
             logger.info("==================================================")
 
@@ -662,7 +684,9 @@ class LLM(BaseModel):
     def load(self, save_path):
         """Loads the model from the given path."""
         weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
-        if self.config_obj.adapter:
+        if getattr(self.config_obj, "adapters", None) is not None:
+            self._load_multi_adapters(weights_save_path)
+        elif self.config_obj.adapter:
             # Check if the saved weights are merged (no adapter_config.json) or adapter-only
             adapter_config_path = os.path.join(weights_save_path, "adapter_config.json")
             if os.path.exists(adapter_config_path):
@@ -686,6 +710,44 @@ class LLM(BaseModel):
             )
         else:
             logger.info("Skipped loading LLM without weight adjustments.")
+
+    def _load_multi_adapters(self, weights_save_path: str) -> None:
+        """Reload a multi-adapter PeftModel saved via `save_pretrained`.
+
+        PEFT stores each named adapter under a subdirectory at `weights_save_path/<name>/`. We load the first adapter
+        via `PeftModel.from_pretrained(base, path, adapter_name=name)` and every additional adapter via
+        `peft_model.load_adapter(path, adapter_name=name)`. The merged adapter (if configured) was saved just like any
+        other named adapter — it is loaded the same way, no special case needed. Finally we activate whichever adapter
+        the config declares via `set_adapter(active)`.
+        """
+        from peft import PeftModel  # noqa
+
+        adapters_cfg = self.config_obj.adapters
+        names = list(adapters_cfg.adapters.keys())
+        if adapters_cfg.merge is not None:
+            names = names + [adapters_cfg.merge.name]
+
+        if isinstance(self.model, PeftModel):
+            # Already wrapped (e.g. resuming from an in-memory init); peel back to the base.
+            self.model = self.model.base_model
+
+        first_name = names[0]
+        first_adapter_dir = os.path.join(weights_save_path, first_name)
+        if os.path.exists(first_adapter_dir):
+            self.model = PeftModel.from_pretrained(self.model, first_adapter_dir, adapter_name=first_name)
+        else:
+            # Fallback: PEFT may have saved adapters directly at `weights_save_path` rather
+            # than in per-name subdirectories (old save layout). Use the original path.
+            self.model = PeftModel.from_pretrained(self.model, weights_save_path, adapter_name=first_name)
+
+        for name in names[1:]:
+            adapter_dir = os.path.join(weights_save_path, name)
+            load_path = adapter_dir if os.path.exists(adapter_dir) else weights_save_path
+            self.model.load_adapter(load_path, adapter_name=name)
+
+        active = adapters_cfg.active or names[0]
+        self.model.set_adapter(active)
+        logger.info("Reloaded adapters: %s (active=%s)", names, active)
 
     def get_args(self):
         """Returns init arguments for constructing this model."""

--- a/ludwig/schema/llms/peft.py
+++ b/ludwig/schema/llms/peft.py
@@ -774,3 +774,121 @@ def AdapterDataclassField(default: str | None = None):
             }
 
     return AdapterSelection().get_default_field()
+
+
+# ================================================================================================
+# Multi-adapter support
+# ================================================================================================
+#
+# The singular `adapter:` field above supports the common case: one adapter attached to one
+# base model. The `adapters:` field below supports the multi-adapter case: several named
+# adapters attached to the same base model, switchable at runtime via PEFT's `set_adapter()`
+# and optionally merged via `add_weighted_adapter()` using combination types like TIES and
+# DARE (Yadav et al., NeurIPS 2023 / Yu et al., ICML 2024).
+#
+# `adapter:` and `adapters:` are mutually exclusive — a config must use one form or the other.
+# Back-compat: existing configs that set `adapter:` continue to work unchanged.
+
+
+@DeveloperAPI
+class MergeAdaptersConfig(schema_utils.LudwigBaseConfig):
+    """Optional weighted merge over a subset of the named adapters.
+
+    Produces a new adapter registered under ``name`` by combining ``sources`` with the
+    matching ``weights`` under ``combination_type``. The merged adapter is added to the
+    model alongside the sources; pick it as ``active`` to make it the default at
+    inference time.
+    """
+
+    name: str = schema_utils.String(
+        default="merged",
+        description="Name to register the merged adapter under.",
+    )
+
+    sources: list | None = schema_utils.List(
+        default=None,
+        allow_none=True,
+        description="Names of the adapters to merge. Each name must appear in the `adapters` map.",
+    )
+
+    weights: list | None = schema_utils.List(
+        default=None,
+        allow_none=True,
+        description=(
+            "Per-source weights; must have the same length as `sources`. " "If null, all weights default to 1.0."
+        ),
+    )
+
+    combination_type: str = schema_utils.StringOptions(
+        options=["linear", "svd", "ties", "dare_linear", "dare_ties", "magnitude_prune"],
+        default="linear",
+        allow_none=False,
+        description=(
+            "PEFT weighted-merge combination type. 'linear' is a plain weighted sum. "
+            "'ties' (Yadav et al., NeurIPS 2023) resolves sign conflicts across source "
+            "deltas before merging. 'dare_linear' / 'dare_ties' (Yu et al., ICML 2024) "
+            "prune a fraction `density` of deltas before merging for smaller footprints."
+        ),
+    )
+
+    density: float = schema_utils.FloatRange(
+        default=0.5,
+        min=0.0,
+        max=1.0,
+        description=(
+            "Fraction of weight deltas kept when `combination_type` is 'ties', "
+            "'dare_linear', 'dare_ties', or 'magnitude_prune'. Ignored for 'linear' / 'svd'."
+        ),
+    )
+
+
+@DeveloperAPI
+class MergeAdaptersConfigField(schema_utils.NestedConfigField):
+    def __init__(self):
+        super().__init__(MergeAdaptersConfig, allow_none=True, default_missing=True)
+
+    def _jsonschema_type_mapping(self):
+        return schema_utils.unload_jsonschema_from_config_class(MergeAdaptersConfig, title="MergeAdapters")
+
+
+@DeveloperAPI
+class NamedAdaptersConfig(schema_utils.LudwigBaseConfig):
+    """Configuration for multiple named PEFT adapters on the same base model."""
+
+    adapters: dict | None = schema_utils.Dict(
+        default=None,
+        allow_none=False,
+        description=(
+            "Mapping of adapter name -> adapter config. Each value is a regular adapter "
+            "config (e.g. ``{type: lora, r: 8}``) identical to what the singular "
+            "`adapter:` field accepts. Adapter names must be unique; PEFT will register "
+            "each one on the model and the first-listed adapter becomes the active one "
+            "unless `active` is set."
+        ),
+    )
+
+    active: str | None = schema_utils.String(
+        default=None,
+        allow_none=True,
+        description=(
+            "Name of the adapter to activate after all adapters are registered. "
+            "If null, the first entry in `adapters` is used. Set this to a merged adapter "
+            "name from `merge:` to activate the merged adapter at inference time."
+        ),
+    )
+
+    merge: MergeAdaptersConfig | None = MergeAdaptersConfigField().get_default_field()
+
+
+@DeveloperAPI
+class NamedAdaptersConfigField(schema_utils.NestedConfigField):
+    def __init__(self):
+        super().__init__(NamedAdaptersConfig, allow_none=True, default_missing=True)
+
+    def _jsonschema_type_mapping(self):
+        return schema_utils.unload_jsonschema_from_config_class(NamedAdaptersConfig, title="NamedAdapters")
+
+
+@DeveloperAPI
+def NamedAdaptersDataclassField():
+    return NamedAdaptersConfigField().get_default_field()

--- a/ludwig/schema/model_types/llm.py
+++ b/ludwig/schema/model_types/llm.py
@@ -1,4 +1,5 @@
 from ludwig.api_annotations import DeveloperAPI
+from ludwig.error import ConfigValidationError
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.defaults.llm import LLMDefaultsConfig, LLMDefaultsField
 from ludwig.schema.features.base import (
@@ -12,7 +13,12 @@ from ludwig.schema.hyperopt import HyperoptConfig, HyperoptField
 from ludwig.schema.llms.base_model import BaseModelDataclassField
 from ludwig.schema.llms.generation import LLMGenerationConfig, LLMGenerationConfigField
 from ludwig.schema.llms.model_parameters import ModelParametersConfig, ModelParametersConfigField
-from ludwig.schema.llms.peft import AdapterDataclassField, BaseAdapterConfig
+from ludwig.schema.llms.peft import (
+    AdapterDataclassField,
+    BaseAdapterConfig,
+    NamedAdaptersConfig,
+    NamedAdaptersDataclassField,
+)
 from ludwig.schema.llms.prompt import PromptConfig, PromptConfigField
 from ludwig.schema.llms.quantization import QuantizationConfig, QuantizationConfigField
 from ludwig.schema.model_types.base import ModelConfig, register_model_type
@@ -46,6 +52,7 @@ class LLMModelConfig(ModelConfig):
     generation: LLMGenerationConfig = LLMGenerationConfigField().get_default_field()
 
     adapter: BaseAdapterConfig | None = AdapterDataclassField()
+    adapters: NamedAdaptersConfig | None = NamedAdaptersDataclassField()
     quantization: QuantizationConfig | None = QuantizationConfigField().get_default_field()
     model_parameters: ModelParametersConfig | None = ModelParametersConfigField().get_default_field()
 
@@ -57,3 +64,50 @@ class LLMModelConfig(ModelConfig):
             "Only enable this for models you trust."
         ),
     )
+
+    def __post_init__(self):
+        super().__post_init__()
+        # `adapter:` (singular) and `adapters:` (plural) are mutually exclusive.
+        # A config must use one form or the other — using both is ambiguous because the
+        # model would have both an anonymous adapter and a registry of named ones.
+        if self.adapter is not None and self.adapters is not None:
+            raise ConfigValidationError(
+                "Cannot set both `adapter:` and `adapters:` — use one form or the other. "
+                "Use `adapter:` for a single adapter (common case). Use `adapters:` to "
+                "register multiple named adapters that can be switched at runtime or merged."
+            )
+        if self.adapters is not None:
+            if not self.adapters.adapters:
+                raise ConfigValidationError(
+                    "`adapters.adapters` must contain at least one entry. To disable "
+                    "parameter-efficient fine-tuning, remove the `adapters:` field entirely."
+                )
+            adapter_names = list(self.adapters.adapters.keys())
+            if self.adapters.active is not None and self.adapters.active not in adapter_names:
+                # The active adapter name may also refer to a merged adapter defined below.
+                if not (self.adapters.merge and self.adapters.merge.name == self.adapters.active):
+                    raise ConfigValidationError(
+                        f"`adapters.active` = {self.adapters.active!r} does not match any "
+                        f"adapter name in `adapters.adapters` ({adapter_names}) or the "
+                        "`adapters.merge.name` field."
+                    )
+            if self.adapters.merge is not None:
+                merge = self.adapters.merge
+                if not merge.sources:
+                    raise ConfigValidationError("`adapters.merge.sources` is required when `adapters.merge` is set.")
+                unknown = [s for s in merge.sources if s not in adapter_names]
+                if unknown:
+                    raise ConfigValidationError(
+                        f"`adapters.merge.sources` references unknown adapter names: {unknown}. "
+                        f"Known adapters: {adapter_names}."
+                    )
+                if merge.weights is not None and len(merge.weights) != len(merge.sources):
+                    raise ConfigValidationError(
+                        f"`adapters.merge.weights` has {len(merge.weights)} entries but "
+                        f"`adapters.merge.sources` has {len(merge.sources)}. Lengths must match."
+                    )
+                if merge.name in adapter_names:
+                    raise ConfigValidationError(
+                        f"`adapters.merge.name` = {merge.name!r} collides with an existing "
+                        "source adapter name. Pick a different name for the merged adapter."
+                    )

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -189,14 +189,22 @@ def initialize_adapter(
 ) -> Union["PeftModel", PreTrainedModel]:  # noqa F821
     """Wrap a pretrained model with a PEFT model for fine-tuning.
 
+    Dispatches to the multi-adapter path when ``config_obj.adapters`` is set (several
+    named adapters registered on the same base, optional weighted merge, runtime
+    switching via ``set_adapter``) and to the single-adapter path for ``config_obj.adapter``.
+    The two fields are mutually exclusive at the schema layer.
+
     Args:
          model: Pretrained model to fine-tune with an adapter.
          config_obj: LLM config
 
     Returns:
-        `model` wrapped in a PEFT model if an adapter config was provided, otherwise `model`.
+        ``model`` wrapped in a PEFT model if an adapter config was provided, otherwise
+        ``model`` unaltered.
     """
-    # Only load a PEFT model if the config specifies an adapter, otherwise return the model unaltered.
+    if getattr(config_obj, "adapters", None) is not None:
+        return _initialize_multi_adapters(model, config_obj)
+
     if config_obj.adapter:
         if config_obj.adapter.pretrained_adapter_weights:
             # Load pretrained adapter weights if specified.
@@ -222,6 +230,85 @@ def initialize_adapter(
             model = get_peft_model(model, peft_config)
 
     return model
+
+
+def _initialize_multi_adapters(
+    model: PreTrainedModel, config_obj: "LLMModelConfig"  # noqa F821
+) -> "PeftModel":  # noqa F821
+    """Attach several named PEFT adapters to ``model`` and (optionally) a merged one.
+
+    PEFT's public multi-adapter surface:
+      * ``get_peft_model(base, cfg, adapter_name=...)`` creates a PeftModel with one named
+        adapter. We use the first configured adapter here as the anchor.
+      * ``peft_model.add_adapter(adapter_name, cfg)`` registers additional adapters on the
+        same PeftModel.
+      * ``peft_model.add_weighted_adapter(source_names, weights, name, combination_type,
+        density)`` produces a new adapter by combining existing ones. Used when
+        ``adapters.merge`` is set.
+      * ``peft_model.set_adapter(name)`` designates the default adapter. Only one adapter
+        is active at a time — users switch explicitly at inference, or ask for the merged
+        adapter as the default.
+    """
+    from peft import get_peft_model, TaskType  # imported inline for minimal installs
+
+    adapters_cfg = config_obj.adapters
+    items = list(adapters_cfg.adapters.items())  # insertion order, validated non-empty by schema
+    first_name, first_cfg = items[0]
+
+    if not hasattr(first_cfg, "to_config"):
+        # The schema stores entries as raw dicts; re-materialize them into adapter configs via
+        # the adapter registry so each has a working `to_config()` method.
+        items = [(name, _materialize_adapter_config(cfg)) for name, cfg in items]
+        first_name, first_cfg = items[0]
+
+    first_peft_config = first_cfg.to_config(task_type=TaskType.CAUSAL_LM, tokenizer_name_or_path=config_obj.base_model)
+    model = get_peft_model(model, first_peft_config, adapter_name=first_name)
+
+    for name, adapter_cfg in items[1:]:
+        peft_config = adapter_cfg.to_config(task_type=TaskType.CAUSAL_LM, tokenizer_name_or_path=config_obj.base_model)
+        model.add_adapter(name, peft_config)
+
+    if adapters_cfg.merge is not None:
+        merge = adapters_cfg.merge
+        weights = merge.weights if merge.weights is not None else [1.0] * len(merge.sources)
+        kwargs = {
+            "adapters": merge.sources,
+            "weights": weights,
+            "adapter_name": merge.name,
+            "combination_type": merge.combination_type,
+        }
+        if merge.combination_type in ("ties", "dare_linear", "dare_ties", "magnitude_prune"):
+            kwargs["density"] = merge.density
+        model.add_weighted_adapter(**kwargs)
+        logger.info(
+            "Merged adapters %s (weights=%s) via %s into %r",
+            merge.sources,
+            weights,
+            merge.combination_type,
+            merge.name,
+        )
+
+    active = adapters_cfg.active or first_name
+    model.set_adapter(active)
+    logger.info("Registered adapters: %s (active=%s)", [n for n, _ in items], active)
+
+    return model
+
+
+def _materialize_adapter_config(raw):
+    """Turn a raw dict from ``adapters.adapters`` into a BaseAdapterConfig instance."""
+    from ludwig.schema.llms.peft import adapter_registry
+
+    if hasattr(raw, "to_config"):
+        return raw
+    if not isinstance(raw, dict):
+        raise TypeError(f"Expected dict adapter config, got {type(raw).__name__}")
+    adapter_type = raw.get("type")
+    if adapter_type is None:
+        raise ValueError("Adapter config is missing required `type` field.")
+    if adapter_type not in adapter_registry:
+        raise ValueError(f"Unknown adapter type {adapter_type!r}. Known: {list(adapter_registry.keys())}")
+    return adapter_registry[adapter_type].model_validate(raw)
 
 
 def get_context_len(model_config: AutoConfig):

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -464,6 +464,83 @@ def _verify_lm_lora_finetuning_layers(
                 ) == expected_lora_num_features
 
 
+@pytest.mark.llm
+def test_llm_multi_adapter_registration_and_merge(tmpdir, csv_filename):
+    """End-to-end smoke test for the ``adapters:`` multi-adapter config.
+
+    Registers two named LoRA adapters on a tiny GPTJ, runs a single fine-tune epoch,
+    attaches a TIES-merged adapter built from both sources, and verifies that:
+
+    * all three adapters (``a``, ``b``, ``merged``) exist on the loaded model,
+    * the active adapter after init matches ``adapters.active`` (``merged``), and
+    * predictions can be generated through the merged adapter.
+
+    Uses ``hf-internal-testing/tiny-random-GPTJForCausalLM`` — the smallest practical
+    causal LM in the Ludwig test suite — to keep wall-time low even on CPU runners.
+    """
+    import peft as _peft  # noqa: F401  (fail the test early on minimal installs)
+
+    input_features = [text_feature(name="input", encoder={"type": "passthrough"})]
+    output_features = [text_feature(name="output")]
+    train_df = generate_data(input_features, output_features, filename=csv_filename, num_examples=12)
+
+    config = {
+        MODEL_TYPE: MODEL_LLM,
+        BASE_MODEL: TEST_MODEL_NAME,
+        INPUT_FEATURES: input_features,
+        OUTPUT_FEATURES: output_features,
+        GENERATION: {"max_new_tokens": 16},
+        TRAINER: {
+            TYPE: "finetune",
+            BATCH_SIZE: 2,
+            EVAL_BATCH_SIZE: 2,
+            EPOCHS: 1,
+        },
+        "adapters": {
+            "adapters": {
+                "adapter_a": {"type": "lora", "r": 4, "alpha": 8},
+                "adapter_b": {"type": "lora", "r": 4, "alpha": 8},
+            },
+            "merge": {
+                "name": "merged",
+                "sources": ["adapter_a", "adapter_b"],
+                "weights": [0.5, 0.5],
+                "combination_type": "ties",
+                "density": 0.5,
+            },
+            "active": "merged",
+        },
+        BACKEND: LOCAL_BACKEND,
+    }
+
+    output_directory: str = str(tmpdir)
+    model_directory: pathlib.Path = pathlib.Path(output_directory) / "api_experiment_run" / MODEL_FILE_NAME
+
+    model = LudwigModel(config)
+    model.train(dataset=train_df, output_directory=output_directory, skip_save_processed_input=False)
+
+    # All three named adapters must be present on the PEFT-wrapped model.
+    peft_adapters = set(model.model.model.peft_config.keys())
+    assert {"adapter_a", "adapter_b", "merged"}.issubset(peft_adapters), f"missing adapters: {peft_adapters}"
+
+    # The active adapter after initialization should be the merged one we requested.
+    active = model.model.model.active_adapter
+    if isinstance(active, (list, tuple, set)):
+        active = next(iter(active))
+    assert active == "merged", f"expected active=merged, got {active!r}"
+
+    # Reload round-trip: the saved model's PEFT dir should carry all three adapters.
+    reloaded = LudwigModel.load(str(model_directory), backend=LOCAL_BACKEND)
+    reloaded_peft_adapters = set(reloaded.model.model.peft_config.keys())
+    assert {"adapter_a", "adapter_b", "merged"}.issubset(reloaded_peft_adapters)
+
+    # Generation through the merged adapter should run to completion.
+    prediction_df = pd.DataFrame([{"input": "The food was amazing!", "output": ""}])
+    preds, _ = reloaded.predict(dataset=prediction_df, output_directory=output_directory)
+    preds = convert_preds(preds)
+    assert preds
+
+
 # TODO(arnav): p-tuning and prefix tuning have errors when enabled that seem to stem from distributed training:
 #
 # prefix tuning:

--- a/tests/ludwig/schema/test_peft_adapters.py
+++ b/tests/ludwig/schema/test_peft_adapters.py
@@ -67,3 +67,176 @@ class TestECDEncoderAdapter:
 
         inst = DenseEncoderConfig.model_validate({"type": "dense", "adapter": {"type": "lora", "r": 8}})
         assert inst.adapter == {"type": "lora", "r": 8}
+
+
+class TestNamedAdapters:
+    """Unit tests for the multi-adapter schema (`adapters:` plural, mutually exclusive with `adapter:`)."""
+
+    def _llm_base(self):
+        return {
+            "model_type": "llm",
+            "base_model": "sshleifer/tiny-gpt2",
+            "input_features": [{"name": "p", "type": "text"}],
+            "output_features": [{"name": "r", "type": "text"}],
+            "trainer": {"type": "finetune"},
+        }
+
+    def test_named_adapters_config_validates(self):
+        from ludwig.schema.llms.peft import NamedAdaptersConfig
+
+        cfg = NamedAdaptersConfig.model_validate(
+            {
+                "adapters": {"a": {"type": "lora", "r": 8}, "b": {"type": "lora", "r": 16}},
+                "active": "a",
+            }
+        )
+        assert cfg.active == "a"
+        assert list(cfg.adapters.keys()) == ["a", "b"]
+        assert cfg.merge is None
+
+    def test_merge_config_validates(self):
+        from ludwig.schema.llms.peft import NamedAdaptersConfig
+
+        cfg = NamedAdaptersConfig.model_validate(
+            {
+                "adapters": {"a": {"type": "lora"}, "b": {"type": "lora"}},
+                "merge": {
+                    "name": "m",
+                    "sources": ["a", "b"],
+                    "weights": [0.7, 0.3],
+                    "combination_type": "ties",
+                    "density": 0.3,
+                },
+            }
+        )
+        assert cfg.merge.name == "m"
+        assert cfg.merge.combination_type == "ties"
+        assert cfg.merge.density == 0.3
+
+    def test_llm_config_accepts_plural(self):
+        from ludwig.schema.model_types.base import ModelConfig
+
+        cfg = {**self._llm_base(), "adapters": {"adapters": {"a": {"type": "lora"}}}}
+        model_cfg = ModelConfig.from_dict(cfg)
+        assert model_cfg.adapter is None
+        assert model_cfg.adapters is not None
+        assert "a" in model_cfg.adapters.adapters
+
+    def test_llm_config_accepts_singular(self):
+        from ludwig.schema.model_types.base import ModelConfig
+
+        cfg = {**self._llm_base(), "adapter": {"type": "lora", "r": 8}}
+        model_cfg = ModelConfig.from_dict(cfg)
+        assert model_cfg.adapter is not None
+        assert model_cfg.adapters is None
+
+    def test_both_adapter_and_adapters_rejected(self):
+        from ludwig.error import ConfigValidationError
+        from ludwig.schema.model_types.base import ModelConfig
+
+        cfg = {
+            **self._llm_base(),
+            "adapter": {"type": "lora", "r": 8},
+            "adapters": {"adapters": {"a": {"type": "lora"}}},
+        }
+        with pytest.raises(ConfigValidationError, match="both `adapter:` and `adapters:`"):
+            ModelConfig.from_dict(cfg)
+
+    def test_empty_adapters_rejected(self):
+        from ludwig.error import ConfigValidationError
+        from ludwig.schema.model_types.base import ModelConfig
+
+        cfg = {**self._llm_base(), "adapters": {"adapters": {}}}
+        with pytest.raises(ConfigValidationError, match="at least one entry"):
+            ModelConfig.from_dict(cfg)
+
+    def test_active_must_reference_known_adapter(self):
+        from ludwig.error import ConfigValidationError
+        from ludwig.schema.model_types.base import ModelConfig
+
+        cfg = {
+            **self._llm_base(),
+            "adapters": {"adapters": {"a": {"type": "lora"}}, "active": "b"},
+        }
+        with pytest.raises(ConfigValidationError, match="does not match any"):
+            ModelConfig.from_dict(cfg)
+
+    def test_active_may_point_at_merged_adapter(self):
+        from ludwig.schema.model_types.base import ModelConfig
+
+        cfg = {
+            **self._llm_base(),
+            "adapters": {
+                "adapters": {"a": {"type": "lora"}, "b": {"type": "lora"}},
+                "active": "m",
+                "merge": {"name": "m", "sources": ["a", "b"], "combination_type": "linear"},
+            },
+        }
+        model_cfg = ModelConfig.from_dict(cfg)
+        assert model_cfg.adapters.active == "m"
+
+    def test_merge_sources_must_exist(self):
+        from ludwig.error import ConfigValidationError
+        from ludwig.schema.model_types.base import ModelConfig
+
+        cfg = {
+            **self._llm_base(),
+            "adapters": {
+                "adapters": {"a": {"type": "lora"}},
+                "merge": {"name": "m", "sources": ["a", "ghost"]},
+            },
+        }
+        with pytest.raises(ConfigValidationError, match="unknown adapter names"):
+            ModelConfig.from_dict(cfg)
+
+    def test_merge_weights_length_must_match_sources(self):
+        from ludwig.error import ConfigValidationError
+        from ludwig.schema.model_types.base import ModelConfig
+
+        cfg = {
+            **self._llm_base(),
+            "adapters": {
+                "adapters": {"a": {"type": "lora"}, "b": {"type": "lora"}},
+                "merge": {"name": "m", "sources": ["a", "b"], "weights": [0.5]},
+            },
+        }
+        with pytest.raises(ConfigValidationError, match="Lengths must match"):
+            ModelConfig.from_dict(cfg)
+
+    def test_merge_name_cannot_collide_with_source(self):
+        from ludwig.error import ConfigValidationError
+        from ludwig.schema.model_types.base import ModelConfig
+
+        cfg = {
+            **self._llm_base(),
+            "adapters": {
+                "adapters": {"a": {"type": "lora"}, "b": {"type": "lora"}},
+                "merge": {"name": "a", "sources": ["a", "b"]},
+            },
+        }
+        with pytest.raises(ConfigValidationError, match="collides with an existing source"):
+            ModelConfig.from_dict(cfg)
+
+
+class TestInitializeAdapterMulti:
+    """Unit tests for `_initialize_multi_adapters` (no base model download)."""
+
+    def test_materialize_adapter_config_from_dict(self):
+        from ludwig.utils.llm_utils import _materialize_adapter_config
+
+        cfg = _materialize_adapter_config({"type": "lora", "r": 8})
+        assert hasattr(cfg, "to_config")
+        assert cfg.type == "lora"
+        assert cfg.r == 8
+
+    def test_materialize_adapter_config_unknown_type_raises(self):
+        from ludwig.utils.llm_utils import _materialize_adapter_config
+
+        with pytest.raises(ValueError, match="Unknown adapter type"):
+            _materialize_adapter_config({"type": "definitely-not-a-real-adapter"})
+
+    def test_materialize_adapter_config_missing_type_raises(self):
+        from ludwig.utils.llm_utils import _materialize_adapter_config
+
+        with pytest.raises(ValueError, match="missing required `type`"):
+            _materialize_adapter_config({"r": 8})


### PR DESCRIPTION
## Summary

First of two PRs closing out the Phase 2 PEFT + quantization leftovers.

Adds a new LLM-config field \`adapters:\` (plural) that registers multiple named PEFT adapters on the same base model, with optional weighted merging via PEFT's \`add_weighted_adapter\` (supporting linear, SVD, TIES, DARE variants, and magnitude_prune). The existing \`adapter:\` (singular) field continues to work unchanged; the two are schema-level mutually exclusive.

## Config surface

\`\`\`yaml
model_type: llm
base_model: meta-llama/Llama-3.1-8B
adapters:
  adapters:
    sentiment: { type: lora, r: 8 }
    summarization: { type: lora, r: 16 }
  merge:
    name: combined
    sources: [sentiment, summarization]
    weights: [0.6, 0.4]
    combination_type: ties     # linear | svd | ties | dare_linear | dare_ties | magnitude_prune
    density: 0.5
  active: combined
\`\`\`

After training this config emits a PEFT model carrying three named adapters (\`sentiment\`, \`summarization\`, \`combined\`), with \`combined\` active by default. Runtime switching is via the standard \`peft\_model.set_adapter(name)\` API.

## Implementation

- **Schema** — new \`NamedAdaptersConfig\` + \`MergeAdaptersConfig\` in \`ludwig/schema/llms/peft.py\` with full JSON-schema generation. Wired onto \`LLMModelConfig\` with strict \`__post_init__\` validation:
  - rejects \`adapter\` + \`adapters\` set together
  - rejects empty \`adapters.adapters\`
  - resolves \`adapters.active\` against the configured adapters + merge name
  - validates \`merge.sources\` reference known adapters, weights length matches sources length, merge name does not collide with a source
- **Application** — \`initialize_adapter\` in \`ludwig/utils/llm_utils.py\` dispatches to \`_initialize_multi_adapters\` when the plural form is present. Uses PEFT's \`get_peft_model(..., adapter_name=)\` + \`add_adapter\` + \`add_weighted_adapter\` + \`set_adapter\` in that order.
- **LLM model** — \`LLM.initialize_adapter\` handles both forms (single/multi) through the existing \`_adapter_initialized\` guard. \`LLM.load\` picks up a new \`_load_multi_adapters\` helper that reloads each named adapter from \`<weights_save_path>/<name>/\`.

## Testing

- **Unit (\`tests/ludwig/schema/test_peft_adapters.py\`)** — 14 new tests covering schema validation, mutual exclusion, merge config validation, active-name resolution, and the adapter config materialization helper. Running \`pytest tests/ludwig/schema/test_peft_adapters.py -x -q\` locally: **33 passing**.
- **Integration (\`tests/integration_tests/test_llm.py\`)** — one GPU smoke test \`test_llm_multi_adapter_registration_and_merge\` using \`hf-internal-testing/tiny-random-GPTJForCausalLM\` (the smallest causal LM in the existing LLM test suite). Trains one epoch with two LoRA adapters and a TIES-merged third, verifies all three live on the PEFT-wrapped model with the requested \`active\`, saves + reloads, re-verifies, then runs generation through the merged adapter. Local run is blocked on a pre-existing bitsandbytes/CUDA mismatch on this machine (same failure as existing \`test_llm_finetuning_strategies[lora-defaults-local]\`); CI is the source of truth.

## Out of scope

- Multi-adapter on ECD text/image encoders (today \`encoder.adapter\` is singular — would need separate schema work and a runtime switching story for the serving path).
- LoRAX-style multi-tenant serving of thousands of adapters (Phase 6.3, separate PR).
- QAT via torchao — covered by the **second** Phase 2 PR.

## Test plan

- [ ] CI green on unit + integration-shard containing the new integration test
- [ ] Manual YAML round-trip on a real model once landed
- [ ] Follow-up: \`LudwigModel.set_adapter(name)\` convenience wrapper on the public API (not required for this PR, but a natural next step)