### PR TITLE
fix: eliminate partd race condition by using tasks-based Dask shuffle

### DIFF
--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -869,6 +869,11 @@ class RayBackend(RemoteTrainingMixin, Backend):
         # Prevent Dask from converting object-dtype columns to PyArrow strings,
         # which corrupts binary data, numpy arrays, and complex Python objects.
         dask.config.set({"dataframe.convert-string": False})
+        # Use in-memory task-based shuffle instead of disk (partd). partd creates
+        # a temp directory per shuffle and its __del__ rmtrees it; under Ray's
+        # parallel task execution multiple workers can race on the same temp dir,
+        # causing FileNotFoundError on the .lock file.
+        dask.config.set({"dataframe.shuffle.method": "tasks"})
 
     def generate_bundles(self, num_cpu):
         # Ray requires that each bundle be scheduleable on a single node.


### PR DESCRIPTION
## Root cause

`test_ray_image_multiple_features` was sporadically failing with:

```
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpXXX.partd/.lock'
```

Three-layer chain:

1. `reset_index_across_all_partitions()` (and the `set_index` call in `DaskDataFrame`) calls `df.set_index()` on data with unknown divisions, which triggers a Dask **shuffle**.
2. Dask's default shuffle backend is **partd** — a disk-based key-value store that creates `/tmp/tmpXXX.partd/` with a `.lock` file per shuffle.
3. With `num_processes=5` (parallel image preprocessing workers), multiple Ray tasks run concurrently. One worker's Python GC fires `Partd.__del__()` → `shutil.rmtree(tmpdir)` while another worker is still mid-shuffle and calls `open(lockfile, "wb")` on the deleted directory.

## Fix

One line in `RayBackend.initialize()`:

```python
dask.config.set({"dataframe.shuffle.method": "tasks"})
```

The `"tasks"` shuffle keeps all data in Ray's object store via the task graph — no temp directories, no disk I/O, no lock files. The race is structurally impossible because there's nothing to delete.

## Why `"tasks"` is correct here

- `"p2p"` requires the Dask distributed scheduler, which Ludwig doesn't use with Ray.
- `"disk"` (partd) is the source of the bug.
- `"tasks"` is the standard recommendation for Ray+Dask integrations and is already what the Ray documentation suggests.

## Test plan

- [ ] CI green (the previously-flaky `test_ray_image_multiple_features` should pass consistently)