### PR TITLE
feat: advanced PEFT adapters — PiSSA/EVA/CorDA, TinyLoRA, C3A, OFT, HRA, WaveFT, LN-Tuning, VBLoRA

### DIFF
--- a/examples/peft_advanced/README.md
+++ b/examples/peft_advanced/README.md
@@ -1,0 +1,55 @@
+# Advanced PEFT Adapters in Ludwig
+
+This directory contains examples demonstrating Ludwig's extended PEFT (Parameter-Efficient Fine-Tuning)
+adapter support, including:
+
+- **PiSSA / EVA / CorDA / LoftQ** — advanced LoRA initializers
+- **rsLoRA** — rank-stabilized LoRA scaling
+- **TinyLoRA** — extreme low-rank fine-tuning (LoRA-XS variant)
+- **C3A** — contextual/conditional/compositional adapters
+- **OFT / HRA** — orthogonal fine-tuning methods
+- **WaveFT** — wavelet-domain fine-tuning
+- **LN-Tuning** — layer normalization only
+- **VBLoRA** — vector bank LoRA
+
+## Files
+
+| File                  | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `pissa_lora.yaml`     | PiSSA initialization (faster convergence than standard LoRA) |
+| `eva_lora.yaml`       | EVA initialization (data-driven, SOTA performance)           |
+| `corda_lora.yaml`     | CorDA initialization (combines PiSSA + context signals)      |
+| `loftq_lora.yaml`     | LoftQ (quantization-aware LoRA init)                         |
+| `rslora_dora.yaml`    | rsLoRA + DoRA combination                                    |
+| `tinylora_llm.yaml`   | TinyLoRA for LLM fine-tuning on minimal hardware             |
+| `c3a_llm.yaml`        | C3A adapter for multi-task scenarios                         |
+| `oft_llm.yaml`        | OFT adapter (orthogonal, preserves pretrained knowledge)     |
+| `hra_llm.yaml`        | HRA adapter (Householder reflections)                        |
+| `waveft_llm.yaml`     | WaveFT adapter (frequency-domain updates)                    |
+| `ln_tuning_llm.yaml`  | LN-Tuning (ultra-lightweight: only LayerNorm weights)        |
+| `vblora_llm.yaml`     | VBLoRA (shared vector bank for extreme compression)          |
+| `compare_adapters.py` | Script comparing adapters by parameter count                 |
+| `train_example.py`    | Full training example with adapter selection                 |
+
+## Quick Start
+
+```bash
+# Train with PiSSA (recommended for most tasks — faster convergence)
+ludwig train --config pissa_lora.yaml --dataset ludwig://imdb
+
+# Ultra-low memory: TinyLoRA
+ludwig train --config tinylora_llm.yaml --dataset ludwig://imdb
+
+# Orthogonal fine-tuning (preserves pretrained knowledge)
+ludwig train --config oft_llm.yaml --dataset ludwig://imdb
+```
+
+## Adapter Selection Guide
+
+| Hardware constraint | Recommended adapter      | Params (7B model) |
+| ------------------- | ------------------------ | ----------------- |
+| 80 GB GPU           | `lora` r=16 + PiSSA init | ~100M             |
+| 24 GB GPU           | `lora` r=8 + rsLoRA      | ~50M              |
+| 16 GB GPU           | `tinylora` r=2           | ~1M               |
+| 8 GB GPU            | `ln_tuning`              | ~0.1M             |
+| Edge / CPU          | `tinylora` r=2, u=13     | \<100K            |

--- a/examples/peft_advanced/compare_adapters.py
+++ b/examples/peft_advanced/compare_adapters.py
@@ -1,0 +1,73 @@
+"""Compare trainable parameter counts across PEFT adapters on a tiny GPT-2 model."""
+
+from __future__ import annotations
+
+from transformers import AutoModelForCausalLM
+
+ADAPTERS = [
+    ("lora (r=8)", {"type": "lora", "r": 8, "alpha": 16}),
+    ("lora+pissa (r=8)", {"type": "lora", "r": 8, "alpha": 16, "init_lora_weights": "pissa"}),
+    ("lora+corda (r=8)", {"type": "lora", "r": 8, "alpha": 16, "init_lora_weights": "corda"}),
+    ("lora+rslora (r=8)", {"type": "lora", "r": 8, "alpha": 16, "use_rslora": True}),
+    ("lora+dora (r=8)", {"type": "lora", "r": 8, "alpha": 16, "use_dora": True}),
+    ("tinylora (r=2, u=64)", {"type": "tinylora", "r": 2, "u": 64}),
+    ("tinylora (r=2, u=13)", {"type": "tinylora", "r": 2, "u": 13}),
+    # OFT/HRA/VBLoRA require nn.Linear layers; not compatible with GPT2's Conv1D.
+    # They work correctly on Llama, Mistral, Falcon, etc.
+    # ("oft (block=32)", {"type": "oft", "oft_block_size": 32}),
+    # ("hra (r=8)", {"type": "hra", "r": 8}),
+    # ("vblora (r=4)", {"type": "vblora", "r": 4, "num_vectors": 256, "vector_length": 768, "topk": 2}),
+    ("ln_tuning", {"type": "ln_tuning"}),
+    ("ia3", {"type": "ia3"}),
+    ("vera (r=256)", {"type": "vera", "r": 256}),
+    ("adalora (r=8)", {"type": "adalora", "r": 8, "target_r": 4, "init_r": 12, "total_step": 100}),
+]
+
+BASE_MODEL = "sshleifer/tiny-gpt2"
+
+
+def count_trainable(model):
+    return sum(p.numel() for p in model.parameters() if p.requires_grad)
+
+
+def count_total(model):
+    return sum(p.numel() for p in model.parameters())
+
+
+def main():
+    from peft import get_peft_model
+
+    from ludwig.schema.llms.peft import adapter_registry
+
+    print(f"Base model: {BASE_MODEL}")
+    base = AutoModelForCausalLM.from_pretrained(BASE_MODEL)
+    total = count_total(base)
+    print(f"Total parameters: {total:,}\n")
+    print(f"{'Adapter':<30} {'Trainable':>12} {'% of total':>12}")
+    print("-" * 58)
+
+    for name, config_dict in ADAPTERS:
+        try:
+            adapter_type = config_dict["type"]
+            if adapter_type not in adapter_registry:
+                print(f"{name:<30} {'N/A (not registered)':>25}")
+                continue
+
+            cls = adapter_registry[adapter_type]
+            inst = cls.model_validate(config_dict)
+            peft_cfg = inst.to_config(task_type="CAUSAL_LM")
+
+            model = AutoModelForCausalLM.from_pretrained(BASE_MODEL)
+            peft_model = get_peft_model(model, peft_cfg)
+            trainable = count_trainable(peft_model)
+            pct = 100.0 * trainable / total
+            print(f"{name:<30} {trainable:>12,} {pct:>11.4f}%")
+        except Exception as e:
+            print(f"{name:<30} {'ERROR: ' + str(e)[:40]:>50}")
+
+    print()
+    print("Full fine-tuning would train all", f"{total:,}", "parameters (100%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/peft_advanced/corda_lora.yaml
+++ b/examples/peft_advanced/corda_lora.yaml
@@ -1,0 +1,26 @@
+model_type: llm
+base_model: meta-llama/Llama-3.2-1B
+
+input_features:
+  - name: instruction
+    type: text
+
+output_features:
+  - name: output
+    type: text
+
+adapter:
+  type: lora
+  r: 16
+  alpha: 32
+  # CorDA: Context-Oriented Decomposition Adaptation.
+  # Combines PiSSA-style SVD init with context signals from the fine-tuning data.
+  # Converges faster than PiSSA in instruction-previewed mode while preserving world knowledge.
+  # Paper: https://arxiv.org/abs/2406.05223
+  init_lora_weights: corda
+
+trainer:
+  type: finetune
+  learning_rate: 0.0001
+  epochs: 3
+  batch_size: 4

--- a/examples/peft_advanced/eva_lora.yaml
+++ b/examples/peft_advanced/eva_lora.yaml
@@ -1,0 +1,34 @@
+model_type: llm
+base_model: meta-llama/Llama-3.2-1B
+
+input_features:
+  - name: instruction
+    type: text
+
+output_features:
+  - name: output
+    type: text
+
+adapter:
+  type: lora
+  r: 16
+  alpha: 32
+  # EVA: Explained Variance Adaptation — initializes from SVD of layer input activations.
+  # Achieves SOTA performance by aligning adapter directions with the actual data distribution.
+  # Requires a calibration pass over the dataset before training.
+  # Paper: https://arxiv.org/abs/2410.07170
+  init_lora_weights: eva
+  eva_config:
+    rho: 2.0
+    tau: 0.99
+    use_label_mask: true
+    adjust_scaling_factors: true
+
+trainer:
+  type: finetune
+  learning_rate: 0.0001
+  epochs: 3
+  batch_size: 4
+
+preprocessing:
+  global_max_sequence_length: 512

--- a/examples/peft_advanced/ln_tuning_llm.yaml
+++ b/examples/peft_advanced/ln_tuning_llm.yaml
@@ -1,0 +1,24 @@
+model_type: llm
+base_model: meta-llama/Llama-3.2-1B
+
+input_features:
+  - name: instruction
+    type: text
+
+output_features:
+  - name: output
+    type: text
+
+# LN-Tuning: fine-tunes only the LayerNorm/RMSNorm weight and bias parameters.
+# Typically <0.1% of total parameters. Surprisingly effective for domain shift tasks.
+# Use this when: extreme memory budget, quick domain adaptation, or as a baseline.
+adapter:
+  type: ln_tuning
+  # Optionally target specific norm layers:
+  # target_modules: ["input_layernorm", "post_attention_layernorm"]
+
+trainer:
+  type: finetune
+  learning_rate: 0.001
+  epochs: 5
+  batch_size: 16

--- a/examples/peft_advanced/loftq_lora.yaml
+++ b/examples/peft_advanced/loftq_lora.yaml
@@ -1,0 +1,28 @@
+model_type: llm
+base_model: meta-llama/Llama-3.2-1B
+
+input_features:
+  - name: instruction
+    type: text
+
+output_features:
+  - name: output
+    type: text
+
+adapter:
+  type: lora
+  r: 16
+  alpha: 32
+  # LoftQ: simultaneously quantizes base weights (4-bit) and initializes LoRA to minimize
+  # the quantization approximation error. Better starting point than QLoRA's zero-init.
+  # Paper: https://arxiv.org/abs/2310.08659
+  init_lora_weights: loftq
+  loftq_config:
+    loftq_bits: 4
+    loftq_iter: 1
+
+trainer:
+  type: finetune
+  learning_rate: 0.0001
+  epochs: 3
+  batch_size: 4

--- a/examples/peft_advanced/oft_llm.yaml
+++ b/examples/peft_advanced/oft_llm.yaml
@@ -1,0 +1,27 @@
+model_type: llm
+base_model: meta-llama/Llama-3.2-1B
+
+input_features:
+  - name: instruction
+    type: text
+
+output_features:
+  - name: output
+    type: text
+
+# OFT: Orthogonal Fine-Tuning. Applies orthogonal transforms to weight matrices.
+# Preserves the hyperspherical energy of the pre-trained model, preventing forgetting.
+# Particularly effective for subject-driven generation and tasks requiring output diversity.
+# Paper: https://arxiv.org/abs/2306.07280
+adapter:
+  type: oft
+  oft_block_size: 32
+  module_dropout: 0.0
+  # Enable COFT for a stronger orthogonality constraint:
+  # coft: true
+  # eps: 0.00006
+
+trainer:
+  type: finetune
+  learning_rate: 0.0001
+  epochs: 3

--- a/examples/peft_advanced/pissa_lora.yaml
+++ b/examples/peft_advanced/pissa_lora.yaml
@@ -1,0 +1,30 @@
+model_type: llm
+base_model: meta-llama/Llama-3.2-1B
+
+input_features:
+  - name: instruction
+    type: text
+
+output_features:
+  - name: output
+    type: text
+
+adapter:
+  type: lora
+  r: 16
+  alpha: 32
+  dropout: 0.05
+  # PiSSA: initialize via principal singular values/vectors of the weight matrix.
+  # Converges faster and often outperforms standard LoRA at the same rank.
+  # Paper: https://arxiv.org/abs/2404.02948
+  init_lora_weights: pissa
+  use_rslora: true
+
+trainer:
+  type: finetune
+  learning_rate: 0.0001
+  epochs: 3
+  batch_size: 4
+
+preprocessing:
+  global_max_sequence_length: 512

--- a/examples/peft_advanced/tinylora_llm.yaml
+++ b/examples/peft_advanced/tinylora_llm.yaml
@@ -1,0 +1,26 @@
+model_type: llm
+base_model: meta-llama/Llama-3.2-1B
+
+input_features:
+  - name: instruction
+    type: text
+
+output_features:
+  - name: output
+    type: text
+
+# TinyLoRA: LoRA-XS variant. Uses SVD + fixed random projection matrices.
+# Achieves fine-tuning with as few as 13 trainable parameters per layer.
+# Ideal for: edge devices, CPU-only inference, extremely memory-constrained GPUs.
+# Paper: https://arxiv.org/abs/2602.04118
+adapter:
+  type: tinylora
+  r: 2          # SVD rank — paper recommends r=2
+  u: 64         # trainable vector dimension — set to 13 for extreme efficiency
+  weight_tying: 0.0  # set > 0 to share trainable vectors across layers
+
+trainer:
+  type: finetune
+  learning_rate: 0.001
+  epochs: 3
+  batch_size: 8

--- a/examples/peft_advanced/train_example.py
+++ b/examples/peft_advanced/train_example.py
@@ -1,0 +1,75 @@
+"""Minimal training demo for advanced PEFT adapters in Ludwig.
+
+Run with: python train_example.py --adapter pissa
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+import yaml
+
+from ludwig.api import LudwigModel
+
+ADAPTER_CONFIGS = {
+    "lora": {"type": "lora", "r": 8, "alpha": 16},
+    "pissa": {"type": "lora", "r": 8, "alpha": 16, "init_lora_weights": "pissa"},
+    "corda": {"type": "lora", "r": 8, "alpha": 16, "init_lora_weights": "corda"},
+    "rslora": {"type": "lora", "r": 8, "alpha": 16, "use_rslora": True},
+    "dora": {"type": "lora", "r": 8, "alpha": 16, "use_dora": True},
+    "tinylora": {"type": "tinylora", "r": 2, "u": 64},
+    "oft": {"type": "oft", "oft_block_size": 32},
+    "hra": {"type": "hra", "r": 8},
+    "ln_tuning": {"type": "ln_tuning"},
+    "vblora": {"type": "vblora", "r": 4, "num_vectors": 256, "vector_length": 768, "topk": 2},
+    "adalora": {"type": "adalora", "r": 8, "target_r": 4, "init_r": 12, "total_step": 1000},
+    "ia3": {"type": "ia3"},
+    "vera": {"type": "vera", "r": 256},
+}
+
+BASE_CONFIG = """
+model_type: llm
+base_model: sshleifer/tiny-gpt2
+
+input_features:
+  - name: text
+    type: text
+
+output_features:
+  - name: label
+    type: text
+
+trainer:
+  type: finetune
+  learning_rate: 0.0001
+  epochs: 1
+  batch_size: 4
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train with a specific PEFT adapter")
+    parser.add_argument("--adapter", default="pissa", choices=list(ADAPTER_CONFIGS.keys()))
+    parser.add_argument("--dataset", default=None, help="Path to dataset CSV (optional)")
+    args = parser.parse_args()
+
+    config = yaml.safe_load(BASE_CONFIG)
+    config["adapter"] = ADAPTER_CONFIGS[args.adapter]
+
+    print(f"Training with adapter: {args.adapter}")
+    print(f"Adapter config: {config['adapter']}")
+    print()
+
+    model = LudwigModel(config=config, logging_level=logging.INFO)
+
+    if args.dataset:
+        stats, _, output_dir = model.train(dataset=args.dataset)
+        print(f"Training complete. Results in: {output_dir}")
+    else:
+        print("No dataset provided — config validated successfully.")
+        print("Pass --dataset <path> to run training.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/peft_advanced/vblora_llm.yaml
+++ b/examples/peft_advanced/vblora_llm.yaml
@@ -1,0 +1,26 @@
+model_type: llm
+base_model: meta-llama/Llama-3.2-1B
+
+input_features:
+  - name: instruction
+    type: text
+
+output_features:
+  - name: output
+    type: text
+
+# VBLoRA: Vector Bank LoRA. Expresses LoRA matrices as a sparse combination of
+# shared vectors from a global bank, reused across all layers.
+# Achieves 10-100x compression vs standard LoRA by sharing vectors across layers.
+# Paper: https://arxiv.org/abs/2405.15179
+adapter:
+  type: vblora
+  r: 4
+  num_vectors: 256   # global bank size
+  vector_length: 256  # set to model hidden size or head dim
+  topk: 2            # vectors selected per column — higher = more expressive
+
+trainer:
+  type: finetune
+  learning_rate: 0.0001
+  epochs: 3

--- a/ludwig/schema/llms/peft.py
+++ b/ludwig/schema/llms/peft.py
@@ -65,11 +65,95 @@ class BaseAdapterConfig(schema_utils.LudwigBaseConfig, ABC):
 
 
 @DeveloperAPI
+class EvaSubConfig(schema_utils.LudwigBaseConfig):
+    """Configuration for EVA (Explained Variance Adaptation) LoRA initialization.
+
+    EVA initializes LoRA based on the SVD of layer input activations, achieving state-of-the-art
+    performance by adapting the adapter directions to the actual data distribution.
+    Paper: https://arxiv.org/abs/2410.07170
+    """
+
+    rho: float = schema_utils.NonNegativeFloat(
+        default=2.0,
+        description="Scaling factor for EVA. Controls how strongly activations influence the initialization.",
+    )
+    tau: float = schema_utils.FloatRange(
+        default=0.99,
+        min=0.0,
+        max=1.0,
+        description="Momentum for running statistics in EVA.",
+    )
+    use_label_mask: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether to mask padding/ignore tokens when computing activation statistics.",
+    )
+    label_mask_value: int = schema_utils.Integer(
+        default=-100,
+        description="Token id to mask out (usually the ignore_index for cross-entropy loss).",
+    )
+    whiten: bool = schema_utils.Boolean(
+        default=False,
+        description="Whether to whiten activations before computing SVD.",
+    )
+    adjust_scaling_factors: bool = schema_utils.Boolean(
+        default=True,
+        description="Adjust LoRA scaling factors after EVA initialization to preserve pre-trained model outputs.",
+    )
+
+
+@DeveloperAPI
+class EvaSubConfigField(schema_utils.NestedConfigField):
+    def __init__(self):
+        super().__init__(EvaSubConfig, allow_none=True, default_missing=True)
+
+    def _jsonschema_type_mapping(self):
+        return schema_utils.unload_jsonschema_from_config_class(EvaSubConfig, title="EvaConfig")
+
+
+@DeveloperAPI
+class LoftQSubConfig(schema_utils.LudwigBaseConfig):
+    """Configuration for LoftQ quantization-aware LoRA initialization.
+
+    LoftQ simultaneously quantizes the backbone weights and initializes LoRA adapters
+    to minimize the quantization error. Requires `init_lora_weights='loftq'`.
+    Paper: https://arxiv.org/abs/2310.08659
+    """
+
+    loftq_bits: int = schema_utils.IntegerOptions(
+        options=[2, 4, 8],
+        default=4,
+        description="Number of bits for LoftQ quantization (2, 4, or 8).",
+    )
+    loftq_iter: int = schema_utils.PositiveInteger(
+        default=1,
+        description="Number of LoftQ iterations. More iterations improve approximation quality.",
+    )
+
+
+@DeveloperAPI
+class LoftQSubConfigField(schema_utils.NestedConfigField):
+    def __init__(self):
+        super().__init__(LoftQSubConfig, allow_none=True, default_missing=True)
+
+    def _jsonschema_type_mapping(self):
+        return schema_utils.unload_jsonschema_from_config_class(LoftQSubConfig, title="LoftQConfig")
+
+
+@DeveloperAPI
 @register_adapter(name="lora")
 class LoraConfig(BaseAdapterConfig):
     def __post_init__(self):
         if self.alpha is None:
             self.alpha = self.r * 2
+        if self.init_lora_weights == "loftq" and self.loftq_config is None:
+            raise ConfigValidationError(
+                "`loftq_config` must be set when `init_lora_weights` is 'loftq'. "
+                "Example: loftq_config: {loftq_bits: 4, loftq_iter: 1}"
+            )
+        if self.init_lora_weights == "eva" and self.eva_config is None:
+            raise ConfigValidationError(
+                "`eva_config` must be set when `init_lora_weights` is 'eva'. " "Example: eva_config: {rho: 2.0}"
+            )
 
     type: str = schema_utils.ProtectedString(
         "lora",
@@ -148,8 +232,93 @@ class LoraConfig(BaseAdapterConfig):
         ),
     )
 
+    init_lora_weights: str | bool = schema_utils.StringOptions(
+        options=["default", "gaussian", "eva", "olora", "pissa", "corda", "loftq", "orthogonal"],
+        default="default",
+        allow_none=False,
+        description=(
+            "Initialization strategy for LoRA weight matrices. "
+            "'default' uses the standard Kaiming uniform init (A) and zeros (B). "
+            "'gaussian' uses Gaussian init for A. "
+            "'pissa' (Principal Singular values and Singular vectors Adaptation) initializes using SVD of the "
+            "pretrained weight, converging faster and often outperforming standard LoRA. "
+            "Paper: https://arxiv.org/abs/2404.02948. "
+            "'eva' (Explained Variance Adaptation) initializes from the SVD of layer input activations — "
+            "requires `eva_config` to be set. Paper: https://arxiv.org/abs/2410.07170. "
+            "'corda' (Context-Oriented Decomposition Adaptation) combines PiSSA and full fine-tuning signals, "
+            "converging faster than PiSSA. Paper: https://arxiv.org/abs/2406.05223. "
+            "'olora' (Orthonormal LoRA) uses QR decomposition for better conditioning. "
+            "'loftq' (LoftQ) jointly quantizes base weights and initializes LoRA — "
+            "requires `loftq_config` to be set. Paper: https://arxiv.org/abs/2310.08659. "
+            "'orthogonal' uses orthogonal initialization."
+        ),
+    )
+
+    eva_config: EvaSubConfig | None = EvaSubConfigField().get_default_field()
+
+    loftq_config: LoftQSubConfig | None = LoftQSubConfigField().get_default_field()
+
+    rank_pattern: dict | None = schema_utils.Dict(
+        default=None,
+        allow_none=True,
+        description=(
+            "Per-layer rank overrides as a mapping of layer name (or regex) to rank integer. "
+            "Overrides the global `r` for matched layers. Useful for LoRA-XS style configurations "
+            "where different layers benefit from different ranks. "
+            "Example: {'model.layers.0.self_attn.q_proj': 4, 'model.layers.0.self_attn.v_proj': 2}"
+        ),
+    )
+
+    alpha_pattern: dict | None = schema_utils.Dict(
+        default=None,
+        allow_none=True,
+        description=(
+            "Per-layer alpha (scaling) overrides as a mapping of layer name (or regex) to float. "
+            "Overrides the global `alpha` for matched layers."
+        ),
+    )
+
+    layer_replication: list | None = schema_utils.List(
+        default=None,
+        allow_none=True,
+        description=(
+            "Layer replication configuration as a list of [start, end] index pairs. Enables depth-wise "
+            "parameter efficiency by sharing LoRA weights across layer ranges. "
+            "Example: [[0, 4], [2, 5]] creates two overlapping groups."
+        ),
+    )
+
     def to_config(self, task_type: str = None, **kwargs) -> "PeftConfig":
         from peft import LoraConfig as _LoraConfig
+
+        init_weights = self.init_lora_weights
+        if init_weights == "default":
+            init_weights = True
+
+        eva_config = None
+        loftq_config = None
+        if init_weights == "eva" and self.eva_config is not None:
+            from peft import EvaConfig as _EvaConfig
+
+            eva_config = _EvaConfig(
+                rho=self.eva_config.rho,
+                tau=self.eva_config.tau,
+                use_label_mask=self.eva_config.use_label_mask,
+                label_mask_value=self.eva_config.label_mask_value,
+                whiten=self.eva_config.whiten,
+                adjust_scaling_factors=self.eva_config.adjust_scaling_factors,
+            )
+        elif init_weights == "loftq" and self.loftq_config is not None:
+            from peft import LoftQConfig as _LoftQConfig
+
+            loftq_config = _LoftQConfig(
+                loftq_bits=self.loftq_config.loftq_bits,
+                loftq_iter=self.loftq_config.loftq_iter,
+            )
+
+        layer_replication = None
+        if self.layer_replication is not None:
+            layer_replication = [tuple(pair) for pair in self.layer_replication]
 
         return _LoraConfig(
             r=self.r,
@@ -160,6 +329,12 @@ class LoraConfig(BaseAdapterConfig):
             task_type=task_type,
             use_rslora=self.use_rslora,
             use_dora=self.use_dora,
+            init_lora_weights=init_weights,
+            eva_config=eva_config,
+            loftq_config=loftq_config,
+            rank_pattern=self.rank_pattern or {},
+            alpha_pattern=self.alpha_pattern or {},
+            layer_replication=layer_replication,
         )
 
     @classmethod
@@ -707,6 +882,427 @@ class BOFTAdapterConfig(BaseAdapterConfig):
             target_modules=self.target_modules,
             task_type=task_type,
         )
+
+
+@DeveloperAPI
+@register_adapter(name="tinylora")
+class TinyLoraAdapterConfig(BaseAdapterConfig):
+    """TinyLoRA: Extreme parameter-efficient fine-tuning via SVD projection.
+
+    Uses SVD decomposition of frozen weights and projects a tiny trainable vector through fixed random tensors.
+    Enables fine-tuning in as few as 13 parameters. Ideal for extremely constrained hardware or edge deployment.
+    Paper: https://arxiv.org/abs/2602.04118
+    """
+
+    type: str = schema_utils.ProtectedString("tinylora", description="TinyLoRA adapter (LoRA-XS equivalent).")
+
+    r: int = schema_utils.PositiveInteger(
+        default=2,
+        description="SVD rank for the frozen U, Sigma, V decomposition. The paper recommends r=2.",
+    )
+
+    u: int = schema_utils.PositiveInteger(
+        default=64,
+        description=(
+            "Trainable vector dimension per group. Controls the expressivity of the adaptation. "
+            "Can be as low as 1–13 for extreme parameter efficiency."
+        ),
+    )
+
+    weight_tying: float = schema_utils.FloatRange(
+        default=0.0,
+        min=0.0,
+        max=1.0,
+        description=(
+            "Degree of weight tying across target modules (0.0 = no sharing, 1.0 = full sharing). "
+            "Sharing trainable vectors across modules further reduces parameter count."
+        ),
+    )
+
+    projection_seed: int = schema_utils.NonNegativeInteger(
+        default=42,
+        description="Random seed for generating the fixed projection matrices.",
+    )
+
+    save_projection: bool = schema_utils.Boolean(
+        default=True,
+        description="Whether to save the projection tensors in the state dict.",
+    )
+
+    tinylora_dropout: float = schema_utils.NonNegativeFloat(
+        default=0.0,
+        description="Dropout probability for TinyLoRA layers.",
+    )
+
+    target_modules: list[str] | None = schema_utils.List(
+        default=None,
+        allow_none=True,
+        description="List of module names or regex to apply TinyLoRA to.",
+    )
+
+    def to_config(self, task_type: str = None, **kwargs):
+        from peft import TinyLoraConfig as _TinyLoraConfig
+
+        return _TinyLoraConfig(
+            r=self.r,
+            u=self.u,
+            weight_tying=self.weight_tying,
+            projection_seed=self.projection_seed,
+            save_projection=self.save_projection,
+            tinylora_dropout=self.tinylora_dropout,
+            target_modules=self.target_modules,
+            task_type=task_type,
+        )
+
+    @classmethod
+    def name(cls) -> str:
+        return "TinyLoRA"
+
+    @classmethod
+    def description(cls) -> str:
+        return "TinyLoRA: extreme parameter-efficient fine-tuning via SVD projection (LoRA-XS variant)."
+
+
+@DeveloperAPI
+@register_adapter(name="c3a")
+class C3AAdapterConfig(BaseAdapterConfig):
+    """C3A: Contextual / Conditional / Compositional Adapter.
+
+    Uses block-diagonal matrices for structured parameter efficiency.
+    Enables context-aware adapter routing and multi-task modularity.
+    """
+
+    type: str = schema_utils.ProtectedString("c3a", description="C3A adapter.")
+
+    block_size: int = schema_utils.PositiveInteger(
+        default=256,
+        description=(
+            "Block size for C3A, must be divisible by both the input size and the output size of each target layer. "
+            "Setting this to the GCD of all target layer dimensions is a safe default. "
+            "Larger block sizes mean fewer parameters."
+        ),
+    )
+
+    target_modules: list[str] | None = schema_utils.List(
+        default=None,
+        allow_none=True,
+        description="List of module names or regex to apply C3A to.",
+    )
+
+    bias_type: str = schema_utils.StringOptions(
+        options=["none", "all", "c3a_only"],
+        default="none",
+        description="Bias type for C3A. 'none' trains no biases; 'all' or 'c3a_only' trains the adapter biases.",
+    )
+
+    def to_config(self, task_type: str = None, **kwargs):
+        from peft import C3AConfig as _C3AConfig
+
+        return _C3AConfig(
+            block_size=self.block_size,
+            target_modules=self.target_modules,
+            bias=self.bias_type,
+            block_size_pattern={},
+            task_type=task_type,
+        )
+
+    @classmethod
+    def name(cls) -> str:
+        return "C3A"
+
+    @classmethod
+    def description(cls) -> str:
+        return "C3A: context-aware block-diagonal adapter for multi-task and compositional fine-tuning."
+
+
+@DeveloperAPI
+@register_adapter(name="oft")
+class OFTAdapterConfig(BaseAdapterConfig):
+    """OFT: Orthogonal Fine-Tuning.
+
+    Applies orthogonal transformations to the weight matrices, preserving the hyperspherical energy
+    of the pre-trained model while adapting to new tasks. Particularly effective for maintaining
+    output diversity and preventing catastrophic forgetting.
+    Paper: https://arxiv.org/abs/2306.07280
+    """
+
+    type: str = schema_utils.ProtectedString("oft", description="OFT adapter.")
+
+    r: int = schema_utils.NonNegativeInteger(
+        default=0,
+        description=(
+            "OFT rank. When 0, the block size (`oft_block_size`) controls the granularity instead. "
+            "Cannot be set simultaneously with `oft_block_size`."
+        ),
+    )
+
+    oft_block_size: int = schema_utils.PositiveInteger(
+        default=32,
+        description="Block size for the butterfly factorization of the orthogonal transform.",
+    )
+
+    module_dropout: float = schema_utils.NonNegativeFloat(
+        default=0.0,
+        description="Probability of randomly zeroing an OFT block during training.",
+    )
+
+    target_modules: list[str] | None = schema_utils.List(
+        default=None,
+        allow_none=True,
+        description="List of module names or regex to apply OFT to.",
+    )
+
+    coft: bool = schema_utils.Boolean(
+        default=False,
+        description="Whether to use Constrained OFT (COFT), which enforces the constraint ||I - R^T R||_F <= eps.",
+    )
+
+    eps: float = schema_utils.NonNegativeFloat(
+        default=6e-5,
+        description="Constraint strength for COFT (only used when `coft=True`).",
+    )
+
+    def to_config(self, task_type: str = None, **kwargs):
+        from peft import OFTConfig as _OFTConfig
+
+        return _OFTConfig(
+            r=self.r,
+            oft_block_size=self.oft_block_size,
+            module_dropout=self.module_dropout,
+            target_modules=self.target_modules,
+            coft=self.coft,
+            eps=self.eps,
+            task_type=task_type,
+        )
+
+    @classmethod
+    def name(cls) -> str:
+        return "OFT"
+
+    @classmethod
+    def description(cls) -> str:
+        return "OFT: Orthogonal Fine-Tuning that preserves hyperspherical energy of the pre-trained model."
+
+
+@DeveloperAPI
+@register_adapter(name="hra")
+class HRAAdapterConfig(BaseAdapterConfig):
+    """HRA: Householder Reflection Adaptation.
+
+    Parameterizes weight updates as products of Householder reflections, which are orthogonal by construction.
+    Provides stronger expressivity than OFT with fewer hyperparameters.
+    Paper: https://arxiv.org/abs/2405.17484
+    """
+
+    type: str = schema_utils.ProtectedString("hra", description="HRA adapter.")
+
+    r: int = schema_utils.PositiveInteger(
+        default=8,
+        description="Number of Householder reflections (rank). More reflections = more expressive adaptation.",
+    )
+
+    apply_GS: bool = schema_utils.Boolean(
+        default=False,
+        description=(
+            "Whether to apply Gram-Schmidt orthogonalization to the Householder vectors. "
+            "Improves numerical stability at the cost of a small overhead."
+        ),
+    )
+
+    target_modules: list[str] | None = schema_utils.List(
+        default=None,
+        allow_none=True,
+        description="List of module names or regex to apply HRA to.",
+    )
+
+    def to_config(self, task_type: str = None, **kwargs):
+        from peft import HRAConfig as _HRAConfig
+
+        return _HRAConfig(
+            r=self.r,
+            apply_GS=self.apply_GS,
+            target_modules=self.target_modules,
+            task_type=task_type,
+        )
+
+    @classmethod
+    def name(cls) -> str:
+        return "HRA"
+
+    @classmethod
+    def description(cls) -> str:
+        return "HRA: Householder Reflection Adaptation — orthogonal updates via Householder reflections."
+
+
+@DeveloperAPI
+@register_adapter(name="waveft")
+class WaveFTAdapterConfig(BaseAdapterConfig):
+    """WaveFT: Wavelet-domain Fine-Tuning.
+
+    Learns weight updates in the wavelet frequency domain using discrete wavelet transforms.
+    Provides a different inductive bias from spatial methods like LoRA, often benefiting
+    tasks with structured or periodic patterns.
+    Paper: https://arxiv.org/abs/2411.09295
+    """
+
+    type: str = schema_utils.ProtectedString("waveft", description="WaveFT adapter.")
+
+    n_frequency: int = schema_utils.PositiveInteger(
+        default=2592,
+        description="Number of wavelet frequency components to learn. Fewer = more parameter efficient.",
+    )
+
+    scaling: float = schema_utils.NonNegativeFloat(
+        default=25.0,
+        description="Scaling factor applied to the wavelet-domain updates.",
+    )
+
+    wavelet_family: str = schema_utils.StringOptions(
+        options=["db1", "db2", "db3", "haar", "sym2", "coif1"],
+        default="db1",
+        description=(
+            "Wavelet family to use for the discrete wavelet transform. "
+            "'db1'/'haar' are simplest; higher-order Daubechies ('db2', 'db3') capture smoother features."
+        ),
+    )
+
+    target_modules: list[str] | None = schema_utils.List(
+        default=None,
+        allow_none=True,
+        description="List of module names or regex to apply WaveFT to.",
+    )
+
+    def to_config(self, task_type: str = None, **kwargs):
+        from peft import WaveFTConfig as _WaveFTConfig
+
+        return _WaveFTConfig(
+            n_frequency=self.n_frequency,
+            scaling=self.scaling,
+            wavelet_family=self.wavelet_family,
+            target_modules=self.target_modules,
+            n_frequency_pattern={},
+            task_type=task_type,
+        )
+
+    @classmethod
+    def name(cls) -> str:
+        return "WaveFT"
+
+    @classmethod
+    def description(cls) -> str:
+        return "WaveFT: Wavelet-domain fine-tuning with structured frequency-domain weight updates."
+
+
+@DeveloperAPI
+@register_adapter(name="ln_tuning")
+class LNTuningAdapterConfig(BaseAdapterConfig):
+    """LN-Tuning: Layer Normalization Tuning.
+
+    Fine-tunes only the layer normalization parameters (weight and bias) of the model.
+    Extremely parameter-efficient — often only ~0.1% of total parameters — while surprisingly
+    effective for domain adaptation tasks.
+    """
+
+    type: str = schema_utils.ProtectedString("ln_tuning", description="LN-Tuning adapter.")
+
+    target_modules: list[str] | None = schema_utils.List(
+        default=None,
+        allow_none=True,
+        description=(
+            "List of layer norm module names or regex to tune. "
+            "Defaults to all LayerNorm / RMSNorm modules in the model."
+        ),
+    )
+
+    def to_config(self, task_type: str = None, **kwargs):
+        from peft import LNTuningConfig as _LNTuningConfig
+
+        return _LNTuningConfig(
+            target_modules=self.target_modules,
+            task_type=task_type,
+        )
+
+    @classmethod
+    def name(cls) -> str:
+        return "LN-Tuning"
+
+    @classmethod
+    def description(cls) -> str:
+        return "LN-Tuning: tunes only the layer normalization parameters for ultra-lightweight adaptation."
+
+
+@DeveloperAPI
+@register_adapter(name="vblora")
+class VBLoRAAdapterConfig(BaseAdapterConfig):
+    """VBLoRA: Vector Bank LoRA.
+
+    Represents LoRA weight matrices as a sparse combination of shared vectors from a global bank.
+    Achieves significant parameter compression by reusing vectors across layers.
+    Paper: https://arxiv.org/abs/2405.15179
+    """
+
+    type: str = schema_utils.ProtectedString("vblora", description="VBLoRA adapter.")
+
+    r: int = schema_utils.PositiveInteger(
+        default=4,
+        description="LoRA rank dimension. Controls the bottleneck size of each adaptation.",
+    )
+
+    num_vectors: int = schema_utils.PositiveInteger(
+        default=256,
+        description="Number of vectors in the global vector bank shared across all layers.",
+    )
+
+    vector_length: int = schema_utils.PositiveInteger(
+        default=256,
+        description="Length (dimension) of each vector in the bank. Usually set to the hidden size or head dim.",
+    )
+
+    topk: int = schema_utils.PositiveInteger(
+        default=2,
+        description=(
+            "Number of top-k vectors selected from the bank for each LoRA matrix column. "
+            "Higher k increases expressivity but also parameter count."
+        ),
+    )
+
+    vblora_dropout: float = schema_utils.NonNegativeFloat(
+        default=0.0,
+        description="Dropout probability for VBLoRA layers.",
+    )
+
+    save_only_topk_weights: bool = schema_utils.Boolean(
+        default=False,
+        description="Whether to save only the top-k selection logits rather than the full bank weights.",
+    )
+
+    target_modules: list[str] | None = schema_utils.List(
+        default=None,
+        allow_none=True,
+        description="List of module names or regex to apply VBLoRA to.",
+    )
+
+    def to_config(self, task_type: str = None, **kwargs):
+        from peft import VBLoRAConfig as _VBLoRAConfig
+
+        return _VBLoRAConfig(
+            r=self.r,
+            num_vectors=self.num_vectors,
+            vector_length=self.vector_length,
+            topk=self.topk,
+            vblora_dropout=self.vblora_dropout,
+            save_only_topk_weights=self.save_only_topk_weights,
+            target_modules=self.target_modules,
+            task_type=task_type,
+        )
+
+    @classmethod
+    def name(cls) -> str:
+        return "VBLoRA"
+
+    @classmethod
+    def description(cls) -> str:
+        return "VBLoRA: Vector Bank LoRA that shares vectors across layers for extreme compression."
 
 
 @DeveloperAPI

--- a/ludwig/schema/llms/peft.py
+++ b/ludwig/schema/llms/peft.py
@@ -107,7 +107,8 @@ class EvaSubConfigField(schema_utils.NestedConfigField):
         super().__init__(EvaSubConfig, allow_none=True, default_missing=True)
 
     def _jsonschema_type_mapping(self):
-        return schema_utils.unload_jsonschema_from_config_class(EvaSubConfig, title="EvaConfig")
+        inner = schema_utils.unload_jsonschema_from_config_class(EvaSubConfig, title="EvaConfig")
+        return {"oneOf": [inner, {"type": "null"}]}
 
 
 @DeveloperAPI
@@ -136,7 +137,8 @@ class LoftQSubConfigField(schema_utils.NestedConfigField):
         super().__init__(LoftQSubConfig, allow_none=True, default_missing=True)
 
     def _jsonschema_type_mapping(self):
-        return schema_utils.unload_jsonschema_from_config_class(LoftQSubConfig, title="LoftQConfig")
+        inner = schema_utils.unload_jsonschema_from_config_class(LoftQSubConfig, title="LoftQConfig")
+        return {"oneOf": [inner, {"type": "null"}]}
 
 
 @DeveloperAPI

--- a/ludwig/schema/metadata/configs/llm.yaml
+++ b/ludwig/schema/metadata/configs/llm.yaml
@@ -120,6 +120,61 @@ adapter:
     use_dora:
       ui_display_name: Enable DoRa
       expected_impact: 2
+    init_lora_weights:
+      ui_display_name: LoRA Initializer
+      expected_impact: 3
+    rank_pattern:
+      ui_display_name: Per-Layer Rank Pattern
+      expected_impact: 2
+    alpha_pattern:
+      ui_display_name: Per-Layer Alpha Pattern
+      expected_impact: 2
+    layer_replication:
+      ui_display_name: Layer Replication
+      expected_impact: 2
+  tinylora:
+    type:
+      long_description: |
+        TinyLoRA is an extremely parameter-efficient fine-tuning method that uses SVD decomposition of frozen weights
+        and projects a tiny trainable vector through fixed random tensors. It can achieve fine-tuning with as few as
+        13 trainable parameters, making it ideal for extremely resource-constrained environments or edge deployment.
+        Paper: https://arxiv.org/abs/2602.04118
+  c3a:
+    type:
+      long_description: |
+        C3A (Contextual/Conditional/Compositional Adapter) uses block-diagonal structured matrices for parameter
+        efficiency. It enables context-aware adapter routing and multi-task modularity, making it well-suited for
+        multi-domain generalization and compositional fine-tuning workflows.
+  oft:
+    type:
+      long_description: |
+        OFT (Orthogonal Fine-Tuning) applies orthogonal transformations to weight matrices, preserving the
+        hyperspherical energy of the pre-trained model. This prevents catastrophic forgetting and maintains output
+        diversity while adapting to new tasks. Paper: https://arxiv.org/abs/2306.07280
+  hra:
+    type:
+      long_description: |
+        HRA (Householder Reflection Adaptation) parameterizes weight updates as products of Householder reflections,
+        which are orthogonal by construction. It provides stronger expressivity than OFT with fewer hyperparameters.
+        Paper: https://arxiv.org/abs/2405.17484
+  waveft:
+    type:
+      long_description: |
+        WaveFT (Wavelet-domain Fine-Tuning) learns weight updates in the wavelet frequency domain. It provides a
+        different inductive bias from spatial methods like LoRA, often benefiting tasks with structured or periodic
+        patterns. Paper: https://arxiv.org/abs/2411.09295
+  ln_tuning:
+    type:
+      long_description: |
+        LN-Tuning fine-tunes only the layer normalization parameters (weight and bias) of the model. It is
+        extremely parameter-efficient (often <0.1% of total parameters) while being surprisingly effective for
+        domain adaptation tasks.
+  vblora:
+    type:
+      long_description: |
+        VBLoRA (Vector Bank LoRA) represents LoRA weight matrices as a sparse combination of shared vectors from a
+        global bank. By reusing vectors across layers, it achieves significant parameter compression beyond standard
+        LoRA. Paper: https://arxiv.org/abs/2405.15179
   adalora:
     type:
       long_description: |

--- a/notebooks/advanced_peft_adapters.ipynb
+++ b/notebooks/advanced_peft_adapters.ipynb
@@ -1,0 +1,447 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Advanced PEFT Adapters in Ludwig\n",
+    "\n",
+    "This notebook demonstrates Ludwig's extended parameter-efficient fine-tuning (PEFT) support:\n",
+    "\n",
+    "- **Advanced LoRA initializers**: PiSSA, EVA, CorDA, LoftQ, OLoRA, orthogonal\n",
+    "- **LoRA extras**: rsLoRA, DoRA, LoRA+, per-layer rank/alpha patterns, layer replication\n",
+    "- **TinyLoRA** — LoRA-XS variant: SVD + fixed projections, as few as 13 parameters\n",
+    "- **C3A** — contextual/conditional/compositional adapter\n",
+    "- **OFT** — orthogonal fine-tuning (preserves hyperspherical energy)\n",
+    "- **HRA** — Householder Reflection Adaptation\n",
+    "- **WaveFT** — wavelet-domain fine-tuning\n",
+    "- **LN-Tuning** — fine-tune only layer normalization parameters\n",
+    "- **VBLoRA** — vector bank LoRA (shared vector reuse across layers)\n",
+    "\n",
+    "**References**: Issue [#4129](https://github.com/ludwig-ai/ludwig/issues/4129)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install dependencies\n",
+    "# !pip install ludwig peft>=0.19.0 transformers torch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Advanced LoRA Initializers\n",
+    "\n",
+    "The `init_lora_weights` field selects how the LoRA A and B matrices are initialized.\n",
+    "The default (`True`) uses Kaiming uniform (A) and zeros (B).\n",
+    "Advanced initializers often converge faster or reach higher final performance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ludwig.schema.llms.peft import LoraConfig, adapter_registry\n",
+    "\n",
+    "# Standard LoRA (baseline)\n",
+    "standard = LoraConfig(r=8, alpha=16)\n",
+    "print(\"Standard LoRA init_lora_weights:\", standard.to_config('CAUSAL_LM').init_lora_weights)\n",
+    "\n",
+    "# PiSSA: Principal Singular values and Singular vectors Adaptation\n",
+    "# Initializes A, B from SVD of the pretrained weight. Faster convergence.\n",
+    "pissa = LoraConfig(r=8, alpha=16, init_lora_weights=\"pissa\")\n",
+    "print(\"PiSSA init_lora_weights:\", pissa.to_config('CAUSAL_LM').init_lora_weights)\n",
+    "\n",
+    "# CorDA: Context-Oriented Decomposition Adaptation\n",
+    "corda = LoraConfig(r=8, alpha=16, init_lora_weights=\"corda\")\n",
+    "print(\"CorDA init_lora_weights:\", corda.to_config('CAUSAL_LM').init_lora_weights)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ludwig.schema.llms.peft import LoraConfig, EvaSubConfig\n",
+    "\n",
+    "# EVA: Explained Variance Adaptation — data-driven initialization from activation SVD\n",
+    "eva_cfg = LoraConfig.model_validate({\n",
+    "    \"type\": \"lora\",\n",
+    "    \"r\": 16,\n",
+    "    \"init_lora_weights\": \"eva\",\n",
+    "    \"eva_config\": {\n",
+    "        \"rho\": 2.0,\n",
+    "        \"tau\": 0.99,\n",
+    "        \"adjust_scaling_factors\": True\n",
+    "    }\n",
+    "})\n",
+    "peft_cfg = eva_cfg.to_config('CAUSAL_LM')\n",
+    "print(\"EVA init:\", peft_cfg.init_lora_weights)\n",
+    "print(\"EVA config rho:\", peft_cfg.eva_config.rho)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ludwig.schema.llms.peft import LoraConfig, LoftQSubConfig\n",
+    "\n",
+    "# LoftQ: jointly quantizes base weights and initializes LoRA to minimize error\n",
+    "loftq_cfg = LoraConfig.model_validate({\n",
+    "    \"type\": \"lora\",\n",
+    "    \"r\": 16,\n",
+    "    \"init_lora_weights\": \"loftq\",\n",
+    "    \"loftq_config\": {\"loftq_bits\": 4, \"loftq_iter\": 1}\n",
+    "})\n",
+    "peft_cfg = loftq_cfg.to_config('CAUSAL_LM')\n",
+    "print(\"LoftQ init:\", peft_cfg.init_lora_weights)\n",
+    "print(\"LoftQ bits:\", peft_cfg.loftq_config['loftq_bits'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Per-Layer Rank Patterns\n",
+    "\n",
+    "Different layers may benefit from different ranks. Use `rank_pattern` and `alpha_pattern`\n",
+    "to override the global `r` and `alpha` for specific layers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ludwig.schema.llms.peft import LoraConfig\n",
+    "\n",
+    "cfg = LoraConfig.model_validate({\n",
+    "    \"type\": \"lora\",\n",
+    "    \"r\": 8,         # global default rank\n",
+    "    \"alpha\": 16,\n",
+    "    \"init_lora_weights\": \"pissa\",\n",
+    "    # Override specific layers: attention layers get higher rank\n",
+    "    \"rank_pattern\": {\n",
+    "        \"model.layers.0.self_attn.q_proj\": 16,\n",
+    "        \"model.layers.0.self_attn.v_proj\": 16,\n",
+    "    },\n",
+    "    \"alpha_pattern\": {\n",
+    "        \"model.layers.0.self_attn.q_proj\": 32.0,\n",
+    "    }\n",
+    "})\n",
+    "peft_cfg = cfg.to_config('CAUSAL_LM')\n",
+    "print(\"rank_pattern:\", peft_cfg.rank_pattern)\n",
+    "print(\"alpha_pattern:\", peft_cfg.alpha_pattern)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. TinyLoRA — Extreme Parameter Efficiency\n",
+    "\n",
+    "TinyLoRA ([arXiv:2602.04118](https://arxiv.org/abs/2602.04118)) achieves fine-tuning with\n",
+    "as few as 13 parameters. It uses SVD decomposition of frozen weights and projects a tiny\n",
+    "trainable vector through fixed random tensors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ludwig.schema.llms.peft import TinyLoraAdapterConfig\n",
+    "\n",
+    "# Standard TinyLoRA: r=2, u=64 (like LoRA-XS)\n",
+    "tinylora = TinyLoraAdapterConfig.model_validate({\"type\": \"tinylora\", \"r\": 2, \"u\": 64})\n",
+    "print(\"TinyLoRA config:\", tinylora)\n",
+    "\n",
+    "# Ultra-minimal: r=2, u=13 (13 parameters per layer group!)\n",
+    "micro = TinyLoraAdapterConfig.model_validate({\"type\": \"tinylora\", \"r\": 2, \"u\": 13})\n",
+    "peft_cfg = micro.to_config('CAUSAL_LM')\n",
+    "print(\"\\nUltra-minimal u:\", peft_cfg.u)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ludwig YAML config equivalent:\n",
+    "tinylora_yaml = \"\"\"\n",
+    "model_type: llm\n",
+    "base_model: meta-llama/Llama-3.2-1B\n",
+    "\n",
+    "input_features:\n",
+    "  - name: instruction\n",
+    "    type: text\n",
+    "\n",
+    "output_features:\n",
+    "  - name: output\n",
+    "    type: text\n",
+    "\n",
+    "adapter:\n",
+    "  type: tinylora\n",
+    "  r: 2\n",
+    "  u: 64\n",
+    "  weight_tying: 0.0  # 0.5 shares vectors across 50% of modules\n",
+    "\n",
+    "trainer:\n",
+    "  type: finetune\n",
+    "  learning_rate: 0.001\n",
+    "  epochs: 3\n",
+    "\"\"\"\n",
+    "print(tinylora_yaml)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. C3A — Contextual/Conditional/Compositional Adapter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ludwig.schema.llms.peft import C3AAdapterConfig\n",
+    "\n",
+    "c3a = C3AAdapterConfig.model_validate({\"type\": \"c3a\", \"block_size\": 256})\n",
+    "peft_cfg = c3a.to_config('CAUSAL_LM')\n",
+    "print(\"C3A block_size:\", peft_cfg.block_size)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Orthogonal Methods: OFT and HRA\n",
+    "\n",
+    "OFT and HRA apply orthogonal transformations to weight matrices, preserving the\n",
+    "hyperspherical energy of the pre-trained model. This prevents catastrophic forgetting\n",
+    "and is particularly effective for subject-driven generation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ludwig.schema.llms.peft import OFTAdapterConfig, HRAAdapterConfig\n",
+    "\n",
+    "# OFT: Orthogonal Fine-Tuning\n",
+    "oft = OFTAdapterConfig.model_validate({\"type\": \"oft\", \"oft_block_size\": 32})\n",
+    "print(\"OFT:\", oft.to_config('CAUSAL_LM'))\n",
+    "\n",
+    "# COFT variant (constrained OFT):\n",
+    "coft = OFTAdapterConfig.model_validate({\"type\": \"oft\", \"coft\": True, \"eps\": 6e-5})\n",
+    "peft_cfg = coft.to_config('CAUSAL_LM')\n",
+    "print(\"\\nCOFT enabled:\", peft_cfg.coft)\n",
+    "\n",
+    "# HRA: Householder Reflection Adaptation\n",
+    "hra = HRAAdapterConfig.model_validate({\"type\": \"hra\", \"r\": 8, \"apply_GS\": True})\n",
+    "print(\"\\nHRA r:\", hra.r, \"apply_GS:\", hra.apply_GS)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. WaveFT — Wavelet-Domain Fine-Tuning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ludwig.schema.llms.peft import WaveFTAdapterConfig\n",
+    "\n",
+    "# db1 (Haar) wavelet — simplest, fastest\n",
+    "waveft = WaveFTAdapterConfig.model_validate({\"type\": \"waveft\", \"wavelet_family\": \"db1\", \"n_frequency\": 2592})\n",
+    "print(\"WaveFT wavelet:\", waveft.wavelet_family, \"n_frequency:\", waveft.n_frequency)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. LN-Tuning — Ultra-Lightweight Adaptation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ludwig.schema.llms.peft import LNTuningAdapterConfig\n",
+    "\n",
+    "# Fine-tune only LayerNorm/RMSNorm params — typically <0.1% of total params\n",
+    "ln = LNTuningAdapterConfig.model_validate({\"type\": \"ln_tuning\"})\n",
+    "print(\"LN-Tuning target_modules:\", ln.target_modules, \"(None = all LayerNorms)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. VBLoRA — Vector Bank LoRA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ludwig.schema.llms.peft import VBLoRAAdapterConfig\n",
+    "\n",
+    "# VBLoRA: shared vector bank across all layers\n",
+    "vblora = VBLoRAAdapterConfig.model_validate({\n",
+    "    \"type\": \"vblora\",\n",
+    "    \"r\": 4,\n",
+    "    \"num_vectors\": 256,\n",
+    "    \"vector_length\": 4096,  # set to model hidden size\n",
+    "    \"topk\": 2,\n",
+    "})\n",
+    "peft_cfg = vblora.to_config('CAUSAL_LM')\n",
+    "print(\"VBLoRA r:\", peft_cfg.r, \"num_vectors:\", peft_cfg.num_vectors, \"topk:\", peft_cfg.topk)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Full End-to-End Training Example\n",
+    "\n",
+    "Here's how to use these adapters in a complete Ludwig training run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "# Choose your adapter:\n",
+    "adapter_configs = {\n",
+    "    \"pissa\": {\"type\": \"lora\", \"r\": 16, \"alpha\": 32, \"init_lora_weights\": \"pissa\"},\n",
+    "    \"tinylora\": {\"type\": \"tinylora\", \"r\": 2, \"u\": 64},\n",
+    "    \"ln_tuning\": {\"type\": \"ln_tuning\"},\n",
+    "    \"oft\": {\"type\": \"oft\", \"oft_block_size\": 32},\n",
+    "}\n",
+    "\n",
+    "selected = \"pissa\"\n",
+    "\n",
+    "config = {\n",
+    "    \"model_type\": \"llm\",\n",
+    "    \"base_model\": \"meta-llama/Llama-3.2-1B\",\n",
+    "    \"input_features\": [{\"name\": \"instruction\", \"type\": \"text\"}],\n",
+    "    \"output_features\": [{\"name\": \"output\", \"type\": \"text\"}],\n",
+    "    \"adapter\": adapter_configs[selected],\n",
+    "    \"trainer\": {\n",
+    "        \"type\": \"finetune\",\n",
+    "        \"learning_rate\": 1e-4,\n",
+    "        \"epochs\": 3,\n",
+    "        \"batch_size\": 4,\n",
+    "    },\n",
+    "    \"preprocessing\": {\"global_max_sequence_length\": 512},\n",
+    "}\n",
+    "\n",
+    "print(f\"Training with {selected} adapter:\")\n",
+    "print(yaml.dump(config, default_flow_style=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to run training:\n",
+    "# from ludwig.api import LudwigModel\n",
+    "# model = LudwigModel(config=config)\n",
+    "# train_stats, _, output_dir = model.train(dataset=\"path/to/dataset.csv\")\n",
+    "# print(\"Results saved to:\", output_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. All Available Adapters\n",
+    "\n",
+    "Check which adapter types are registered:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ludwig.schema.llms.peft import adapter_registry\n",
+    "\n",
+    "print(\"Registered PEFT adapters:\")\n",
+    "for name, cls in adapter_registry.items():\n",
+    "    print(f\"  {name:<20} -> {cls.__name__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Adapter | Key benefit | Params vs. LoRA r=8 |\n",
+    "|---------|-------------|---------------------|\n",
+    "| `lora` + PiSSA | Faster convergence, same params | Same |\n",
+    "| `lora` + EVA | SOTA via data-driven init | Same |\n",
+    "| `lora` + CorDA | Fast convergence + knowledge preservation | Same |\n",
+    "| `lora` + LoftQ | Better QLoRA starting point | Same |\n",
+    "| `tinylora` r=2, u=64 | ~10x fewer params than LoRA | ~10x fewer |\n",
+    "| `tinylora` r=2, u=13 | 13 params per layer group | ~100x fewer |\n",
+    "| `c3a` | Multi-task modular composition | Varies |\n",
+    "| `oft` | Preserves pretrained knowledge | Comparable |\n",
+    "| `hra` | Orthogonal, fewer hyperparams | Comparable |\n",
+    "| `waveft` | Frequency-domain inductive bias | Varies |\n",
+    "| `ln_tuning` | Ultra-lightweight domain shift | <0.1% of total |\n",
+    "| `vblora` | Layer-shared vectors, extreme compression | 10-100x fewer |\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/ludwig/schema/test_peft_adapters.py
+++ b/tests/ludwig/schema/test_peft_adapters.py
@@ -4,20 +4,52 @@ import pytest
 
 from ludwig.schema.llms.peft import adapter_registry
 
+_ALL_ADAPTERS = [
+    "lora",
+    "adalora",
+    "ia3",
+    "vera",
+    "loha",
+    "lokr",
+    "fourierft",
+    "boft",
+    "tinylora",
+    "c3a",
+    "oft",
+    "hra",
+    "waveft",
+    "ln_tuning",
+    "vblora",
+]
+_ADAPTERS_WITH_TARGET_MODULES = [
+    "vera",
+    "loha",
+    "lokr",
+    "fourierft",
+    "boft",
+    "tinylora",
+    "c3a",
+    "oft",
+    "hra",
+    "waveft",
+    "ln_tuning",
+    "vblora",
+]
+
 
 class TestAdapterRegistry:
     def test_all_adapters_registered(self):
-        expected = {"lora", "adalora", "ia3", "vera", "loha", "lokr", "fourierft", "boft"}
+        expected = set(_ALL_ADAPTERS)
         assert expected.issubset(set(adapter_registry.keys()))
 
-    @pytest.mark.parametrize("adapter_type", ["lora", "adalora", "ia3", "vera", "loha", "lokr", "fourierft", "boft"])
+    @pytest.mark.parametrize("adapter_type", _ALL_ADAPTERS)
     def test_adapter_creates_valid_peft_config(self, adapter_type):
         cls = adapter_registry[adapter_type]
         inst = cls.model_validate({"type": adapter_type})
         peft_config = inst.to_config()
         assert peft_config is not None
 
-    @pytest.mark.parametrize("adapter_type", ["vera", "loha", "lokr", "fourierft", "boft"])
+    @pytest.mark.parametrize("adapter_type", _ADAPTERS_WITH_TARGET_MODULES)
     def test_new_adapter_has_target_modules(self, adapter_type):
         cls = adapter_registry[adapter_type]
         inst = cls.model_validate({"type": adapter_type})
@@ -53,6 +85,266 @@ class TestLoraPlus:
         assert len(groups) == 3
         lrs = sorted(g["lr"] for g in groups)
         assert lrs == [0.001, 0.001, 0.008]
+
+
+class TestLoraInitializers:
+    """Tests for PiSSA, EVA, CorDA, LoftQ, and other init_lora_weights options."""
+
+    @pytest.mark.parametrize("init", ["default", "gaussian", "pissa", "olora", "orthogonal"])
+    def test_init_lora_weights_string_options(self, init):
+        from ludwig.schema.llms.peft import LoraConfig
+
+        cfg = LoraConfig.model_validate({"type": "lora", "init_lora_weights": init})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        expected = True if init == "default" else init
+        assert peft_cfg.init_lora_weights == expected
+
+    def test_pissa_init(self):
+        from ludwig.schema.llms.peft import LoraConfig
+
+        cfg = LoraConfig.model_validate({"type": "lora", "r": 4, "init_lora_weights": "pissa"})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.init_lora_weights == "pissa"
+        assert peft_cfg.r == 4
+
+    def test_eva_init_requires_eva_config(self):
+        from pydantic import ValidationError
+
+        from ludwig.schema.llms.peft import LoraConfig
+
+        with pytest.raises(ValidationError, match="eva_config"):
+            LoraConfig.model_validate({"type": "lora", "init_lora_weights": "eva"})
+
+    def test_eva_init_with_config(self):
+        from ludwig.schema.llms.peft import LoraConfig
+
+        cfg = LoraConfig.model_validate(
+            {
+                "type": "lora",
+                "init_lora_weights": "eva",
+                "eva_config": {"rho": 3.0, "tau": 0.95},
+            }
+        )
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.init_lora_weights == "eva"
+        assert peft_cfg.eva_config is not None
+        assert peft_cfg.eva_config.rho == 3.0
+
+    def test_loftq_init_requires_loftq_config(self):
+        from pydantic import ValidationError
+
+        from ludwig.schema.llms.peft import LoraConfig
+
+        with pytest.raises(ValidationError, match="loftq_config"):
+            LoraConfig.model_validate({"type": "lora", "init_lora_weights": "loftq"})
+
+    def test_loftq_init_with_config(self):
+        from ludwig.schema.llms.peft import LoraConfig
+
+        cfg = LoraConfig.model_validate(
+            {
+                "type": "lora",
+                "init_lora_weights": "loftq",
+                "loftq_config": {"loftq_bits": 4, "loftq_iter": 2},
+            }
+        )
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.init_lora_weights == "loftq"
+        assert peft_cfg.loftq_config["loftq_bits"] == 4
+        assert peft_cfg.loftq_config["loftq_iter"] == 2
+
+    def test_corda_init(self):
+        from ludwig.schema.llms.peft import LoraConfig
+
+        cfg = LoraConfig.model_validate({"type": "lora", "init_lora_weights": "corda"})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.init_lora_weights == "corda"
+
+    def test_rank_pattern(self):
+        from ludwig.schema.llms.peft import LoraConfig
+
+        pattern = {"model.layers.0.self_attn.q_proj": 4, "model.layers.0.self_attn.v_proj": 2}
+        cfg = LoraConfig.model_validate({"type": "lora", "r": 8, "rank_pattern": pattern})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.rank_pattern == pattern
+
+    def test_alpha_pattern(self):
+        from ludwig.schema.llms.peft import LoraConfig
+
+        pattern = {"model.layers.0.self_attn.q_proj": 16.0}
+        cfg = LoraConfig.model_validate({"type": "lora", "alpha_pattern": pattern})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.alpha_pattern == pattern
+
+    def test_layer_replication(self):
+        from ludwig.schema.llms.peft import LoraConfig
+
+        cfg = LoraConfig.model_validate({"type": "lora", "layer_replication": [[0, 4], [2, 5]]})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.layer_replication == [(0, 4), (2, 5)]
+
+    def test_default_rank_pattern_is_empty(self):
+        from ludwig.schema.llms.peft import LoraConfig
+
+        cfg = LoraConfig.model_validate({"type": "lora"})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.rank_pattern == {}
+        assert peft_cfg.alpha_pattern == {}
+
+
+class TestTinyLoraAdapter:
+    def test_defaults(self):
+        from ludwig.schema.llms.peft import TinyLoraAdapterConfig
+
+        cfg = TinyLoraAdapterConfig.model_validate({"type": "tinylora"})
+        assert cfg.r == 2
+        assert cfg.u == 64
+        assert cfg.weight_tying == 0.0
+
+    def test_custom_params(self):
+        from ludwig.schema.llms.peft import TinyLoraAdapterConfig
+
+        cfg = TinyLoraAdapterConfig.model_validate({"type": "tinylora", "r": 4, "u": 16, "weight_tying": 0.5})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.r == 4
+        assert peft_cfg.u == 16
+        assert peft_cfg.weight_tying == 0.5
+
+    def test_name_and_description(self):
+        from ludwig.schema.llms.peft import TinyLoraAdapterConfig
+
+        assert TinyLoraAdapterConfig.name() == "TinyLoRA"
+        assert "SVD" in TinyLoraAdapterConfig.description()
+
+
+class TestC3AAdapter:
+    def test_defaults(self):
+        from ludwig.schema.llms.peft import C3AAdapterConfig
+
+        cfg = C3AAdapterConfig.model_validate({"type": "c3a"})
+        assert cfg.block_size == 256
+
+    def test_custom_block_size(self):
+        from ludwig.schema.llms.peft import C3AAdapterConfig
+
+        cfg = C3AAdapterConfig.model_validate({"type": "c3a", "block_size": 128})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.block_size == 128
+
+    def test_name(self):
+        from ludwig.schema.llms.peft import C3AAdapterConfig
+
+        assert C3AAdapterConfig.name() == "C3A"
+
+
+class TestOFTAdapter:
+    def test_defaults(self):
+        from ludwig.schema.llms.peft import OFTAdapterConfig
+
+        cfg = OFTAdapterConfig.model_validate({"type": "oft"})
+        assert cfg.oft_block_size == 32
+        assert not cfg.coft
+
+    def test_coft_enabled(self):
+        from ludwig.schema.llms.peft import OFTAdapterConfig
+
+        cfg = OFTAdapterConfig.model_validate({"type": "oft", "coft": True, "eps": 1e-4})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.coft is True
+        assert peft_cfg.eps == 1e-4
+
+    def test_name(self):
+        from ludwig.schema.llms.peft import OFTAdapterConfig
+
+        assert OFTAdapterConfig.name() == "OFT"
+
+
+class TestHRAAdapter:
+    def test_defaults(self):
+        from ludwig.schema.llms.peft import HRAAdapterConfig
+
+        cfg = HRAAdapterConfig.model_validate({"type": "hra"})
+        assert cfg.r == 8
+        assert not cfg.apply_GS
+
+    def test_gram_schmidt(self):
+        from ludwig.schema.llms.peft import HRAAdapterConfig
+
+        cfg = HRAAdapterConfig.model_validate({"type": "hra", "r": 16, "apply_GS": True})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.r == 16
+        assert peft_cfg.apply_GS is True
+
+    def test_name(self):
+        from ludwig.schema.llms.peft import HRAAdapterConfig
+
+        assert HRAAdapterConfig.name() == "HRA"
+
+
+class TestWaveFTAdapter:
+    def test_defaults(self):
+        from ludwig.schema.llms.peft import WaveFTAdapterConfig
+
+        cfg = WaveFTAdapterConfig.model_validate({"type": "waveft"})
+        assert cfg.wavelet_family == "db1"
+        assert cfg.n_frequency == 2592
+
+    def test_custom_wavelet(self):
+        from ludwig.schema.llms.peft import WaveFTAdapterConfig
+
+        cfg = WaveFTAdapterConfig.model_validate({"type": "waveft", "wavelet_family": "db2", "n_frequency": 512})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.wavelet_family == "db2"
+        assert peft_cfg.n_frequency == 512
+
+    def test_name(self):
+        from ludwig.schema.llms.peft import WaveFTAdapterConfig
+
+        assert WaveFTAdapterConfig.name() == "WaveFT"
+
+
+class TestLNTuningAdapter:
+    def test_defaults(self):
+        from ludwig.schema.llms.peft import LNTuningAdapterConfig
+
+        cfg = LNTuningAdapterConfig.model_validate({"type": "ln_tuning"})
+        assert cfg.target_modules is None
+
+    def test_custom_target_modules(self):
+        from ludwig.schema.llms.peft import LNTuningAdapterConfig
+
+        cfg = LNTuningAdapterConfig.model_validate({"type": "ln_tuning", "target_modules": ["norm1", "norm2"]})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.target_modules == ["norm1", "norm2"]
+
+    def test_name(self):
+        from ludwig.schema.llms.peft import LNTuningAdapterConfig
+
+        assert LNTuningAdapterConfig.name() == "LN-Tuning"
+
+
+class TestVBLoRAAdapter:
+    def test_defaults(self):
+        from ludwig.schema.llms.peft import VBLoRAAdapterConfig
+
+        cfg = VBLoRAAdapterConfig.model_validate({"type": "vblora"})
+        assert cfg.r == 4
+        assert cfg.num_vectors == 256
+        assert cfg.topk == 2
+
+    def test_custom_params(self):
+        from ludwig.schema.llms.peft import VBLoRAAdapterConfig
+
+        cfg = VBLoRAAdapterConfig.model_validate({"type": "vblora", "r": 8, "num_vectors": 128, "topk": 4})
+        peft_cfg = cfg.to_config(task_type="CAUSAL_LM")
+        assert peft_cfg.r == 8
+        assert peft_cfg.num_vectors == 128
+        assert peft_cfg.topk == 4
+
+    def test_name(self):
+        from ludwig.schema.llms.peft import VBLoRAAdapterConfig
+
+        assert VBLoRAAdapterConfig.name() == "VBLoRA"
 
 
 class TestECDEncoderAdapter:


### PR DESCRIPTION
Closes #4129

## Summary

Extends Ludwig's PEFT support with all adapters and initializers requested in #4129, implemented against PEFT 0.19.1.

### New LoRA initializers (`init_lora_weights` field)

| Value | Method | Paper |
|-------|--------|-------|
| `pissa` | Principal Singular values & Singular vectors Adaptation | [arXiv:2404.02948](https://arxiv.org/abs/2404.02948) |
| `eva` | Explained Variance Adaptation (data-driven, SOTA) | [arXiv:2410.07170](https://arxiv.org/abs/2410.07170) |
| `corda` | Context-Oriented Decomposition Adaptation | [arXiv:2406.05223](https://arxiv.org/abs/2406.05223) |
| `loftq` | LoftQ quantization-aware init | [arXiv:2310.08659](https://arxiv.org/abs/2310.08659) |
| `olora` | Orthonormal LoRA | — |
| `orthogonal` | Orthogonal init | — |
| `gaussian` | Gaussian init for A matrix | — |

Also adds `rank_pattern` (per-layer rank overrides), `alpha_pattern`, and `layer_replication` to `LoraConfig`.

EVA and LoftQ require companion sub-configs (`eva_config`, `loftq_config`).

### New adapters

| Key | Adapter | Paper |
|-----|---------|-------|
| `tinylora` | TinyLoRA — LoRA-XS variant, SVD + fixed projections, down to 13 params | [arXiv:2602.04118](https://arxiv.org/abs/2602.04118) |
| `c3a` | Contextual/Conditional/Compositional Adapter | — |
| `oft` | Orthogonal Fine-Tuning (+ COFT variant) | [arXiv:2306.07280](https://arxiv.org/abs/2306.07280) |
| `hra` | Householder Reflection Adaptation | [arXiv:2405.17484](https://arxiv.org/abs/2405.17484) |
| `waveft` | Wavelet-domain Fine-Tuning | [arXiv:2411.09295](https://arxiv.org/abs/2411.09295) |
| `ln_tuning` | Layer Normalization Tuning (<0.1% of params) | — |
| `vblora` | Vector Bank LoRA (shared vectors across layers) | [arXiv:2405.15179](https://arxiv.org/abs/2405.15179) |

Total registered adapters: **15** (was 8).

## Examples

```yaml
# PiSSA — faster convergence, same param count as LoRA
adapter:
  type: lora
  r: 16
  init_lora_weights: pissa

# TinyLoRA — extreme low-rank (LoRA-XS)
adapter:
  type: tinylora
  r: 2
  u: 64   # set to 13 for ~13 trainable params per layer group

# OFT — orthogonal, prevents forgetting
adapter:
  type: oft
  oft_block_size: 32

# LN-Tuning — ultra-lightweight
adapter:
  type: ln_tuning
```

## Test plan

- [x] 83 unit tests in `tests/ludwig/schema/test_peft_adapters.py` (all passing)
- [x] Every adapter: `to_config()` round-trip against PEFT 0.19.1
- [x] All `init_lora_weights` options validated
- [x] EVA/LoftQ validation errors on missing sub-config
- [x] `rank_pattern`, `alpha_pattern`, `layer_replication` round-trip
- [x] Pre-commit hooks (black, isort, flake8) passing

## Artifacts

- `examples/peft_advanced/` — YAML configs + `compare_adapters.py` + `train_example.py`
- `notebooks/advanced_peft_adapters.ipynb` — full tutorial notebook