### PR TITLE
ci: run pytest on PRs targeting future-capabilities

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,9 +2,9 @@ name: pytest
 
 on:
   push:
-    branches: ["main", "release-*"]
+    branches: ["main", "release-*", "future-capabilities"]
   pull_request:
-    branches: ["main", "release-*"]
+    branches: ["main", "release-*", "future-capabilities"]
 
 concurrency:
   group: pytest-${{ github.head_ref || github.sha }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,14 @@ ci:
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
   autoupdate_schedule: weekly
 
+# Pin every hook's Python interpreter to 3.12. pre-commit.ci's hosted runners otherwise
+# default to Python 3.14, which fails to build the older `untokenize` dependency pulled
+# in by docformatter (AttributeError: 'Constant' object has no attribute 's' — the `.s`
+# alias on ast.Constant was removed in 3.14). 3.12 matches Ludwig's own supported runtime
+# and keeps hook installs reproducible with local `pre-commit run`.
+default_language_version:
+  python: python3.12
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -156,6 +156,16 @@ class TrainingStats:
     def __getitem__(self, key):
         return {TRAINING: self.training, VALIDATION: self.validation, TEST: self.test}[key]
 
+    # Make TrainingStats a proper Mapping: keys() + __iter__ so that dict(ts) and
+    # generic helpers like ludwig.utils.numerical_test_utils.assert_all_finite treat
+    # it as a dict rather than falling back to integer-index iteration (which raises
+    # KeyError(0) against our string-keyed __getitem__).
+    def keys(self):
+        return (TRAINING, VALIDATION, TEST)
+
+    def __iter__(self):
+        return iter(self.keys())
+
 
 @PublicAPI
 @dataclass

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -823,6 +823,14 @@ class LudwigModel:
                 self.backend.sync_model(self.model)
 
                 print_boxed("FINISHED")
+                # `preprocessed_data` is a 4-tuple from the two construction sites above
+                # (either built from pre-provided datasets or from self.preprocess()).
+                # TrainingResults declares `preprocessed_data: PreprocessedDataset`, so
+                # wrap the tuple before returning — downstream callers like
+                # `experiment()` access attributes (.validation_set etc.) rather than
+                # unpacking positionally.
+                if isinstance(preprocessed_data, tuple):
+                    preprocessed_data = PreprocessedDataset(*preprocessed_data)
                 return TrainingResults(train_stats, preprocessed_data, output_url)
 
     def train_online(

--- a/ludwig/utils/numerical_test_utils.py
+++ b/ludwig/utils/numerical_test_utils.py
@@ -36,7 +36,10 @@ def _enumerable(x):
     """Returns true if an object is enumerable, false if not."""
     try:
         _ = enumerate(x)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, KeyError):
+        # Same rationale as _dict_like: an object exposing only ``__getitem__`` falls
+        # back to integer-index iteration, which raises KeyError against a string-keyed
+        # accessor.  Treat those as not-enumerable here.
         return False
     return True
 

--- a/ludwig/utils/numerical_test_utils.py
+++ b/ludwig/utils/numerical_test_utils.py
@@ -22,7 +22,12 @@ def _dict_like(x):
     """Returns true if an object is a dict or convertible to one, false if not."""
     try:
         _ = dict(x)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, KeyError):
+        # Objects that implement ``__getitem__`` without ``__iter__`` / ``keys()`` (e.g.
+        # dataclasses with a string-keyed accessor like ``TrainingStats``) make
+        # ``dict(x)`` fall back to integer-index iteration, which raises ``KeyError`` —
+        # not ``IndexError`` — when the ``__getitem__`` only accepts string keys.  Treat
+        # those as not-dict-like rather than letting the KeyError bubble up.
         return False
     return True
 


### PR DESCRIPTION
The Phase 6 feature PRs (#4119, #4120, #4121, #4122, #4123, #4124) all target `future-capabilities` but the pytest workflow only ran on PRs into main / release-*. This PR:

- Adds `future-capabilities` to both the push and pull_request branch filters in `pytest.yml`
- Pins `default_language_version: python: python3.12` in `.pre-commit-config.yaml` so pre-commit.ci uses Python 3.12 rather than the hosted runner default (3.14 breaks the `untokenize` dependency pulled in by docformatter)
- Makes `TrainingStats` a proper Mapping by adding `keys()` and `__iter__`; without these, `dict(ts)` falls back to integer-index iteration and raises `KeyError(0)` against string-keyed `__getitem__`
- Wraps the `preprocessed_data` 4-tuple as `PreprocessedDataset` before returning from `LudwigModel.train()` so downstream callers can access `.validation_set` etc. by attribute
- Hardens `_dict_like` / `_enumerable` in `numerical_test_utils.py` to catch `KeyError` in addition to `TypeError`/`ValueError`

Needs to land before the six feature PRs can exercise CI.