### PR TITLE
ci: replace EnricoMi test-results bot with dorny/test-reporter

### DIFF
--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,10 +1,27 @@
 name: test results
 
+# Post a clean check-run summary per test suite after the pytest workflow finishes.
+#
+# Replaces the older EnricoMi/publish-unit-test-result-action bot that posted busy
+# emoji-table PR comments accumulating across runs. dorny/test-reporter@v2 instead
+# posts a single well-formatted check run per suite with a table of passed / failed
+# tests, collapsible stack traces for failures, and source-line annotations. No
+# PR-comment spam; the result lives in the checks UI and on the "Details" page.
+#
+# Runs inside a workflow_run triggered by pytest so the downloaded JUnit XML
+# artifacts come with the write permissions needed to post check runs from
+# forked PRs (where the triggering workflow itself is read-only).
+
 on:
   workflow_run:
     workflows: ["pytest"]
     types:
       - completed
+
+permissions:
+  contents: read
+  checks: write
+  actions: read
 
 jobs:
   test-results:
@@ -13,25 +30,41 @@ jobs:
     if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:
-      - name: Download and Extract Artifacts
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: |
-           mkdir -p artifacts && cd artifacts
-
-           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
-
-           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
-           do
-             IFS=$'\t' read name url <<< "$artifact"
-             gh api $url > "$name.zip"
-             unzip -d "$name" "$name.zip"
-           done
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+      - name: Unit Tests report
+        uses: dorny/test-reporter@v2
         with:
-          commit: ${{ github.event.workflow_run.head_sha }}
-          event_file: artifacts/Event File/event.json
-          event_name: ${{ github.event.workflow_run.event }}
-          files: "artifacts/**/*.xml"
+          artifact: Unit Test Results
+          name: Unit Tests
+          path: "*.xml"
+          reporter: java-junit
+          fail-on-error: false
+          list-suites: failed
+          list-tests: failed
+          max-annotations: 50
+
+      - name: Integration Tests report
+        uses: dorny/test-reporter@v2
+        with:
+          # Six matrix jobs upload artifacts named
+          # "Integration Test Results (integration_tests_a)" .. _f. Match them all with
+          # a regex and aggregate into a single report.
+          artifact: /Integration Test Results .*/
+          name: Integration Tests
+          path: "*.xml"
+          reporter: java-junit
+          fail-on-error: false
+          list-suites: failed
+          list-tests: failed
+          max-annotations: 50
+
+      - name: Distributed Tests report
+        uses: dorny/test-reporter@v2
+        with:
+          artifact: Distributed Test Results
+          name: Distributed Tests
+          path: "*.xml"
+          reporter: java-junit
+          fail-on-error: false
+          list-suites: failed
+          list-tests: failed
+          max-annotations: 50

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,14 @@ ci:
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
   autoupdate_schedule: weekly
 
+# Pin every hook's Python interpreter to 3.12. pre-commit.ci's hosted runners otherwise
+# default to Python 3.14, which fails to build the older `untokenize` dependency pulled
+# in by docformatter (AttributeError: 'Constant' object has no attribute 's' — the `.s`
+# alias on ast.Constant was removed in 3.14). 3.12 matches Ludwig's own supported runtime
+# and keeps hook installs reproducible with local `pre-commit run`.
+default_language_version:
+  python: python3.12
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
The current `test-results.yml` workflow uses `EnricoMi/publish-unit-test-result-action@v2`, which posts large emoji-table **PR comments** after every CI run. They're hard to read at a glance and accumulate across pushes — classic CI noise.

This PR swaps it for [`dorny/test-reporter@v2`](https://github.com/dorny/test-reporter), the modern standard for this job:

- Posts a **single well-formatted check run** per suite (Unit Tests / Integration Tests / Distributed Tests) instead of a PR comment.
- Tables pass / fail counts with **collapsible stack traces** for failures.
- **Annotates failing tests inline** in the PR diff (up to 50 per run).
- **No PR comments** — the PR conversation stays focused on review.

## What's preserved

- The `workflow_run` indirection from the old setup still stands, so check runs post correctly even from **forked PRs** (where the triggering `pytest` workflow is read-only).
- The six `integration_tests_*` matrix artifacts are aggregated into a single "Integration Tests" report via the regex pattern `artifact: /Integration Test Results .*/`.
- Added an explicit `permissions:` block (`checks: write`, `actions: read`, `contents: read`) so the workflow doesn't depend on account-level default-permissions settings.

## Verification

Workflow YAML passes pre-commit cleanly. The actual `check-run` rendering will be visible the first time a `pytest` run completes on `main` (or on any PR once this lands).