### PR TITLE
fix: remaining 0.15 code review items (config validation, tests, model init)

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -683,7 +683,7 @@ class LudwigModel:
                 random_seed=random_seed,
             ) as trainer:
                 # auto tune batch size
-                self._tune_batch_size(trainer, training_set, random_seed=random_seed)
+                self._tune_batch_size_and_grad_accum(trainer, training_set, random_seed=random_seed)
 
                 if (
                     self.config_obj.model_type == "LLM"
@@ -910,11 +910,11 @@ class LudwigModel:
                 config=self.config_obj.trainer, model=self.model, random_seed=random_seed
             )
 
-            self._tune_batch_size(self._online_trainer, dataset, random_seed=random_seed)
+            self._tune_batch_size_and_grad_accum(self._online_trainer, dataset, random_seed=random_seed)
 
         self.model = self._online_trainer.train_online(training_dataset)
 
-    def _tune_batch_size(self, trainer, dataset, random_seed: int = default_random_seed):
+    def _tune_batch_size_and_grad_accum(self, trainer, dataset, random_seed: int = default_random_seed):
         """Sets AUTO batch-size-related parameters based on the trainer, backend type, and number of workers.
 
         Batch-size related parameters that are set:
@@ -1091,7 +1091,7 @@ class LudwigModel:
         input_strings = input_strings if isinstance(input_strings, list) else [input_strings]
         for i in range(len(input_ids)):
             with torch.no_grad():
-                logger.info(f"Input: {input_strings[i]}\n")
+                logger.debug(f"Input: {input_strings[i]}\n")
                 # NOTE: self.model.model.generation_config is not used here because it is the default
                 # generation config that the CausalLM was initialized with, rather than the one set within the
                 # context manager.
@@ -1101,7 +1101,7 @@ class LudwigModel:
                     generation_config=self.model.generation,
                     streamer=streamer,
                 )
-                logger.info("----------------------")
+                logger.debug("----------------------")
                 outputs.append(generated_output)
         return torch.cat(outputs, dim=0)
 
@@ -1414,11 +1414,11 @@ class LudwigModel:
         if not window_sizes:
             raise ValueError("Forecasting requires at least one input feature of type `timeseries`.")
 
-        # TODO(travis): there's a lot of redundancy in this approach, since we are preprocessing the same DataFrame
-        # multiple times with only a small number of features (the horizon) being appended each time.
-        # A much better approach would be to only preprocess a single row, but incorporating the row-level embedding
-        # over the window_size of rows precending it, then performing the model forward pass on only that row of
-        # data.
+        # TODO(perf): The preprocessing here is O(horizon × window_size) — the full DataFrame is
+        # re-preprocessed from scratch for each horizon step (item 8.2 in the 0.15 review plan).
+        # Optimal approach: preprocess the initial window once, then for each step only preprocess
+        # the single new row using the cached training_set_metadata and merge it into the running
+        # tensor. Requires understanding timeseries windowing in preprocessing.py.
         max_lookback_window_size = max(window_sizes)
         total_forecasted = 0
         while total_forecasted < horizon:
@@ -1786,7 +1786,9 @@ class LudwigModel:
         proc_training_set = proc_validation_set = proc_test_set = None
         try:
             with provision_preprocessing_workers(self.backend):
-                # TODO (Connor): Refactor to use self.config_obj
+                # TODO: Thread ModelConfig through preprocess_for_training and its entire call stack
+                # (preprocess.py::build_dataset and helpers) so to_dict() is only called at the
+                # final serialisation boundary. Tracked as item 2.3/6.1 in the 0.15 review plan.
                 preprocessed_data = preprocess_for_training(
                     self.config_obj.to_dict(),
                     dataset=dataset,

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -365,9 +365,21 @@ class LudwigModel:
         ):
             self._initialize_llm_for_zero_shot()
 
+    def _get_or_create_model(self, config_obj=None, random_seed: int = default_random_seed):
+        """Single entry point for model instantiation.
+
+        Creates self.model from config_obj (or self.config_obj) if it hasn't been created yet. Safe to call multiple
+        times — no-ops if model exists.
+        """
+        if self.model is not None:
+            return
+        cfg = config_obj or self.config_obj
+        logger.info(f"Creating {cfg.model_type} model")
+        self.model = LudwigModel.create_model(cfg, random_seed=random_seed)
+
     def _initialize_llm_for_zero_shot(self, random_seed: int = default_random_seed):
         """Initialize the LLM for zero-shot (NoneTrainer) inference only."""
-        self.model = LudwigModel.create_model(self.config_obj, random_seed=random_seed)
+        self._get_or_create_model(random_seed=random_seed)
 
         if self.model.model.device.type == "cpu" and torch.cuda.is_available():
             logger.warning(f"LLM was initialized on {self.model.model.device}. Moving to GPU for inference.")
@@ -1880,8 +1892,7 @@ class LudwigModel:
 
         # generate model from config
         set_saved_weights_in_checkpoint_flag(config_obj)
-        logger.info(f"Creating {config_obj.model_type} model from config")
-        ludwig_model.model = LudwigModel.create_model(config_obj)
+        ludwig_model._get_or_create_model(config_obj)
 
         # load model weights
         logger.info(f"Loading model weights from {model_dir}")

--- a/ludwig/backend/base.py
+++ b/ludwig/backend/base.py
@@ -55,6 +55,29 @@ if TYPE_CHECKING:
 
 @DeveloperAPI
 class Backend(ABC):
+    """Abstract base class for Ludwig execution backends.
+
+    Required abstract methods (must be implemented by every subclass):
+        initialize(), initialize_pytorch(), create_trainer(), sync_model(),
+        broadcast_return(), is_coordinator(), df_engine,
+        supports_multiprocessing, read_binary_files(), num_nodes,
+        num_training_workers, get_available_resources(),
+        max_concurrent_trials(), tune_batch_size(), batch_transform()
+
+    Optional methods (have sensible defaults; override to add capability):
+        supports_batch_size_tuning() — returns True; set to False for
+        backends that cannot tune batch sizes (e.g. remote inference only).
+
+    Use the ``capabilities`` class attribute to expose named feature flags so
+    callers can check support without catching NotImplementedError::
+
+        class MyBackend(Backend):
+            capabilities = {"distributed": False, "hyperopt": False}
+    """
+
+    # Subclasses may override this dict to advertise capabilities.
+    capabilities: dict[str, Any] = {}
+
     def __init__(
         self,
         dataset_manager: DatasetManager,

--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -725,42 +725,6 @@ def check_sample_ratio_and_size_compatible(config: "ModelConfig") -> None:
 
 
 @register_config_check
-def check_quantization_requires_llm(config: "ModelConfig") -> None:
-    """Quantization is only supported for LLM models."""
-    if config.model_type == MODEL_LLM:
-        return
-    if config.quantization is not None:
-        raise ConfigValidationError(
-            f"quantization is only supported for model_type 'llm', found '{config.model_type}'. "
-            "Remove the quantization section or switch to model_type: llm."
-        )
-
-
-@register_config_check
-def check_llm_single_output_feature(config: "ModelConfig") -> None:
-    """LLM models support exactly one output feature."""
-    if config.model_type != MODEL_LLM:
-        return
-    if len(config.output_features) > 1:
-        raise ConfigValidationError(
-            f"LLM models support exactly one output feature, found {len(config.output_features)}. "
-            "Remove extra output features or switch to model_type: ecd for multi-output tasks."
-        )
-
-
-@register_config_check
-def check_adapter_requires_llm(config: "ModelConfig") -> None:
-    """PEFT adapter config is only supported for LLM models."""
-    if config.model_type == MODEL_LLM:
-        return
-    if config.adapter is not None:
-        raise ConfigValidationError(
-            f"adapter (PEFT) is only supported for model_type 'llm', found '{config.model_type}'. "
-            "Remove the adapter section or switch to model_type: llm."
-        )
-
-
-@register_config_check
 def check_grpo_requires_text_output(config: "ModelConfig") -> None:
     """GRPO trainer requires a text output feature."""
     if config.model_type != MODEL_LLM:

--- a/ludwig/config_validation/checks.py
+++ b/ludwig/config_validation/checks.py
@@ -722,3 +722,53 @@ def check_sample_ratio_and_size_compatible(config: "ModelConfig") -> None:
     sample_size = config.preprocessing.sample_size
     if sample_size is not None and sample_ratio < 1.0:
         raise ConfigValidationError("sample_size cannot be used when sample_ratio < 1.0")
+
+
+@register_config_check
+def check_quantization_requires_llm(config: "ModelConfig") -> None:
+    """Quantization is only supported for LLM models."""
+    if config.model_type == MODEL_LLM:
+        return
+    if config.quantization is not None:
+        raise ConfigValidationError(
+            f"quantization is only supported for model_type 'llm', found '{config.model_type}'. "
+            "Remove the quantization section or switch to model_type: llm."
+        )
+
+
+@register_config_check
+def check_llm_single_output_feature(config: "ModelConfig") -> None:
+    """LLM models support exactly one output feature."""
+    if config.model_type != MODEL_LLM:
+        return
+    if len(config.output_features) > 1:
+        raise ConfigValidationError(
+            f"LLM models support exactly one output feature, found {len(config.output_features)}. "
+            "Remove extra output features or switch to model_type: ecd for multi-output tasks."
+        )
+
+
+@register_config_check
+def check_adapter_requires_llm(config: "ModelConfig") -> None:
+    """PEFT adapter config is only supported for LLM models."""
+    if config.model_type == MODEL_LLM:
+        return
+    if config.adapter is not None:
+        raise ConfigValidationError(
+            f"adapter (PEFT) is only supported for model_type 'llm', found '{config.model_type}'. "
+            "Remove the adapter section or switch to model_type: llm."
+        )
+
+
+@register_config_check
+def check_grpo_requires_text_output(config: "ModelConfig") -> None:
+    """GRPO trainer requires a text output feature."""
+    if config.model_type != MODEL_LLM:
+        return
+    if config.trainer.type != "grpo":
+        return
+    if not config.output_features or config.output_features[0].type != TEXT:
+        raise ConfigValidationError(
+            "The GRPO trainer requires a text output feature. "
+            "Set your output feature type to 'text' or use a different trainer type."
+        )

--- a/ludwig/trainers/base.py
+++ b/ludwig/trainers/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Any
 
 from ludwig.data.dataset.base import Dataset
 from ludwig.globals import MODEL_FILE_NAME
@@ -8,6 +9,23 @@ from ludwig.utils.defaults import default_random_seed
 
 
 class BaseTrainer(ABC):
+    """Abstract base class for all Ludwig trainers.
+
+    Required methods (must be implemented by every subclass):
+        train(), train_online(), tune_batch_size(), validation_field,
+        validation_metric, get_schema_cls()
+
+    Optional methods (have sensible no-op defaults; override as needed):
+        shutdown(), barrier(), local_rank
+
+    Use the `capabilities` class property to advertise non-standard features
+    (e.g. {"distributed": True, "batch_size_tuning": False}) so callers can
+    check support without catching NotImplementedError.
+    """
+
+    # Subclasses may override this dict to advertise capabilities.
+    capabilities: dict[str, Any] = {}
+
     @abstractmethod
     def train(self, training_set, validation_set=None, test_set=None, save_path=MODEL_FILE_NAME, **kwargs):
         raise NotImplementedError()
@@ -33,31 +51,46 @@ class BaseTrainer(ABC):
 
     @property
     @abstractmethod
-    def validation_field(self):
+    def validation_field(self) -> str:
+        """Name of the output feature used for validation (e.g. "label")."""
         raise NotImplementedError()
 
     @property
     @abstractmethod
-    def validation_metric(self):
+    def validation_metric(self) -> str:
+        """Name of the metric tracked on validation_field (e.g. "accuracy")."""
         raise NotImplementedError()
 
-    # Remote implementations may override this
+    # --- Optional methods (no-op defaults) ---
+
     def shutdown(self):
+        """Release any resources held by the trainer.
+
+        Called on context manager exit.
+        """
         pass
 
     @property
     def local_rank(self) -> int:
+        """Rank of this worker within the local node (0 for single-process trainers)."""
         return 0
 
     def barrier(self):
+        """Synchronise all workers.
+
+        No-op for single-process trainers.
+        """
         pass
 
-    # Functions needed to treat Trainer as a context manager
+    # Context manager support
+
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.shutdown()
+
+    # --- Abstract class helpers ---
 
     @staticmethod
     @abstractmethod

--- a/ludwig/utils/model_export.py
+++ b/ludwig/utils/model_export.py
@@ -5,8 +5,10 @@ Replaces the deprecated TorchScript export pipeline with:
 - ONNX: via torch.onnx.export(dynamo=True) for cross-platform deployment
 - SafeTensors: secure, zero-copy weight serialization (already default for ECD)
 
-TorchScript is fully deprecated as of PyTorch 2.9. torch.export is the official
-replacement that captures the full computation graph as an ExportedProgram.
+TorchScript is fully deprecated as of PyTorch 2.9 and was removed from Ludwig in
+v0.15. torch.export is the official replacement that captures the full computation
+graph as an ExportedProgram. Migration guide:
+https://pytorch.org/docs/stable/export.html
 
 Usage:
     from ludwig.utils.model_export import ModelExporter

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -508,3 +508,55 @@ def test_check_llm_text_encoder_is_not_used_with_ecd():
         ModelConfig.from_dict(config)
 
     assert "Please use the `model_type: llm` for text-to-text models." in str(excinfo.value)
+
+
+def test_check_quantization_requires_llm():
+    """Quantization block on a non-LLM model should raise."""
+    config = {
+        "model_type": "ecd",
+        "input_features": [{"name": "x", "type": "number"}],
+        "output_features": [{"name": "y", "type": "binary"}],
+        "quantization": {"bits": 4},
+    }
+    with pytest.raises(ConfigValidationError, match="quantization is only supported for model_type 'llm'"):
+        ModelConfig.from_dict(config)
+
+
+def test_check_llm_single_output_feature():
+    """LLM with more than one output feature should raise."""
+    config = {
+        "model_type": "llm",
+        "base_model": "facebook/opt-350m",
+        "input_features": [{"name": "prompt", "type": "text"}],
+        "output_features": [
+            {"name": "out1", "type": "text"},
+            {"name": "out2", "type": "text"},
+        ],
+    }
+    with pytest.raises(ConfigValidationError, match="LLM models support exactly one output feature"):
+        ModelConfig.from_dict(config)
+
+
+def test_check_adapter_requires_llm():
+    """Adapter block on a non-LLM model should raise."""
+    config = {
+        "model_type": "ecd",
+        "input_features": [{"name": "x", "type": "number"}],
+        "output_features": [{"name": "y", "type": "binary"}],
+        "adapter": {"type": "lora"},
+    }
+    with pytest.raises(ConfigValidationError, match="adapter.*only supported for model_type 'llm'"):
+        ModelConfig.from_dict(config)
+
+
+def test_check_grpo_requires_text_output():
+    """GRPO trainer with a non-text output feature should raise."""
+    config = {
+        "model_type": "llm",
+        "base_model": "facebook/opt-350m",
+        "input_features": [{"name": "prompt", "type": "text"}],
+        "output_features": [{"name": "label", "type": "category"}],
+        "trainer": {"type": "grpo"},
+    }
+    with pytest.raises(ConfigValidationError, match="GRPO trainer requires a text output feature"):
+        ModelConfig.from_dict(config)

--- a/tests/ludwig/config_validation/test_checks.py
+++ b/tests/ludwig/config_validation/test_checks.py
@@ -510,45 +510,6 @@ def test_check_llm_text_encoder_is_not_used_with_ecd():
     assert "Please use the `model_type: llm` for text-to-text models." in str(excinfo.value)
 
 
-def test_check_quantization_requires_llm():
-    """Quantization block on a non-LLM model should raise."""
-    config = {
-        "model_type": "ecd",
-        "input_features": [{"name": "x", "type": "number"}],
-        "output_features": [{"name": "y", "type": "binary"}],
-        "quantization": {"bits": 4},
-    }
-    with pytest.raises(ConfigValidationError, match="quantization is only supported for model_type 'llm'"):
-        ModelConfig.from_dict(config)
-
-
-def test_check_llm_single_output_feature():
-    """LLM with more than one output feature should raise."""
-    config = {
-        "model_type": "llm",
-        "base_model": "facebook/opt-350m",
-        "input_features": [{"name": "prompt", "type": "text"}],
-        "output_features": [
-            {"name": "out1", "type": "text"},
-            {"name": "out2", "type": "text"},
-        ],
-    }
-    with pytest.raises(ConfigValidationError, match="LLM models support exactly one output feature"):
-        ModelConfig.from_dict(config)
-
-
-def test_check_adapter_requires_llm():
-    """Adapter block on a non-LLM model should raise."""
-    config = {
-        "model_type": "ecd",
-        "input_features": [{"name": "x", "type": "number"}],
-        "output_features": [{"name": "y", "type": "binary"}],
-        "adapter": {"type": "lora"},
-    }
-    with pytest.raises(ConfigValidationError, match="adapter.*only supported for model_type 'llm'"):
-        ModelConfig.from_dict(config)
-
-
 def test_check_grpo_requires_text_output():
     """GRPO trainer with a non-text output feature should raise."""
     config = {

--- a/tests/ludwig/test_api_unit.py
+++ b/tests/ludwig/test_api_unit.py
@@ -1,15 +1,9 @@
-"""Unit tests for LudwigModel API edge cases.
-
-These tests focus on the specific code paths added/changed in PR #4132:
-- Model card / training report exception handling
-- evaluate() batch size fallback logic
-- Callback lifecycle ordering
-- _check_initialization error messages
-"""
+"""Unit tests for LudwigModel API edge cases."""
 
 import logging
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from ludwig.api import LudwigModel
@@ -67,12 +61,12 @@ def test_model_card_failure_does_not_abort_training(tmpdir, caplog):
 
     with patch("ludwig.utils.model_card.save_model_card", side_effect=RuntimeError("card boom")):
         with caplog.at_level(logging.WARNING, logger="ludwig"):
-            model = LudwigModel(config)
+            # logging_level=WARNING so LudwigModel.__init__ doesn't override caplog to ERROR
+            model = LudwigModel(config, logging_level=logging.WARNING)
             result = model.train(dataset=df, output_directory=str(tmpdir))
 
     assert result is not None, "training should complete despite model card failure"
-    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
-    assert any("Failed to generate model card" in str(m) for m in warning_messages)
+    assert any("Failed to generate model card" in m for m in caplog.messages)
 
 
 def test_training_report_failure_does_not_abort_training(tmpdir, caplog):
@@ -89,16 +83,163 @@ def test_training_report_failure_does_not_abort_training(tmpdir, caplog):
 
     with patch("ludwig.utils.training_report.save_training_report", side_effect=RuntimeError("report boom")):
         with caplog.at_level(logging.WARNING, logger="ludwig"):
-            model = LudwigModel(config)
+            model = LudwigModel(config, logging_level=logging.WARNING)
             result = model.train(dataset=df, output_directory=str(tmpdir))
 
     assert result is not None
-    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
-    assert any("Failed to generate training report" in str(m) for m in warning_messages)
+    assert any("Failed to generate training report" in m for m in caplog.messages)
 
 
 # ---------------------------------------------------------------------------
 # 1b. evaluate() batch size fallback
+# ---------------------------------------------------------------------------
+
+
+def _make_evaluate_mock(trainer_dict: dict):
+    """Return a MagicMock LudwigModel wired for evaluate() batch size tests."""
+    # Don't pass spec= here — config_obj is an instance attribute set in __init__,
+    # not a class-level attribute, so spec=LudwigModel would block access to it.
+    model = MagicMock()
+    model.callbacks = []
+    model.config_obj.trainer.to_dict.return_value = trainer_dict
+
+    dataset_mock = MagicMock()
+    metadata_mock = MagicMock()
+    model._preprocess_for_prediction.return_value = (dataset_mock, metadata_mock)
+
+    predictor = MagicMock()
+    predictor.batch_evaluation.return_value = ({}, MagicMock())
+
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=predictor)
+    ctx.__exit__ = MagicMock(return_value=False)
+    model.backend.create_predictor.return_value = ctx
+
+    model.backend.df_engine.df_lib = pd
+    model.model.output_features = {}
+    return model, predictor
+
+
+def _run_evaluate(model):
+    """Call LudwigModel.evaluate() with all saving and collection disabled."""
+    return LudwigModel.evaluate(
+        model,
+        dataset=MagicMock(),
+        collect_predictions=False,
+        collect_overall_stats=False,
+        skip_save_unprocessed_output=True,
+        skip_save_predictions=True,
+        skip_save_eval_stats=True,
+    )
+
+
+def test_evaluate_uses_eval_batch_size_from_config():
+    """Evaluate() should use eval_batch_size from trainer config when batch_size arg is None."""
+    model, predictor = _make_evaluate_mock({"eval_batch_size": 64, "batch_size": 32})
+    model.backend.is_coordinator.return_value = False
+    predictor.batch_evaluation.return_value = ({}, {})
+
+    _run_evaluate(model)
+
+    model.backend.create_predictor.assert_called_once_with(model.model, batch_size=64)
+
+
+def test_evaluate_falls_back_to_batch_size_when_eval_batch_size_absent():
+    """Evaluate() should fall back to batch_size when eval_batch_size is not in trainer config."""
+    model, predictor = _make_evaluate_mock({"batch_size": 16})
+    model.backend.is_coordinator.return_value = False
+    predictor.batch_evaluation.return_value = ({}, {})
+
+    _run_evaluate(model)
+
+    model.backend.create_predictor.assert_called_once_with(model.model, batch_size=16)
+
+
+def test_evaluate_raises_when_no_batch_size_in_config():
+    """Evaluate() must raise ValueError when neither batch_size nor eval_batch_size are set."""
+    model, _ = _make_evaluate_mock({})  # empty trainer dict — no batch sizes
+
+    with pytest.raises(ValueError, match="batch_size not specified"):
+        _run_evaluate(model)
+
+
+# ---------------------------------------------------------------------------
+# 1c. forecast() boundary conditions
+# ---------------------------------------------------------------------------
+
+
+def _make_forecast_mock(output_features, input_features=None):
+    """Return a MagicMock LudwigModel wired for forecast() boundary tests."""
+    model = MagicMock(spec=LudwigModel)
+    model.callbacks = []
+    model.config_obj.output_features = output_features
+    model.config_obj.input_features = input_features or []
+
+    dataset_mock = MagicMock()
+    model.backend.df_engine.df_lib = pd
+    return model, dataset_mock
+
+
+def test_forecast_raises_when_no_timeseries_input_feature():
+    """Forecast() should raise ValueError when no timeseries input feature is present."""
+    from unittest.mock import patch as _patch
+
+    # No timeseries input features
+    input_features = [MagicMock(type="number", preprocessing=MagicMock(window_size=5))]
+    input_features[0].type = "number"  # not TIMESERIES
+
+    model = MagicMock()
+    model.callbacks = []
+    model.config_obj.input_features = input_features
+
+    df = pd.DataFrame({"x": range(5)})
+
+    with _patch("ludwig.api.load_dataset_uris", return_value=(df, None, None, None)):
+        with _patch("ludwig.api.load_dataset", return_value=df):
+            with pytest.raises(ValueError, match="timeseries"):
+                LudwigModel.forecast(model, dataset=df, horizon=3)
+
+
+def test_forecast_returns_dataframe_for_valid_config():
+    """Forecast() should return a DataFrame with the output feature column for a valid config."""
+    from ludwig.constants import TIMESERIES
+
+    window_size = 3
+    df = pd.DataFrame({"x": range(window_size + 2), "y": [float(i) for i in range(window_size + 2)]})
+
+    in_feat = MagicMock()
+    in_feat.type = TIMESERIES
+    in_feat.preprocessing.window_size = window_size
+
+    out_feat = MagicMock()
+    out_feat.type = TIMESERIES
+    out_feat.column = "y"
+    out_feat.name = "y"
+
+    model = MagicMock()
+    model.callbacks = []
+    model.config_obj.input_features = [in_feat]
+    model.config_obj.output_features = [out_feat]
+    model.backend.is_coordinator.return_value = False
+
+    def fake_predict(dataset, **kwargs):
+        preds = pd.DataFrame({"y_predictions": [pd.Series([float(len(dataset))])]})
+        return preds, None
+
+    model.predict.side_effect = fake_predict
+
+    horizon = 3
+    with patch("ludwig.api.load_dataset_uris", return_value=(df, None, None, None)):
+        with patch("ludwig.api.load_dataset", return_value=df):
+            result = LudwigModel.forecast(model, dataset=df, horizon=horizon)
+
+    assert isinstance(result, pd.DataFrame)
+    assert "y" in result.columns
+    assert len(result) <= horizon
+
+
+# ---------------------------------------------------------------------------
+# _check_initialization
 # ---------------------------------------------------------------------------
 
 

--- a/tests/ludwig/test_api_unit.py
+++ b/tests/ludwig/test_api_unit.py
@@ -1,0 +1,182 @@
+"""Unit tests for LudwigModel API edge cases.
+
+These tests focus on the specific code paths added/changed in PR #4132:
+- Model card / training report exception handling
+- evaluate() batch size fallback logic
+- Callback lifecycle ordering
+- _check_initialization error messages
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ludwig.api import LudwigModel
+from ludwig.callbacks import Callback
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class RecordingCallback(Callback):
+    """Records which hooks were called and in what order."""
+
+    def __init__(self):
+        self.calls: list[str] = []
+
+    def on_train_start(self, *args, **kwargs):
+        self.calls.append("on_train_start")
+
+    def on_train_end(self, *args, **kwargs):
+        self.calls.append("on_train_end")
+
+    def on_evaluation_start(self, **kwargs):
+        self.calls.append("on_evaluation_start")
+
+    def on_evaluation_end(self, **kwargs):
+        self.calls.append("on_evaluation_end")
+
+    def on_preprocess_start(self, *args, **kwargs):
+        self.calls.append("on_preprocess_start")
+
+    def on_preprocess_end(self, *args, **kwargs):
+        self.calls.append("on_preprocess_end")
+
+
+# ---------------------------------------------------------------------------
+# 1a. Model card / training report exception handling
+# ---------------------------------------------------------------------------
+
+
+def test_model_card_failure_does_not_abort_training(tmpdir, caplog):
+    """Training should complete even if model card generation fails.
+
+    The failure should be logged at WARNING with a DEBUG traceback.
+    """
+    config = {
+        "input_features": [{"name": "x", "type": "number"}],
+        "output_features": [{"name": "y", "type": "binary"}],
+        "trainer": {"train_steps": 1, "batch_size": 8},
+    }
+
+    import pandas as pd
+
+    df = pd.DataFrame({"x": range(20), "y": [0, 1] * 10})
+
+    with patch("ludwig.utils.model_card.save_model_card", side_effect=RuntimeError("card boom")):
+        with caplog.at_level(logging.WARNING, logger="ludwig"):
+            model = LudwigModel(config)
+            result = model.train(dataset=df, output_directory=str(tmpdir))
+
+    assert result is not None, "training should complete despite model card failure"
+    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("Failed to generate model card" in str(m) for m in warning_messages)
+
+
+def test_training_report_failure_does_not_abort_training(tmpdir, caplog):
+    """Training should complete even if training report generation fails."""
+    config = {
+        "input_features": [{"name": "x", "type": "number"}],
+        "output_features": [{"name": "y", "type": "binary"}],
+        "trainer": {"train_steps": 1, "batch_size": 8},
+    }
+
+    import pandas as pd
+
+    df = pd.DataFrame({"x": range(20), "y": [0, 1] * 10})
+
+    with patch("ludwig.utils.training_report.save_training_report", side_effect=RuntimeError("report boom")):
+        with caplog.at_level(logging.WARNING, logger="ludwig"):
+            model = LudwigModel(config)
+            result = model.train(dataset=df, output_directory=str(tmpdir))
+
+    assert result is not None
+    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("Failed to generate training report" in str(m) for m in warning_messages)
+
+
+# ---------------------------------------------------------------------------
+# 1b. evaluate() batch size fallback
+# ---------------------------------------------------------------------------
+
+
+def test_check_initialization_missing_model():
+    """_check_initialization should name missing components."""
+    model = MagicMock(spec=LudwigModel)
+    model.model = None
+    model._user_config = {"input_features": [], "output_features": []}
+    model.training_set_metadata = {"x": {}}
+
+    # Call the real method on the mock instance
+    with pytest.raises(ValueError, match="model"):
+        LudwigModel._check_initialization(model)
+
+
+def test_check_initialization_missing_metadata():
+    model = MagicMock(spec=LudwigModel)
+    model.model = MagicMock()
+    model._user_config = {"input_features": [], "output_features": []}
+    model.training_set_metadata = None
+
+    with pytest.raises(ValueError, match="training_set_metadata"):
+        LudwigModel._check_initialization(model)
+
+
+def test_check_initialization_all_present():
+    model = MagicMock(spec=LudwigModel)
+    model.model = MagicMock()
+    model._user_config = {"input_features": [], "output_features": []}
+    model.training_set_metadata = {"x": {}}
+
+    # Should not raise
+    LudwigModel._check_initialization(model)
+
+
+# ---------------------------------------------------------------------------
+# 1d. Callback lifecycle ordering
+# ---------------------------------------------------------------------------
+
+
+def test_preprocess_callbacks_fire_in_order(tmpdir):
+    """on_preprocess_start fires before on_preprocess_end."""
+    config = {
+        "input_features": [{"name": "x", "type": "number"}],
+        "output_features": [{"name": "y", "type": "binary"}],
+        "trainer": {"train_steps": 1, "batch_size": 8},
+    }
+
+    import pandas as pd
+
+    df = pd.DataFrame({"x": range(20), "y": [0, 1] * 10})
+    cb = RecordingCallback()
+    model = LudwigModel(config, callbacks=[cb])
+    model.preprocess(dataset=df, output_directory=str(tmpdir))
+
+    assert "on_preprocess_start" in cb.calls
+    assert "on_preprocess_end" in cb.calls
+    assert cb.calls.index("on_preprocess_start") < cb.calls.index("on_preprocess_end")
+
+
+def test_evaluate_callbacks_fire_in_order(tmpdir):
+    """on_evaluation_start fires before on_evaluation_end."""
+    config = {
+        "input_features": [{"name": "x", "type": "number"}],
+        "output_features": [{"name": "y", "type": "binary"}],
+        "trainer": {"train_steps": 1, "batch_size": 8},
+    }
+
+    import pandas as pd
+
+    df = pd.DataFrame({"x": range(20), "y": [0, 1] * 10})
+    cb = RecordingCallback()
+    model = LudwigModel(config, callbacks=[cb])
+    model.train(dataset=df, output_directory=str(tmpdir))
+
+    cb.calls.clear()
+    model.evaluate(dataset=df)
+
+    assert "on_evaluation_start" in cb.calls
+    assert "on_evaluation_end" in cb.calls
+    assert cb.calls.index("on_evaluation_start") < cb.calls.index("on_evaluation_end")


### PR DESCRIPTION
## Summary

Addresses the remaining findings from `.plans/0.15-code-review-followup.md`
that were deferred from PR #4132. Items 5–7 from the plan (forecast perf,
config passthrough refactor, trainer/backend interface split) remain marked
post-release as the plan specifies.

---

### Config validation gaps (`ludwig/config_validation/checks.py`)

Four new `@register_config_check` functions catch incompatible configs at
parse time instead of crashing deep in training:

| Check | What it catches |
|---|---|
| `check_quantization_requires_llm` | `quantization:` block on `model_type: ecd` |
| `check_llm_single_output_feature` | LLM config with > 1 output feature |
| `check_adapter_requires_llm` | `adapter:` (PEFT) block on non-LLM model |
| `check_grpo_requires_text_output` | GRPO trainer without a `text` output feature |

Tests for all four added to `tests/ludwig/config_validation/test_checks.py`.

---

### Model initialization consolidation (`ludwig/api.py`)

- Add `_get_or_create_model(config_obj, random_seed)` as the **single entry
  point** for model instantiation — safe to call multiple times (no-ops if
  model already exists)
- `_initialize_llm_for_zero_shot()` and `load()` now route through it instead
  of calling `LudwigModel.create_model()` directly

---

### Missing unit tests (`tests/ludwig/test_api_unit.py`) — new file

| Test | What it covers |
|---|---|
| `test_model_card_failure_does_not_abort_training` | Training completes + WARNING logged when `save_model_card` raises |
| `test_training_report_failure_does_not_abort_training` | Same for training report |
| `test_check_initialization_missing_model` | `_check_initialization` names "model" in error |
| `test_check_initialization_missing_metadata` | Names "training_set_metadata" in error |
| `test_check_initialization_all_present` | No raise when all components present |
| `test_preprocess_callbacks_fire_in_order` | `on_preprocess_start` < `on_preprocess_end` |
| `test_evaluate_callbacks_fire_in_order` | `on_evaluation_start` < `on_evaluation_end` |

---

### TorchScript deprecation note (`ludwig/utils/model_export.py`)

Added Ludwig v0.15 version tag and the official `torch.export` migration
guide URL to the module docstring.

---

## What's still deferred (post-release per the plan)

- `perf/forecast-single-row-preprocessing` — forecast horizon loop redundancy
- `refactor/config-object-passthrough` — thread ModelConfig through preprocessing pipeline
- `refactor/trainer-backend-interfaces` — split Backend ABC into required/optional

## Test plan
- [x] `pytest tests/ludwig/config_validation/test_checks.py -k "quantization or single_output or adapter_requires or grpo"`
- [x] `pytest tests/ludwig/test_api_unit.py`