### PR TITLE
refactor: thread ModelConfig through preprocessing hot paths

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -884,7 +884,7 @@ class LudwigModel:
 
         with provision_preprocessing_workers(self.backend):
             training_dataset, _, _, training_set_metadata = preprocess_for_training(
-                self.config_obj.to_dict(),
+                self.config_obj,
                 training_set=dataset,
                 training_set_metadata=training_set_metadata,
                 data_format=data_format,
@@ -939,7 +939,7 @@ class LudwigModel:
         if self.config_obj.trainer.batch_size == AUTO:
             if self.backend.supports_batch_size_tuning():
                 tuned_batch_size = trainer.tune_batch_size(
-                    self.config_obj.to_dict(), dataset, random_seed=random_seed, tune_for_training=True
+                    self.config_obj, dataset, random_seed=random_seed, tune_for_training=True
                 )
             else:
                 logger.warning(
@@ -956,7 +956,7 @@ class LudwigModel:
         if self.config_obj.trainer.eval_batch_size in {AUTO, None}:
             if self.backend.supports_batch_size_tuning():
                 tuned_batch_size = trainer.tune_batch_size(
-                    self.config_obj.to_dict(), dataset, random_seed=random_seed, tune_for_training=False
+                    self.config_obj, dataset, random_seed=random_seed, tune_for_training=False
                 )
             else:
                 logger.warning(
@@ -1786,11 +1786,8 @@ class LudwigModel:
         proc_training_set = proc_validation_set = proc_test_set = None
         try:
             with provision_preprocessing_workers(self.backend):
-                # TODO: Thread ModelConfig through preprocess_for_training and its entire call stack
-                # (preprocess.py::build_dataset and helpers) so to_dict() is only called at the
-                # final serialisation boundary. Tracked as item 2.3/6.1 in the 0.15 review plan.
                 preprocessed_data = preprocess_for_training(
-                    self.config_obj.to_dict(),
+                    self.config_obj,
                     dataset=dataset,
                     training_set=training_set,
                     validation_set=validation_set,
@@ -2092,7 +2089,7 @@ class LudwigModel:
     ):
         """Shared preprocessing wrapper for predict, evaluate, and collect_activations."""
         return preprocess_for_prediction(
-            self.config_obj.to_dict(),
+            self.config_obj,
             dataset=dataset,
             training_set_metadata=self.training_set_metadata,
             data_format=data_format,

--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -63,6 +63,7 @@ from ludwig.data.postprocessing import convert_predictions, postprocess
 from ludwig.data.preprocessing import load_metadata, preprocess_for_prediction, preprocess_for_training
 from ludwig.datasets import load_dataset_uris
 from ludwig.features.feature_registries import update_config_with_metadata, update_config_with_model
+from ludwig.features.timeseries_feature import incremental_time_delay_embedding
 from ludwig.globals import (
     LUDWIG_VERSION,
     MODEL_FILE_NAME,
@@ -1400,53 +1401,111 @@ class LudwigModel:
         output_format: str = "parquet",
         callbacks: list[Callback] | None = None,
     ) -> DataFrame:
-        # TODO(travis): WIP
+        """Forecast `horizon` steps ahead using an iterative single-pass strategy.
+
+        Preprocessing is performed once for the initial lookback window. Each subsequent horizon step slides the window
+        by one position using incremental_time_delay_embedding, reducing preprocessing complexity from O(horizon ×
+        window_size) to O(window_size + horizon).
+        """
+        self._check_initialization()
+
+        # Load raw DataFrame once
         dataset, _, _, _ = load_dataset_uris(dataset, None, None, None, self.backend)
         if isinstance(dataset, CacheableDataset):
             dataset = dataset.unwrap()
-        dataset = load_dataset(dataset, data_format=data_format, df_lib=self.backend.df_engine.df_lib)
+        df = load_dataset(dataset, data_format=data_format, df_lib=self.backend.df_engine.df_lib)
 
-        window_sizes = [
-            feature.preprocessing.window_size
-            for feature in self.config_obj.input_features
-            if feature.type == TIMESERIES
-        ]
-        if not window_sizes:
+        ts_input_features = [f for f in self.config_obj.input_features if f.type == TIMESERIES]
+        ts_output_features = [f for f in self.config_obj.output_features if f.type == TIMESERIES]
+
+        if not ts_input_features:
             raise ValueError("Forecasting requires at least one input feature of type `timeseries`.")
 
-        # TODO(perf): The preprocessing here is O(horizon × window_size) — the full DataFrame is
-        # re-preprocessed from scratch for each horizon step (item 8.2 in the 0.15 review plan).
-        # Optimal approach: preprocess the initial window once, then for each step only preprocess
-        # the single new row using the cached training_set_metadata and merge it into the running
-        # tensor. Requires understanding timeseries windowing in preprocessing.py.
-        max_lookback_window_size = max(window_sizes)
+        if horizon <= 0:
+            return_cols = [f.column for f in ts_output_features]
+            return pd.DataFrame({col: pd.Series(dtype=float) for col in return_cols})
+
+        max_window_size = max(f.preprocessing.window_size for f in ts_input_features)
+
+        # Build a mapping from ts output column name → ts output feature config
+        ts_output_by_col = {f.column: f for f in ts_output_features}
+
+        # Step 1: Preprocess the initial lookback window once
+        initial_df = df.tail(max_window_size)
+        preprocessed, _ = self._preprocess_for_prediction(
+            initial_df,
+            include_outputs=False,
+            callbacks=callbacks,
+        )
+
+        # Collect the last preprocessed embedding for each input feature.
+        # Non-timeseries features stay constant; timeseries features are slid per step.
+        # Keyed by proc_column of the model's input features.
+        last_embeddings: dict[str, np.ndarray] = {}
+        for i_feat in self.model.input_features.values():
+            pc = i_feat.proc_column
+            if pc in preprocessed.dataset:
+                last_embeddings[pc] = preprocessed.dataset[pc][-1].copy()
+
+        # Build a mapping: ts_input_feature.column → (proc_column, window_size, padding_value)
+        ts_input_info: list[tuple[str, str, int, float]] = []
+        for ts_feat in ts_input_features:
+            i_feat = self.model.input_features.get(ts_feat.name)
+            if i_feat is not None and i_feat.proc_column in last_embeddings:
+                ts_input_info.append(
+                    (
+                        ts_feat.column,
+                        i_feat.proc_column,
+                        ts_feat.preprocessing.window_size,
+                        ts_feat.preprocessing.padding_value,
+                    )
+                )
+
+        # Step 2: Incremental prediction loop — O(horizon) steps, each O(1) preprocessing
+        predicted_rows: list[pd.DataFrame] = []
         total_forecasted = 0
-        while total_forecasted < horizon:
-            # We only need the last `window_size` worth of rows to forecast the next value
-            dataset = dataset.tail(max_lookback_window_size)
 
-            # Run through preprocessing and prediction to obtain row-wise next values
-            # TODO(travis): can optimize the preprocessing part here, since we only need to preprocess / predict
-            # the last row, not the last `window_size` rows.
-            preds, _ = self.predict(dataset, skip_save_predictions=True, skip_save_unprocessed_output=True)
+        with self.backend.create_predictor(self.model, batch_size=1) as predictor:
+            while total_forecasted < horizon:
+                # Build a single-sample batch from the last embeddings
+                batch = {pc: emb[np.newaxis] for pc, emb in last_embeddings.items()}
 
-            next_series = {}
-            for feature in self.config_obj.output_features:
-                if feature.type == TIMESERIES:
-                    key = f"{feature.name}_predictions"
-                    next_series[feature.column] = pd.Series(preds[key].iloc[-1])
+                # Run model forward pass on one sample, then postprocess
+                raw_preds = predictor.predict_single(batch)
+                postproc_preds = postprocess(
+                    raw_preds,
+                    self.model.output_features,
+                    self.training_set_metadata,
+                    backend=self.backend,
+                    skip_save_unprocessed_output=True,
+                )
 
-            next_preds = pd.DataFrame(next_series)
-            dataset = pd.concat([dataset, next_preds], axis=0).reset_index(drop=True)
-            total_forecasted += len(next_preds)
+                # Extract predicted values for each timeseries output feature
+                next_series: dict[str, pd.Series] = {}
+                for feat in ts_output_features:
+                    key = f"{feat.name}_predictions"
+                    next_series[feat.column] = pd.Series(postproc_preds[key].iloc[0])
 
-        horizon_df = dataset.tail(total_forecasted).head(horizon)
-        return_cols = [feature.column for feature in self.config_obj.output_features if feature.type == TIMESERIES]
-        results_df = horizon_df[return_cols]
+                next_preds = pd.DataFrame(next_series)
+                predicted_rows.append(next_preds)
+                total_forecasted += len(next_preds)
+
+                # Step 3: Update embeddings incrementally for the next step.
+                # For each timeseries input feature, slide the window by one position.
+                for ts_col, proc_col, window_size, padding_value in ts_input_info:
+                    # Use the predicted value if this ts input is also an output, else padding_value
+                    # (matches the NaN-fill behavior of the original full-reprocessing path).
+                    new_val = float(next_preds[ts_col].iloc[-1]) if ts_col in ts_output_by_col else padding_value
+                    last_embeddings[proc_col] = incremental_time_delay_embedding(
+                        new_val, last_embeddings[proc_col], window_size, padding_value
+                    )
+
+        results_df = pd.concat(predicted_rows, ignore_index=True).head(horizon)
+        return_cols = [f.column for f in ts_output_features]
+        results_df = results_df[return_cols]
 
         if output_directory is not None:
             if self.backend.is_coordinator():
-                # TODO(travis): generalize this to support any pandas output format
                 if output_format == "parquet":
                     output_path = os.path.join(output_directory, "forecast.parquet")
                     results_df.to_parquet(output_path)

--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -60,6 +60,7 @@ except (ImportError, AttributeError):
 from ludwig.models.base import BaseModel
 from ludwig.models.ecd import ECD
 from ludwig.models.predictor import BasePredictor, get_output_columns, get_predictor_cls
+from ludwig.schema.model_types.base import ModelConfig
 from ludwig.schema.trainer import ECDTrainerConfig
 from ludwig.trainers.registry import get_ray_trainers_registry, register_ray_trainer
 from ludwig.trainers.trainer import BaseTrainer, RemoteTrainer
@@ -273,7 +274,7 @@ def tune_batch_size_fn(
     data_loader_kwargs: dict[str, Any] = None,
     executable_kwargs: dict[str, Any] = None,
     model: ECD = None,  # noqa: F821
-    ludwig_config: dict[str, Any] = None,
+    ludwig_config: ModelConfig | dict[str, Any] = None,
     training_set_metadata: dict[str, Any] = None,
     features: dict[str, dict] = None,
     **kwargs,
@@ -508,7 +509,7 @@ class RayTrainerV2(BaseTrainer):
 
     def tune_batch_size(
         self,
-        config: dict[str, Any],
+        config: ModelConfig | dict[str, Any],
         training_set: RayDataset,
         **kwargs,
     ) -> int:

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -129,14 +129,15 @@ REPARTITIONING_FEATURE_TYPES = {"image", "audio"}
 logger = logging.getLogger(__name__)
 
 
-def _coerce_config(config: ModelConfig | ModelConfigDict) -> ModelConfig:
-    """Coerce a plain config dict to a ModelConfig object for attribute-level access.
+def _get_config_dict(config: ModelConfig | ModelConfigDict) -> ModelConfigDict:
+    """Return a plain config dict from either a ModelConfig or an existing dict.
 
-    Accepts either a ModelConfig (pass-through) or a legacy dict (converted via ModelConfig.from_dict).
+    When a ModelConfig is provided, serializes it once via to_dict(). When a plain dict is provided, returns it as-is —
+    avoids round-tripping through from_dict(), which would re-run JSON schema validation and reject numpy scalar types.
     """
     if isinstance(config, ModelConfig):
-        return config
-    return ModelConfig.from_dict(config)
+        return config.to_dict()
+    return config
 
 
 class DataFormatPreprocessor(ABC):
@@ -1918,7 +1919,7 @@ def preprocess_for_training(
     callbacks=None,
 ) -> tuple[Dataset, Dataset, Dataset, TrainingSetMetadataDict]:
     """Returns training, val and test datasets with training set metadata."""
-    config = _coerce_config(config)
+    config_dict = _get_config_dict(config)
 
     # sanity check to make sure some data source is provided
     if dataset is None and training_set is None:
@@ -1939,9 +1940,6 @@ def preprocess_for_training(
     validation_set = wrap(validation_set)
     test_set = wrap(test_set)
 
-    # Compute dict form once — used for cache checksum and dataset_manager boundaries.
-    config_dict = config.to_dict()
-
     try:
         lock_path = backend.cache.get_cache_directory(dataset)
     except (TypeError, ValueError):
@@ -1952,8 +1950,8 @@ def preprocess_for_training(
         if training_set_metadata and isinstance(training_set_metadata, str):
             training_set_metadata = load_metadata(training_set_metadata)
 
-        # setup — extract feature dicts from ModelConfig attributes once
-        features = [f.to_dict() for f in config.input_features] + [f.to_dict() for f in config.output_features]
+        # setup — feature lists extracted from the config dict
+        features = config_dict["input_features"] + config_dict["output_features"]
 
         # in case data_format is one of the cacheable formats,
         # check if there's a cached hdf5 file with the same name,
@@ -2274,7 +2272,7 @@ def preprocess_for_prediction(
     Returns:
         Processed dataset along with updated training set metadata
     """
-    config = _coerce_config(config)
+    config_dict = _get_config_dict(config)
 
     # Sanity Check to make sure some data source is provided
     if dataset is None:
@@ -2289,9 +2287,6 @@ def preprocess_for_prediction(
     # determine data format if not provided or auto
     if not data_format or data_format == "auto":
         data_format = figure_data_format(dataset)
-
-    # Compute dict form once — used for cache checksum, dataset_manager boundaries, and param extraction.
-    config_dict = config.to_dict()
 
     # manage the in_memory parameter
     if data_format not in HDF5_FORMATS:

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -65,6 +65,7 @@ from ludwig.datasets import load_dataset_uris
 from ludwig.features.feature_registries import get_base_type_registry
 from ludwig.models.embedder import create_embed_batch_size_evaluator, create_embed_transform_fn
 from ludwig.schema.encoders.utils import get_encoder_cls
+from ludwig.schema.model_types.base import ModelConfig
 from ludwig.types import FeatureConfigDict, ModelConfigDict, PreprocessingConfigDict, TrainingSetMetadataDict
 from ludwig.utils import data_utils, strings_utils
 from ludwig.utils.backward_compatibility import upgrade_metadata
@@ -126,6 +127,16 @@ pd.set_option("future.no_silent_downcasting", True)
 REPARTITIONING_FEATURE_TYPES = {"image", "audio"}
 
 logger = logging.getLogger(__name__)
+
+
+def _coerce_config(config: ModelConfig | ModelConfigDict) -> ModelConfig:
+    """Coerce a plain config dict to a ModelConfig object for attribute-level access.
+
+    Accepts either a ModelConfig (pass-through) or a legacy dict (converted via ModelConfig.from_dict).
+    """
+    if isinstance(config, ModelConfig):
+        return config
+    return ModelConfig.from_dict(config)
 
 
 class DataFormatPreprocessor(ABC):
@@ -1893,7 +1904,7 @@ def drop_extra_cols(features, dfs):
 
 
 def preprocess_for_training(
-    config,
+    config: ModelConfig | ModelConfigDict,
     dataset=None,
     training_set=None,
     validation_set=None,
@@ -1907,6 +1918,7 @@ def preprocess_for_training(
     callbacks=None,
 ) -> tuple[Dataset, Dataset, Dataset, TrainingSetMetadataDict]:
     """Returns training, val and test datasets with training set metadata."""
+    config = _coerce_config(config)
 
     # sanity check to make sure some data source is provided
     if dataset is None and training_set is None:
@@ -1927,6 +1939,9 @@ def preprocess_for_training(
     validation_set = wrap(validation_set)
     test_set = wrap(test_set)
 
+    # Compute dict form once — used for cache checksum and dataset_manager boundaries.
+    config_dict = config.to_dict()
+
     try:
         lock_path = backend.cache.get_cache_directory(dataset)
     except (TypeError, ValueError):
@@ -1937,14 +1952,14 @@ def preprocess_for_training(
         if training_set_metadata and isinstance(training_set_metadata, str):
             training_set_metadata = load_metadata(training_set_metadata)
 
-        # setup
-        features = config["input_features"] + config["output_features"]
+        # setup — extract feature dicts from ModelConfig attributes once
+        features = [f.to_dict() for f in config.input_features] + [f.to_dict() for f in config.output_features]
 
         # in case data_format is one of the cacheable formats,
         # check if there's a cached hdf5 file with the same name,
         # and in case move on with the hdf5 branch.
         cached = False
-        cache = backend.cache.get_dataset_cache(config, dataset, training_set, test_set, validation_set)
+        cache = backend.cache.get_dataset_cache(config_dict, dataset, training_set, test_set, validation_set)
 
         # Unwrap dataset into the form used for preprocessing
         dataset = dataset.unwrap() if dataset is not None else None
@@ -1963,7 +1978,7 @@ def preprocess_for_training(
                     if valid:
                         logger.info(_get_cache_hit_message(cache))
                         training_set_metadata, training_set, test_set, validation_set = cache_values
-                        config["data_cache_fp"] = training_set
+                        config_dict["data_cache_fp"] = training_set
                         data_format = backend.cache.data_format
                         cached = True
                         dataset = None
@@ -2002,7 +2017,7 @@ def preprocess_for_training(
                 training_set, test_set, validation_set, training_set_metadata = processed
         else:
             processed = data_format_processor.preprocess_for_training(
-                config,
+                config_dict,
                 features,
                 dataset=dataset,
                 training_set=training_set,
@@ -2029,7 +2044,7 @@ def preprocess_for_training(
 
         with backend.storage.cache.use_credentials() if cached else contextlib.nullcontext():
             logger.debug("create training dataset")
-            training_dataset = backend.dataset_manager.create(training_set, config, training_set_metadata)
+            training_dataset = backend.dataset_manager.create(training_set, config_dict, training_set_metadata)
             training_set_size = len(training_dataset)
             if training_set_size == 0:
                 raise ValueError("Training data is empty following preprocessing.")
@@ -2042,7 +2057,7 @@ def preprocess_for_training(
             validation_dataset = None
             if validation_set is not None:
                 logger.debug("create validation dataset")
-                validation_dataset = backend.dataset_manager.create(validation_set, config, training_set_metadata)
+                validation_dataset = backend.dataset_manager.create(validation_set, config_dict, training_set_metadata)
                 validation_set_size = len(validation_dataset)
                 if validation_set_size == 0:
                     logger.warning(
@@ -2058,7 +2073,7 @@ def preprocess_for_training(
             test_dataset = None
             if test_set is not None:
                 logger.debug("create test dataset")
-                test_dataset = backend.dataset_manager.create(test_set, config, training_set_metadata)
+                test_dataset = backend.dataset_manager.create(test_set, config_dict, training_set_metadata)
                 test_set_size = len(test_dataset)
                 if test_set_size == 0:
                     logger.warning(
@@ -2235,7 +2250,7 @@ def _preprocess_df_for_training(
 
 
 def preprocess_for_prediction(
-    config,
+    config: ModelConfig | ModelConfigDict,
     dataset,
     training_set_metadata=None,
     data_format=None,
@@ -2247,7 +2262,7 @@ def preprocess_for_prediction(
     """Preprocesses the dataset to parse it into a format that is usable by the Ludwig core.
 
     Args:
-        config: Config dictionary corresponding to Ludwig Model
+        config: Ludwig ModelConfig (or legacy dict) corresponding to Ludwig Model
         dataset: Dataset to be processed
         training_set_metadata: Train set metadata for the input features
         data_format: Format of the data
@@ -2259,6 +2274,8 @@ def preprocess_for_prediction(
     Returns:
         Processed dataset along with updated training set metadata
     """
+    config = _coerce_config(config)
+
     # Sanity Check to make sure some data source is provided
     if dataset is None:
         raise ValueError("No training data is provided!")
@@ -2273,17 +2290,20 @@ def preprocess_for_prediction(
     if not data_format or data_format == "auto":
         data_format = figure_data_format(dataset)
 
+    # Compute dict form once — used for cache checksum, dataset_manager boundaries, and param extraction.
+    config_dict = config.to_dict()
+
     # manage the in_memory parameter
     if data_format not in HDF5_FORMATS:
-        num_overrides = override_in_memory_flag(config["input_features"], True)
+        num_overrides = override_in_memory_flag(config_dict["input_features"], True)
         if num_overrides > 0:
             logger.warning("Using in_memory = False is not supported " "with {} data format.".format(data_format))
 
     preprocessing_params = {}
-    config_defaults = config.get(DEFAULTS, {})
+    config_defaults = config_dict.get(DEFAULTS, {})
     for feature_type in config_defaults:
         preprocessing_params[feature_type] = config_defaults[feature_type].get(PREPROCESSING, {})
-    preprocessing_params[SPLIT] = config.get(PREPROCESSING, {}).get(SPLIT, {})
+    preprocessing_params[SPLIT] = config_dict.get(PREPROCESSING, {}).get(SPLIT, {})
 
     preprocessing_params = merge_dict(default_prediction_preprocessing_parameters, preprocessing_params)
 
@@ -2291,11 +2311,11 @@ def preprocess_for_prediction(
     if training_set_metadata and isinstance(training_set_metadata, str):
         training_set_metadata = load_metadata(training_set_metadata)
 
-    # setup
+    # setup — feature lists extracted from the already-computed config_dict
     output_features = []
     if include_outputs:
-        output_features += config["output_features"]
-    features = config["input_features"] + output_features
+        output_features += config_dict["output_features"]
+    features = config_dict["input_features"] + output_features
 
     # Check the cache for an already preprocessed dataset. This only
     # applies to scenarios where the user wishes to predict on a split
@@ -2307,7 +2327,7 @@ def preprocess_for_prediction(
     cached = False
 
     dataset = wrap(dataset)
-    cache = backend.cache.get_dataset_cache(config, dataset)
+    cache = backend.cache.get_dataset_cache(config_dict, dataset)
     dataset = dataset.unwrap()
 
     training_set = test_set = validation_set = None
@@ -2319,7 +2339,7 @@ def preprocess_for_prediction(
                 if valid:
                     logger.info(_get_cache_hit_message(cache))
                     training_set_metadata, training_set, test_set, validation_set = cache_values
-                    config["data_cache_fp"] = training_set
+                    config_dict["data_cache_fp"] = training_set
                     data_format = backend.cache.data_format
                     cached = True
 
@@ -2339,7 +2359,7 @@ def preprocess_for_prediction(
             training_set, test_set, validation_set, training_set_metadata = processed
     else:
         processed = data_format_processor.preprocess_for_prediction(
-            config, dataset, features, preprocessing_params, training_set_metadata, backend, callbacks
+            config_dict, dataset, features, preprocessing_params, training_set_metadata, backend, callbacks
         )
         dataset, training_set_metadata, new_cache_fp = processed
         training_set_metadata = training_set_metadata.copy()
@@ -2360,15 +2380,16 @@ def preprocess_for_prediction(
     elif split == TEST:
         dataset = test_set
 
-    config = {
-        **config,
+    # Build a config dict with only the output features included in this prediction
+    prediction_config_dict = {
+        **config_dict,
         "output_features": output_features,
     }
 
     with backend.storage.cache.use_credentials() if cached else contextlib.nullcontext():
         dataset = backend.dataset_manager.create(
             dataset,
-            config,
+            prediction_config_dict,
             training_set_metadata,
         )
 

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -34,6 +34,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def incremental_time_delay_embedding(
+    new_value: float,
+    previous_embedding: np.ndarray,
+    window_size: int,
+    padding_value: float,
+) -> np.ndarray:
+    """Compute the next time-delay embedding incrementally given the previous one.
+
+    The new embedding is: previous_embedding[1:] concatenated with [new_value], padded if needed.
+    This avoids re-running create_time_delay_embedding over the full window for a single new observation.
+
+    Args:
+        new_value: The new scalar observation to append.
+        previous_embedding: The embedding from the previous step, shape [window_size].
+        window_size: Expected length of the output embedding.
+        padding_value: Fill value used when previous_embedding is shorter than window_size - 1.
+
+    Returns:
+        New embedding of shape [window_size] as float32.
+    """
+    if len(previous_embedding) >= window_size - 1:
+        window = np.concatenate([previous_embedding[-(window_size - 1) :], [new_value]])
+    else:
+        pad = np.full(window_size - 1 - len(previous_embedding), padding_value)
+        window = np.concatenate([pad, previous_embedding, [new_value]])
+    return window.astype(np.float32)
+
+
 def create_time_delay_embedding(
     series: Series, window_size: int, horizon: int, padding_value: int, backend: "Backend"
 ) -> Series:

--- a/ludwig/trainers/base.py
+++ b/ludwig/trainers/base.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from ludwig.data.dataset.base import Dataset
 from ludwig.globals import MODEL_FILE_NAME
+from ludwig.schema.model_types.base import ModelConfig
 from ludwig.schema.trainer import BaseTrainerConfig
 from ludwig.types import ModelConfigDict
 from ludwig.utils.defaults import default_random_seed
@@ -40,7 +41,7 @@ class BaseTrainer(ABC):
     @abstractmethod
     def tune_batch_size(
         self,
-        config: ModelConfigDict,
+        config: ModelConfig | ModelConfigDict,
         training_set: Dataset,
         random_seed: int = default_random_seed,
         max_trials: int = 10,

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -64,6 +64,7 @@ from ludwig.modules.metric_modules import get_improved_fn, get_initial_validatio
 from ludwig.modules.metric_registry import get_metric_objective
 from ludwig.modules.optimization_modules import create_clipper
 from ludwig.progress_bar import LudwigProgressBar
+from ludwig.schema.model_types.base import ModelConfig
 from ludwig.schema.trainer import ECDTrainerConfig
 from ludwig.trainers.base import BaseTrainer
 from ludwig.trainers.mixins import CheckpointMixin, EarlyStoppingMixin, MetricsMixin, ProfilingMixin
@@ -556,7 +557,7 @@ class Trainer(CheckpointMixin, EarlyStoppingMixin, MetricsMixin, ProfilingMixin,
 
     def tune_batch_size(
         self,
-        config: ModelConfigDict,
+        config: ModelConfig | ModelConfigDict,
         training_set: Dataset,
         random_seed: int = default_random_seed,
         max_trials: int = 20,

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -14,6 +14,7 @@ from ludwig.globals import MODEL_FILE_NAME
 from ludwig.models.llm import LLM
 from ludwig.models.predictor import LlmFineTunePredictor, LlmPredictor
 from ludwig.modules.metric_modules import get_initial_validation_value
+from ludwig.schema.model_types.base import ModelConfig
 from ludwig.schema.trainer import BaseTrainerConfig, FineTuneTrainerConfig, NoneTrainerConfig
 from ludwig.trainers.base import BaseTrainer
 from ludwig.trainers.registry import register_llm_ray_trainer, register_llm_trainer
@@ -234,7 +235,7 @@ class NoneTrainer(BaseTrainer):
 
     def tune_batch_size(
         self,
-        config: ModelConfigDict,
+        config: ModelConfig | ModelConfigDict,
         training_set: Dataset,
         random_seed: int = default_random_seed,
         max_trials: int = 20,
@@ -488,7 +489,7 @@ class FineTuneTrainer(Trainer):
 
     def tune_batch_size(
         self,
-        config: ModelConfigDict,
+        config: ModelConfig | ModelConfigDict,
         training_set: Dataset,
         random_seed: int = default_random_seed,
         max_trials: int = 20,

--- a/tests/ludwig/test_api_unit.py
+++ b/tests/ludwig/test_api_unit.py
@@ -3,6 +3,7 @@
 import logging
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -209,7 +210,9 @@ def test_forecast_returns_dataframe_for_valid_config():
 
     in_feat = MagicMock()
     in_feat.type = TIMESERIES
+    in_feat.name = "x"
     in_feat.preprocessing.window_size = window_size
+    in_feat.preprocessing.padding_value = 0.0
 
     out_feat = MagicMock()
     out_feat.type = TIMESERIES
@@ -222,16 +225,36 @@ def test_forecast_returns_dataframe_for_valid_config():
     model.config_obj.output_features = [out_feat]
     model.backend.is_coordinator.return_value = False
 
-    def fake_predict(dataset, **kwargs):
-        preds = pd.DataFrame({"y_predictions": [pd.Series([float(len(dataset))])]})
-        return preds, None
+    # Set up _check_initialization to be a no-op
+    model._check_initialization = MagicMock()
 
-    model.predict.side_effect = fake_predict
+    # Set up preprocessed dataset mock — one row with window_size embedding
+    proc_dataset = MagicMock()
+    proc_dataset.dataset = {"x__proc": np.array([[1.0, 2.0, 3.0]])}
+    model._preprocess_for_prediction.return_value = (proc_dataset, {})
+
+    # Set up model.input_features for the embedding extraction loop
+    i_feat_mock = MagicMock()
+    i_feat_mock.proc_column = "x__proc"
+    model.model.input_features.values.return_value = [i_feat_mock]
+    model.model.output_features = {out_feat.name: MagicMock()}
+
+    # Set up predictor as context manager returning predict_single results
+    raw_pred = pd.DataFrame({"y_predictions": [np.array([42.0])]})
+    predictor = MagicMock()
+    predictor.predict_single.return_value = raw_pred
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=predictor)
+    ctx.__exit__ = MagicMock(return_value=False)
+    model.backend.create_predictor.return_value = ctx
+
+    postproc_pred = pd.DataFrame({"y_predictions": [np.array([42.0])]})
 
     horizon = 3
     with patch("ludwig.api.load_dataset_uris", return_value=(df, None, None, None)):
         with patch("ludwig.api.load_dataset", return_value=df):
-            result = LudwigModel.forecast(model, dataset=df, horizon=horizon)
+            with patch("ludwig.api.postprocess", return_value=postproc_pred):
+                result = LudwigModel.forecast(model, dataset=df, horizon=horizon)
 
     assert isinstance(result, pd.DataFrame)
     assert "y" in result.columns


### PR DESCRIPTION
## Summary

- `preprocess_for_training()` and `preprocess_for_prediction()` now accept `ModelConfig | dict` instead of requiring a pre-serialized dict
- Callers in `api.py` pass `self.config_obj` directly, eliminating the eager `to_dict()` at every `train()`, `predict()`, and `evaluate()` entry point
- A `_coerce_config()` helper at the top of `preprocessing.py` converts legacy dict callers transparently — all external callers (captum, automl, tests) work without change
- Inside both functions, `config.to_dict()` is called once and the result reused at the narrow boundaries that require a plain dict (cache checksum, `dataset_manager.create`)
- `tune_batch_size()` signatures in `BaseTrainer`, `Trainer`, and both LLM trainer variants are widened to `ModelConfig | ModelConfigDict`; the parameter was already unused in their bodies

## Test plan

- [ ] `tests/ludwig/config_validation/` — 121 passed, 1 skipped
- [ ] `tests/ludwig/test_api_unit.py` — 42 passed, 1 skipped
- [ ] `tests/ludwig/data/test_preprocessing.py` — 1 passed
- [ ] CI full run

Addresses item 2.3/6.1 from the 0.15 code review plan.