### PR TITLE
feat: torchao quantization backend with QAT support (Phase 2.6.3)

### DIFF
--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -187,20 +187,48 @@ class LLM(BaseModel):
     def prepare_for_training(self):
         """Prepare the model for training by setting up quantization and adapters.
 
-        Safe to call multiple times (e.g. when resuming from a checkpoint). Quantization is applied at model-load time
-        in __init__ via load_pretrained_from_config, so prepare_model_for_kbit_training only needs to cast non-quantized
-        layers to float32 and freeze the quantized base — both operations are idempotent. Adapter initialization is
-        guarded by _adapter_initialized so the PEFT wrapper is only created once; on resume the saved adapter weights
-        are subsequently loaded by the trainer via load_state_dict.
+        Safe to call multiple times (e.g. when resuming from a checkpoint). For the bitsandbytes backend, quantization
+        is applied at model-load time in __init__ via load_pretrained_from_config, so prepare_model_for_kbit_training
+        only needs to cast non-quantized layers to float32 and freeze the quantized base — both operations are
+        idempotent. For the torchao backend, quantization / QAT preparation happens here after load. Adapter
+        initialization is guarded by _adapter_initialized so the PEFT wrapper is only created once; on resume the saved
+        adapter weights are subsequently loaded by the trainer via load_state_dict.
         """
-        if self.config_obj.quantization:
-            self.prepare_for_quantized_training()
+        quantization = self.config_obj.quantization
+        backend = getattr(quantization, "backend", "bitsandbytes") if quantization else None
+        if quantization:
+            if backend == "bitsandbytes":
+                self.prepare_for_quantized_training()
+            elif backend == "torchao":
+                self._prepare_for_torchao_training()
         self.initialize_adapter()
 
     def prepare_for_quantized_training(self):
         from peft import prepare_model_for_kbit_training
 
         self.model = prepare_model_for_kbit_training(self.model, use_gradient_checkpointing=False)
+
+    def _prepare_for_torchao_training(self):
+        """Insert torchao fake-quant observers for QAT, or defer PTQ until save for non-QAT.
+
+        * QAT (``quantization.qat: true``): insert fake-quant observers *before* training so
+          the model is trained in the target low-precision regime. Guarded by
+          ``_torchao_qat_prepared`` so repeated prepare_for_training calls do not re-wrap.
+        * PTQ (``quantization.qat: false``): do nothing here — we quantize at save time so
+          gradients flow through the trainable fp32 weights during fine-tuning. For inference-only
+          LLM configs this still gives quantized weights at export via ``save``.
+        """
+        quantization = self.config_obj.quantization
+        if not quantization.qat:
+            return
+        if getattr(self, "_torchao_qat_prepared", False):
+            return
+
+        from ludwig.utils.quantization import prepare_qat_model
+
+        logger.info("Preparing LLM for torchao QAT (mode=%s)", quantization.mode)
+        self.model = prepare_qat_model(self.model, quantization.mode)
+        self._torchao_qat_prepared = True
 
     def to_device(self, device):
         # Always refresh curr_device from actual parameter location, since
@@ -591,11 +619,38 @@ class LLM(BaseModel):
         # avoid this hack
         if self.config_obj.trainer.type != "none":
             weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
+            self._apply_torchao_save_time_quantization()
             # We initialize the model's generation configuration; otherwise, we get a validation error.
             self.model.generation_config = self.generation
             self.model.save_pretrained(weights_save_path)
         else:
             logger.info("Skipped saving LLM without weight adjustments.")
+
+    def _apply_torchao_save_time_quantization(self):
+        """For the torchao backend, quantize (or convert QAT -> quantized) at save time.
+
+        * PTQ (``qat: false``): apply torchao PTQ now so the saved weights are quantized.
+        * QAT (``qat: true``): convert the QAT-prepared model (fake-quant observers) to real
+          quantized weights via ``convert_qat_model``.
+
+        Idempotent via ``_torchao_quantized``: if training checkpoints call save() multiple
+        times we don't double-quantize.
+        """
+        quantization = self.config_obj.quantization
+        if not quantization or getattr(quantization, "backend", "bitsandbytes") != "torchao":
+            return
+        if getattr(self, "_torchao_quantized", False):
+            return
+
+        from ludwig.utils.quantization import convert_qat_model, quantize_model
+
+        if quantization.qat:
+            logger.info("Converting QAT-prepared LLM to %s quantized weights for save", quantization.mode)
+            self.model = convert_qat_model(self.model, quantization.mode)
+        else:
+            logger.info("Applying torchao PTQ (%s) before saving LLM", quantization.mode)
+            self.model = quantize_model(self.model, quantization.mode)
+        self._torchao_quantized = True
 
     def save_base_model(self, save_path):
         """Saves the base LLM model to the given path."""

--- a/ludwig/schema/llms/quantization.py
+++ b/ludwig/schema/llms/quantization.py
@@ -3,6 +3,7 @@ import warnings
 from transformers import BitsAndBytesConfig
 
 from ludwig.api_annotations import DeveloperAPI
+from ludwig.error import ConfigValidationError
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.metadata import LLM_METADATA
 from ludwig.schema.metadata.parameter_metadata import convert_metadata_to_json
@@ -14,8 +15,45 @@ warnings.filterwarnings(
 )
 
 
+# Valid torchao modes. Keep in sync with `ludwig/utils/quantization.py::quantize_model`.
+_TORCHAO_MODES = ["int4_weight_only", "int8_weight_only", "int8_dynamic", "float8"]
+
+
 @DeveloperAPI
 class QuantizationConfig(schema_utils.LudwigBaseConfig):
+    backend: str = schema_utils.StringOptions(
+        options=["bitsandbytes", "torchao"],
+        default="bitsandbytes",
+        allow_none=False,
+        description=(
+            "Quantization backend. 'bitsandbytes' (default) applies 4-bit / 8-bit quantization at "
+            "model load time via the bitsandbytes library — the existing QLoRA fine-tuning path. "
+            "'torchao' applies PyTorch-native quantization via torchao after model load, and can "
+            "additionally run quantization-aware training (QAT) when `qat: true` is set."
+        ),
+    )
+
+    mode: str | None = schema_utils.StringOptions(
+        options=_TORCHAO_MODES,
+        default=None,
+        allow_none=True,
+        description=(
+            "torchao-only quantization mode. Ignored when `backend` is 'bitsandbytes'. "
+            "'int4_weight_only' and 'int8_weight_only' quantize only the weight matrices (activations "
+            "stay in fp16/bf16). 'int8_dynamic' quantizes activations to int8 dynamically per-forward. "
+            "'float8' stores weights in fp8 (useful on H100+)."
+        ),
+    )
+
+    qat: bool = schema_utils.Boolean(
+        default=False,
+        description=(
+            "torchao-only. When true, inserts fake-quant observers into the model before training "
+            "(QAT). The model is trained in the target low-precision numerical regime, then converted "
+            "to actually-quantized weights at save time. Ignored when `backend` is 'bitsandbytes'."
+        ),
+    )
+
     bits: int = schema_utils.IntegerOptions(
         options=[4, 8],
         default=4,
@@ -79,6 +117,32 @@ class QuantizationConfig(schema_utils.LudwigBaseConfig):
             bnb_4bit_use_double_quant=self.bnb_4bit_use_double_quant,
             bnb_4bit_quant_type=self.bnb_4bit_quant_type,
         )
+
+    def validate_backend(self) -> None:
+        """Cross-validate backend-specific fields.
+
+        Called from :class:`~ludwig.schema.model_types.llm.LLMModelConfig.__post_init__`
+        rather than from this class's own ``__post_init__`` because errors raised from a
+        nested config's post-init get wrapped into a generic "Invalid params" message by
+        the parent's :class:`NestedConfigField`, losing the specific reason.
+        """
+        if self.backend == "torchao":
+            if self.mode is None:
+                raise ConfigValidationError(
+                    "`quantization.mode` is required when `quantization.backend` is 'torchao'. "
+                    f"Options: {_TORCHAO_MODES}."
+                )
+        else:  # bitsandbytes
+            if self.mode is not None:
+                raise ConfigValidationError(
+                    "`quantization.mode` is only supported for `backend: torchao`. Remove the "
+                    "field or switch the backend to 'torchao'."
+                )
+            if self.qat:
+                raise ConfigValidationError(
+                    "`quantization.qat: true` is only supported for `backend: torchao`. "
+                    "The bitsandbytes backend does not implement quantization-aware training."
+                )
 
 
 @DeveloperAPI

--- a/ludwig/schema/model_types/llm.py
+++ b/ludwig/schema/model_types/llm.py
@@ -57,3 +57,11 @@ class LLMModelConfig(ModelConfig):
             "Only enable this for models you trust."
         ),
     )
+
+    def __post_init__(self):
+        super().__post_init__()
+        # Cross-validate the quantization backend/mode/qat combination here (rather than in
+        # QuantizationConfig.__post_init__) so the user sees the real reason in the error
+        # message — see QuantizationConfig.validate_backend for why.
+        if self.quantization is not None:
+            self.quantization.validate_backend()

--- a/ludwig/utils/llm_utils.py
+++ b/ludwig/utils/llm_utils.py
@@ -41,17 +41,20 @@ def load_pretrained_from_config(
     weights_save_path: str | None = None,
 ) -> PreTrainedModel:
     load_kwargs = {}
-    if config_obj.quantization:
-        # Apply quantization configuration at model load time
-        load_kwargs["dtype"] = getattr(torch, config_obj.quantization.bnb_4bit_compute_dtype)
-        load_kwargs["quantization_config"] = config_obj.quantization.to_bitsandbytes()
+    quantization = config_obj.quantization
+    if quantization and getattr(quantization, "backend", "bitsandbytes") == "bitsandbytes":
+        # Apply bitsandbytes quantization configuration at model load time.
+        load_kwargs["dtype"] = getattr(torch, quantization.bnb_4bit_compute_dtype)
+        load_kwargs["quantization_config"] = quantization.to_bitsandbytes()
         load_kwargs["device_map"] = "auto"
 
         if transformers_436:
             load_kwargs["attn_implementation"] = "eager"
     else:
-        # Load in float32 by default to avoid CUBLAS errors with small hidden sizes
-        # and to ensure numerical stability during training without mixed-precision.
+        # Either no quantization, or torchao — which quantizes the model *after* load, not
+        # via transformers' BitsAndBytesConfig. Load in float32 by default to avoid CUBLAS
+        # errors with small hidden sizes and to ensure numerical stability during training
+        # without mixed-precision.
         load_kwargs["dtype"] = torch.float32
 
     config_modified = False

--- a/ludwig/utils/quantization.py
+++ b/ludwig/utils/quantization.py
@@ -1,16 +1,28 @@
 """PyTorch-native quantization via torchao.
 
 Provides int4, int8, and float8 weight quantization without requiring
-bitsandbytes. Uses torchao's quantize_() for in-place model quantization.
+bitsandbytes. Exposes three operations:
 
-Usage in Ludwig config:
-    trainer:
-      quantization:
-        type: int4_weight_only    # or int8_weight_only, int8_dynamic, float8
+* :func:`quantize_model` — post-training quantization (PTQ). Call on a trained
+  fp16/bf16/fp32 model to produce a quantized model.
+* :func:`prepare_qat_model` — insert fake-quant observers before training
+  (quantization-aware training). Train as usual in the target low-precision
+  regime.
+* :func:`convert_qat_model` — after QAT training, convert the observed model
+  to actually-quantized weights for inference.
 
-Or programmatically:
-    from ludwig.utils.quantization import quantize_model
-    quantize_model(model, "int4_weight_only")
+Usage in Ludwig config (Post-training quantization / PTQ):
+
+    quantization:
+      backend: torchao
+      mode: int4_weight_only    # or int8_weight_only, int8_dynamic, float8
+
+Usage in Ludwig config (Quantization-aware training / QAT):
+
+    quantization:
+      backend: torchao
+      mode: int4_weight_only
+      qat: true
 """
 
 import logging
@@ -18,17 +30,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def quantize_model(model, quantization_type: str):
-    """Apply torchao quantization to a model in-place.
+# Canonical mode list. Keep in sync with ``_TORCHAO_MODES`` in ``ludwig/schema/llms/quantization.py``.
+_VALID_MODES = ("int4_weight_only", "int8_weight_only", "int8_dynamic", "float8")
 
-    Args:
-        model: PyTorch model to quantize.
-        quantization_type: One of "int4_weight_only", "int8_weight_only",
-            "int8_dynamic", "float8".
 
-    Returns:
-        The quantized model (modified in-place).
-    """
+def _import_torchao_ptq():
+    """Import torchao's PTQ API or raise a clear error if torchao is missing."""
     try:
         from torchao.quantization import (
             float8_weight_only,
@@ -37,23 +44,141 @@ def quantize_model(model, quantization_type: str):
             int8_weight_only,
             quantize_,
         )
-    except ImportError:
-        logger.error("torchao is required for quantization. Install with: pip install torchao")
-        raise
+    except ImportError as exc:
+        raise ImportError(
+            "torchao is required for the 'torchao' quantization backend. "
+            "Install with: pip install 'ludwig[llm]' or pip install torchao."
+        ) from exc
 
-    config_map = {
+    return quantize_, {
         "int4_weight_only": int4_weight_only,
         "int8_weight_only": int8_weight_only,
         "int8_dynamic": int8_dynamic_activation_int8_weight,
         "float8": float8_weight_only,
     }
 
-    if quantization_type not in config_map:
-        raise ValueError(f"Unknown quantization type '{quantization_type}'. Options: {list(config_map.keys())}")
 
-    config_fn = config_map[quantization_type]
-    logger.info(f"Applying {quantization_type} quantization via torchao")
-    quantize_(model, config_fn())
+def _import_torchao_qat():
+    """Import torchao's QAT API or raise a clear error if torchao is missing.
+
+    The QAT submodule has moved between torchao releases, so we try the modern namespace first and fall back to the
+    pre-0.9 location.
+    """
+    try:
+        from torchao.quantization.qat import (
+            FakeQuantizeConfig,
+            from_intx_quantization_aware_training,
+            intx_quantization_aware_training,
+        )
+    except ImportError:
+        try:
+            from torchao.quantization.prototype.qat import (  # type: ignore[no-redef]
+                FakeQuantizeConfig,
+                from_intx_quantization_aware_training,
+                intx_quantization_aware_training,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "torchao QAT is required for `quantization.qat: true`. "
+                "Install torchao >= 0.9 with: pip install 'ludwig[llm]'."
+            ) from exc
+
+    return intx_quantization_aware_training, from_intx_quantization_aware_training, FakeQuantizeConfig
+
+
+def _validate_mode(mode: str) -> None:
+    if mode not in _VALID_MODES:
+        raise ValueError(f"Unknown quantization mode '{mode}'. Options: {list(_VALID_MODES)}")
+
+
+def quantize_model(model, quantization_type: str):
+    """Apply torchao post-training quantization (PTQ) to ``model`` in-place.
+
+    Args:
+        model: PyTorch model to quantize.
+        quantization_type: One of :data:`_VALID_MODES`.
+
+    Returns:
+        The quantized model (modified in-place).
+    """
+    _validate_mode(quantization_type)
+    quantize_, config_map = _import_torchao_ptq()
+    logger.info("Applying %s quantization via torchao (PTQ)", quantization_type)
+    quantize_(model, config_map[quantization_type]())
     logger.info("Quantization complete")
+    return model
 
+
+def _qat_bit_width(mode: str) -> int:
+    if mode.startswith("int4"):
+        return 4
+    if mode.startswith("int8"):
+        return 8
+    # float8 isn't a standard IntXQAT path; reject explicitly rather than silently quantize wrong.
+    raise ValueError(
+        f"QAT is not supported for quantization mode '{mode}'. "
+        f"Use PTQ (qat: false) for 'float8', or pick an int4/int8 mode for QAT."
+    )
+
+
+def prepare_qat_model(model, quantization_type: str, group_size: int = 32):
+    """Insert fake-quant observers into ``model`` for quantization-aware training.
+
+    Call this once on the unquantized model **before** training starts. Ludwig's
+    ``LLM.prepare_for_training`` handles this automatically when
+    ``quantization.qat: true`` is set in the user's config.
+
+    After training completes, call :func:`convert_qat_model` to convert the
+    observed model to actually-quantized weights for inference / export.
+
+    Args:
+        model: PyTorch model to prepare for QAT.
+        quantization_type: One of :data:`_VALID_MODES` (int4/int8 only; float8
+            is PTQ-only in torchao).
+        group_size: Group size for per-group weight quantization. 32 is a sane
+            default for small / medium LMs.
+
+    Returns:
+        The model modified in-place with fake-quant observers inserted.
+    """
+    _validate_mode(quantization_type)
+    intx_qat, _, FakeQuantizeConfig = _import_torchao_qat()
+
+    bit_width = _qat_bit_width(quantization_type)
+    weight_cfg = FakeQuantizeConfig(dtype=f"int{bit_width}", group_size=group_size)
+    activation_cfg = None
+    if quantization_type == "int8_dynamic":
+        activation_cfg = FakeQuantizeConfig(dtype="int8", is_dynamic=True)
+
+    logger.info("Preparing model for QAT via torchao (%s, group_size=%d)", quantization_type, group_size)
+    # intx_quantization_aware_training returns a transform that quantize_ applies.
+    from torchao.quantization import quantize_
+
+    quantize_(model, intx_qat(activation_cfg, weight_cfg))
+    return model
+
+
+def convert_qat_model(model, quantization_type: str):
+    """Convert a QAT-prepared model to actually-quantized weights.
+
+    Call after QAT training finishes — typically from the LLM save / export path.
+    Undoes the fake-quant observers inserted by :func:`prepare_qat_model` and replaces
+    them with real quantized tensors matching the original ``quantization_type``.
+
+    Args:
+        model: Model previously prepared via :func:`prepare_qat_model`.
+        quantization_type: The same mode that was passed to ``prepare_qat_model``.
+
+    Returns:
+        The model modified in-place.
+    """
+    _validate_mode(quantization_type)
+    _, from_intx_qat, _ = _import_torchao_qat()
+    quantize_, config_map = _import_torchao_ptq()
+
+    logger.info("Converting QAT-prepared model to %s quantized weights", quantization_type)
+    # First strip the fake-quant observers back to plain Linear...
+    quantize_(model, from_intx_qat())
+    # ...then apply real PTQ to get the final quantized tensors.
+    quantize_(model, config_map[quantization_type]())
     return model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ llm = [
     "accelerate",
     "loralib",
     "peft>=0.10.0",
+    "torchao>=0.9.0",
 ]
 explain = [
     "captum",

--- a/tests/integration_tests/test_llm.py
+++ b/tests/integration_tests/test_llm.py
@@ -464,6 +464,65 @@ def _verify_lm_lora_finetuning_layers(
                 ) == expected_lora_num_features
 
 
+@pytest.mark.llm
+def test_llm_qat_torchao_end_to_end(tmpdir, csv_filename):
+    """End-to-end smoke test for torchao quantization-aware training (QAT) on an LLM.
+
+    Fine-tunes ``hf-internal-testing/tiny-random-GPTJForCausalLM`` for a single epoch with
+    ``quantization.backend: torchao``, ``mode: int8_weight_only``, ``qat: true`` and verifies:
+
+    * QAT observers are inserted before training (``_torchao_qat_prepared`` is set after
+      ``prepare_for_training``).
+    * Training completes without errors.
+    * Save applies the conversion — after ``model.save_pretrained`` runs, the saved
+      checkpoint reflects the quantized weights, the ``_torchao_quantized`` flag is set,
+      and the model is reloadable for inference.
+
+    Paired with ``adapter: lora`` because Ludwig requires an adapter whenever quantization
+    is active on a finetune trainer (matches the existing QLoRA integration test pattern).
+    """
+    pytest.importorskip("torchao", reason="torchao required for QAT tests")
+
+    input_features = [text_feature(name="input", encoder={"type": "passthrough"})]
+    output_features = [text_feature(name="output")]
+    train_df = generate_data(input_features, output_features, filename=csv_filename, num_examples=12)
+
+    config = {
+        MODEL_TYPE: MODEL_LLM,
+        BASE_MODEL: TEST_MODEL_NAME,
+        INPUT_FEATURES: input_features,
+        OUTPUT_FEATURES: output_features,
+        GENERATION: {"max_new_tokens": 16},
+        TRAINER: {
+            TYPE: "finetune",
+            BATCH_SIZE: 2,
+            EVAL_BATCH_SIZE: 2,
+            EPOCHS: 1,
+        },
+        ADAPTER: {TYPE: "lora", "r": 4, "alpha": 8},
+        QUANTIZATION: {"backend": "torchao", "mode": "int8_weight_only", "qat": True},
+        BACKEND: LOCAL_BACKEND,
+    }
+
+    output_directory: str = str(tmpdir)
+    model_directory: pathlib.Path = pathlib.Path(output_directory) / "api_experiment_run" / MODEL_FILE_NAME
+
+    model = LudwigModel(config)
+    model.train(dataset=train_df, output_directory=output_directory, skip_save_processed_input=False)
+
+    # QAT observers should have been inserted before training.
+    assert getattr(model.model, "_torchao_qat_prepared", False), "QAT preparation did not run"
+    # Save-time conversion should have fired.
+    assert getattr(model.model, "_torchao_quantized", False), "save-time quantization conversion did not run"
+
+    # Reload and verify inference runs through the QAT-converted model.
+    reloaded = LudwigModel.load(str(model_directory), backend=LOCAL_BACKEND)
+    prediction_df = pd.DataFrame([{"input": "Hello world", "output": ""}])
+    preds, _ = reloaded.predict(dataset=prediction_df, output_directory=output_directory)
+    preds = convert_preds(preds)
+    assert preds
+
+
 # TODO(arnav): p-tuning and prefix tuning have errors when enabled that seem to stem from distributed training:
 #
 # prefix tuning:

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -868,6 +868,106 @@ def test_llm_finetuning_output_feature_config():
     ModelConfig.from_dict(config)
 
 
+class TestTorchaoQuantization:
+    """Schema tests for the torchao quantization backend (PTQ and QAT)."""
+
+    def _llm_base(self) -> dict:
+        # Use default (non-finetune) trainer so the adapter-required-with-quantization check
+        # doesn't fire — we're testing the quantization schema surface, not the finetune path.
+        return {
+            MODEL_TYPE: MODEL_LLM,
+            BASE_MODEL: "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+            INPUT_FEATURES: [{NAME: "text_input", TYPE: "text"}],
+            OUTPUT_FEATURES: [{NAME: "text_output", TYPE: "text"}],
+            "adapter": {"type": "lora", "r": 4},
+            "trainer": {"type": "finetune"},
+        }
+
+    def test_bnb_backend_backcompat(self):
+        cfg = ModelConfig.from_dict({**self._llm_base(), "quantization": {"bits": 4}})
+        assert cfg.quantization.backend == "bitsandbytes"
+        assert cfg.quantization.bits == 4
+        assert cfg.quantization.mode is None
+        assert cfg.quantization.qat is False
+
+    def test_torchao_ptq(self):
+        cfg = ModelConfig.from_dict(
+            {**self._llm_base(), "quantization": {"backend": "torchao", "mode": "int4_weight_only"}}
+        )
+        assert cfg.quantization.backend == "torchao"
+        assert cfg.quantization.mode == "int4_weight_only"
+        assert cfg.quantization.qat is False
+
+    def test_torchao_qat(self):
+        cfg = ModelConfig.from_dict(
+            {
+                **self._llm_base(),
+                "quantization": {"backend": "torchao", "mode": "int8_weight_only", "qat": True},
+            }
+        )
+        assert cfg.quantization.qat is True
+        assert cfg.quantization.mode == "int8_weight_only"
+
+    def test_torchao_requires_mode(self):
+        with pytest.raises(ConfigValidationError, match="`quantization.mode` is required"):
+            ModelConfig.from_dict({**self._llm_base(), "quantization": {"backend": "torchao"}})
+
+    def test_bnb_rejects_mode(self):
+        with pytest.raises(ConfigValidationError, match="only supported for `backend: torchao`"):
+            ModelConfig.from_dict(
+                {**self._llm_base(), "quantization": {"backend": "bitsandbytes", "mode": "int4_weight_only"}}
+            )
+
+    def test_bnb_rejects_qat(self):
+        with pytest.raises(ConfigValidationError, match="`quantization.qat: true`"):
+            ModelConfig.from_dict({**self._llm_base(), "quantization": {"backend": "bitsandbytes", "qat": True}})
+
+    @pytest.mark.parametrize("mode", ["int4_weight_only", "int8_weight_only", "int8_dynamic", "float8"])
+    def test_all_torchao_modes_parse(self, mode):
+        cfg = ModelConfig.from_dict({**self._llm_base(), "quantization": {"backend": "torchao", "mode": mode}})
+        assert cfg.quantization.mode == mode
+
+
+class TestTorchaoQuantizationUtil:
+    """Unit tests for ludwig.utils.quantization helpers (no torchao install required)."""
+
+    def test_validate_mode_accepts_known(self):
+        from ludwig.utils.quantization import _VALID_MODES, _validate_mode
+
+        for mode in _VALID_MODES:
+            _validate_mode(mode)  # should not raise
+
+    def test_validate_mode_rejects_unknown(self):
+        from ludwig.utils.quantization import _validate_mode
+
+        with pytest.raises(ValueError, match="Unknown quantization mode"):
+            _validate_mode("bogus")
+
+    def test_qat_bit_width_int4(self):
+        from ludwig.utils.quantization import _qat_bit_width
+
+        assert _qat_bit_width("int4_weight_only") == 4
+
+    def test_qat_bit_width_int8(self):
+        from ludwig.utils.quantization import _qat_bit_width
+
+        assert _qat_bit_width("int8_weight_only") == 8
+        assert _qat_bit_width("int8_dynamic") == 8
+
+    def test_qat_rejects_float8(self):
+        from ludwig.utils.quantization import _qat_bit_width
+
+        with pytest.raises(ValueError, match="QAT is not supported"):
+            _qat_bit_width("float8")
+
+    def test_quantize_model_rejects_unknown_mode(self):
+        # Don't need torchao installed — _validate_mode fires before the import.
+        from ludwig.utils.quantization import quantize_model
+
+        with pytest.raises(ValueError, match="Unknown quantization mode"):
+            quantize_model(object(), "bogus")
+
+
 @pytest.mark.skip(
     reason="TODO(geoffrey, arnav): re-enable this when we have reconciled the config with the backend kwarg in api.py"
 )


### PR DESCRIPTION
## Summary

Second of two PRs closing out the Phase 2 PEFT + quantization leftovers. Companion to the multi-adapter PR #4117.

Wires **torchao** into the LLM quantization path alongside the existing bitsandbytes backend. Users can now:

- Pick the backend via a new \`backend:\` field on \`quantization:\` (default \`bitsandbytes\` — existing configs unchanged).
- Opt into **quantization-aware training (QAT)** via \`qat: true\` when using torchao.
- Use post-training quantization (PTQ) via \`qat: false\` (default).

## Config surface

### Post-training quantization (PTQ)

\`\`\`yaml
quantization:
  backend: torchao
  mode: int4_weight_only        # or int8_weight_only, int8_dynamic, float8
\`\`\`

### Quantization-aware training (QAT)

\`\`\`yaml
quantization:
  backend: torchao
  mode: int8_weight_only
  qat: true
\`\`\`

### BitsAndBytes (unchanged — same as before this PR)

\`\`\`yaml
quantization:
  bits: 4
\`\`\`

## Implementation

- **\`pyproject.toml\`** — \`torchao>=0.9\` added to the \`llm\` optional extra so \`pip install 'ludwig[llm]'\` pulls it in.
- **\`ludwig/schema/llms/quantization.py\`** — new \`backend\`, \`mode\`, \`qat\` fields on \`QuantizationConfig\`. A new \`validate_backend()\` method rejects bad combinations: torchao without a mode, mode on bitsandbytes, qat on bitsandbytes.
- **\`ludwig/schema/model_types/llm.py\`** — new \`LLMModelConfig.__post_init__\` calls \`validate_backend()\` (keeping the error message specific; nested \`__post_init__\` errors get wrapped into "Invalid params" by \`NestedConfigField\`).
- **\`ludwig/utils/quantization.py\`** — three clearly-scoped helpers:
  - \`quantize_model\`: PTQ entry point (already existed; kept signature intact).
  - \`prepare_qat_model\`: insert fake-quant observers via \`torchao.quantization.qat.intx_quantization_aware_training\`.
  - \`convert_qat_model\`: strip observers via \`from_intx_quantization_aware_training\` and apply real PTQ. Lazy torchao import with clear "install torchao" error, and tries the pre-0.9 submodule path as a fallback.
- **\`ludwig/utils/llm_utils.py::load_pretrained_from_config\`** — only attach bitsandbytes' \`BitsAndBytesConfig\` when \`backend == bitsandbytes\`. For torchao, load in fp32 and defer quantization.
- **\`ludwig/models/llm.py\`** — \`prepare_for_training\` branches on \`quantization.backend\`. torchao + \`qat: true\` calls \`prepare_qat_model\` and sets \`_torchao_qat_prepared\`; \`qat: false\` defers so gradients flow through fp32 weights. New \`_apply_torchao_save_time_quantization\` runs PTQ (or QAT→quantized conversion) once at save, guarded by \`_torchao_quantized\`.

## Tests

### Unit (16 new, all passing locally)

- \`tests/ludwig/schema/test_model_config.py::TestTorchaoQuantization\` — 7 tests covering bnb back-compat, torchao PTQ, torchao QAT, every rejection rule (missing mode, bnb+mode, bnb+qat), and round-trips for all four torchao modes.
- \`TestTorchaoQuantizationUtil\` — 9 tests covering \`_validate_mode\`, \`_qat_bit_width\` (int4 / int8 / float8-rejection), and the public \`quantize_model\` early-exit on unknown mode. These don't require torchao installed — they exercise the guards.

### Integration (GPU smoke test)

- \`tests/integration_tests/test_llm.py::test_llm_qat_torchao_end_to_end\` — fine-tunes \`hf-internal-testing/tiny-random-GPTJForCausalLM\` for one epoch with \`backend: torchao\`, \`mode: int8_weight_only\`, \`qat: true\` plus a tiny LoRA adapter, then verifies:
  1. QAT observers were inserted before training (\`_torchao_qat_prepared\` flag set).
  2. Save-time conversion fired (\`_torchao_quantized\` flag set).
  3. Reloaded model runs inference end-to-end.

The test uses \`pytest.importorskip("torchao")\` so it cleanly skips when torchao isn't installed (as on my local dev env). CI with \`ludwig[llm]\` installed will exercise it.

## Scope / non-goals

- Not multi-adapter — that's PR #4117, separate branch off main.
- Not torchao for ECD encoders — the LLM path was the ask from the modernization plan (2.6.3). Extending torchao quantization to ECD text / image encoders is a natural follow-up but out of scope here.

Closes the Phase 2 leftover list (together with #4117).