### PR TITLE
fix: set dask convert-string:False at import time to prevent UnicodeDecodeError on image bytes

### DIFF
--- a/ludwig/__init__.py
+++ b/ludwig/__init__.py
@@ -21,3 +21,18 @@ logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
 
 # Disable annoying message about NUMEXPR_MAX_THREADS
 logging.getLogger("numexpr").setLevel(logging.WARNING)
+
+# Prevent Dask from converting object-dtype columns to PyArrow strings.
+# Dask's default convert-string:True tries to decode every object column as
+# UTF-8, which corrupts binary data (image bytes, numpy arrays, etc.) with a
+# UnicodeDecodeError.  This must be set at import time — before the caller
+# creates any Dask DataFrame — because the _to_string_dtype expression node is
+# baked into the task graph at dd.from_pandas() / dd.read_*() time.
+# Setting it in RayBackend.initialize() (which happens after train() is called)
+# is too late to help user-provided DataFrames.  GitHub issue #4149.
+try:
+    import dask
+
+    dask.config.set({"dataframe.convert-string": False})
+except ImportError:
+    pass

--- a/tests/ludwig/data/dataframe/test_dask.py
+++ b/tests/ludwig/data/dataframe/test_dask.py
@@ -1,8 +1,52 @@
+import io
+
+import numpy as np
 import pandas as pd
 import pytest
 
 from ludwig.api import LudwigModel
 from tests.integration_tests.utils import generate_data_as_dataframe
+
+
+def test_dask_image_bytes_no_unicode_error():
+    """Regression test for GitHub #4149.
+
+    Dask's default dataframe.convert-string:True tries to decode all object-dtype
+    columns as UTF-8 strings.  JPEG/PNG bytes start with 0xFF/0x89 — invalid UTF-8
+    start bytes — so the conversion raises UnicodeDecodeError.
+
+    Ludwig fixes this by setting dataframe.convert-string:False at import time
+    (ludwig/__init__.py), before the caller creates any Dask DataFrame.  The old fix
+    in RayBackend.initialize() was too late: user DataFrames are created before
+    model.train() is called, so the broken _to_string_dtype node was already baked
+    into the task graph.
+    """
+    import dask
+    import dask.dataframe as dd
+    from PIL import Image
+
+    from ludwig.data.dataframe.dask import reset_index_across_all_partitions
+
+    assert (
+        dask.config.get("dataframe.convert-string") is False
+    ), "Ludwig must set dataframe.convert-string:False at import time (ludwig/__init__.py)"
+
+    def _jpeg_bytes() -> bytes:
+        buf = io.BytesIO()
+        Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8)).save(buf, "JPEG")
+        return buf.getvalue()
+
+    n = 16
+    df = dd.from_pandas(
+        pd.DataFrame({"image_data": [_jpeg_bytes() for _ in range(n)], "label": np.arange(n, dtype=float)}),
+        npartitions=4,
+    )
+
+    # reset_index is called inside Ludwig's build_dataset; it must not raise.
+    result = reset_index_across_all_partitions(df)
+    computed = result.compute()
+    assert len(computed) == n
+    assert computed["image_data"].iloc[0][:2] == b"\xff\xd8"  # JPEG magic bytes intact
 
 
 @pytest.mark.distributed

--- a/tests/ultra_slow/test_ultra_slow.py
+++ b/tests/ultra_slow/test_ultra_slow.py
@@ -25,6 +25,7 @@ Sections
   vector, timeseries
 """
 
+import io
 import os
 import tempfile
 
@@ -1095,3 +1096,73 @@ class TestOutputTypesRay:
             self._df,
             backend=ray_1gpu,
         )
+
+
+# ---------------------------------------------------------------------------
+# IMAGE input — binary bytes in a pre-existing Dask DataFrame (GitHub #4149)
+# ---------------------------------------------------------------------------
+
+
+def _jpeg_bytes_col(n: int = N) -> list[bytes]:
+    """Return n small (8×8 RGB) JPEG-encoded images as raw bytes."""
+    from PIL import Image
+
+    result = []
+    for i in range(n):
+        buf = io.BytesIO()
+        arr = np.full((32, 32, 3), [i % 256, (i * 7) % 256, (i * 13) % 256], dtype=np.uint8)
+        Image.fromarray(arr).save(buf, "JPEG")
+        result.append(buf.getvalue())
+    return result
+
+
+class TestImageBytesRay:
+    """Regression tests for GitHub #4149.
+
+    The bug: when a user passes a Dask DataFrame whose image column contains raw
+    binary bytes (JPEG/PNG), Dask's _to_string_dtype tries to decode the bytes as
+    UTF-8, failing with UnicodeDecodeError.  The fix moves
+    dask.config(dataframe.convert-string:False) to ludwig/__init__.py so it is set
+    before the user ever creates a Dask DataFrame.
+    """
+
+    _IMAGE_CONFIG = {
+        "input_features": [
+            {
+                "name": "image_data",
+                "type": "image",
+                "preprocessing": {"height": 32, "width": 32, "num_channels": 3},
+                "encoder": {"type": "stacked_cnn", "output_size": 16},
+            }
+        ],
+        "output_features": [{"name": "label", "type": "number"}],
+        "trainer": {"epochs": 1, "learning_rate": LR, "batch_size": 16},
+    }
+
+    def test_image_bytes_pandas_local_backend(self):
+        """Pandas DataFrame with bytes column — verifies local image-bytes path works."""
+        pd_df = pd.DataFrame({"image_data": _jpeg_bytes_col(), "label": RNG.standard_normal(N).tolist()})
+        with tempfile.TemporaryDirectory() as out:
+            model = LudwigModel(self._IMAGE_CONFIG, logging_level=40)
+            result = model.train(dataset=pd_df, output_directory=out)
+            assert result.train_stats is not None
+
+    def test_image_bytes_dask_ray_backend(self, ray_1gpu):
+        """Dask DataFrame with bytes column + Ray backend — the exact scenario from #4149.
+
+        The Dask DataFrame is created before model.train() is called to faithfully
+        replicate the user scenario where dd.from_pandas() would fail with
+        UnicodeDecodeError if dask.config.convert-string is not set to False.
+        """
+        import dask.dataframe as dd
+
+        pd_df = pd.DataFrame({"image_data": _jpeg_bytes_col(), "label": RNG.standard_normal(N).tolist()})
+        # Create Dask DataFrame before calling train — this is the user pattern that
+        # triggered the original bug.
+        dask_df = dd.from_pandas(pd_df, npartitions=4)
+
+        config = {**self._IMAGE_CONFIG, "backend": ray_1gpu}
+        with tempfile.TemporaryDirectory() as out:
+            model = LudwigModel(config, logging_level=40)
+            result = model.train(dataset=dask_df, output_directory=out)
+            assert result.train_stats is not None


### PR DESCRIPTION
## Summary

- Moves `dask.config.set({"dataframe.convert-string": False})` from `RayBackend.initialize()` to `ludwig/__init__.py`
- The old location was too late: user Dask DataFrames are created *before* `model.train()` is called, so Dask's `_to_string_dtype` node was already baked into the task graph when `RayBackend.initialize()` ran
- In newer Dask (dask-expr), `_to_string_dtype` fires at `dd.from_pandas()` time when computing `_meta`; in older Dask it fires during the first `set_index(sorted=True)` → `compute_current_divisions()` call — both fail with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff` for JPEG/PNG bytes

## Test plan

- [x] `tests/ludwig/data/dataframe/test_dask.py::test_dask_image_bytes_no_unicode_error` — fast regression test: asserts config is `False` at import time, creates a Dask DataFrame with JPEG bytes, verifies `dd.from_pandas()` and `reset_index_across_all_partitions()` work without error
- [x] `tests/ultra_slow/test_ultra_slow.py::TestImageBytesRay::test_image_bytes_pandas_local_backend` — full 1-epoch training with pandas DataFrame + bytes column
- [x] `tests/ultra_slow/test_ultra_slow.py::TestImageBytesRay::test_image_bytes_dask_ray_backend` — full 1-epoch training replicating the exact user scenario: Dask DataFrame created before `train()`, Ray backend

Closes #4149