### PR TITLE
ci: replace test-results bot, pin pre-commit Python, fix Docker torch version pins

### DIFF
--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,10 +1,27 @@
 name: test results
 
+# Post a clean check-run summary per test suite after the pytest workflow finishes.
+#
+# Replaces the older EnricoMi/publish-unit-test-result-action bot that posted busy
+# emoji-table PR comments accumulating across runs. dorny/test-reporter@v2 instead
+# posts a single well-formatted check run per suite with a table of passed / failed
+# tests, collapsible stack traces for failures, and source-line annotations. No
+# PR-comment spam; the result lives in the checks UI and on the "Details" page.
+#
+# Runs inside a workflow_run triggered by pytest so the downloaded JUnit XML
+# artifacts come with the write permissions needed to post check runs from
+# forked PRs (where the triggering workflow itself is read-only).
+
 on:
   workflow_run:
     workflows: ["pytest"]
     types:
       - completed
+
+permissions:
+  contents: read
+  checks: write
+  actions: read
 
 jobs:
   test-results:
@@ -13,25 +30,41 @@ jobs:
     if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:
-      - name: Download and Extract Artifacts
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: |
-           mkdir -p artifacts && cd artifacts
-
-           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
-
-           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
-           do
-             IFS=$'\t' read name url <<< "$artifact"
-             gh api $url > "$name.zip"
-             unzip -d "$name" "$name.zip"
-           done
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+      - name: Unit Tests report
+        uses: dorny/test-reporter@v2
         with:
-          commit: ${{ github.event.workflow_run.head_sha }}
-          event_file: artifacts/Event File/event.json
-          event_name: ${{ github.event.workflow_run.event }}
-          files: "artifacts/**/*.xml"
+          artifact: Unit Test Results
+          name: Unit Tests
+          path: "*.xml"
+          reporter: java-junit
+          fail-on-error: false
+          list-suites: failed
+          list-tests: failed
+          max-annotations: 50
+
+      - name: Integration Tests report
+        uses: dorny/test-reporter@v2
+        with:
+          # Six matrix jobs upload artifacts named
+          # "Integration Test Results (integration_tests_a)" .. _f. Match them all with
+          # a regex and aggregate into a single report.
+          artifact: /Integration Test Results .*/
+          name: Integration Tests
+          path: "*.xml"
+          reporter: java-junit
+          fail-on-error: false
+          list-suites: failed
+          list-tests: failed
+          max-annotations: 50
+
+      - name: Distributed Tests report
+        uses: dorny/test-reporter@v2
+        with:
+          artifact: Distributed Test Results
+          name: Distributed Tests
+          path: "*.xml"
+          reporter: java-junit
+          fail-on-error: false
+          list-suites: failed
+          list-tests: failed
+          max-annotations: 50

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,14 @@ ci:
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
   autoupdate_schedule: weekly
 
+# Pin every hook's Python interpreter to 3.12. pre-commit.ci's hosted runners otherwise
+# default to Python 3.14, which fails to build the older `untokenize` dependency pulled
+# in by docformatter (AttributeError: 'Constant' object has no attribute 's' — the `.s`
+# alias on ast.Constant was removed in 3.14). 3.12 matches Ludwig's own supported runtime
+# and keeps hook installs reproducible with local `pre-commit run`.
+default_language_version:
+  python: python3.12
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/docker/ludwig-gpu/Dockerfile
+++ b/docker/ludwig-gpu/Dockerfile
@@ -30,14 +30,13 @@ ARG LUDWIG_VERSION
 
 WORKDIR /ludwig
 
-RUN pip install --no-cache-dir torch==2.6.0 torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu124
-
 COPY . .
 RUN if [ -n "${LUDWIG_VERSION}" ]; then \
-      pip install --no-cache-dir "ludwig[full]==${LUDWIG_VERSION}"; \
+      pip install --no-cache-dir "ludwig[full]==${LUDWIG_VERSION}" --extra-index-url https://download.pytorch.org/whl/cu124; \
     else \
-      pip install --no-cache-dir '.[full]'; \
+      pip install --no-cache-dir '.[full]' --extra-index-url https://download.pytorch.org/whl/cu124; \
     fi
+RUN pip install --no-cache-dir --force-reinstall torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --extra-index-url https://download.pytorch.org/whl/cu124
 
 WORKDIR /data
 

--- a/docker/ludwig-ray-gpu/Dockerfile
+++ b/docker/ludwig-ray-gpu/Dockerfile
@@ -31,11 +31,10 @@ ARG LUDWIG_VERSION
 
 WORKDIR /ludwig
 
-RUN pip install --no-cache-dir torch==2.6.0 torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu124
-
 COPY . .
 RUN if [ -n "${LUDWIG_VERSION}" ]; then \
-      pip install --no-cache-dir "ludwig[full]==${LUDWIG_VERSION}"; \
+      pip install --no-cache-dir "ludwig[full]==${LUDWIG_VERSION}" --extra-index-url https://download.pytorch.org/whl/cu124; \
     else \
-      pip install --no-cache-dir '.[full]'; \
+      pip install --no-cache-dir '.[full]' --extra-index-url https://download.pytorch.org/whl/cu124; \
     fi
+RUN pip install --no-cache-dir --force-reinstall torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --extra-index-url https://download.pytorch.org/whl/cu124

--- a/docker/ludwig-ray/Dockerfile
+++ b/docker/ludwig-ray/Dockerfile
@@ -30,11 +30,10 @@ ARG LUDWIG_VERSION
 
 WORKDIR /ludwig
 
-RUN pip install --no-cache-dir torch==2.6.0 torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
-
 COPY . .
 RUN if [ -n "${LUDWIG_VERSION}" ]; then \
       pip install --no-cache-dir "ludwig[full]==${LUDWIG_VERSION}" --extra-index-url https://download.pytorch.org/whl/cpu; \
     else \
       pip install --no-cache-dir '.[full]' --extra-index-url https://download.pytorch.org/whl/cpu; \
     fi
+RUN pip install --no-cache-dir --force-reinstall torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/docker/ludwig/Dockerfile
+++ b/docker/ludwig/Dockerfile
@@ -26,14 +26,13 @@ ARG LUDWIG_VERSION
 
 WORKDIR /ludwig
 
-RUN pip install --no-cache-dir torch==2.6.0 torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
-
 COPY . .
 RUN if [ -n "${LUDWIG_VERSION}" ]; then \
-      pip install --no-cache-dir "ludwig[full]==${LUDWIG_VERSION}"; \
+      pip install --no-cache-dir "ludwig[full]==${LUDWIG_VERSION}" --extra-index-url https://download.pytorch.org/whl/cpu; \
     else \
-      pip install --no-cache-dir '.[full]'; \
+      pip install --no-cache-dir '.[full]' --extra-index-url https://download.pytorch.org/whl/cpu; \
     fi
+RUN pip install --no-cache-dir --force-reinstall torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
 
 WORKDIR /data
 


### PR DESCRIPTION
## Summary

- Replace EnricoMi/publish-unit-test-result-action with dorny/test-reporter (EnricoMi bot was removed)
- Pin pre-commit.ci hook to Python 3.12
- Fix Docker builds: install ludwig first then force-reinstall torch ecosystem with explicit version pins so torchaudio>=2.0 resolution cannot overwrite the compatible torch 2.6.0 wheel

## Test plan

- [ ] CI passes on merge
- [ ] Manually trigger docker workflow after merge with `ludwig_version=0.14.1, latest=true` to rebuild published images with the fix