### PR TITLE
docs: convert experiment.py and sequence_encoders.py docstrings to Google style

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -1818,30 +1818,18 @@ class LudwigModel:
     ) -> bool:
         """Uploads trained model artifacts to the HuggingFace Hub.
 
-        # Inputs
+        Args:
+            repo_id: A namespace (user or an organization) and a repo name separated by a `/`.
+            model_path: The path of the saved model. This is either (a) the folder where the 'model_weights'
+                folder and the 'model_hyperparameters.json' file are stored, or (b) the parent of that folder.
+            private: Whether the model repo should be private. Defaults to False.
+            repo_type: Set to `"dataset"` or `"space"` if uploading to a dataset or space, `None` or `"model"`
+                if uploading to a model. Default is `None`.
+            commit_message: The summary / title / first line of the generated commit.
+            commit_description: The description of the generated commit.
 
-        :param repo_id: (`str`)
-            A namespace (user or an organization) and a repo name separated
-            by a `/`.
-        :param model_path: (`str`)
-            The path of the saved model. This is either (a) the folder where
-            the 'model_weights' folder and the 'model_hyperparameters.json' file
-            are stored, or (b) the parent of that folder.
-        :param private: (`bool`, *optional*, defaults to `False`)
-            Whether the model repo should be private.
-        :param repo_type: (`str`, *optional*)
-            Set to `"dataset"` or `"space"` if uploading to a dataset or
-            space, `None` or `"model"` if uploading to a model. Default is
-            `None`.
-        :param commit_message: (`str`, *optional*)
-            The summary / title / first line of the generated commit. Defaults to:
-            `f"Upload {path_in_repo} with huggingface_hub"`
-        :param commit_description: (`str` *optional*)
-            The description of the generated commit
-
-        # Returns
-
-        :return: (bool) True for success, False for failure.
+        Returns:
+            True for success, False for failure.
         """
         if model_weights_exist(os.path.join(model_path, MODEL_FILE_NAME)) and os.path.exists(
             os.path.join(model_path, MODEL_FILE_NAME, MODEL_HYPERPARAMETERS_FILE_NAME)
@@ -1872,13 +1860,8 @@ class LudwigModel:
     def save_config(self, save_path: str) -> None:
         """Save config to specified location.
 
-        # Inputs
-
-        :param save_path: (str) filepath string to save config as a
-            JSON file.
-
-        # Return
-        :return: `None`
+        Args:
+            save_path: filepath string to save config as a JSON file.
         """
         os.makedirs(save_path, exist_ok=True)
         model_hyperparameters_path = os.path.join(save_path, MODEL_HYPERPARAMETERS_FILE_NAME)
@@ -1952,11 +1935,12 @@ class LudwigModel:
     def create_model(config_obj: ModelConfig | dict, random_seed: int = default_random_seed) -> BaseModel:
         """Instantiates BaseModel object.
 
-        # Inputs
-        :param config_obj: (Union[Config, dict]) Ludwig config object
-        :param random_seed: (int, default: ludwig default random seed) Random seed used for weights initialization,
-            splits and any other random function. # Return
-        :return: (ludwig.models.BaseModel) Instance of the Ludwig model object.
+        Args:
+            config_obj: Ludwig config object.
+            random_seed: Random seed used for weights initialization, splits and any other random function.
+
+        Returns:
+            Instance of the Ludwig model object.
         """
         if isinstance(config_obj, dict):
             config_obj = ModelConfig.from_dict(config_obj)
@@ -1967,14 +1951,9 @@ class LudwigModel:
     def set_logging_level(logging_level: int) -> None:
         """Sets level for log messages.
 
-        # Inputs
-
-        :param logging_level: (int) Set/Update the logging level. Use logging
-        constants like `logging.DEBUG` , `logging.INFO` and `logging.ERROR`.
-
-        # Return
-
-        :return: `None`
+        Args:
+            logging_level: Set/Update the logging level. Use logging constants like `logging.DEBUG`,
+                `logging.INFO` and `logging.ERROR`.
         """
         logging.getLogger("ludwig").setLevel(logging_level)
         if logging_level in {logging.WARNING, logging.ERROR, logging.CRITICAL}:

--- a/ludwig/automl/base_config.py
+++ b/ludwig/automl/base_config.py
@@ -79,11 +79,11 @@ class DatasetInfo:
 def allocate_experiment_resources(resources: Resources) -> dict:
     """Allocates ray trial resources based on available resources.
 
-    # Inputs :param resources (dict) specifies all available GPUs, CPUs and associated     metadata of the machines
-    (i.e. memory)
+    Args:
+        resources: specifies all available GPUs, CPUs and associated metadata of the machines (i.e. memory).
 
-    # Return
-    :return: (dict) gpu and cpu resources per trial
+    Returns:
+        gpu and cpu resources per trial.
     """
     # TODO (ASN):
     # (1) expand logic to support multiple GPUs per trial (multi-gpu training)
@@ -176,21 +176,18 @@ def create_default_config(
     - infers resource constraints and adds gpu and cpu resource allocation per
       trial
 
-    # Inputs
-    :param dataset_info: (str) filepath Dataset Info object.
-    :param target_name: (str, List[str]) name of target feature
-    :param time_limit_s: (int, float) total time allocated to auto_train. acts
-                                    as the stopping parameter
-    :param random_seed: (int, default: `42`) a random seed that will be used anywhere
-                        there is a call to a random number generator, including
-                        hyperparameter search sampling, as well as data splitting,
-                        parameter initialization and training set shuffling
-    :param imbalance_threshold: (float) maximum imbalance ratio (minority / majority) to perform stratified sampling
-    :param backend: (Backend) backend to use for training.
+    Args:
+        dataset_info: Dataset Info object.
+        target_name: name of target feature.
+        time_limit_s: total time allocated to auto_train. Acts as the stopping parameter.
+        random_seed: a random seed that will be used anywhere there is a call to a random number generator,
+            including hyperparameter search sampling, as well as data splitting, parameter initialization and
+            training set shuffling.
+        imbalance_threshold: maximum imbalance ratio (minority / majority) to perform stratified sampling.
+        backend: backend to use for training.
 
-    # Return
-    :return: (dict) dictionaries contain auto train config files for all available
-    combiner types
+    Returns:
+        dictionaries containing auto train config files for all available combiner types.
     """
     base_automl_config = load_yaml(BASE_AUTOML_CONFIG)
     base_automl_config.update(features_config)
@@ -256,9 +253,11 @@ def get_dataset_info(df: pd.DataFrame | dd.DataFrame) -> DatasetInfo:
     """Constructs FieldInfo objects for each feature in dataset. These objects are used for downstream type
     inference.
 
-    # Inputs
-    :param df: (Union[pd.DataFrame, dd.DataFrame]) Pandas or Dask dataframe.  # Return
-    :return: (DatasetInfo) Structure containing list of FieldInfo objects.
+    Args:
+        df: Pandas or Dask dataframe.
+
+    Returns:
+        Structure containing list of FieldInfo objects.
     """
     source = wrap_data_source(df)
     return get_dataset_info_from_source(source)
@@ -291,9 +290,11 @@ def get_dataset_info_from_source(source: DataSource) -> DatasetInfo:
     """Constructs FieldInfo objects for each feature in dataset. These objects are used for downstream type
     inference.
 
-    # Inputs
-    :param source: (DataSource) A wrapper around a data source, which may represent a pandas or Dask dataframe. # Return
-    :return: (DatasetInfo) Structure containing list of FieldInfo objects.
+    Args:
+        source: A wrapper around a data source, which may represent a pandas or Dask dataframe.
+
+    Returns:
+        Structure containing list of FieldInfo objects.
     """
     row_count = len(source)
     fields = []
@@ -346,11 +347,13 @@ def get_features_config(
     """Constructs FieldInfo objects for each feature in dataset. These objects are used for downstream type
     inference.
 
-    # Inputs
-    :param fields: (List[FieldInfo]) FieldInfo objects for all fields in dataset
-    :param row_count: (int) total number of entries in original dataset :param target_name (str, List[str]) name of
-        target feature # Return
-    :return: (dict) section of auto_train config for input_features and output_features
+    Args:
+        fields: FieldInfo objects for all fields in dataset.
+        row_count: total number of entries in original dataset.
+        target_name: name of target feature.
+
+    Returns:
+        Section of auto_train config for input_features and output_features.
     """
     targets = convert_targets(target_name)
     metadata = get_field_metadata(fields, row_count, targets)
@@ -369,10 +372,12 @@ def convert_targets(target_name: str | list[str] | None = None) -> set[str]:
 def get_config_from_metadata(metadata: list[FieldMetadata], targets: set[str] | None = None) -> dict:
     """Builds input/output feature sections of auto-train config using field metadata.
 
-    # Inputs
-    :param metadata: (List[FieldMetadata]) field descriptions :param targets (Set[str]) names of target features #
-        Return
-    :return: (dict) section of auto_train config for input_features and output_features
+    Args:
+        metadata: FieldMetadata objects describing each field.
+        targets: names of target features.
+
+    Returns:
+        Section of auto_train config for input_features and output_features.
     """
     config = {
         "input_features": [],
@@ -392,11 +397,13 @@ def get_config_from_metadata(metadata: list[FieldMetadata], targets: set[str] | 
 def get_field_metadata(fields: list[FieldInfo], row_count: int, targets: set[str] | None = None) -> list[FieldMetadata]:
     """Computes metadata for each field in dataset.
 
-    # Inputs
-    :param fields: (List[FieldInfo]) FieldInfo objects for all fields in dataset
-    :param row_count: (int) total number of entries in original dataset :param targets (Set[str]) names of target
-        features # Return
-    :return: (List[FieldMetadata]) list of objects containing metadata for each field
+    Args:
+        fields: FieldInfo objects for all fields in dataset.
+        row_count: total number of entries in original dataset.
+        targets: names of target features.
+
+    Returns:
+        List of objects containing metadata for each field.
     """
 
     metadata = []

--- a/ludwig/benchmarking/examples/process_config.py
+++ b/ludwig/benchmarking/examples/process_config.py
@@ -9,10 +9,12 @@ def process_config(ludwig_config: dict, experiment_dict: dict) -> dict:
      attributes of `experiment_dict` (e.g. dataset_name) removing the need to manually apply
      small changes to configs on many datasets.
 
-    :param ludwig_config: a Ludwig config.
-    :param experiment_dict: a benchmarking config experiment dictionary.
+    Args:
+        ludwig_config: A Ludwig config.
+        experiment_dict: A benchmarking config experiment dictionary.
 
-    Returns: a modified Ludwig config.
+    Returns:
+        A modified Ludwig config.
     """
 
     # only keep input_features and output_features

--- a/ludwig/benchmarking/reporting.py
+++ b/ludwig/benchmarking/reporting.py
@@ -13,7 +13,8 @@ from ludwig.constants import LUDWIG_TAG
 def initialize_stats_dict(main_function_events: list[profiler_util.FunctionEvent]) -> dict[str, list]:
     """Initialize dictionary which stores resource usage information per tagged code block.
 
-    :param main_function_events: list of main function events.
+    Args:
+        main_function_events: list of main function events.
     """
     info = {}
     for event_name in [evt.name for evt in main_function_events]:
@@ -24,7 +25,8 @@ def initialize_stats_dict(main_function_events: list[profiler_util.FunctionEvent
 def get_memory_details(kineto_event: _KinetoEvent) -> tuple[str, int]:
     """Get device name and number of bytes (de)allocated during an event.
 
-    :param kineto_event: a Kineto event instance.
+    Args:
+        kineto_event: a Kineto event instance.
     """
     if kineto_event.device_type() in [DeviceType.CPU, DeviceType.MKLDNN, DeviceType.IDEEP]:
         return "cpu", kineto_event.nbytes()
@@ -39,8 +41,9 @@ def get_device_memory_usage(
 ) -> dict[str, DeviceUsageMetrics]:
     """Get CPU and CUDA memory usage for an event.
 
-    :param kineto_event: a Kineto event instance.
-    :param memory_events: list of memory events.
+    Args:
+        kineto_event: a Kineto event instance.
+        memory_events: list of memory events.
     """
     mem_records_acc = profiler_util.MemRecordsAcc(memory_events)
     start_us = kineto_event.start_ns() / 1000
@@ -70,8 +73,9 @@ def get_device_memory_usage(
 def get_torch_op_time(events: list[profiler_util.FunctionEvent], attr: str) -> int | float:
     """Get time torch operators spent executing for a list of events.
 
-    :param events: list of events.
-    :param attr: a FunctionEvent attribute. Expecting one of "cpu_time_total", "device_time_total".
+    Args:
+        events: list of events.
+        attr: a FunctionEvent attribute. Expecting one of "cpu_time_total", "device_time_total".
     """
     if attr not in ["cpu_time_total", "device_time_total"]:
         return -1
@@ -90,7 +94,8 @@ def get_torch_op_time(events: list[profiler_util.FunctionEvent], attr: str) -> i
 def get_device_run_durations(function_event: profiler_util.FunctionEvent) -> tuple[float, float]:
     """Get CPU and device run durations for an event.
 
-    :param function_event: a function event instance.
+    Args:
+        function_event: a function event instance.
     """
     torch_cpu_time = get_torch_op_time(function_event.cpu_children, "cpu_time_total")
     torch_device_time = get_torch_op_time(function_event.cpu_children, "device_time_total")
@@ -114,11 +119,12 @@ def get_resource_usage_report(
 ) -> dict[str, list[TorchProfilerMetrics]]:
     """Get relevant information from Kineto events and function events exported by the profiler.
 
-    :param main_kineto_events: list of main Kineto events.
-    :param main_function_events: list of main function events.
-    :param memory_events: list of memory events.
-    :param out_of_memory_events: list of out of memory events.
-    :param info: dictionary used to record resource usage metrics.
+    Args:
+        main_kineto_events: list of main Kineto events.
+        main_function_events: list of main function events.
+        memory_events: list of memory events.
+        out_of_memory_events: list of out of memory events.
+        info: dictionary used to record resource usage metrics.
     """
     main_kineto_events = sorted(
         (evt for evt in main_kineto_events if LUDWIG_TAG in evt.name()), key=lambda x: x.correlation_id()
@@ -152,8 +158,9 @@ def get_all_events(
     """Return main Kineto and function events, memory and OOM events for functions/code blocks tagged in
     LudwigProfiler.
 
-    :param kineto_events: list of Kineto Events.
-    :param function_events: list of function events.
+    Args:
+        kineto_events: list of Kineto Events.
+        function_events: list of function events.
     """
     # LUDWIG_TAG is prepended to LudwigProfiler tags. This edited tag is passed in to `torch.profiler.record_function`
     # so we can easily retrieve events for code blocks wrapped with LudwigProfiler.
@@ -176,8 +183,9 @@ def get_metrics_from_torch_profiler(profile: torch.profiler.profiler.profile) ->
     The torch profiler surfaces these metrics that are tracked under the hood by `libkineto`.
     More on the Kineto project: https://github.com/pytorch/kineto
 
-    :param profile: profiler object that contains all the events that
-        were registered during the execution of the wrapped code block.
+    Args:
+        profile: profiler object that contains all the events that were registered during the execution of the
+            wrapped code block.
     """
     # events in both of these lists are in chronological order.
     kineto_events = profile.profiler.kineto_results.events()
@@ -199,7 +207,8 @@ def get_metrics_from_torch_profiler(profile: torch.profiler.profiler.profile) ->
 def get_metrics_from_system_usage_profiler(system_usage_info: dict) -> SystemResourceMetrics:
     """Package system resource usage metrics (no torch operators) in a dataclass.
 
-    :param system_usage_info: dictionary containing resource usage information.
+    Args:
+        system_usage_info: dictionary containing resource usage information.
     """
     device_usage_dict: dict[str, DeviceUsageMetrics] = {}
     for key in system_usage_info:

--- a/ludwig/benchmarking/summarize.py
+++ b/ludwig/benchmarking/summarize.py
@@ -21,12 +21,13 @@ def summarize_metrics(
 ) -> tuple[list[str], list[MetricsDiff], list[list[ResourceUsageDiff]]]:
     """Build metric and resource usage diffs from experiment artifacts.
 
-    bench_config_path: bench config file path. Can be the same one that was used to run
-        these experiments.
-    base_experiment: name of the experiment we're comparing against.
-    experimental_experiment: name of the experiment we're comparing.
-    download_base_path: base path under which live the stored artifacts of
-        the benchmarking experiments.
+    Args:
+        bench_config_path: Bench config file path. Can be the same one that was used to run
+            these experiments.
+        base_experiment: Name of the experiment we're comparing against.
+        experimental_experiment: Name of the experiment we're comparing.
+        download_base_path: Base path under which live the stored artifacts of
+            the benchmarking experiments.
     """
     local_dir, dataset_list = download_artifacts(
         bench_config_path, base_experiment, experimental_experiment, download_base_path
@@ -55,9 +56,10 @@ def export_and_print(
 ) -> None:
     """Export to CSV and print a diff of performance and resource usage metrics of two experiments.
 
-    :param dataset_list: list of datasets for which to print the diffs.
-    :param metric_diffs: Diffs for the performance metrics by dataset.
-    :param resource_usage_diffs: Diffs for the resource usage metrics per dataset per LudwigProfiler tag.
+    Args:
+        dataset_list: List of datasets for which to print the diffs.
+        metric_diffs: Diffs for the performance metrics by dataset.
+        resource_usage_diffs: Diffs for the resource usage metrics per dataset per LudwigProfiler tag.
     """
     for dataset_name, experiment_metric_diff in zip(dataset_list, metric_diffs):
         output_path = os.path.join("summarize_output", "performance_metrics", dataset_name)

--- a/ludwig/benchmarking/summary_dataclasses.py
+++ b/ludwig/benchmarking/summary_dataclasses.py
@@ -53,9 +53,10 @@ class MetricDiff:
 def build_diff(name: str, base_value: float, experimental_value: float) -> MetricDiff:
     """Build a diff between any type of metric.
 
-    :param name: name assigned to the metric to be diff-ed.
-    :param base_value: base value of the metric.
-    :param experimental_value: experimental value of the metric.
+    Args:
+        name: name assigned to the metric to be diff-ed.
+        base_value: base value of the metric.
+        experimental_value: experimental value of the metric.
     """
     diff = experimental_value - base_value
     diff_percentage = 100 * diff / base_value if base_value != 0 else "inf"
@@ -160,8 +161,9 @@ class MetricsDiff:
 def export_metrics_diff_to_csv(metrics_diff: MetricsDiff, path: str):
     """Export metrics report to .csv.
 
-    :param metrics_diff: MetricsDiff object containing the diff for two experiments on a dataset.
-    :param path: file name of the exported csv.
+    Args:
+        metrics_diff: MetricsDiff object containing the diff for two experiments on a dataset.
+        path: file name of the exported csv.
     """
     with open(path, "w", newline="") as f:
         writer = csv.DictWriter(
@@ -204,8 +206,9 @@ def export_metrics_diff_to_csv(metrics_diff: MetricsDiff, path: str):
 def build_metrics_summary(experiment_local_directory: str) -> MetricsSummary:
     """Build a metrics summary for an experiment.
 
-    :param experiment_local_directory: directory where the experiment artifacts live.
-        e.g. local_experiment_repo/ames_housing/some_experiment/
+    Args:
+        experiment_local_directory: directory where the experiment artifacts live.
+            e.g. local_experiment_repo/ames_housing/some_experiment/
     """
     config = load_json(
         os.path.join(experiment_local_directory, "experiment_run", MODEL_FILE_NAME, MODEL_HYPERPARAMETERS_FILE_NAME)
@@ -235,10 +238,11 @@ def build_metrics_diff(
 ) -> MetricsDiff:
     """Build a MetricsDiff object between two experiments on a dataset.
 
-    :param dataset_name: the name of the Ludwig dataset.
-    :param base_experiment_name: the name of the base experiment.
-    :param experimental_experiment_name: the name of the experimental experiment.
-    :param local_directory: the local directory where the experiment artifacts are downloaded.
+    Args:
+        dataset_name: the name of the Ludwig dataset.
+        base_experiment_name: the name of the base experiment.
+        experimental_experiment_name: the name of the experimental experiment.
+        local_directory: the local directory where the experiment artifacts are downloaded.
     """
     base_summary: MetricsSummary = build_metrics_summary(
         os.path.join(local_directory, dataset_name, base_experiment_name)
@@ -331,8 +335,9 @@ class ResourceUsageDiff:
 def export_resource_usage_diff_to_csv(resource_usage_diff: ResourceUsageDiff, path: str):
     """Export resource usage metrics report to .csv.
 
-    :param resource_usage_diff: ResourceUsageDiff object containing the diff for two experiments on a dataset.
-    :param path: file name of the exported csv.
+    Args:
+        resource_usage_diff: ResourceUsageDiff object containing the diff for two experiments on a dataset.
+        path: file name of the exported csv.
     """
     with open(path, "w", newline="") as f:
         writer = csv.DictWriter(
@@ -370,9 +375,10 @@ def average_runs(path_to_runs_dir: str) -> dict[str, int | float]:
 
     Metrics for code blocks/functions that were executed exactly once will be returned as is.
 
-    :param path_to_runs_dir: path to where metrics specific to a tag are stored.
-        e.g. resource_usage_out_dir/torch_ops_resource_usage/LudwigModel.evaluate/
-        This directory will contain JSON files with the following pattern run_*.json
+    Args:
+        path_to_runs_dir: path to where metrics specific to a tag are stored.
+            e.g. resource_usage_out_dir/torch_ops_resource_usage/LudwigModel.evaluate/
+            This directory will contain JSON files with the following pattern run_*.json
     """
     runs = [load_json(os.path.join(path_to_runs_dir, run)) for run in os.listdir(path_to_runs_dir)]
     # asserting that keys to each of the dictionaries are consistent throughout the runs.
@@ -390,8 +396,9 @@ def summarize_resource_usage(path: str, tags: list[str] | None = None) -> list[R
     Each entry of the list corresponds to the metrics collected from a code block/function run.
     Important: code blocks that ran more than once are averaged.
 
-    :param path: corresponds to the `output_dir` argument in a ResourceUsageTracker run.
-    :param tags: (optional) list of tags to create summary for. If None, metrics from all tags will be summarized.
+    Args:
+        path: corresponds to the `output_dir` argument in a ResourceUsageTracker run.
+        tags: optional list of tags to create summary for. If None, metrics from all tags will be summarized.
     """
     summary = {}
     # metric types: system_resource_usage, torch_ops_resource_usage.
@@ -431,8 +438,9 @@ def build_resource_usage_diff(
 ) -> list[ResourceUsageDiff]:
     """Build and return a ResourceUsageDiff object to diff resource usage metrics between two experiments.
 
-    :param base_path: corresponds to the `output_dir` argument in the base ResourceUsageTracker run.
-    :param experimental_path: corresponds to the `output_dir` argument in the experimental ResourceUsageTracker run.
+    Args:
+        base_path: corresponds to the `output_dir` argument in the base ResourceUsageTracker run.
+        experimental_path: corresponds to the `output_dir` argument in the experimental ResourceUsageTracker run.
     """
     base_summary_list = summarize_resource_usage(base_path)
     experimental_summary_list = summarize_resource_usage(experimental_path)

--- a/ludwig/collect.py
+++ b/ludwig/collect.py
@@ -53,44 +53,28 @@ def collect_activations(
     """Uses the pretrained model to collect the tensors corresponding to a datapoint in the dataset. Saves the
     tensors to the experiment directory.
 
-    # Inputs
+    Args:
+        model_path: Filepath to pre-trained model.
+        layers: List of strings for layer names in the model to collect activations.
+        dataset: Source containing the data to make predictions.
+        data_format: Format to interpret data sources. Will be inferred automatically if not specified.
+            Valid formats are 'auto', 'csv', 'excel', 'feather', 'fwf', 'hdf5' (cache file produced
+            during previous training), 'html' (file containing a single HTML table), 'json', 'jsonl',
+            'parquet', 'pickle' (pickled Pandas DataFrame), 'sas', 'spss', 'stata', 'tsv'.
+        split: Split on which to perform predictions. Valid values are 'training', 'validation',
+            'test' and 'full'.
+        batch_size: Size of batches for processing.
+        output_directory: The directory that will contain the training statistics, TensorBoard logs,
+            the saved model and the training progress files.
+        gpus: List of GPUs that are available for training.
+        gpu_memory_limit: Maximum memory fraction [0, 1] allowed to allocate per GPU device.
+        allow_parallel_threads: Allow PyTorch to use multithreading parallelism to improve performance
+            at the cost of determinism.
+        callbacks: A list of `ludwig.callbacks.Callback` objects that provide hooks into the Ludwig pipeline.
+        backend: Backend or string name of backend to use to execute preprocessing / training steps.
 
-    :param model_path: (str) filepath to pre-trained model.
-    :param layers: (List[str]) list of strings for layer names in the model
-        to collect activations.
-    :param dataset: (str) source
-        containing the data to make predictions.
-    :param data_format: (str, default: `None`) format to interpret data
-        sources. Will be inferred automatically if not specified.  Valid
-        formats are `'auto'`, `'csv'`, `'excel'`, `'feather'`,
-        `'fwf'`, `'hdf5'` (cache file produced during previous training),
-        `'html'` (file containing a single HTML `<table>`), `'json'`, `'jsonl'`,
-        `'parquet'`, `'pickle'` (pickled Pandas DataFrame), `'sas'`, `'spss'`,
-        `'stata'`, `'tsv'`.
-    :param split: (str, default: `full`) split on which
-        to perform predictions. Valid values are `'training'`, `'validation'`,
-        `'test'` and `'full'`.
-    :param batch_size: (int, default `128`) size of batches for processing.
-    :param output_directory: (str, default: `'results'`) the directory that
-        will contain the training statistics, TensorBoard logs, the saved
-        model and the training progress files.
-    :param gpus: (list, default: `None`) list of GPUs that are available
-        for training.
-    :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
-        [0, 1] allowed to allocate per GPU device.
-    :param allow_parallel_threads: (bool, default: `True`) allow PyTorch
-        to use multithreading parallelism to improve performance at
-        the cost of determinism.
-    :param callbacks: (list, default: `None`) a list of
-        `ludwig.callbacks.Callback` objects that provide hooks into the
-        Ludwig pipeline.
-    :param backend: (Union[Backend, str]) `Backend` or string name
-        of backend to use to execute preprocessing / training steps.
-
-    # Return
-
-    :return: (List[str]) list of filepath to `*.npy` files containing
-        the activations.
+    Returns:
+        List of filepath to *.npy files containing the activations.
     """
     logger.info(f"Dataset path: {dataset}")
     logger.info(f"Model path: {model_path}")
@@ -123,17 +107,13 @@ def collect_activations(
 def collect_weights(model_path: str, tensors: list[str], output_directory: str = "results", **kwargs) -> list[str]:
     """Loads a pretrained model and collects weights.
 
-    # Inputs
-    :param model_path: (str) filepath to pre-trained model.
-    :param tensors: (list, default: `None`) List of tensor names to collect
-        weights
-    :param output_directory: (str, default: `'results'`) the directory where
-        collected weights will be stored.
+    Args:
+        model_path: Filepath to pre-trained model.
+        tensors: List of tensor names to collect weights.
+        output_directory: The directory where collected weights will be stored.
 
-    # Return
-
-    :return: (List[str]) list of filepath to `*.npy` files containing
-        the weights.
+    Returns:
+        List of filepath to *.npy files containing the weights.
     """
     logger.info(f"Model path: {model_path}")
     logger.info(f"Output path: {output_directory}")
@@ -167,11 +147,8 @@ def save_tensors(collected_tensors, output_directory):
 def print_model_summary(model_path: str, **kwargs) -> None:
     """Loads a pretrained model and prints names of weights and layers activations.
 
-    # Inputs
-    :param model_path: (str) filepath to pre-trained model.
-
-    # Return
-    :return: (`None`)
+    Args:
+        model_path: Filepath to pre-trained model.
     """
     model = LudwigModel.load(model_path)
     # Move model to CPU for torchinfo summary to avoid device mismatch issues.
@@ -190,11 +167,8 @@ def print_model_summary(model_path: str, **kwargs) -> None:
 def pretrained_summary(pretrained_model: str, **kwargs) -> None:
     """Loads a pretrained model from Huggingface or Torchvision models and prints names of layers.
 
-    # Inputs
-    :param pretrained_model: (str) name of model to load (case sensitive).
-
-    # Return
-    :return: (`None`)
+    Args:
+        pretrained_model: Name of model to load (case sensitive).
     """
     from transformers import AutoConfig, AutoModel
 

--- a/ludwig/contribs/mlflow/model.py
+++ b/ludwig/contribs/mlflow/model.py
@@ -26,10 +26,7 @@ _logger = logging.getLogger(__name__)
 
 
 def get_default_conda_env():
-    """
-    :return: The default Conda environment for MLflow Models produced by calls to
-             :func:`save_model()` and :func:`log_model()`.
-    """
+    """Returns the default Conda environment for MLflow Models produced by calls to save_model() and log_model()."""
     import ludwig
 
     # Ludwig is not yet available via the default conda channels, so we install it via pip
@@ -51,48 +48,21 @@ def save_model(
 ):
     """Save a Ludwig model to a path on the local file system.
 
-    :param ludwig_model: Ludwig model (an instance of `ludwig.api.LudwigModel`_) to be saved.
-    :param path: Local path where the model is to be saved.
-    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
-                      Conda environment yaml file. If provided, this describes the environment
-                      this model should be run in. At minimum, it should specify the dependencies
-                      contained in :func:`get_default_conda_env()`. If ``None``, the default
-                      :func:`get_default_conda_env()` environment is added to the model.
-                      The following is an *example* dictionary representation of a Conda
-                      environment::
-
-                        {
-                            'name': 'mlflow-env',
-                            'channels': ['defaults'],
-                            'dependencies': [
-                                'python=3.7.0',
-                                'pip': [
-                                    'ludwig==0.4.0'
-                                ]
-                            ]
-                        }
-
-    :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
-
-    :param signature: (Experimental) :py:class:`ModelSignature <mlflow.models.ModelSignature>`
-                      describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
-                      The model signature can be :py:func:`inferred <mlflow.models.infer_signature>`
-                      from datasets with valid model input (e.g. the training dataset with target
-                      column omitted) and valid model output (e.g. model predictions generated on
-                      the training dataset), for example:
-
-                      .. code-block:: python
-
-                        from mlflow.models.signature import infer_signature
-
-                        train = df.drop_column("target_label")
-                        predictions = ...  # compute model predictions
-                        signature = infer_signature(train, predictions)
-    :param input_example: (Experimental) Input example provides one or several instances of valid
-                          model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+    Args:
+        ludwig_model: Ludwig model (an instance of `ludwig.api.LudwigModel`) to be saved.
+        path: Local path where the model is to be saved.
+        conda_env: Either a dictionary representation of a Conda environment or the path to a Conda environment
+            yaml file. If provided, this describes the environment this model should be run in. At minimum, it
+            should specify the dependencies contained in `get_default_conda_env()`. If ``None``, the default
+            `get_default_conda_env()` environment is added to the model.
+        mlflow_model: `mlflow.models.Model` this flavor is being added to.
+        signature: Describes model input and output schema. The model signature can be inferred from datasets
+            with valid model input (e.g. the training dataset with target column omitted) and valid model output
+            (e.g. model predictions generated on the training dataset).
+        input_example: Input example provides one or several instances of valid model input. The example can be
+            used as a hint of what data to feed the model. The given example will be converted to a Pandas
+            DataFrame and then serialized to json using the Pandas split-oriented format. Bytes are
+            base64-encoded.
     """
     import ludwig
 
@@ -190,7 +160,8 @@ def _load_model(path):
 def _load_pyfunc(path):
     """Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
 
-    :param path: Local filesystem path to the MLflow Model with the ``ludwig`` flavor.
+    Args:
+        path: Local filesystem path to the MLflow Model with the ``ludwig`` flavor.
     """
     return _LudwigModelWrapper(_load_model(path))
 
@@ -198,18 +169,18 @@ def _load_pyfunc(path):
 def load_model(model_uri):
     """Load a Ludwig model from a local file or a run.
 
-    :param model_uri: The location, in URI format, of the MLflow model. For example:
+    Args:
+        model_uri: The location, in URI format, of the MLflow model. For example:
+            - ``/Users/me/path/to/local/model``
+            - ``relative/path/to/local/model``
+            - ``s3://my_bucket/path/to/model``
+            - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
 
-                      - ``/Users/me/path/to/local/model``
-                      - ``relative/path/to/local/model``
-                      - ``s3://my_bucket/path/to/model``
-                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+            For more information about supported URI schemes, see
+            `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#artifact-locations>`_.
 
-                      For more information about supported URI schemes, see
-                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/tracking.html#
-                      artifact-locations>`_.
-
-    :return: A Ludwig model (an instance of `ludwig.api.LudwigModel`_).
+    Returns:
+        A Ludwig model (an instance of `ludwig.api.LudwigModel`).
     """
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)

--- a/ludwig/data/dataset_synthesizer.py
+++ b/ludwig/data/dataset_synthesizer.py
@@ -180,12 +180,12 @@ def build_synthetic_dataset_df(dataset_size: int, config: ModelConfigDict) -> pd
 def build_synthetic_dataset(dataset_size: int, features: list[dict], outdir: str | None = None):
     """Synthesizes a dataset for testing purposes.
 
-    :param dataset_size: (int) size of the dataset
-    :param features: (List[dict]) list of features to generate in YAML format.
-        Provide a list containing one dictionary for each feature,
-        each dictionary must include a name, a type
-        and can include some generation parameters depending on the type
-    :param outdir: (str) Path to an output directory. Used for saving synthetic image and audio files.
+    Args:
+        dataset_size: size of the dataset.
+        features: list of features to generate in YAML format. Provide a list containing one dictionary for
+            each feature, each dictionary must include a name, a type and can include some generation parameters
+            depending on the type.
+        outdir: Path to an output directory. Used for saving synthetic image and audio files.
 
     Example content for features:
 
@@ -534,14 +534,14 @@ cyclers_registry = {"category": cycle_category, "binary": cycle_binary}
 
 
 def cli_synthesize_dataset(dataset_size: int, features: list[dict], output_path: str, **kwargs) -> None:
-    """Symthesizes a dataset for testing purposes.
+    """Synthesizes a dataset for testing purposes.
 
-    :param dataset_size: (int) size of the dataset
-    :param features: (List[dict]) list of features to generate in YAML format.
-        Provide a list contaning one dictionary for each feature,
-        each dictionary must include a name, a type
-        and can include some generation parameters depending on the type
-    :param output_path: (str) path where to save the output CSV file
+    Args:
+        dataset_size: size of the dataset.
+        features: list of features to generate in YAML format. Provide a list containing one dictionary for
+            each feature, each dictionary must include a name, a type and can include some generation parameters
+            depending on the type.
+        output_path: path where to save the output CSV file.
 
     Example content for features:
 

--- a/ludwig/data/preprocessing.py
+++ b/ludwig/data/preprocessing.py
@@ -2105,17 +2105,20 @@ def _preprocess_file_for_training(
 ):
     """Method to pre-process csv data.
 
-    :param features: list of all features (input + output)
-    :param dataset: path to the data
-    :param training_set: training data
-    :param validation_set: validation data
-    :param test_set: test data
-    :param training_set_metadata: train set metadata
-    :param skip_save_processed_input: if False, the pre-processed data is saved as .hdf5 files in the same location as
-        the csv files with the same names.
-    :param preprocessing_params: preprocessing parameters
-    :param random_seed: random seed
-    :return: training, test, validation datasets, training metadata
+    Args:
+        features: list of all features (input + output).
+        dataset: path to the data.
+        training_set: training data.
+        validation_set: validation data.
+        test_set: test data.
+        training_set_metadata: train set metadata.
+        skip_save_processed_input: if False, the pre-processed data is saved as .hdf5 files in the same location
+            as the csv files with the same names.
+        preprocessing_params: preprocessing parameters.
+        random_seed: random seed.
+
+    Returns:
+        training, test, validation datasets, training metadata.
     """
     if dataset:
         # Use data and ignore _train, _validation and _test.

--- a/ludwig/data/sampler.py
+++ b/ludwig/data/sampler.py
@@ -75,6 +75,7 @@ class DistributedSampler:
         When `shuffle=True`, this ensures all replicas use a different random ordering for each epoch. Otherwise, the
         next iteration of this sampler will yield the same ordering.
 
-        :param epoch: (int) epoch number
+        Args:
+            epoch: Epoch number.
         """
         self.epoch = epoch

--- a/ludwig/datasets/__init__.py
+++ b/ludwig/datasets/__init__.py
@@ -239,11 +239,14 @@ def get_datasets_output_features(
     Because Hugging Face Datasets are loaded dynamically through a shared connector, they don't have fixed output
     features. As such, we exclude Hugging Face datasets here.
 
-    :param dataset: (str) name of the dataset
-    :param include_competitions: (bool) whether to include the output features from kaggle competition datasets
-    :param include_data_modalities: (bool) whether to include the data modalities associated with the prediction task
-    :return: (dict) dictionary with the output features for each dataset or a dictionary with the output features for
-        the specified dataset
+    Args:
+        dataset: Name of the dataset.
+        include_competitions: Whether to include the output features from kaggle competition datasets.
+        include_data_modalities: Whether to include the data modalities associated with the prediction task.
+
+    Returns:
+        Dictionary with the output features for each dataset, or a dictionary with the output features for
+        the specified dataset.
     """
     ordered_configs = OrderedDict(sorted(_get_dataset_configs().items()))
     competition_datasets = []

--- a/ludwig/datasets/loaders/dataset_loader.py
+++ b/ludwig/datasets/loaders/dataset_loader.py
@@ -46,13 +46,12 @@ class TqdmUpTo(tqdm):
     """
 
     def update_to(self, b=1, bsize=1, tsize=None):
-        """
-        b  : int, optional
-            Number of blocks transferred so far [default: 1].
-        bsize  : int, optional
-            Size of each block (in tqdm units) [default: 1].
-        tsize  : int, optional
-            Total size (in tqdm units). If [default: None] remains unchanged.
+        """Update progress bar.
+
+        Args:
+            b: Number of blocks transferred so far.
+            bsize: Size of each block (in tqdm units).
+            tsize: Total size (in tqdm units). If None, remains unchanged.
         """
         if tsize is not None:
             self.total = tsize
@@ -293,10 +292,11 @@ class DatasetLoader:
         Note: This method is also responsible for splitting the data, returning a single dataframe if split=False, and a
         3-tuple of train, val, test if split=True.
 
-        :param kaggle_username: (str) username on Kaggle platform
-        :param kaggle_key: (str) dataset key on Kaggle platform
-        :param split: (bool) splits dataset along 'split' column if present. The split column should always have values
-            0: train, 1: validation, 2: test.
+        Args:
+            kaggle_username: Username on Kaggle platform.
+            kaggle_key: Dataset key on Kaggle platform.
+            split: Splits dataset along 'split' column if present. The split column should always have values
+                0: train, 1: validation, 2: test.
         """
         self._download_and_process(kaggle_username=kaggle_username, kaggle_key=kaggle_key)
         if self.state == DatasetState.TRANSFORMED:

--- a/ludwig/datasets/loaders/hugging_face.py
+++ b/ludwig/datasets/loaders/hugging_face.py
@@ -38,8 +38,9 @@ class HFLoader(DatasetLoader):
     def load_hf_to_dict(hf_id: str | None = None, hf_subsample: str | None = None) -> dict[str, pd.DataFrame]:
         """Returns a map of split -> pd.DataFrame for the given HF dataset.
 
-        :param hf_id: (str) path to dataset on HuggingFace platform
-        :param hf_subsample: (str) name of dataset configuration on HuggingFace platform
+        Args:
+            hf_id: path to dataset on HuggingFace platform.
+            hf_subsample: name of dataset configuration on HuggingFace platform.
         """
         dataset_dict: dict[str, datasets.Dataset] = datasets.load_dataset(path=hf_id, name=hf_subsample)
         pandas_dict = {}
@@ -57,8 +58,6 @@ class HFLoader(DatasetLoader):
         containing train, validation, and test data or one dataframe that is the concatenation of all three
         depending on whether `split` is set to True or False.
 
-        :param split: (bool) directive for how to interpret if dataset contains validation or test set (see below)
-
         Note that some datasets may not provide a validation set or a test set. In this case:
         - If split is True, the DataFrames corresponding to the missing sets are initialized to be empty
         - If split is False, the "split" column in the resulting DataFrame will reflect the fact that there is no
@@ -66,8 +65,10 @@ class HFLoader(DatasetLoader):
 
         A train set should always be provided by Hugging Face.
 
-        :param hf_id: (str) path to dataset on HuggingFace platform
-        :param hf_subsample: (str) name of dataset configuration on HuggingFace platform
+        Args:
+            hf_id: path to dataset on HuggingFace platform.
+            hf_subsample: name of dataset configuration on HuggingFace platform.
+            split: directive for how to interpret if dataset contains validation or test set.
         """
         self.config.huggingface_dataset_id = hf_id
         self.config.huggingface_subsample = hf_subsample

--- a/ludwig/encoders/bag_encoders.py
+++ b/ludwig/encoders/bag_encoders.py
@@ -101,11 +101,13 @@ class BagEmbedWeightedEncoder(Encoder):
         return self.fc_stack.output_shape
 
     def forward(self, inputs: torch.Tensor) -> EncoderOutputDict:
-        """
-        :param inputs: The inputs fed into the encoder.
-               Shape: [batch x vocab size], type torch.int32
+        """Forward pass through the encoder.
 
-        :param return: embeddings of shape [batch x embed size], type torch.float32
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x vocab size].
+
+        Returns:
+            Embeddings of shape [batch x embed size].
         """
         hidden = self.embed_weighted(inputs)
         hidden = self.fc_stack(hidden)

--- a/ludwig/encoders/category_encoders.py
+++ b/ludwig/encoders/category_encoders.py
@@ -50,8 +50,8 @@ class CategoricalPassthroughEncoder(Encoder):
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
         """
-        :param inputs: The inputs fed into the encoder.
-               Shape: [batch x 1]
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x 1]
         """
         return {"encoder_output": self.identity(inputs.float())}
 
@@ -106,10 +106,11 @@ class CategoricalEmbedEncoder(Encoder):
 
     def forward(self, inputs: torch.Tensor) -> EncoderOutputDict:
         """
-        :param inputs: The inputs fed into the encoder.
-               Shape: [batch x 1], type torch.int32
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x 1], type torch.int32.
 
-        :param return: embeddings of shape [batch x embed size], type torch.float32
+        Returns:
+            embeddings of shape [batch x embed size], type torch.float32.
         """
         embedded = self.embed(inputs)
         return {ENCODER_OUTPUT: embedded}
@@ -161,10 +162,11 @@ class CategoricalSparseEncoder(Encoder):
 
     def forward(self, inputs: torch.Tensor) -> EncoderOutputDict:
         """
-        :param inputs: The inputs fed into the encoder.
-               Shape: [batch x 1], type torch.int32
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x 1], type torch.int32.
 
-        :param return: embeddings of shape [batch x embed size], type torch.float32
+        Returns:
+            embeddings of shape [batch x embed size], type torch.float32.
         """
         embedded = self.embed(inputs)
         return {ENCODER_OUTPUT: embedded}
@@ -200,8 +202,8 @@ class CategoricalOneHotEncoder(Encoder):
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
         """
-        :param inputs: The inputs fed into the encoder.
-               Shape: [batch, 1] or [batch]
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch, 1] or [batch]
         """
         t = inputs.reshape(-1).long()
         # the output of this must be a float so that it can be concatenated with other
@@ -250,8 +252,8 @@ class CategoricalTargetEncoder(Encoder):
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
         """
-        :param inputs: The inputs fed into the encoder.
-               Shape: [batch x 1], type torch.int32
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x 1], type torch.int32.
         """
         return {ENCODER_OUTPUT: self.target_values(inputs.long().squeeze(-1))}
 
@@ -297,8 +299,8 @@ class CategoricalHashEncoder(Encoder):
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
         """
-        :param inputs: The inputs fed into the encoder.
-               Shape: [batch x 1], type torch.int32
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x 1], type torch.int32.
         """
         # Hash input indices to bucket range
         hashed = inputs.long().squeeze(-1) % self.num_hash_buckets

--- a/ludwig/encoders/generic_encoders.py
+++ b/ludwig/encoders/generic_encoders.py
@@ -39,9 +39,10 @@ class PassthroughEncoder(Encoder):
         self.input_size = input_size
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param inputs: The inputs fed into the encoder.
-               Shape: [batch x 1], type tf.float32
+        """Forward pass through the encoder.
+
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x 1].
         """
         return {ENCODER_OUTPUT: inputs}
 
@@ -99,9 +100,10 @@ class DenseEncoder(Encoder):
         )
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param inputs: The inputs fed into the encoder.
-               Shape: [batch x 1], type tf.float32
+        """Forward pass through the encoder.
+
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x 1].
         """
         return {ENCODER_OUTPUT: self.fc_stack(inputs)}
 

--- a/ludwig/encoders/image/base.py
+++ b/ludwig/encoders/image/base.py
@@ -142,9 +142,10 @@ class Stacked2DCNN(ImageEncoder):
         )
 
     def forward(self, inputs: torch.Tensor) -> EncoderOutputDict:
-        """
-        :param inputs: The inputs fed into the encoder.
-                Shape: [batch x channels x height x width], type torch.uint8
+        """Forward pass through the encoder.
+
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x channels x height x width].
         """
 
         hidden = self.conv_stack_2d(inputs)

--- a/ludwig/encoders/sequence_encoders.py
+++ b/ludwig/encoders/sequence_encoders.py
@@ -81,16 +81,16 @@ class SequencePassthroughEncoder(SequenceEncoder):
         encoder_config=None,
         **kwargs,
     ):
-        """
-        :param reduce_output: defines how to reduce the output tensor along
-               the `s` sequence length dimension if the rank of the tensor
-               is greater than 2. Available values are: `sum`,
-               `mean` or `avg`, `max`, `concat` (concatenates along
-               the first dimension), `last` (returns the last vector of the
-               first dimension) and `None` or `null` (which does not reduce
-               and returns the full tensor).
-        :param max_sequence_length: The maximum sequence length.
-        :param encoding_size: The size of the encoding vector, or None if sequence elements are scalars.
+        """Initializes SequencePassthroughEncoder.
+
+        Args:
+            reduce_output: Defines how to reduce the output tensor along the `s` sequence length
+                dimension if the rank of the tensor is greater than 2. Available values are: `sum`,
+                `mean` or `avg`, `max`, `concat` (concatenates along the first dimension), `last`
+                (returns the last vector of the first dimension) and `None` or `null` (which does
+                not reduce and returns the full tensor).
+            max_sequence_length: The maximum sequence length.
+            encoding_size: The size of the encoding vector, or None if sequence elements are scalars.
         """
         super().__init__()
         self.config = encoder_config
@@ -106,14 +106,13 @@ class SequencePassthroughEncoder(SequenceEncoder):
             self.supports_masking = True
 
     def forward(self, input_sequence: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param input_sequence: The input sequence fed into the encoder.
-               Shape: [batch x sequence length], type torch.int32 or
-                      [batch x sequence length x encoding size], type torch.float32
-        :type input_sequence: Tensor
-        :param mask: Sequence mask (not yet implemented).
-               Shape: [batch x sequence length]
-        :type mask: Tensor
+        """Encodes the input sequence by casting to float and optionally reducing.
+
+        Args:
+            input_sequence: The input sequence fed into the encoder.
+                Shape: [batch x sequence length], type torch.int32 or
+                [batch x sequence length x encoding size], type torch.float32.
+            mask: Sequence mask (not yet implemented). Shape: [batch x sequence length].
         """
         input_sequence = input_sequence.type(torch.float32)
         while len(input_sequence.shape) < 3:
@@ -170,72 +169,34 @@ class SequenceEmbedEncoder(SequenceEncoder):
         encoder_config=None,
         **kwargs,
     ):
-        """
-        :param vocab: Vocabulary of the input feature to encode
-        :type vocab: List
-        :param max_sequence_length: The maximum sequence length.
-        :type max_sequence_length: int
-        :param representation: the possible values are `dense` and `sparse`.
-               `dense` means the embeddings are initialized randomly,
-               `sparse` means they are initialized to be one-hot encodings.
-        :type representation: str (one of 'dense' or 'sparse')
-        :param embedding_size: it is the maximum embedding size, the actual
-               size will be `min(vocabulary_size, embedding_size)`
-               for `dense` representations and exactly `vocabulary_size`
-               for the `sparse` encoding, where `vocabulary_size` is
-               the number of different strings appearing in the training set
-               in the column the feature is named after (plus 1 for `<UNK>`).
-        :type embedding_size: Integer
-        :param embeddings_trainable: If `True` embeddings are trained during
-               the training process, if `False` embeddings are fixed.
-               It may be useful when loading pretrained embeddings
-               for avoiding finetuning them. This parameter has effect only
-               for `representation` is `dense` as `sparse` one-hot encodings
-                are not trainable.
-        :type embeddings_trainable: Boolean
-        :param pretrained_embeddings: by default `dense` embeddings
-               are initialized randomly, but this parameter allows to specify
-               a path to a file containing embeddings in the GloVe format.
-               When the file containing the embeddings is loaded, only the
-               embeddings with labels present in the vocabulary are kept,
-               the others are discarded. If the vocabulary contains strings
-               that have no match in the embeddings file, their embeddings
-               are initialized with the average of all other embedding plus
-               some random noise to make them different from each other.
-               This parameter has effect only if `representation` is `dense`.
-        :type pretrained_embeddings: str (filepath)
-        :param embeddings_on_cpu: by default embeddings matrices are stored
-               on GPU memory if a GPU is used, as it allows
-               for faster access, but in some cases the embedding matrix
-               may be really big and this parameter forces the placement
-               of the embedding matrix in regular memory and the CPU is used
-               to resolve them, slightly slowing down the process
-               as a result of data transfer between CPU and GPU memory.
-        :type embeddings_on_cpu: Boolean
-        :param weights_initializer: the initializer to use. If `None`, the default
-               initialized of each variable is used (`xavier_uniform`
-               in most cases). Options are: `constant`, `identity`, `zeros`,
-                `ones`, `orthogonal`, `normal`, `uniform`,
-                `truncated_normal`, `variance_scaling`, `xavier_normal`,
-                `xavier_uniform`, `xavier_normal`,
-                `he_normal`, `he_uniform`, `lecun_normal`, `lecun_uniform`.
-                Alternatively it is possible to specify a dictionary with
-                a key `type` that identifies the type of initializer and
-                other keys for its parameters, e.g.
-                `{type: normal, mean: 0, stddev: 0}`.
-                To know the parameters of each initializer, please refer to
-                PyTorch's documentation.
-        :type weights_initializer: str
-        :param dropout: Tensor (torch.float) The dropout probability.
-        :type dropout: Tensor
-        :param reduce_output: defines how to reduce the output tensor along
-               the `s` sequence length dimension if the rank of the tensor
-               is greater than 2. Available values are: `sum`,
-               `mean` or `avg`, `max`, `concat` (concatenates along
-               the first dimension), `last` (returns the last vector of the
-               first dimension) and `None` or `null` (which does not reduce
-               and returns the full tensor).
-        :type reduce_output: str
+        """Initializes SequenceEmbedEncoder.
+
+        Args:
+            vocab: Vocabulary of the input feature to encode.
+            max_sequence_length: The maximum sequence length.
+            representation: The possible values are `dense` and `sparse`. `dense` means the
+                embeddings are initialized randomly, `sparse` means they are initialized to be
+                one-hot encodings.
+            embedding_size: The maximum embedding size; the actual size will be
+                `min(vocabulary_size, embedding_size)` for `dense` representations and exactly
+                `vocabulary_size` for the `sparse` encoding.
+            embeddings_trainable: If `True` embeddings are trained during the training process,
+                if `False` embeddings are fixed. Only applies when `representation` is `dense`.
+            pretrained_embeddings: Path to a file containing embeddings in the GloVe format.
+                Only applies when `representation` is `dense`.
+            embeddings_on_cpu: If True, forces the embedding matrix to be stored in CPU memory
+                rather than GPU memory, slightly slowing down access.
+            weights_initializer: The initializer to use. If `None`, uses `xavier_uniform`.
+                Options include: `constant`, `identity`, `zeros`, `ones`, `orthogonal`, `normal`,
+                `uniform`, `truncated_normal`, `variance_scaling`, `xavier_normal`,
+                `xavier_uniform`, `he_normal`, `he_uniform`, `lecun_normal`, `lecun_uniform`.
+                Can also be a dict with a `type` key and initializer parameters.
+            dropout: The dropout probability.
+            reduce_output: Defines how to reduce the output tensor along the `s` sequence length
+                dimension if the rank of the tensor is greater than 2. Available values are:
+                `sum`, `mean` or `avg`, `max`, `concat` (concatenates along the first dimension),
+                `last` (returns the last vector of the first dimension) and `None` or `null`
+                (which does not reduce and returns the full tensor).
         """
         super().__init__()
         self.config = encoder_config
@@ -268,10 +229,12 @@ class SequenceEmbedEncoder(SequenceEncoder):
         )
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param inputs: The input sequence fed into the encoder.
-               Shape: [batch x sequence length], type torch.int32
-        :param mask: Input mask (unused, not yet implemented in EmbedSequence)
+        """Encodes the input sequence by embedding tokens and reducing the sequence.
+
+        Args:
+            inputs: The input sequence fed into the encoder.
+                Shape: [batch x sequence length], type torch.int32.
+            mask: Input mask (unused, not yet implemented in EmbedSequence).
         """
         embedded_sequence = self.embed_sequence(inputs, mask=mask)
         hidden = self.reduce_sequence(embedded_sequence)
@@ -346,136 +309,47 @@ class ParallelCNN(SequenceEncoder):
         encoder_config=None,
         **kwargs,
     ):
-        # todo: revise docstring
-        """
-        :param should_embed: If True the input sequence is expected
-               to be made of integers and will be mapped into embeddings
-        :type should_embed: Boolean
-        :param vocab: Vocabulary of the input feature to encode
-        :type vocab: List
-        :param representation: the possible values are `dense` and `sparse`.
-               `dense` means the embeddings are initialized randomly,
-               `sparse` means they are initialized to be one-hot encodings.
-        :type representation: Str (one of 'dense' or 'sparse')
-        :param embedding_size: it is the maximum embedding size, the actual
-               size will be `min(vocabulary_size, embedding_size)`
-               for `dense` representations and exactly `vocabulary_size`
-               for the `sparse` encoding, where `vocabulary_size` is
-               the number of different strings appearing in the training set
-               in the column the feature is named after (plus 1 for `<UNK>`).
-        :type embedding_size: Integer
-        :param embeddings_trainable: If `True` embeddings are trained during
-               the training process, if `False` embeddings are fixed.
-               It may be useful when loading pretrained embeddings
-               for avoiding finetuning them. This parameter has effect only
-               for `representation` is `dense` as `sparse` one-hot encodings
-                are not trainable.
-        :type embeddings_trainable: Boolean
-        :param pretrained_embeddings: by default `dense` embeddings
-               are initialized randomly, but this parameter allows to specify
-               a path to a file containing embeddings in the GloVe format.
-               When the file containing the embeddings is loaded, only the
-               embeddings with labels present in the vocabulary are kept,
-               the others are discarded. If the vocabulary contains strings
-               that have no match in the embeddings file, their embeddings
-               are initialized with the average of all other embedding plus
-               some random noise to make them different from each other.
-               This parameter has effect only if `representation` is `dense`.
-        :type pretrained_embeddings: str (filepath)
-        :param embeddings_on_cpu: by default embeddings matrices are stored
-               on GPU memory if a GPU is used, as it allows
-               for faster access, but in some cases the embedding matrix
-               may be really big and this parameter forces the placement
-               of the embedding matrix in regular memroy and the CPU is used
-               to resolve them, slightly slowing down the process
-               as a result of data transfer between CPU and GPU memory.
-        :param conv_layers: it is a list of dictionaries containing
-               the parameters of all the convolutional layers. The length
-               of the list determines the number of parallel convolutional
-               layers and the content of each dictionary determines
-               the parameters for a specific layer. The available parameters
-               for each layer are: `filter_size`, `num_filters`, `pool`,
-               `norm`, and `activation`. If any of those values
-               is missing from the dictionary, the default one specified
-               as a parameter of the encoder will be used instead. If both
-               `conv_layers` and `num_conv_layers` are `None`, a default
-               list will be assigned to `conv_layers` with the value
-               `[{filter_size: 2}, {filter_size: 3}, {filter_size: 4},
-               {filter_size: 5}]`.
-        :type conv_layers: List
-        :param num_conv_layers: if `conv_layers` is `None`, this is
-               the number of parallel convolutional layers.
-        :type num_conv_layers: Integer
-        :param filter_size:  if a `filter_size` is not already specified in
-               `conv_layers` this is the default `filter_size` that
-               will be used for each layer. It indicates how wide is
-               the 1d convolutional filter.
-        :type filter_size: Integer
-        :param num_filters: if a `num_filters` is not already specified in
-               `conv_layers` this is the default `num_filters` that
-               will be used for each layer. It indicates the number
-               of filters, and by consequence the output channels of
-               the 1d convolution.
-        :type num_filters: Integer
-        :param pool_size: if a `pool_size` is not already specified
-              in `conv_layers` this is the default `pool_size` that
-              will be used for each layer. It indicates the size of
-              the max pooling that will be performed along the `s` sequence
-              dimension after the convolution operation.
-        :type pool_size: Integer
-        :param fc_layers: it is a list of dictionaries containing
-               the parameters of all the fully connected layers. The length
-               of the list determines the number of stacked fully connected
-               layers and the content of each dictionary determines
-               the parameters for a specific layer. The available parameters
-               for each layer are: `output_size`, `norm` and `activation`.
-               If any of those values is missing from
-               the dictionary, the default one specified as a parameter of
-               the encoder will be used instead. If both `fc_layers` and
-               `num_fc_layers` are `None`, a default list will be assigned
-               to `fc_layers` with the value
-               `[{output_size: 512}, {output_size: 256}]`
-               (only applies if `reduce_output` is not `None`).
-        :type fc_layers: List
-        :param num_fc_layers: if `fc_layers` is `None`, this is the number
-               of stacked fully connected layers (only applies if
-               `reduce_output` is not `None`).
-        :type num_fc_layers: Integer
-        :param output_size: if a `output_size` is not already specified in
-               `fc_layers` this is the default `output_size` that will be used
-               for each layer. It indicates the size of the output
-               of a fully connected layer.
-        :type output_size: Integer
-        :param norm: if a `norm` is not already specified in `conv_layers`
-               or `fc_layers` this is the default `norm` that will be used
-               for each layer. It indicates the norm of the output.
-        :type norm: str
-        :param activation: Default activation function to use
-        :type activation: Str
-        :param dropout: determines if there should be a dropout layer before
-               returning the encoder output.
-        :type dropout: Boolean
-        :param initializer: the initializer to use. If `None` it uses
-               `xavier_uniform`. Options are: `constant`, `identity`,
-               `zeros`, `ones`, `orthogonal`, `normal`, `uniform`,
-               `truncated_normal`, `variance_scaling`, `xavier_normal`,
-               `xavier_uniform`, `xavier_normal`,
-               `he_normal`, `he_uniform`, `lecun_normal`, `lecun_uniform`.
-               Alternatively it is possible to specify a dictionary with
-               a key `type` that identifies the type of initializer and
-               other keys for its parameters,
-               e.g. `{type: normal, mean: 0, stddev: 0}`.
-               To know the parameters of each initializer, please refer
-               to PyTorch's documentation.
-        :type initializer: str
-        :param reduce_output: defines how to reduce the output tensor of
-               the convolutional layers along the `s` sequence length
-               dimension if the rank of the tensor is greater than 2.
-               Available values are: `sum`, `mean` or `avg`, `max`, `concat`
-               (concatenates along the first dimension), `last` (returns
-               the last vector of the first dimension) and `None` or `null`
-               (which does not reduce and returns the full tensor).
-        :type reduce_output: str
+        """Initializes ParallelCNN.
+
+        Args:
+            should_embed: If True, the input sequence is expected to be made of integers and will
+                be mapped into embeddings.
+            vocab: Vocabulary of the input feature to encode.
+            representation: The possible values are `dense` and `sparse`. `dense` means the
+                embeddings are initialized randomly, `sparse` means they are initialized to be
+                one-hot encodings.
+            embedding_size: The maximum embedding size; the actual size will be
+                `min(vocabulary_size, embedding_size)` for `dense` representations and exactly
+                `vocabulary_size` for the `sparse` encoding.
+            embeddings_trainable: If `True` embeddings are trained during the training process,
+                if `False` embeddings are fixed. Only applies when `representation` is `dense`.
+            pretrained_embeddings: Path to a file containing embeddings in the GloVe format.
+                Only applies when `representation` is `dense`.
+            embeddings_on_cpu: If True, forces the embedding matrix to be stored in CPU memory
+                rather than GPU memory, slightly slowing down access.
+            conv_layers: A list of dicts containing the parameters of the parallel convolutional
+                layers. Keys per dict: `filter_size`, `num_filters`, `pool`, `norm`, `activation`.
+                Missing values fall back to encoder-level defaults. If both `conv_layers` and
+                `num_conv_layers` are `None`, defaults to
+                `[{filter_size: 2}, {filter_size: 3}, {filter_size: 4}, {filter_size: 5}]`.
+            num_conv_layers: If `conv_layers` is `None`, the number of parallel convolutional layers.
+            filter_size: Default filter size for convolutional layers (width of 1D filter).
+            num_filters: Default number of filters (output channels) for convolutional layers.
+            pool_size: Default pool size for max pooling along the sequence dimension after convolution.
+            fc_layers: A list of dicts containing the parameters of the fully connected layers.
+                Keys per dict: `output_size`, `norm`, `activation`. Missing values fall back to
+                encoder-level defaults. Defaults to `[{output_size: 512}, {output_size: 256}]`
+                when `reduce_output` is not `None`.
+            num_fc_layers: If `fc_layers` is `None`, the number of stacked fully connected layers.
+            output_size: Default output size for fully connected layers.
+            norm: Default norm to use for convolutional and fully connected layers.
+            activation: Default activation function to use.
+            dropout: Dropout probability.
+            weights_initializer: The initializer to use. If `None`, uses `xavier_uniform`.
+            bias_initializer: The bias initializer to use.
+            reduce_output: Defines how to reduce the output tensor along the `s` sequence length
+                dimension. Available values: `sum`, `mean` or `avg`, `max`, `concat`, `last`,
+                `None` or `null`.
         """
         super().__init__()
         self.config = encoder_config
@@ -569,10 +443,12 @@ class ParallelCNN(SequenceEncoder):
             )
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param inputs: The input sequence fed into the encoder.
-               Shape: [batch x sequence length], type torch.int32
-        :param mask: Input mask (unused, not yet implemented)
+        """Encodes the input sequence through parallel convolutions and optional FC layers.
+
+        Args:
+            inputs: The input sequence fed into the encoder.
+                Shape: [batch x sequence length], type torch.int32.
+            mask: Input mask (unused, not yet implemented).
         """
         # ================ Embeddings ================
         if self.should_embed:
@@ -677,136 +553,46 @@ class StackedCNN(SequenceEncoder):
         encoder_config=None,
         **kwargs,
     ):
-        # todo: fixup docstring
-        """
-        :param should_embed: If True the input sequence is expected
-               to be made of integers and will be mapped into embeddings
-        :type should_embed: Boolean
-        :param vocab: Vocabulary of the input feature to encode
-        :type vocab: List
-        :param representation: the possible values are `dense` and `sparse`.
-               `dense` means the embeddings are initialized randomly,
-               `sparse` means they are initialized to be one-hot encodings.
-        :type representation: Str (one of 'dense' or 'sparse')
-        :param embedding_size: it is the maximum embedding size, the actual
-               size will be `min(vocabulary_size, embedding_size)`
-               for `dense` representations and exactly `vocabulary_size`
-               for the `sparse` encoding, where `vocabulary_size` is
-               the number of different strings appearing in the training set
-               in the column the feature is named after (plus 1 for `<UNK>`).
-        :type embedding_size: Integer
-        :param embeddings_trainable: If `True` embeddings are trained during
-               the training process, if `False` embeddings are fixed.
-               It may be useful when loading pretrained embeddings
-               for avoiding finetuning them. This parameter has effect only
-               for `representation` is `dense` as `sparse` one-hot encodings
-                are not trainable.
-        :type embeddings_trainable: Boolean
-        :param pretrained_embeddings: by default `dense` embeddings
-               are initialized randomly, but this parameter allows to specify
-               a path to a file containing embeddings in the GloVe format.
-               When the file containing the embeddings is loaded, only the
-               embeddings with labels present in the vocabulary are kept,
-               the others are discarded. If the vocabulary contains strings
-               that have no match in the embeddings file, their embeddings
-               are initialized with the average of all other embedding plus
-               some random noise to make them different from each other.
-               This parameter has effect only if `representation` is `dense`.
-        :type pretrained_embeddings: str (filepath)
-        :param embeddings_on_cpu: by default embeddings matrices are stored
-               on GPU memory if a GPU is used, as it allows
-               for faster access, but in some cases the embedding matrix
-               may be really big and this parameter forces the placement
-               of the embedding matrix in regular memroy and the CPU is used
-               to resolve them, slightly slowing down the process
-               as a result of data transfer between CPU and GPU memory.
-        :param conv_layers: it is a list of dictionaries containing
-               the parameters of all the convolutional layers. The length
-               of the list determines the number of parallel convolutional
-               layers and the content of each dictionary determines
-               the parameters for a specific layer. The available parameters
-               for each layer are: `filter_size`, `num_filters`, `pool`,
-               `norm` and `activation`. If any of those values
-               is missing from the dictionary, the default one specified
-               as a parameter of the encoder will be used instead. If both
-               `conv_layers` and `num_conv_layers` are `None`, a default
-               list will be assigned to `conv_layers` with the value
-               `[{filter_size: 2}, {filter_size: 3}, {filter_size: 4},
-               {filter_size: 5}]`.
-        :type conv_layers: List
-        :param num_conv_layers: if `conv_layers` is `None`, this is
-               the number of stacked convolutional layers.
-        :type num_conv_layers: Integer
-        :param filter_size:  if a `filter_size` is not already specified in
-               `conv_layers` this is the default `filter_size` that
-               will be used for each layer. It indicates how wide is
-               the 1d convolutional filter.
-        :type filter_size: Integer
-        :param num_filters: if a `num_filters` is not already specified in
-               `conv_layers` this is the default `num_filters` that
-               will be used for each layer. It indicates the number
-               of filters, and by consequence the output channels of
-               the 1d convolution.
-        :type num_filters: Integer
-        :param pool_size: if a `pool_size` is not already specified
-              in `conv_layers` this is the default `pool_size` that
-              will be used for each layer. It indicates the size of
-              the max pooling that will be performed along the `s` sequence
-              dimension after the convolution operation.
-        :type pool_size: Integer
-        :param fc_layers: it is a list of dictionaries containing
-               the parameters of all the fully connected layers. The length
-               of the list determines the number of stacked fully connected
-               layers and the content of each dictionary determines
-               the parameters for a specific layer. The available parameters
-               for each layer are: `output_size`, `norm` and `activation`.
-               If any of those values is missing from
-               the dictionary, the default one specified as a parameter of
-               the encoder will be used instead. If both `fc_layers` and
-               `num_fc_layers` are `None`, a default list will be assigned
-               to `fc_layers` with the value
-               `[{output_size: 512}, {output_size: 256}]`
-               (only applies if `reduce_output` is not `None`).
-        :type fc_layers: List
-        :param num_fc_layers: if `fc_layers` is `None`, this is the number
-               of stacked fully connected layers (only applies if
-               `reduce_output` is not `None`).
-        :type num_fc_layers: Integer
-        :param output_size: if a `output_size` is not already specified in
-               `fc_layers` this is the default `output_size` that will be used
-               for each layer. It indicates the size of the output
-               of a fully connected layer.
-        :type output_size: Integer
-        :param norm: if a `norm` is not already specified in `conv_layers`
-               or `fc_layers` this is the default `norm` that will be used
-               for each layer. It indicates the norm of the output.
-        :type norm: str
-        :param activation: Default activation function to use
-        :type activation: Str
-        :param dropout: determines if there should be a dropout layer before
-               returning the encoder output.
-        :type dropout: Boolean
-        :param initializer: the initializer to use. If `None` it uses
-               `xavier_uniform`. Options are: `constant`, `identity`,
-               `zeros`, `ones`, `orthogonal`, `normal`, `uniform`,
-               `truncated_normal`, `variance_scaling`, `xavier_normal`,
-               `xavier_uniform`, `xavier_normal`,
-               `he_normal`, `he_uniform`, `lecun_normal`, `lecun_uniform`.
-               Alternatively it is possible to specify a dictionary with
-               a key `type` that identifies the type of initializer and
-               other keys for its parameters,
-               e.g. `{type: normal, mean: 0, stddev: 0}`.
-               To know the parameters of each initializer, please refer
-               to PyTorch's documentation.
-        :type initializer: str
-        :param reduce_output: defines how to reduce the output tensor of
-               the convolutional layers along the `s` sequence length
-               dimension if the rank of the tensor is greater than 2.
-               Available values are: `sum`, `mean` or `avg`, `max`, `concat`
-               (concatenates along the first dimension), `last` (returns
-               the last vector of the first dimension) and `None` or `null`
-               (which does not reduce and returns the full tensor).
-        :type reduce_output: str
+        """Initializes StackedCNN.
+
+        Args:
+            should_embed: If True, the input sequence is expected to be made of integers and will
+                be mapped into embeddings.
+            vocab: Vocabulary of the input feature to encode.
+            representation: The possible values are `dense` and `sparse`. `dense` means the
+                embeddings are initialized randomly, `sparse` means they are initialized to be
+                one-hot encodings.
+            embedding_size: The maximum embedding size; the actual size will be
+                `min(vocabulary_size, embedding_size)` for `dense` representations and exactly
+                `vocabulary_size` for the `sparse` encoding.
+            embeddings_trainable: If `True` embeddings are trained during the training process,
+                if `False` embeddings are fixed. Only applies when `representation` is `dense`.
+            pretrained_embeddings: Path to a file containing embeddings in the GloVe format.
+                Only applies when `representation` is `dense`.
+            embeddings_on_cpu: If True, forces the embedding matrix to be stored in CPU memory
+                rather than GPU memory, slightly slowing down access.
+            conv_layers: A list of dicts containing the parameters of the stacked convolutional
+                layers. Keys per dict: `filter_size`, `num_filters`, `pool`, `norm`, `activation`.
+                Missing values fall back to encoder-level defaults. If both `conv_layers` and
+                `num_conv_layers` are `None`, a default 6-layer architecture is used.
+            num_conv_layers: If `conv_layers` is `None`, the number of stacked convolutional layers.
+            filter_size: Default filter size for convolutional layers (width of 1D filter).
+            num_filters: Default number of filters (output channels) for convolutional layers.
+            pool_size: Default pool size for max pooling along the sequence dimension after convolution.
+            fc_layers: A list of dicts containing the parameters of the fully connected layers.
+                Keys per dict: `output_size`, `norm`, `activation`. Missing values fall back to
+                encoder-level defaults. Defaults to `[{output_size: 512}, {output_size: 256}]`
+                when `reduce_output` is not `None`.
+            num_fc_layers: If `fc_layers` is `None`, the number of stacked fully connected layers.
+            output_size: Default output size for fully connected layers.
+            norm: Default norm to use for convolutional and fully connected layers.
+            activation: Default activation function to use.
+            dropout: Dropout probability.
+            weights_initializer: The initializer to use. If `None`, uses `xavier_uniform`.
+            bias_initializer: The bias initializer to use.
+            reduce_output: Defines how to reduce the output tensor along the `s` sequence length
+                dimension. Available values: `sum`, `mean` or `avg`, `max`, `concat`, `last`,
+                `None` or `null`.
         """
         super().__init__()
         self.config = encoder_config
@@ -943,10 +729,12 @@ class StackedCNN(SequenceEncoder):
         return self.fc_stack.output_shape
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param inputs: The input sequence fed into the encoder.
-               Shape: [batch x sequence length], type torch.int32
-        :param mask: Input mask (unused, not yet implemented)
+        """Encodes the input sequence through stacked convolutions and optional FC layers.
+
+        Args:
+            inputs: The input sequence fed into the encoder.
+                Shape: [batch x sequence length], type torch.int32.
+            mask: Input mask (unused, not yet implemented).
         """
         # ================ Embeddings ================
         if self.should_embed:
@@ -1030,143 +818,48 @@ class StackedParallelCNN(SequenceEncoder):
         encoder_config=None,
         **kwargs,
     ):
-        # todo: review docstring
-        """
-        :param should_embed: If True the input sequence is expected
-               to be made of integers and will be mapped into embeddings
-        :type should_embed: Boolean
-        :param vocab: Vocabulary of the input feature to encode
-        :type vocab: List
-        :param representation: the possible values are `dense` and `sparse`.
-               `dense` means the embeddings are initialized randomly,
-               `sparse` means they are initialized to be one-hot encodings.
-        :type representation: Str (one of 'dense' or 'sparse')
-        :param embedding_size: it is the maximum embedding size, the actual
-               size will be `min(vocabulary_size, embedding_size)`
-               for `dense` representations and exactly `vocabulary_size`
-               for the `sparse` encoding, where `vocabulary_size` is
-               the number of different strings appearing in the training set
-               in the column the feature is named after (plus 1 for `<UNK>`).
-        :type embedding_size: Integer
-        :param embeddings_trainable: If `True` embeddings are trained during
-               the training process, if `False` embeddings are fixed.
-               It may be useful when loading pretrained embeddings
-               for avoiding finetuning them. This parameter has effect only
-               for `representation` is `dense` as `sparse` one-hot encodings
-                are not trainable.
-        :type embeddings_trainable: Boolean
-        :param pretrained_embeddings: by default `dense` embeddings
-               are initialized randomly, but this parameter allows to specify
-               a path to a file containing embeddings in the GloVe format.
-               When the file containing the embeddings is loaded, only the
-               embeddings with labels present in the vocabulary are kept,
-               the others are discarded. If the vocabulary contains strings
-               that have no match in the embeddings file, their embeddings
-               are initialized with the average of all other embedding plus
-               some random noise to make them different from each other.
-               This parameter has effect only if `representation` is `dense`.
-        :type pretrained_embeddings: str (filepath)
-        :param embeddings_on_cpu: by default embeddings matrices are stored
-               on GPU memory if a GPU is used, as it allows
-               for faster access, but in some cases the embedding matrix
-               may be really big and this parameter forces the placement
-               of the embedding matrix in regular memroy and the CPU is used
-               to resolve them, slightly slowing down the process
-               as a result of data transfer between CPU and GPU memory.
-        :param stacked_layers: it is a of lists of list of dictionaries
-               containing the parameters of the stack of
-               parallel convolutional layers. The length of the list
-               determines the number of stacked parallel
-               convolutional layers, length of the sub-lists determines
-               the number of parallel conv layers and the content
-               of each dictionary determines the parameters for
-               a specific layer. The available parameters for each layer are:
-               `filter_size`, `num_filters`, `pool_size`, `norm` and
-               `activation`. If any of those values
-               is missing from the dictionary, the default one specified
-               as a parameter of the encoder will be used instead. If both
-               `stacked_layers` and `num_stacked_layers` are `None`,
-               a default list will be assigned to `stacked_layers` with
-               the value `[[{filter_size: 2}, {filter_size: 3},
-               {filter_size: 4}, {filter_size: 5}], [{filter_size: 2},
-               {filter_size: 3}, {filter_size: 4}, {filter_size: 5}],
-               [{filter_size: 2}, {filter_size: 3}, {filter_size: 4},
-               {filter_size: 5}]]`.
-        :type stacked_layers: List
-        :param num_stacked_layers: if `stacked_layers` is `None`, this is
-               the number of elements in the stack of
-               parallel convolutional layers.
-        :type num_stacked_layers: Integer
-        :param filter_size:  if a `filter_size` is not already specified in
-               `conv_layers` this is the default `filter_size` that
-               will be used for each layer. It indicates how wide is
-               the 1d convolutional filter.
-        :type filter_size: Integer
-        :param num_filters: if a `num_filters` is not already specified in
-               `conv_layers` this is the default `num_filters` that
-               will be used for each layer. It indicates the number
-               of filters, and by consequence the output channels of
-               the 1d convolution.
-        :type num_filters: Integer
-        :param pool_size: if a `pool_size` is not already specified
-              in `conv_layers` this is the default `pool_size` that
-              will be used for each layer. It indicates the size of
-              the max pooling that will be performed along the `s` sequence
-              dimension after the convolution operation.
-        :type pool_size: Integer
-        :param fc_layers: it is a list of dictionaries containing
-               the parameters of all the fully connected layers. The length
-               of the list determines the number of stacked fully connected
-               layers and the content of each dictionary determines
-               the parameters for a specific layer. The available parameters
-               for each layer are: `output_size`, `norm` and `activation`.
-               If any of those values is missing from
-               the dictionary, the default one specified as a parameter of
-               the encoder will be used instead. If both `fc_layers` and
-               `num_fc_layers` are `None`, a default list will be assigned
-               to `fc_layers` with the value
-               `[{output_size: 512}, {output_size: 256}]`
-               (only applies if `reduce_output` is not `None`).
-        :type fc_layers: List
-        :param num_fc_layers: if `fc_layers` is `None`, this is the number
-               of stacked fully connected layers (only applies if
-               `reduce_output` is not `None`).
-        :type num_fc_layers: Integer
-        :param output_size: if a `output_size` is not already specified in
-               `fc_layers` this is the default `output_size` that will be used
-               for each layer. It indicates the size of the output
-               of a fully connected layer.
-        :type output_size: Integer
-        :param norm: if a `norm` is not already specified in `conv_layers`
-               or `fc_layers` this is the default `norm` that will be used
-               for each layer. It indicates the norm of the output.
-        :type norm: str
-        :param activation: Default activation function to use
-        :type activation: Str
-        :param dropout: determines if there should be a dropout layer before
-               returning the encoder output.
-        :type dropout: Boolean
-        :param initializer: the initializer to use. If `None` it uses
-               `xavier_uniform`. Options are: `constant`, `identity`,
-               `zeros`, `ones`, `orthogonal`, `normal`, `uniform`,
-               `truncated_normal`, `variance_scaling`, `xavier_normal`,
-               `xavier_uniform`, `xavier_normal`,
-               `he_normal`, `he_uniform`, `lecun_normal`, `lecun_uniform`.
-               Alternatively it is possible to specify a dictionary with
-               a key `type` that identifies the type of initializer and
-               other keys for its parameters,
-               e.g. `{type: normal, mean: 0, stddev: 0}`.
-               To know the parameters of each initializer, please refer
-               to PyTorch's documentation.
-        :type initializer: str
-        :param reduce_output: defines how to reduce the output tensor of
-               the convolutional layers along the `s` sequence length
-               dimension if the rank of the tensor is greater than 2.
-               Available values are: `sum`, `mean` or `avg`, `max`, `concat`
-               (concatenates along the first dimension), `last` (returns
-               the last vector of the first dimension) and `None` or `null`
-               (which does not reduce and returns the full tensor).
-        :type reduce_output: str
+        """Initializes StackedParallelCNN.
+
+        Args:
+            should_embed: If True, the input sequence is expected to be made of integers and will
+                be mapped into embeddings.
+            vocab: Vocabulary of the input feature to encode.
+            representation: The possible values are `dense` and `sparse`. `dense` means the
+                embeddings are initialized randomly, `sparse` means they are initialized to be
+                one-hot encodings.
+            embedding_size: The maximum embedding size; the actual size will be
+                `min(vocabulary_size, embedding_size)` for `dense` representations and exactly
+                `vocabulary_size` for the `sparse` encoding.
+            embeddings_trainable: If `True` embeddings are trained during the training process,
+                if `False` embeddings are fixed. Only applies when `representation` is `dense`.
+            pretrained_embeddings: Path to a file containing embeddings in the GloVe format.
+                Only applies when `representation` is `dense`.
+            embeddings_on_cpu: If True, forces the embedding matrix to be stored in CPU memory
+                rather than GPU memory, slightly slowing down access.
+            stacked_layers: A list of lists of dicts specifying the stacked parallel convolutional
+                layers. The outer list length is the number of stacked levels; each inner list
+                specifies the parallel conv layers at that level. Keys per dict: `filter_size`,
+                `num_filters`, `pool_size`, `norm`, `activation`. If both `stacked_layers` and
+                `num_stacked_layers` are `None`, defaults to 3 stacked levels each with filter
+                sizes [2, 3, 4, 5].
+            num_stacked_layers: If `stacked_layers` is `None`, the number of stacked parallel
+                convolutional levels.
+            filter_size: Default filter size for convolutional layers (width of 1D filter).
+            num_filters: Default number of filters (output channels) for convolutional layers.
+            pool_size: Default pool size for max pooling along the sequence dimension after convolution.
+            fc_layers: A list of dicts containing the parameters of the fully connected layers.
+                Keys per dict: `output_size`, `norm`, `activation`. Defaults to
+                `[{output_size: 512}, {output_size: 256}]` when `reduce_output` is not `None`.
+            num_fc_layers: If `fc_layers` is `None`, the number of stacked fully connected layers.
+            output_size: Default output size for fully connected layers.
+            norm: Default norm to use for convolutional and fully connected layers.
+            activation: Default activation function to use.
+            dropout: Dropout probability.
+            weights_initializer: The initializer to use. If `None`, uses `xavier_uniform`.
+            bias_initializer: The bias initializer to use.
+            reduce_output: Defines how to reduce the output tensor along the `s` sequence length
+                dimension. Available values: `sum`, `mean` or `avg`, `max`, `concat`, `last`,
+                `None` or `null`.
         """
         super().__init__()
         self.config = encoder_config
@@ -1278,10 +971,12 @@ class StackedParallelCNN(SequenceEncoder):
         return self.parallel_conv1d_stack.output_shape
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param inputs: The input sequence fed into the encoder.
-               Shape: [batch x sequence length], type torch.int32
-        :param mask: Input mask (unused, not yet implemented)
+        """Encodes the input sequence through stacked parallel convolutions and optional FC layers.
+
+        Args:
+            inputs: The input sequence fed into the encoder.
+                Shape: [batch x sequence length], type torch.int32.
+            mask: Input mask (unused, not yet implemented).
         """
         # ================ Embeddings ================
         if self.should_embed:
@@ -1368,122 +1063,35 @@ class StackedRNN(SequenceEncoder):
         encoder_config=None,
         **kwargs,
     ):
-        # todo: fix up docstring
-        """
-        :param should_embed: If True the input sequence is expected
-               to be made of integers and will be mapped into embeddings
-        :type should_embed: Boolean
-        :param vocab: Vocabulary of the input feature to encode
-        :type vocab: List
-        :param representation: the possible values are `dense` and `sparse`.
-               `dense` means the embeddings are initialized randomly,
-               `sparse` means they are initialized to be one-hot encodings.
-        :type representation: Str (one of 'dense' or 'sparse')
-        :param embedding_size: it is the maximum embedding size, the actual
-               size will be `min(vocabulary_size, embedding_size)`
-               for `dense` representations and exactly `vocabulary_size`
-               for the `sparse` encoding, where `vocabulary_size` is
-               the number of different strings appearing in the training set
-               in the column the feature is named after (plus 1 for `<UNK>`).
-        :type embedding_size: Integer
-        :param embeddings_trainable: If `True` embeddings are trained during
-               the training process, if `False` embeddings are fixed.
-               It may be useful when loading pretrained embeddings
-               for avoiding finetuning them. This parameter has effect only
-               for `representation` is `dense` as `sparse` one-hot encodings
-                are not trainable.
-        :type embeddings_trainable: Boolean
-        :param pretrained_embeddings: by default `dense` embeddings
-               are initialized randomly, but this parameter allows to specify
-               a path to a file containing embeddings in the GloVe format.
-               When the file containing the embeddings is loaded, only the
-               embeddings with labels present in the vocabulary are kept,
-               the others are discarded. If the vocabulary contains strings
-               that have no match in the embeddings file, their embeddings
-               are initialized with the average of all other embedding plus
-               some random noise to make them different from each other.
-               This parameter has effect only if `representation` is `dense`.
-        :type pretrained_embeddings: str (filepath)
-        :param embeddings_on_cpu: by default embeddings matrices are stored
-               on GPU memory if a GPU is used, as it allows
-               for faster access, but in some cases the embedding matrix
-               may be really big and this parameter forces the placement
-               of the embedding matrix in regular memroy and the CPU is used
-               to resolve them, slightly slowing down the process
-               as a result of data transfer between CPU and GPU memory.
-        :param conv_layers: it is a list of dictionaries containing
-               the parameters of all the convolutional layers. The length
-               of the list determines the number of parallel convolutional
-               layers and the content of each dictionary determines
-               the parameters for a specific layer. The available parameters
-               for each layer are: `filter_size`, `num_filters`, `pool`,
-               `norm`, `activation` and `regularize`. If any of those values
-               is missing from the dictionary, the default one specified
-               as a parameter of the encoder will be used instead. If both
-               `conv_layers` and `num_conv_layers` are `None`, a default
-               list will be assigned to `conv_layers` with the value
-               `[{filter_size: 2}, {filter_size: 3}, {filter_size: 4},
-               {filter_size: 5}]`.
-        :type conv_layers: List
-        :param num_conv_layers: if `conv_layers` is `None`, this is
-               the number of stacked convolutional layers.
-        :type num_conv_layers: Integer
-        :param filter_size:  if a `filter_size` is not already specified in
-               `conv_layers` this is the default `filter_size` that
-               will be used for each layer. It indicates how wide is
-               the 1d convolutional filter.
-        :type filter_size: Integer
-        :param num_filters: if a `num_filters` is not already specified in
-               `conv_layers` this is the default `num_filters` that
-               will be used for each layer. It indicates the number
-               of filters, and by consequence the output channels of
-               the 1d convolution.
-        :type num_filters: Integer
-        :param pool_size: if a `pool_size` is not already specified
-              in `conv_layers` this is the default `pool_size` that
-              will be used for each layer. It indicates the size of
-              the max pooling that will be performed along the `s` sequence
-              dimension after the convolution operation.
-        :type pool_size: Integer
-        :param num_rec_layers: the number of stacked recurrent layers.
-        :type num_rec_layers: Integer
-        :param cell_type: the type of recurrent cell to use.
-               Available values are: `rnn`, `lstm`, `gru`.
-               For reference about the differences between the cells please
-               refer to PyTorch's documentation.
-        :type cell_type: str
-        :param state_size: the size of the state of the rnn.
-        :type state_size: Integer
-        :param bidirectional: if `True` two recurrent networks will perform
-               encoding in the forward and backward direction and
-               their outputs will be concatenated.
-        :type bidirectional: Boolean
-        :param dropout: determines if there should be a dropout layer before
-               returning the encoder output.
-        :type dropout: Boolean
-        :param recurrent_dropout: Dropout rate for the recurrent stack.
-        :type recurrent_dropout: float
-        :param initializer: the initializer to use. If `None` it uses
-               `xavier_uniform`. Options are: `constant`, `identity`,
-               `zeros`, `ones`, `orthogonal`, `normal`, `uniform`,
-               `truncated_normal`, `variance_scaling`, `xavier_normal`,
-               `xavier_uniform`, `xavier_normal`,
-               `he_normal`, `he_uniform`, `lecun_normal`, `lecun_uniform`.
-               Alternatively it is possible to specify a dictionary with
-               a key `type` that identifies the type of initializer and
-               other keys for its parameters,
-               e.g. `{type: normal, mean: 0, stddev: 0}`.
-               To know the parameters of each initializer, please refer
-               to PyTorch's documentation.
-        :type initializer: str
-        :param reduce_output: defines how to reduce the output tensor of
-               the convolutional layers along the `s` sequence length
-               dimension if the rank of the tensor is greater than 2.
-               Available values are: `sum`, `mean` or `avg`, `max`, `concat`
-               (concatenates along the first dimension), `last` (returns
-               the last vector of the first dimension) and `None` or `null`
-               (which does not reduce and returns the full tensor).
-        :type reduce_output: str
+        """Initializes StackedRNN.
+
+        Args:
+            should_embed: If True, the input sequence is expected to be made of integers and will
+                be mapped into embeddings.
+            vocab: Vocabulary of the input feature to encode.
+            representation: The possible values are `dense` and `sparse`. `dense` means the
+                embeddings are initialized randomly, `sparse` means they are initialized to be
+                one-hot encodings.
+            embedding_size: The maximum embedding size; the actual size will be
+                `min(vocabulary_size, embedding_size)` for `dense` representations and exactly
+                `vocabulary_size` for the `sparse` encoding.
+            embeddings_trainable: If `True` embeddings are trained during the training process,
+                if `False` embeddings are fixed. Only applies when `representation` is `dense`.
+            pretrained_embeddings: Path to a file containing embeddings in the GloVe format.
+                Only applies when `representation` is `dense`.
+            embeddings_on_cpu: If True, forces the embedding matrix to be stored in CPU memory
+                rather than GPU memory, slightly slowing down access.
+            num_layers: The number of stacked recurrent layers.
+            cell_type: The type of recurrent cell to use. Available values: `rnn`, `lstm`, `gru`.
+            state_size: The size of the recurrent state.
+            bidirectional: If `True`, two recurrent networks encode in forward and backward
+                directions and their outputs are concatenated.
+            dropout: Dropout probability.
+            recurrent_dropout: Dropout rate for the recurrent stack.
+            weights_initializer: The initializer to use. If `None`, uses `xavier_uniform`.
+            reduce_output: Defines how to reduce the output tensor along the `s` sequence length
+                dimension. Available values: `sum`, `mean` or `avg`, `max`, `concat`, `last`,
+                `None` or `null`.
         """
         super().__init__()
         self.config = encoder_config
@@ -1572,10 +1180,12 @@ class StackedRNN(SequenceEncoder):
         return torch.int32
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param inputs: The input sequence fed into the encoder.
-               Shape: [batch x sequence length], type torch.int32
-        :param mask: Input mask (unused, not yet implemented)
+        """Encodes the input sequence through stacked recurrent layers and optional FC layers.
+
+        Args:
+            inputs: The input sequence fed into the encoder.
+                Shape: [batch x sequence length], type torch.int32.
+            mask: Input mask (unused, not yet implemented).
         """
         # ================ Embeddings ================
         if self.should_embed:
@@ -1675,88 +1285,35 @@ class StackedCNNRNN(SequenceEncoder):
         encoder_config=None,
         **kwargs,
     ):
-        # todo: fix up docstring
-        """
-        :param should_embed: If True the input sequence is expected
-               to be made of integers and will be mapped into embeddings
-        :type should_embed: Boolean
-        :param vocab: Vocabulary of the input feature to encode
-        :type vocab: List
-        :param representation: the possible values are `dense` and `sparse`.
-               `dense` means the embeddings are initialized randomly,
-               `sparse` means they are initialized to be one-hot encodings.
-        :type representation: Str (one of 'dense' or 'sparse')
-        :param embedding_size: it is the maximum embedding size, the actual
-               size will be `min(vocabulary_size, embedding_size)`
-               for `dense` representations and exactly `vocabulary_size`
-               for the `sparse` encoding, where `vocabulary_size` is
-               the number of different strings appearing in the training set
-               in the column the feature is named after (plus 1 for `<UNK>`).
-        :type embedding_size: Integer
-        :param embeddings_trainable: If `True` embeddings are trained during
-               the training process, if `False` embeddings are fixed.
-               It may be useful when loading pretrained embeddings
-               for avoiding finetuning them. This parameter has effect only
-               for `representation` is `dense` as `sparse` one-hot encodings
-                are not trainable.
-        :type embeddings_trainable: Boolean
-        :param pretrained_embeddings: by default `dense` embeddings
-               are initialized randomly, but this parameter allows to specify
-               a path to a file containing embeddings in the GloVe format.
-               When the file containing the embeddings is loaded, only the
-               embeddings with labels present in the vocabulary are kept,
-               the others are discarded. If the vocabulary contains strings
-               that have no match in the embeddings file, their embeddings
-               are initialized with the average of all other embedding plus
-               some random noise to make them different from each other.
-               This parameter has effect only if `representation` is `dense`.
-        :type pretrained_embeddings: str (filepath)
-        :param embeddings_on_cpu: by default embeddings matrices are stored
-               on GPU memory if a GPU is used, as it allows
-               for faster access, but in some cases the embedding matrix
-               may be really big and this parameter forces the placement
-               of the embedding matrix in regular memroy and the CPU is used
-               to resolve them, slightly slowing down the process
-               as a result of data transfer between CPU and GPU memory.
-        :param num_layers: the number of stacked recurrent layers.
-        :type num_layers: Integer
-        :param cell_type: the type of recurrent cell to use.
-               Available values are: `rnn`, `lstm`, `gru`.
-               For reference about the differences between the cells please
-               refer to PyTorch's documentation.
-        :type cell_type: str
-        :param state_size: the size of the state of the rnn.
-        :type state_size: Integer
-        :param bidirectional: if `True` two recurrent networks will perform
-               encoding in the forward and backward direction and
-               their outputs will be concatenated.
-        :type bidirectional: Boolean
-        :param dropout: determines if there should be a dropout layer before
-               returning the encoder output.
-        :type dropout: Boolean
-        :param recurrent_dropout: Dropout rate for the recurrent stack.
-        :type recurrent_dropout: float
-        :param initializer: the initializer to use. If `None` it uses
-               `xavier_uniform`. Options are: `constant`, `identity`,
-               `zeros`, `ones`, `orthogonal`, `normal`, `uniform`,
-               `truncated_normal`, `variance_scaling`, `xavier_normal`,
-               `xavier_uniform`, `xavier_normal`,
-               `he_normal`, `he_uniform`, `lecun_normal`, `lecun_uniform`.
-               Alternatively it is possible to specify a dictionary with
-               a key `type` that identifies the type of initializer and
-               other keys for its parameters,
-               e.g. `{type: normal, mean: 0, stddev: 0}`.
-               To know the parameters of each initializer, please refer
-               to PyTorch's documentation.
-        :type initializer: str
-        :param reduce_output: defines how to reduce the output tensor of
-               the convolutional layers along the `s` sequence length
-               dimension if the rank of the tensor is greater than 2.
-               Available values are: `sum`, `mean` or `avg`, `max`, `concat`
-               (concatenates along the first dimension), `last` (returns
-               the last vector of the first dimension) and `None` or `null`
-               (which does not reduce and returns the full tensor).
-        :type reduce_output: str
+        """Initializes StackedCNNRNN.
+
+        Args:
+            should_embed: If True, the input sequence is expected to be made of integers and will
+                be mapped into embeddings.
+            vocab: Vocabulary of the input feature to encode.
+            representation: The possible values are `dense` and `sparse`. `dense` means the
+                embeddings are initialized randomly, `sparse` means they are initialized to be
+                one-hot encodings.
+            embedding_size: The maximum embedding size; the actual size will be
+                `min(vocabulary_size, embedding_size)` for `dense` representations and exactly
+                `vocabulary_size` for the `sparse` encoding.
+            embeddings_trainable: If `True` embeddings are trained during the training process,
+                if `False` embeddings are fixed. Only applies when `representation` is `dense`.
+            pretrained_embeddings: Path to a file containing embeddings in the GloVe format.
+                Only applies when `representation` is `dense`.
+            embeddings_on_cpu: If True, forces the embedding matrix to be stored in CPU memory
+                rather than GPU memory, slightly slowing down access.
+            num_rec_layers: The number of stacked recurrent layers.
+            cell_type: The type of recurrent cell to use. Available values: `rnn`, `lstm`, `gru`.
+            state_size: The size of the recurrent state.
+            bidirectional: If `True`, two recurrent networks encode in forward and backward
+                directions and their outputs are concatenated.
+            dropout: Dropout probability.
+            recurrent_dropout: Dropout rate for the recurrent stack.
+            weights_initializer: The initializer to use. If `None`, uses `xavier_uniform`.
+            reduce_output: Defines how to reduce the output tensor along the `s` sequence length
+                dimension. Available values: `sum`, `mean` or `avg`, `max`, `concat`, `last`,
+                `None` or `null`.
         """
         super().__init__()
         self.config = encoder_config
@@ -1875,10 +1432,12 @@ class StackedCNNRNN(SequenceEncoder):
         return self.recurrent_stack.output_shape
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param inputs: The input sequence fed into the encoder.
-               Shape: [batch x sequence length], type torch.int32
-        :param mask: Input mask (unused, not yet implemented)
+        """Encodes the input sequence through CNN layers then recurrent layers.
+
+        Args:
+            inputs: The input sequence fed into the encoder.
+                Shape: [batch x sequence length], type torch.int32.
+            mask: Input mask (unused, not yet implemented).
         """
         # ================ Embeddings ================
         if self.should_embed:
@@ -1968,123 +1527,36 @@ class StackedTransformer(SequenceEncoder):
         encoder_config=None,
         **kwargs,
     ):
-        # todo: update docstring as needed
-        """
-        :param should_embed: If True the input sequence is expected
-               to be made of integers and will be mapped into embeddings
-        :type should_embed: Boolean
-        :param vocab: Vocabulary of the input feature to encode
-        :type vocab: List
-        :param representation: the possible values are `dense` and `sparse`.
-               `dense` means the embeddings are initialized randomly,
-               `sparse` means they are initialized to be one-hot encodings.
-        :type representation: Str (one of 'dense' or 'sparse')
-        :param embedding_size: it is the maximum embedding size, the actual
-               size will be `min(vocabulary_size, embedding_size)`
-               for `dense` representations and exactly `vocabulary_size`
-               for the `sparse` encoding, where `vocabulary_size` is
-               the number of different strings appearing in the training set
-               in the column the feature is named after (plus 1 for `<UNK>`).
-        :type embedding_size: Integer
-        :param embeddings_trainable: If `True` embeddings are trained during
-               the training process, if `False` embeddings are fixed.
-               It may be useful when loading pretrained embeddings
-               for avoiding finetuning them. This parameter has effect only
-               for `representation` is `dense` as `sparse` one-hot encodings
-                are not trainable.
-        :type embeddings_trainable: Boolean
-        :param pretrained_embeddings: by default `dense` embeddings
-               are initialized randomly, but this parameter allows to specify
-               a path to a file containing embeddings in the GloVe format.
-               When the file containing the embeddings is loaded, only the
-               embeddings with labels present in the vocabulary are kept,
-               the others are discarded. If the vocabulary contains strings
-               that have no match in the embeddings file, their embeddings
-               are initialized with the average of all other embedding plus
-               some random noise to make them different from each other.
-               This parameter has effect only if `representation` is `dense`.
-        :type pretrained_embeddings: str (filepath)
-        :param embeddings_on_cpu: by default embeddings matrices are stored
-               on GPU memory if a GPU is used, as it allows
-               for faster access, but in some cases the embedding matrix
-               may be really big and this parameter forces the placement
-               of the embedding matrix in regular memroy and the CPU is used
-               to resolve them, slightly slowing down the process
-               as a result of data transfer between CPU and GPU memory.
-        :param conv_layers: it is a list of dictionaries containing
-               the parameters of all the convolutional layers. The length
-               of the list determines the number of parallel convolutional
-               layers and the content of each dictionary determines
-               the parameters for a specific layer. The available parameters
-               for each layer are: `filter_size`, `num_filters`, `pool`,
-               `norm`, `activation` and `regularize`. If any of those values
-               is missing from the dictionary, the default one specified
-               as a parameter of the encoder will be used instead. If both
-               `conv_layers` and `num_conv_layers` are `None`, a default
-               list will be assigned to `conv_layers` with the value
-               `[{filter_size: 2}, {filter_size: 3}, {filter_size: 4},
-               {filter_size: 5}]`.
-        :type conv_layers: List
-        :param num_conv_layers: if `conv_layers` is `None`, this is
-               the number of stacked convolutional layers.
-        :type num_conv_layers: Integer
-        :param filter_size:  if a `filter_size` is not already specified in
-               `conv_layers` this is the default `filter_size` that
-               will be used for each layer. It indicates how wide is
-               the 1d convolutional filter.
-        :type filter_size: Integer
-        :param num_filters: if a `num_filters` is not already specified in
-               `conv_layers` this is the default `num_filters` that
-               will be used for each layer. It indicates the number
-               of filters, and by consequence the output channels of
-               the 1d convolution.
-        :type num_filters: Integer
-        :param pool_size: if a `pool_size` is not already specified
-              in `conv_layers` this is the default `pool_size` that
-              will be used for each layer. It indicates the size of
-              the max pooling that will be performed along the `s` sequence
-              dimension after the convolution operation.
-        :type pool_size: Integer
-        :param num_rec_layers: the number of stacked recurrent layers.
-        :type num_rec_layers: Integer
-        :param cell_type: the type of recurrent cell to use.
-               Available values are: `rnn`, `lstm`, `lstm_block`, `lstm`,
-               `ln`, `lstm_cudnn`, `gru`, `gru_block`, `gru_cudnn`.
-               For reference about the differences between the cells please
-               refer to PyTorch's documentation. We suggest to use the
-               `block` variants on CPU and the `cudnn` variants on GPU
-               because of their increased speed.
-        :type cell_type: str
-        :param state_size: the size of the state of the rnn.
-        :type state_size: Integer
-        :param bidirectional: if `True` two recurrent networks will perform
-               encoding in the forward and backward direction and
-               their outputs will be concatenated.
-        :type bidirectional: Boolean
-        :param dropout: determines if there should be a dropout layer before
-               returning the encoder output.
-        :type dropout: Boolean
-        :param initializer: the initializer to use. If `None` it uses
-               `xavier_uniform`. Options are: `constant`, `identity`,
-               `zeros`, `ones`, `orthogonal`, `normal`, `uniform`,
-               `truncated_normal`, `variance_scaling`, `xavier_normal`,
-               `xavier_uniform`, `xavier_normal`,
-               `he_normal`, `he_uniform`, `lecun_normal`, `lecun_uniform`.
-               Alternatively it is possible to specify a dictionary with
-               a key `type` that identifies the type of initializer and
-               other keys for its parameters,
-               e.g. `{type: normal, mean: 0, stddev: 0}`.
-               To know the parameters of each initializer, please refer
-               to PyTorch's documentation.
-        :type initializer: str
-        :param reduce_output: defines how to reduce the output tensor of
-               the convolutional layers along the `s` sequence length
-               dimension if the rank of the tensor is greater than 2.
-               Available values are: `sum`, `mean` or `avg`, `max`, `concat`
-               (concatenates along the first dimension), `last` (returns
-               the last vector of the first dimension) and `None` or `null`
-               (which does not reduce and returns the full tensor).
-        :type reduce_output: str
+        """Initializes StackedTransformer.
+
+        Args:
+            max_sequence_length: Maximum sequence length.
+            should_embed: If True, the input sequence is expected to be made of integers and will
+                be mapped into embeddings.
+            vocab: Vocabulary of the input feature to encode.
+            representation: The possible values are `dense` and `sparse`. `dense` means the
+                embeddings are initialized randomly, `sparse` means they are initialized to be
+                one-hot encodings.
+            embedding_size: The maximum embedding size; the actual size will be
+                `min(vocabulary_size, embedding_size)` for `dense` representations and exactly
+                `vocabulary_size` for the `sparse` encoding.
+            embeddings_trainable: If `True` embeddings are trained during the training process,
+                if `False` embeddings are fixed. Only applies when `representation` is `dense`.
+            pretrained_embeddings: Path to a file containing embeddings in the GloVe format.
+                Only applies when `representation` is `dense`.
+            embeddings_on_cpu: If True, forces the embedding matrix to be stored in CPU memory
+                rather than GPU memory, slightly slowing down access.
+            num_layers: Number of Transformer blocks to stack.
+            hidden_size: Hidden dimension of the Transformer.
+            num_heads: Number of self-attention heads.
+            transformer_output_size: Output size of the feedforward layer inside each Transformer block.
+            dropout: Dropout probability.
+            use_rope: If True, use Rotary Position Embeddings (RoPE) instead of learned positional
+                embeddings.
+            weights_initializer: The initializer to use. If `None`, uses `xavier_uniform`.
+            reduce_output: Defines how to reduce the output tensor along the `s` sequence length
+                dimension. Available values: `sum`, `mean` or `avg`, `max`, `concat`, `last`,
+                `None` or `null`.
         """
         super().__init__()
         self.config = encoder_config
@@ -2187,10 +1659,12 @@ class StackedTransformer(SequenceEncoder):
         return self.transformer_stack.output_shape
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param inputs: The input sequence fed into the encoder.
-               Shape: [batch x sequence length], type torch.int32
-        :param mask: Input mask (unused, not yet implemented)
+        """Encodes the input sequence through Transformer blocks and optional FC layers.
+
+        Args:
+            inputs: The input sequence fed into the encoder.
+                Shape: [batch x sequence length], type torch.int32.
+            mask: Input mask (unused, not yet implemented).
         """
         # ================ Embeddings ================
         if self.should_embed:
@@ -2329,19 +1803,21 @@ class MambaEncoder(SequenceEncoder):
         encoder_config=None,
         **kwargs,
     ):
-        """
-        :param max_sequence_length: Maximum sequence length.
-        :param should_embed: If True, input tokens (integers) are mapped to embeddings.
-        :param vocab: Vocabulary of the input feature.
-        :param representation: 'dense' for learned embeddings, 'sparse' for one-hot.
-        :param embedding_size: Size of token embeddings.
-        :param d_model: Hidden dimension of the SSM layers.
-        :param n_layers: Number of stacked SSM layers.
-        :param d_state: State dimension (unused in gated-conv fallback, reserved for full Mamba).
-        :param d_conv: Kernel size of the depthwise convolution in each SSM layer.
-        :param expand_factor: Expansion factor for the inner dimension of SSM layers.
-        :param dropout: Dropout rate.
-        :param reduce_output: How to reduce the sequence dimension. Default 'mean'.
+        """Initializes MambaEncoder.
+
+        Args:
+            max_sequence_length: Maximum sequence length.
+            should_embed: If True, input tokens (integers) are mapped to embeddings.
+            vocab: Vocabulary of the input feature.
+            representation: 'dense' for learned embeddings, 'sparse' for one-hot.
+            embedding_size: Size of token embeddings.
+            d_model: Hidden dimension of the SSM layers.
+            n_layers: Number of stacked SSM layers.
+            d_state: State dimension (unused in gated-conv fallback, reserved for full Mamba).
+            d_conv: Kernel size of the depthwise convolution in each SSM layer.
+            expand_factor: Expansion factor for the inner dimension of SSM layers.
+            dropout: Dropout rate.
+            reduce_output: How to reduce the sequence dimension. Default 'mean'.
         """
         super().__init__()
         self.config = encoder_config
@@ -2431,10 +1907,12 @@ class MambaEncoder(SequenceEncoder):
         return torch.Size([self.max_sequence_length, self.d_model])
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param inputs: The input sequence fed into the encoder.
-               Shape: [batch x sequence length], type torch.int32
-        :param mask: Input mask (unused in current SSM implementation)
+        """Encodes the input sequence through SSM layers and optional FC layers.
+
+        Args:
+            inputs: The input sequence fed into the encoder.
+                Shape: [batch x sequence length], type torch.int32.
+            mask: Input mask (unused in current SSM implementation).
         """
         # ================ Embeddings ================
         if self.should_embed:

--- a/ludwig/evaluate.py
+++ b/ludwig/evaluate.py
@@ -52,55 +52,32 @@ def evaluate_cli(
 ) -> None:
     """Loads pre-trained model and evaluates its performance by comparing the predictions against ground truth.
 
-     # Inputs
-
-     :param model_path: (str) filepath to pre-trained model.
-     :param dataset: (Union[str, dict, pandas.DataFrame], default: `None`)
-         source containing the entire dataset to be used in the evaluation.
-     :param data_format: (str, default: `None`) format to interpret data
-         sources. Will be inferred automatically if not specified.  Valid
-         formats are `'auto'`, `'csv'`, `'excel'`, `'feather'`,
-         `'fwf'`, `'hdf5'` (cache file produced during previous training),
-         `'html'` (file containing a single HTML `<table>`), `'json'`, `'jsonl'`,
-         `'parquet'`, `'pickle'` (pickled Pandas DataFrame), `'sas'`, `'spss'`,
-         `'stata'`, `'tsv'`.
-     :param split: (str, default: `full`) split on which
-         to perform predictions. Valid values are `'training'`, `'validation'`,
-         `'test'` and `'full'`.
-     :param batch_size: (int, default `128`) size of batches for processing.
-     :param skip_save_unprocessed_output: (bool, default: `False`) by default
-         predictions and their probabilities are saved in both raw
-         unprocessed numpy files containing tensors and as postprocessed
-         CSV files (one for each output feature). If this parameter is True,
-         only the CSV ones are saved and the numpy ones are skipped.
-     :param skip_save_predictions: (bool, default: `False`) skips saving test
-         predictions CSV files
-     :param skip_save_eval_stats: (bool, default: `False`) skips saving test
-         statistics JSON file
-    :param skip_collect_predictions: (bool, default: `False`) skips
-         collecting post-processed predictions during eval.
-     :param skip_collect_overall_stats: (bool, default: `False`) skips
-         collecting overall stats during eval.
-     :param output_directory: (str, default: `'results'`) the directory that
-         will contain the training statistics, TensorBoard logs, the saved
-         model and the training progress files.
-     :param gpus: (list, default: `None`) list of GPUs that are available
-         for training.
-     :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
-            [0, 1] allowed to allocate per GPU device.
-     :param allow_parallel_threads: (bool, default: `True`) allow PyTorch
-         to use multithreading parallelism to improve performance at
-         the cost of determinism.
-     :param callbacks: (list, default: `None`) a list of
-         `ludwig.callbacks.Callback` objects that provide hooks into the
-         Ludwig pipeline.
-     :param backend: (Union[Backend, str]) `Backend` or string name
-         of backend to use to execute preprocessing / training steps.
-     :param logging_level: (int) Log level that will be sent to stderr.
-
-     # Returns
-
-     :return: (`None`)
+    Args:
+        model_path: Filepath to pre-trained model.
+        dataset: Source containing the entire dataset to be used in the evaluation.
+        data_format: Format to interpret data sources. Will be inferred automatically if not specified.
+            Valid formats are 'auto', 'csv', 'excel', 'feather', 'fwf', 'hdf5' (cache file produced
+            during previous training), 'html' (file containing a single HTML table), 'json', 'jsonl',
+            'parquet', 'pickle' (pickled Pandas DataFrame), 'sas', 'spss', 'stata', 'tsv'.
+        split: Split on which to perform predictions. Valid values are 'training', 'validation',
+            'test' and 'full'.
+        batch_size: Size of batches for processing.
+        skip_save_unprocessed_output: By default predictions and their probabilities are saved in both
+            raw unprocessed numpy files containing tensors and as postprocessed CSV files (one for each
+            output feature). If True, only the CSV ones are saved and the numpy ones are skipped.
+        skip_save_predictions: Skips saving test predictions CSV files.
+        skip_save_eval_stats: Skips saving test statistics JSON file.
+        skip_collect_predictions: Skips collecting post-processed predictions during eval.
+        skip_collect_overall_stats: Skips collecting overall stats during eval.
+        output_directory: The directory that will contain the training statistics, TensorBoard logs,
+            the saved model and the training progress files.
+        gpus: List of GPUs that are available for training.
+        gpu_memory_limit: Maximum memory fraction [0, 1] allowed to allocate per GPU device.
+        allow_parallel_threads: Allow PyTorch to use multithreading parallelism to improve performance
+            at the cost of determinism.
+        callbacks: A list of `ludwig.callbacks.Callback` objects that provide hooks into the Ludwig pipeline.
+        backend: Backend or string name of backend to use to execute preprocessing / training steps.
+        logging_level: Log level that will be sent to stderr.
     """
     model = LudwigModel.load(
         model_path,

--- a/ludwig/experiment.py
+++ b/ludwig/experiment.py
@@ -67,123 +67,66 @@ def experiment_cli(
     logging_level: int = logging.INFO,
     **kwargs,
 ):
-    """Trains a model on a dataset's training and validation splits and uses it to predict on the test split. It
-    saves the trained model and the statistics of training and testing.
+    """Train a model and evaluate it on a test split, saving both model and statistics.
 
-     # Inputs
+    Args:
+        config: In-memory config dict or path to a YAML config file.
+        dataset: Source containing the entire dataset. If it has a split
+            column, it will be used for splitting (0: train, 1: validation,
+            2: test); otherwise the dataset will be randomly split.
+        training_set: Source containing training data.
+        validation_set: Source containing validation data.
+        test_set: Source containing test data.
+        training_set_metadata: Metadata JSON file or loaded metadata dict.
+        data_format: Format to interpret data sources. Inferred automatically
+            if not specified. Valid values: ``'auto'``, ``'csv'``,
+            ``'excel'``, ``'feather'``, ``'fwf'``, ``'hdf5'``,
+            ``'html'``, ``'json'``, ``'jsonl'``, ``'parquet'``,
+            ``'pickle'``, ``'sas'``, ``'spss'``, ``'stata'``, ``'tsv'``.
+        experiment_name: Name for the experiment.
+        model_name: Name of the model being used.
+        model_load_path: If specified, load this pre-trained model as
+            initialization (useful for transfer learning).
+        model_resume_path: Resume training from this checkpoint directory.
+        eval_split: Split to evaluate on. Valid values: ``'training'``,
+            ``'validation'``, ``'test'``.
+        skip_save_training_description: Disable saving the description JSON
+            file.
+        skip_save_training_statistics: Disable saving training statistics
+            JSON file.
+        skip_save_model: Disable saving model weights after each epoch the
+            validation metric improves.
+        skip_save_progress: Disable saving weights and stats after each epoch.
+        skip_save_log: Disable saving TensorBoard logs.
+        skip_save_processed_input: Disable caching preprocessed input.
+        skip_save_unprocessed_output: If ``True``, skip saving raw numpy
+            output files; only postprocessed CSV files are saved.
+        skip_save_predictions: Disable saving test prediction CSV files.
+        skip_save_eval_stats: Disable saving test statistics JSON file.
+        skip_collect_predictions: Skip collecting postprocessed predictions
+            during evaluation.
+        skip_collect_overall_stats: Skip collecting overall stats during
+            evaluation.
+        output_directory: Directory that will contain all results.
+        gpus: List of GPUs available for training.
+        gpu_memory_limit: Maximum memory fraction ``[0, 1]`` allowed to
+            allocate per GPU device.
+        allow_parallel_threads: Allow PyTorch to use multithreading
+            parallelism.
+        callbacks: List of ``Callback`` objects providing hooks into the
+            Ludwig pipeline.
+        backend: Backend or string name of the backend to use.
+        random_seed: Random seed for weights initialization, splits, and
+            shuffling.
+        logging_level: Log level sent to stderr.
 
-     :param config: (Union[str, dict]) in-memory representation of
-             config or string path to a YAML config file.
-     :param dataset: (Union[str, dict, pandas.DataFrame], default: `None`)
-         source containing the entire dataset to be used in the experiment.
-         If it has a split column, it will be used for splitting (0 for train,
-         1 for validation, 2 for test), otherwise the dataset will be
-         randomly split.
-     :param training_set: (Union[str, dict, pandas.DataFrame], default: `None`)
-         source containing training data.
-     :param validation_set: (Union[str, dict, pandas.DataFrame], default: `None`)
-         source containing validation data.
-     :param test_set: (Union[str, dict, pandas.DataFrame], default: `None`)
-         source containing test data.
-     :param training_set_metadata: (Union[str, dict], default: `None`)
-         metadata JSON file or loaded metadata.  Intermediate preprocessed
-         structure containing the mappings of the input
-         dataset created the first time an input file is used in the same
-         directory with the same name and a '.meta.json' extension.
-     :param data_format: (str, default: `None`) format to interpret data
-         sources. Will be inferred automatically if not specified.  Valid
-         formats are `'auto'`, `'csv'`, `'excel'`, `'feather'`,
-         `'fwf'`, `'hdf5'` (cache file produced during previous training),
-         `'html'` (file containing a single HTML `<table>`), `'json'`, `'jsonl'`,
-         `'parquet'`, `'pickle'` (pickled Pandas DataFrame), `'sas'`, `'spss'`,
-         `'stata'`, `'tsv'`.
-     :param experiment_name: (str, default: `'experiment'`) name for
-         the experiment.
-     :param model_name: (str, default: `'run'`) name of the model that is
-         being used.
-     :param model_load_path: (str, default: `None`) if this is specified the
-         loaded model will be used as initialization
-         (useful for transfer learning).
-     :param model_resume_path: (str, default: `None`) resumes training of
-         the model from the path specified. The config is restored.
-         In addition to config, training statistics and loss for
-         epoch and the state of the optimizer are restored such that
-         training can be effectively continued from a previously interrupted
-         training process.
-     :param eval_split: (str, default: `test`) split on which
-         to perform evaluation. Valid values are `training`, `validation`
-         and `test`.
-     :param skip_save_training_description: (bool, default: `False`) disables
-         saving the description JSON file.
-     :param skip_save_training_statistics: (bool, default: `False`) disables
-         saving training statistics JSON file.
-     :param skip_save_model: (bool, default: `False`) disables
-         saving model weights and hyperparameters each time the model
-         improves. By default Ludwig saves model weights after each epoch
-         the validation metric improves, but if the model is really big
-         that can be time consuming. If you do not want to keep
-         the weights and just find out what performance a model can get
-         with a set of hyperparameters, use this parameter to skip it,
-         but the model will not be loadable later on and the returned model
-         will have the weights obtained at the end of training, instead of
-         the weights of the epoch with the best validation performance.
-    :param skip_save_progress: (bool, default: `False`) disables saving
-         progress each epoch. By default Ludwig saves weights and stats
-         after each epoch for enabling resuming of training, but if
-         the model is really big that can be time consuming and will uses
-         twice as much space, use this parameter to skip it, but training
-         cannot be resumed later on.
-     :param skip_save_log: (bool, default: `False`) disables saving
-         TensorBoard logs. By default Ludwig saves logs for the TensorBoard,
-         but if it is not needed turning it off can slightly increase the
-         overall speed.
-     :param skip_save_processed_input: (bool, default: `False`) if input
-         dataset is provided it is preprocessed and cached by saving an HDF5
-         and JSON files to avoid running the preprocessing again. If this
-         parameter is `False`, the HDF5 and JSON file are not saved.
-     :param skip_save_unprocessed_output: (bool, default: `False`) by default
-         predictions and their probabilities are saved in both raw
-         unprocessed numpy files containing tensors and as postprocessed
-         CSV files (one for each output feature). If this parameter is True,
-         only the CSV ones are saved and the numpy ones are skipped.
-     :param skip_save_predictions: (bool, default: `False`) skips saving test
-         predictions CSV files
-     :param skip_save_eval_stats: (bool, default: `False`) skips saving test
-         statistics JSON file
-    :param skip_collect_predictions: (bool, default: `False`) skips
-         collecting post-processed predictions during eval.
-     :param skip_collect_overall_stats: (bool, default: `False`) skips
-         collecting overall stats during eval.
-     :param output_directory: (str, default: `'results'`) the directory that
-         will contain the training statistics, TensorBoard logs, the saved
-         model and the training progress files.
-     :param gpus: (list, default: `None`) list of GPUs that are available
-         for training.
-     :param gpu_memory_limit: (float: default: `None`) maximum memory fraction
-            [0, 1] allowed to allocate per GPU device.
-     :param allow_parallel_threads: (bool, default: `True`) allow PyTorch
-         to use multithreading parallelism to improve performance at
-         the cost of determinism.
-     :param callbacks: (list, default: `None`) a list of
-         `ludwig.callbacks.Callback` objects that provide hooks into the
-         Ludwig pipeline.
-     :param backend: (Union[Backend, str]) `Backend` or string name
-         of backend to use to execute preprocessing / training steps.
-     :param random_seed: (int: default: 42) random seed used for weights
-         initialization, splits and any other random function.
-     :param logging_level: (int) Log level that will be sent to stderr.
-
-     # Return
-     :return: (Tuple[LudwigModel, dict, dict, tuple, str)):
-        `(model, evaluation_statistics, training_statistics, preprocessed_data, output_directory)`
-         `model` LudwigModel instance
-         `evaluation_statistics` dictionary with evaluation performance
-             statistics on the test_set,
-         `training_statistics` is a nested dictionary of dataset -> feature_name -> metric_name -> List of metrics.
-                Each metric corresponds to each training checkpoint.
-         `preprocessed_data` tuple containing preprocessed
-         `(training_set, validation_set, test_set)`, `output_directory`
-         filepath string to where results are stored.
+    Returns:
+        Tuple of ``(model, eval_stats, train_stats, preprocessed_data,
+        output_directory)`` where ``model`` is the trained ``LudwigModel``,
+        ``eval_stats`` are per-split evaluation metrics, ``train_stats``
+        are per-epoch training metrics, ``preprocessed_data`` is a tuple of
+        ``(training_set, validation_set, test_set)``, and
+        ``output_directory`` is the path where results were saved.
     """
     if HYPEROPT in config:
         if not query_yes_no(HYPEROPT_WARNING + CONTINUE_PROMPT):
@@ -252,17 +195,17 @@ def kfold_cross_validate_cli(
     skip_save_k_fold_split_indices=False,
     **kwargs,
 ):
-    """Wrapper function to performs k-fold cross validation.
+    """Run k-fold cross validation and save results to ``output_directory``.
 
-    # Inputs
-    :param k_fold: (int) number of folds to create for the cross-validation
-    :param config: (Union[str, dict], default: None) a dictionary or file path containing model configuration. Refer to
-        the [User Guide] (http://ludwig.ai/user_guide/#model-config) for details.
-    :param dataset: (string, default: None)
-    :param output_directory: (string, default: 'results')
-    :param random_seed: (int) Random seed used k-fold splits.
-    :param skip_save_k_fold_split_indices: (boolean, default: False) Disables saving k-fold split indices
-    :return: None
+    Args:
+        k_fold: Number of folds to create for cross-validation.
+        config: Config dict or path to a YAML config file.
+        dataset: Dataset source.
+        data_format: Format to interpret the dataset.
+        output_directory: Directory into which to write results.
+        random_seed: Random seed used for k-fold splits.
+        skip_save_k_fold_split_indices: If ``True``, skip saving the per-fold
+            split index arrays.
     """
 
     kfold_cv_stats, kfold_split_indices = kfold_cross_validate(

--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -156,16 +156,16 @@ class IntegratedGradientsExplainer(Explainer):
     def explain(self) -> ExplanationsResult:
         """Explain the model's predictions using Integrated Gradients.
 
-        # Return
+        Returns:
+            ExplanationsResult containing the explanations.
 
-        :return: ExplanationsResult containing the explanations.
-            `global_explanations`: (Explanation) Aggregate explanation for the entire input data.
+            `global_explanations`: Aggregate explanation for the entire input data.
 
-            `row_explanations`: (List[Explanation]) A list of explanations, one for each row in the input data. Each
+            `row_explanations`: A list of explanations, one for each row in the input data. Each
             explanation contains the integrated gradients for each label in the target feature's vocab with respect to
             each input feature.
 
-            `expected_values`: (List[float]) of length [output feature cardinality] Average convergence delta for each
+            `expected_values`: Of length [output feature cardinality]. Average convergence delta for each
             label in the target feature's vocab.
         """
 
@@ -271,11 +271,12 @@ def get_input_tensors(
 ) -> list[torch.Tensor]:
     """Convert the input data into a list of variables, one for each input feature.
 
-    # Inputs
+    Args:
+        model: The LudwigModel to use for encoding.
+        input_set: The input data to encode of shape [batch size, num input features].
 
-    :param model: The LudwigModel to use for encoding.
-    :param input_set: The input data to encode of shape [batch size, num input features].  # Return
-    :return: A list of variables, one for each input feature. Shape of each variable is [batch size, embedding size].
+    Returns:
+        A list of variables, one for each input feature. Shape of each variable is [batch size, embedding size].
     """
     # Ignore sample_ratio and sample_size from the model config, since we want to explain all the data.
     sample_ratio_bak = model.config_obj.preprocessing.sample_ratio

--- a/ludwig/explain/explainer.py
+++ b/ludwig/explain/explainer.py
@@ -20,12 +20,11 @@ class Explainer(metaclass=ABCMeta):
     ):
         """Constructor for the explainer.
 
-        # Inputs
-
-        :param model: (LudwigModel) The LudwigModel to explain.
-        :param inputs_df: (pd.DataFrame) The input data to explain.
-        :param sample_df: (pd.DataFrame) A sample of the ground truth data.
-        :param target: (str) The name of the target to explain.
+        Args:
+            model: The LudwigModel to explain.
+            inputs_df: The input data to explain.
+            sample_df: A sample of the ground truth data.
+            target: The name of the target to explain.
         """
         self.model = model
         self.inputs_df = inputs_df
@@ -68,7 +67,6 @@ class Explainer(metaclass=ABCMeta):
     def explain(self) -> ExplanationsResult:
         """Explain the model's predictions.
 
-        # Return
-
-        :return: ExplanationsResult containing the explanations.
+        Returns:
+            ExplanationsResult containing the explanations.
         """

--- a/ludwig/export.py
+++ b/ludwig/export.py
@@ -28,10 +28,10 @@ logger = logging.getLogger(__name__)
 def export_mlflow(model_path, output_path="mlflow", registered_model_name=None, callbacks=None, **kwargs):
     """Exports a trained Ludwig model as an MLflow model.
 
-    # Inputs
-    :param model_path: (str) filepath to the trained Ludwig model.
-    :param output_path: (str) output directory for the MLflow model.
-    :param registered_model_name: (str, default: `None`) register model with this name.
+    Args:
+        model_path: filepath to the trained Ludwig model.
+        output_path: output directory for the MLflow model.
+        registered_model_name: register model with this name. Defaults to None.
     """
     logger.info(f"Loading Ludwig model from {model_path}")
 
@@ -47,10 +47,10 @@ def export_mlflow(model_path, output_path="mlflow", registered_model_name=None, 
 def export_model(model_path, output_path, format="safetensors", **kwargs):
     """Exports a trained Ludwig model in various formats.
 
-    # Inputs
-    :param model_path: (str) filepath to the trained Ludwig model.
-    :param output_path: (str) output directory for the exported model.
-    :param format: (str) export format: safetensors, torch_export, onnx.
+    Args:
+        model_path: filepath to the trained Ludwig model.
+        output_path: output directory for the exported model.
+        format: export format: safetensors, torch_export, onnx.
     """
     logger.info(f"Loading Ludwig model from {model_path}")
     model = LudwigModel.load(model_path)

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -462,20 +462,26 @@ class ImageFeatureMixin(BaseFeatureMixin):
         standardize_image: str,
         channel_class_map: torch.Tensor,
     ) -> np.ndarray | None:
-        """:param img_entry Union[bytes, torch.Tensor, np.ndarray, str]: if str file path to the image else
-        torch.Tensor of the image itself :param img_width: expected width of the image :param img_height: expected
-        height of the image :param should_resize: Should the image be resized? :param resize_method: type of
-        resizing method :param num_channels: expected number of channels in the first image :param
-        user_specified_num_channels: did the user specify num channels? :param standardize_image: specifies whether
-        to standarize image with imagenet1k specifications :param channel_class_map: A tensor mapping channel
-        values to classes, where dim=0 is the class :return: image object as a numpy array.
+        """Helper method to read and resize an image according to model definition. If the user doesn't specify a
+        number of channels, we use the first image in the dataset as the source of truth. If any image in the
+        dataset doesn't have the same number of channels as the first image, raise an exception.
 
-        Helper method to read and resize an image according to model definition. If the user doesn't specify a number of
-        channels, we use the first image in the dataset as the source of truth. If any image in the dataset doesn't have
-        the same number of channels as the first image, raise an exception.
+        If the user specifies a number of channels, we try to convert all the images to the specifications by
+        dropping channels/padding 0 channels.
 
-        If the user specifies a number of channels, we try to convert all the images to the specifications by dropping
-        channels/padding 0 channels
+        Args:
+            img_entry: if str, file path to the image; otherwise a torch.Tensor, np.ndarray, or bytes of the image.
+            img_width: expected width of the image.
+            img_height: expected height of the image.
+            should_resize: Should the image be resized?
+            resize_method: type of resizing method.
+            num_channels: expected number of channels in the first image.
+            user_specified_num_channels: did the user specify num channels?
+            standardize_image: specifies whether to standardize image with imagenet1k specifications.
+            channel_class_map: A tensor mapping channel values to classes, where dim=0 is the class.
+
+        Returns:
+            image object as a numpy array.
         """
 
         if isinstance(img_entry, bytes):

--- a/ludwig/forecast.py
+++ b/ludwig/forecast.py
@@ -28,27 +28,16 @@ def forecast_cli(
 ) -> None:
     """Loads pre-trained model to forecast on the provided dataset.
 
-    # Inputs
-
-    :param model_path: (str) filepath to pre-trained model.
-    :param dataset: (Union[str, dict, pandas.DataFrame], default: `None`)
-        source containing the entire dataset to be used in the prediction.
-    :param data_format: (str, default: `None`) format to interpret data
-        sources. Will be inferred automatically if not specified.
-    :param horizon: How many samples into the future to forecast.
-    :param output_directory: (str, default: `'results'`) the directory that
-        will contain the forecasted values.
-    :param output_format: (str) format of the output dataset.
-    :param callbacks: (list, default: `None`) a list of
-        `ludwig.callbacks.Callback` objects that provide hooks into the
-        Ludwig pipeline.
-    :param backend: (Union[Backend, str]) `Backend` or string name
-        of backend to use to execute preprocessing / training steps.
-    :param logging_level: (int) Log level that will be sent to stderr.
-
-    # Returns
-
-    :return: ('None')
+    Args:
+        model_path: Filepath to pre-trained model.
+        dataset: Source containing the entire dataset to be used in the prediction.
+        data_format: Format to interpret data sources. Will be inferred automatically if not specified.
+        horizon: How many samples into the future to forecast.
+        output_directory: The directory that will contain the forecasted values.
+        output_format: Format of the output dataset.
+        callbacks: A list of `ludwig.callbacks.Callback` objects that provide hooks into the Ludwig pipeline.
+        backend: Backend or string name of backend to use to execute preprocessing / training steps.
+        logging_level: Log level that will be sent to stderr.
     """
     model = LudwigModel.load(
         model_path,

--- a/ludwig/models/predictor.py
+++ b/ludwig/models/predictor.py
@@ -92,12 +92,13 @@ class Predictor(BasePredictor):
         **kwargs,
     ):
         """
-        :param dist_model: model to use for prediction, post-wrap for distributed training
-        :param batch_size: batch size to use for prediction
-        :param distributed: distributed strategy to use for prediction
-        :param report_tqdm_to_ray: whether to report tqdm progress to Ray
-        :param model: Ludwig BaseModel before being wrapped for distributed training.
-            Used to call Ludwig helper functions.
+        Args:
+            dist_model: model to use for prediction, post-wrap for distributed training.
+            batch_size: batch size to use for prediction.
+            distributed: distributed strategy to use for prediction.
+            report_tqdm_to_ray: whether to report tqdm progress to Ray.
+            model: Ludwig BaseModel before being wrapped for distributed training. Used to call Ludwig helper
+                functions.
         """
         model = model or dist_model
         if not isinstance(model, BaseModel):

--- a/ludwig/modules/optimization_modules.py
+++ b/ludwig/modules/optimization_modules.py
@@ -39,7 +39,8 @@ def get_optimizer_class_and_kwargs(
 ) -> tuple[type[torch.optim.Optimizer], dict]:
     """Returns the optimizer class and kwargs for the optimizer.
 
-    :return: Tuple of optimizer class and kwargs for the optimizer.
+    Returns:
+        Tuple of optimizer class and kwargs for the optimizer.
     """
     from ludwig.schema.optimizers import optimizer_registry
 
@@ -132,10 +133,13 @@ def create_optimizer(
 ) -> torch.optim.Optimizer:
     """Returns a ready-to-use torch optimizer instance based on the given optimizer config.
 
-    :param model: Underlying Ludwig model
-    :param learning_rate: Initial learning rate for the optimizer
-    :param optimizer_config: Instance of `ludwig.modules.optimization_modules.BaseOptimizerConfig`.
-    :return: Initialized instance of a torch optimizer.
+    Args:
+        model: Underlying Ludwig model.
+        learning_rate: Initial learning rate for the optimizer.
+        optimizer_config: Instance of `ludwig.modules.optimization_modules.BaseOptimizerConfig`.
+
+    Returns:
+        Initialized instance of a torch optimizer.
     """
     # Make sure the optimizer is compatible with the available resources:
     if (optimizer_config.is_paged or optimizer_config.is_8bit) and (

--- a/ludwig/modules/reduction_modules.py
+++ b/ludwig/modules/reduction_modules.py
@@ -54,17 +54,19 @@ class AttentionPooling(nn.Module):
 
 
 class SequenceReducer(LudwigModule):
-    """Reduces the sequence dimension of an input tensor according to the specified reduce_mode.  Any additional
-    kwargs are passed on to the reduce mode's constructor.  If using reduce_mode=="attention", the input_size kwarg
+    """Reduces the sequence dimension of an input tensor according to the specified reduce_mode. Any additional
+    kwargs are passed on to the reduce mode's constructor. If using reduce_mode=="attention", the input_size kwarg
     must also be specified.
 
     A sequence is a tensor of 2 or more dimensions, where the shape is [batch size x sequence length x ...].
 
-    :param reduce_mode: The reduction mode, one of {"last", "sum", "mean", "max", "concat", "attention",
-                        "attention_pooling", "none"}
-    :param max_sequence_length The maximum sequence length.  Only used for computation of shapes - inputs passed
-                               at runtime may have a smaller sequence length.
-    :param encoding_size The size of each sequence element/embedding vector, or None if input is a sequence of scalars.
+    Args:
+        reduce_mode: The reduction mode, one of {"last", "sum", "mean", "max", "concat", "attention",
+            "attention_pooling", "none"}.
+        max_sequence_length: The maximum sequence length. Only used for computation of shapes - inputs passed
+            at runtime may have a smaller sequence length.
+        encoding_size: The size of each sequence element/embedding vector, or None if input is a sequence of
+            scalars.
     """
 
     def __init__(
@@ -85,10 +87,12 @@ class SequenceReducer(LudwigModule):
     def forward(self, inputs, mask=None):
         """Forward pass of reducer.
 
-        :param inputs: A tensor of 2 or more dimensions, where the shape is [batch size x sequence length x ...].
-        :param mask: A mask tensor of 2 dimensions [batch size x sequence length].  Not yet implemented.
+        Args:
+            inputs: A tensor of 2 or more dimensions, where the shape is [batch size x sequence length x ...].
+            mask: A mask tensor of 2 dimensions [batch size x sequence length]. Not yet implemented.
 
-        :return: The input after applying the reduction operation to sequence dimension.
+        Returns:
+            The input after applying the reduction operation to sequence dimension.
         """
         return self._reduce_obj(inputs, mask=mask)
 

--- a/ludwig/schema/hyperopt/scheduler.py
+++ b/ludwig/schema/hyperopt/scheduler.py
@@ -479,9 +479,12 @@ def SchedulerDataclassField(default={"type": "fifo"}, description="Hyperopt sche
     """Custom dataclass field that when used inside of a dataclass will allow any scheduler in
     `ludwig.schema.hyperopt.scheduler.scheduler_registry`. Sets default scheduler to 'fifo'.
 
-    :param default: Dict specifying a scheduler with a `type` field and its associated parameters. Will attempt to use
-           `type` to load scheduler from registry with given params. (default: {"type": "fifo"}).
-    :return: Initialized dataclass field that converts untyped dicts with params to scheduler dataclass instances.
+    Args:
+        default: Dict specifying a scheduler with a `type` field and its associated parameters. Will attempt to
+            use `type` to load scheduler from registry with given params. (default: {"type": "fifo"}).
+
+    Returns:
+        Initialized dataclass field that converts untyped dicts with params to scheduler dataclass instances.
     """
 
     class SchedulerConfigField(schema_utils.SchemaField):

--- a/ludwig/schema/optimizers.py
+++ b/ludwig/schema/optimizers.py
@@ -1189,7 +1189,11 @@ if _SOAPOptimizer is not None:
 @DeveloperAPI
 def get_optimizer_conds():
     """Returns a JSON schema of conditionals to validate against optimizer types defined in
-    `ludwig.modules.optimization_modules.optimizer_registry`."""
+    `ludwig.modules.optimization_modules.optimizer_registry`.
+
+    Returns:
+        List of JSON schema conditionals for all registered optimizer types.
+    """
     conds = []
     for optimizer in optimizer_registry:
         optimizer_cls = optimizer_registry[optimizer][1]
@@ -1210,9 +1214,12 @@ def OptimizerDataclassField(default="adam", description="", parameter_metadata: 
 
     Sets default optimizer to 'adam'.
 
-    :param default: Dict specifying an optimizer with a `type` field and its associated parameters. Will attempt to use
-           `type` to load optimizer from registry with given params. (default: {"type": "adam"}).
-    :return: Initialized dataclass field that converts untyped dicts with params to optimizer dataclass instances.
+    Args:
+        default: Dict specifying an optimizer with a `type` field and its associated parameters. Will attempt
+            to use `type` to load optimizer from registry with given params. (default: {"type": "adam"}).
+
+    Returns:
+        Initialized dataclass field that converts untyped dicts with params to optimizer dataclass instances.
     """
 
     class OptimizerSelection(schema_utils.TypeSelection):
@@ -1284,8 +1291,9 @@ def GradientClippingDataclassField(description: str, default: dict = {}):
     """Returns custom dataclass field for `ludwig.modules.optimization_modules.GradientClippingConfig`. Allows
     `None` by default.
 
-    :param description: Description of the gradient dataclass field
-    :param default: dict that specifies clipping param values that will be loaded by its schema class (default: {}).
+    Args:
+        description: Description of the gradient dataclass field.
+        default: Dict that specifies clipping param values that will be loaded by its schema class (default: {}).
     """
     allow_none = True
 

--- a/ludwig/schema/profiler.py
+++ b/ludwig/schema/profiler.py
@@ -52,8 +52,9 @@ class ProfilerConfig(schema_utils.LudwigBaseConfig):
 def ProfilerDataclassField(description: str, default: dict = {}):
     """Returns custom dataclass field for `ludwig.modules.profiler.ProfilerConfig`. Allows `None` by default.
 
-    :param description: Description of the torch profiler field
-    :param default: dict that specifies clipping param values that will be loaded by its schema class (default: {}).
+    Args:
+        description: Description of the torch profiler field.
+        default: Dict that specifies clipping param values that will be loaded by its schema class (default: {}).
     """
     allow_none = True
 

--- a/ludwig/trainers/trainer.py
+++ b/ludwig/trainers/trainer.py
@@ -125,35 +125,27 @@ class Trainer(CheckpointMixin, EarlyStoppingMixin, MetricsMixin, ProfilingMixin,
     ):
         """Trains a model with a set of options and hyperparameters listed below. Customizable.
 
-        :param model: Underlying Ludwig model
-        :type model: `ludwig.models.ecd.ECD`
-        :param resume: Resume training a model that was being trained. (default: False).
-        :type resume: Boolean
-        :param skip_save_model: Disables saving model weights and hyperparameters each time the model improves. By
-                default Ludwig saves model weights after each round of evaluation the validation metric (improves, but
+        Args:
+            model: Underlying Ludwig model (`ludwig.models.ecd.ECD`).
+            resume: Resume training a model that was being trained. (default: False).
+            skip_save_model: Disables saving model weights and hyperparameters each time the model improves. By
+                default Ludwig saves model weights after each round of evaluation the validation metric improves, but
                 if the model is really big that can be time consuming. If you do not want to keep the weights and just
                 find out what performance a model can get with a set of hyperparameters, use this parameter to skip it,
                 but the model will not be loadable later on. (default: False).
-        :type skip_save_model: Boolean
-        :param skip_save_progress: Disables saving progress each round of evaluation. By default Ludwig saves weights
+            skip_save_progress: Disables saving progress each round of evaluation. By default Ludwig saves weights
                 and stats after each round of evaluation for enabling resuming of training, but if the model is really
                 big that can be time consuming and will uses twice as much space, use this parameter to skip it, but
                 training cannot be resumed later on. (default: False).
-        :type skip_save_progress: Boolean
-        :param skip_save_log: Disables saving TensorBoard logs. By default Ludwig saves logs for the TensorBoard, but if
+            skip_save_log: Disables saving TensorBoard logs. By default Ludwig saves logs for the TensorBoard, but if
                 it is not needed turning it off can slightly increase the overall speed. (default: False).
-        :type skip_save_log: Boolean
-        :param callbacks: List of `ludwig.callbacks.Callback` objects that provide hooks into the Ludwig pipeline.
+            callbacks: List of `ludwig.callbacks.Callback` objects that provide hooks into the Ludwig pipeline.
                 (default: None).
-        :type callbacks: list
-        :param report_tqdm_to_ray: Enables using the ray based tqdm Callback for progress bar reporting
-        :param random_seed: Default initialization for the random seeds (default: 42).
-        :type random_seed: Float
-        :param distributed: Distributed strategy (default: None).
-        :type distributed: `DistributedStrategy`
-        :param device: Device to load the model on from a saved checkpoint (default: None).
-        :type device: str
-        :param config: `ludwig.schema.trainer.BaseTrainerConfig` instance that specifies training hyperparameters
+            report_tqdm_to_ray: Enables using the ray based tqdm Callback for progress bar reporting.
+            random_seed: Default initialization for the random seeds (default: 42).
+            distributed: Distributed strategy (default: None).
+            device: Device to load the model on from a saved checkpoint (default: None).
+            config: `ludwig.schema.trainer.BaseTrainerConfig` instance that specifies training hyperparameters
                 (default: `ludwig.schema.trainer.ECDTrainerConfig()`).
         """
         self.distributed = distributed if distributed is not None else LocalStrategy()
@@ -847,11 +839,12 @@ class Trainer(CheckpointMixin, EarlyStoppingMixin, MetricsMixin, ProfilingMixin,
     ):
         """Trains a model with a set of hyperparameters listed below. Customizable.
 
-        :param training_set: The training set
-        :param validation_set: The validation dataset
-        :param test_set: The test dataset
-        :param save_path: The directory that will contain the saved model
-        :param return_state_dict: Whether to return the state dict of the model instead of the model itself
+        Args:
+            training_set: The training set.
+            validation_set: The validation dataset.
+            test_set: The test dataset.
+            save_path: The directory that will contain the saved model.
+            return_state_dict: Whether to return the state dict of the model instead of the model itself.
         """
         # ====== General setup =======
         output_features = self.model.output_features

--- a/ludwig/trainers/trainer_llm.py
+++ b/ludwig/trainers/trainer_llm.py
@@ -60,36 +60,28 @@ class NoneTrainer(BaseTrainer):
         **kwargs,
     ):
         """
-        :param config: `ludwig.schema.trainer.NoneTrainerConfig` instance that specifies training hyperparameters
-        (default: `ludwig.schema.trainer.NoneTrainerConfig()`).
-        :param model: Underlying Ludwig model
-        :type model: `ludwig.models.llm.LLM`
-        :param resume: Resume training a model that was being trained. (default: False).
-        :type resume: Boolean
-        :param skip_save_model: Disables saving model weights and hyperparameters each time the model improves. By
-                default Ludwig saves model weights after each round of evaluation the validation metric (improves, but
+        Args:
+            config: `ludwig.schema.trainer.NoneTrainerConfig` instance that specifies training hyperparameters
+                (default: `ludwig.schema.trainer.NoneTrainerConfig()`).
+            model: Underlying Ludwig model (`ludwig.models.llm.LLM`).
+            resume: Resume training a model that was being trained. (default: False).
+            skip_save_model: Disables saving model weights and hyperparameters each time the model improves. By
+                default Ludwig saves model weights after each round of evaluation the validation metric improves, but
                 if the model is really big that can be time consuming. If you do not want to keep the weights and just
                 find out what performance a model can get with a set of hyperparameters, use this parameter to skip it,
                 but the model will not be loadable later on. (default: False).
-        :type skip_save_model: Boolean
-        :param skip_save_progress: Disables saving progress each round of evaluation. By default Ludwig saves weights
+            skip_save_progress: Disables saving progress each round of evaluation. By default Ludwig saves weights
                 and stats after each round of evaluation for enabling resuming of training, but if the model is really
                 big that can be time consuming and will uses twice as much space, use this parameter to skip it, but
                 training cannot be resumed later on. (default: False).
-        :type skip_save_progress: Boolean
-        :param skip_save_log: Disables saving TensorBoard logs. By default Ludwig saves logs for the TensorBoard, but if
+            skip_save_log: Disables saving TensorBoard logs. By default Ludwig saves logs for the TensorBoard, but if
                 it is not needed turning it off can slightly increase the overall speed. (default: False).
-        :type skip_save_log: Boolean
-        :param callbacks: List of `ludwig.callbacks.Callback` objects that provide hooks into the Ludwig pipeline.
+            callbacks: List of `ludwig.callbacks.Callback` objects that provide hooks into the Ludwig pipeline.
                 (default: None).
-        :type callbacks: list
-        :param report_tqdm_to_ray: Enables using the ray based tqdm Callback for progress bar reporting
-        :param random_seed: Default initialization for the random seeds (default: 42).
-        :type random_seed: Float
-        :param distributed: Distributed strategy (default: None).
-        :type distributed: `DistributedStrategy`
-        :param device: Device to load the model on from a saved checkpoint (default: None).
-        :type device: str
+            report_tqdm_to_ray: Enables using the ray based tqdm Callback for progress bar reporting.
+            random_seed: Default initialization for the random seeds (default: 42).
+            distributed: Distributed strategy (default: None).
+            device: Device to load the model on from a saved checkpoint (default: None).
         """
 
         super().__init__()

--- a/ludwig/utils/automl/type_inference.py
+++ b/ludwig/utils/automl/type_inference.py
@@ -18,11 +18,13 @@ TEXT_AVG_WORDS_CUTOFF = 5
 def infer_type(field: FieldInfo, missing_value_percent: float, row_count: int) -> str:
     """Perform type inference on field.
 
-    # Inputs
-    :param field: (FieldInfo) object describing field
-    :param missing_value_percent: (float) percent of missing values in the column
-    :param row_count: (int) total number of entries in original dataset  # Return
-    :return: (str) feature type
+    Args:
+        field: Object describing field.
+        missing_value_percent: Percent of missing values in the column.
+        row_count: Total number of entries in original dataset.
+
+    Returns:
+        Feature type string.
     """
     if field.dtype == DATE or field.dtype.startswith("datetime"):
         return DATE

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -175,14 +175,17 @@ def read_xsv(data_fp, df_lib=PANDAS_DF, separator=",", header=0, nrows=None, ski
     """Helper method to read a csv file. Wraps around pd.read_csv to handle some exceptions. Can extend to cover
     cases as necessary.
 
-    :param data_fp: path to the xsv file
-    :param df_lib: DataFrame library used to read in the CSV
-    :param separator: defaults separator to use for splitting
-    :param header: header argument for pandas to read the csv
-    :param nrows: number of rows to read from the csv, None means all
-    :param skiprows: number of rows to skip from the csv, None means no skips
-    :param dtype: dtype to use for columns. Defaults to object to disable type inference.
-    :return: Pandas dataframe with the data
+    Args:
+        data_fp: path to the xsv file
+        df_lib: DataFrame library used to read in the CSV
+        separator: defaults separator to use for splitting
+        header: header argument for pandas to read the csv
+        nrows: number of rows to read from the csv, None means all
+        skiprows: number of rows to skip from the csv, None means no skips
+        dtype: dtype to use for columns. Defaults to object to disable type inference.
+
+    Returns:
+        Pandas dataframe with the data
     """
     with open_file(data_fp, "r", encoding="utf8") as csvfile:
         try:
@@ -729,13 +732,17 @@ def class_counts(dataset, labels_field):
 def load_from_file(file_name, field=None, dtype=int, ground_truth_split=2):
     """Load experiment data from supported file formats.
 
-    Experiment data can be test/train statistics, model predictions, probability, ground truth,  ground truth metadata.
-    :param file_name: Path to file to be loaded
-    :param field: Target Prediction field.
-    :param dtype:
-    :param ground_truth_split: Ground truth split filter where 0 is train 1 is validation and 2 is test split. By
-        default test split is used when loading ground truth from hdf5.
-    :return: Experiment data as array
+    Experiment data can be test/train statistics, model predictions, probability, ground truth, ground truth metadata.
+
+    Args:
+        file_name: Path to file to be loaded.
+        field: Target Prediction field.
+        dtype: dtype to use when loading matrix data.
+        ground_truth_split: Ground truth split filter where 0 is train 1 is validation and 2 is test split. By
+            default test split is used when loading ground truth from hdf5.
+
+    Returns:
+        Experiment data as array.
     """
     if file_name.endswith(".hdf5") and field is not None:
         dataset = pd.read_hdf(file_name, key=HDF5_COLUMNS_KEY)
@@ -752,12 +759,14 @@ def load_from_file(file_name, field=None, dtype=int, ground_truth_split=2):
 
 @DeveloperAPI
 def replace_file_extension(file_path, extension):
-    """Return a file path for a file with same name but different format. a.csv, json -> a.json a.csv, hdf5 ->
-    a.hdf5.
+    """Return a file path for a file with same name but different format. a.csv, json -> a.json a.csv, hdf5 -> a.hdf5.
 
-    :param file_path: original file path
-    :param extension: file extension
-    :return: file path with same name but different format
+    Args:
+        file_path: original file path
+        extension: file extension
+
+    Returns:
+        file path with same name but different format
     """
     if file_path is None:
         return None
@@ -780,9 +789,10 @@ def add_sequence_feature_column(df, col_name, seq_length):
     delimited strings composed of preceding values of the same column up to seq_length. For example values of the
     i-th row of the new column will be a space-delimited string of df[col_name][i-seq_length].
 
-    :param df: input dataframe
-    :param col_name: column name containing sequential data
-    :param seq_length: length of an array of preceeding column values to use
+    Args:
+        df: input dataframe
+        col_name: column name containing sequential data
+        seq_length: length of an array of preceeding column values to use
     """
     if col_name not in df.columns.values:
         logger.error(f"{col_name} column does not exist")

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -52,9 +52,9 @@ def merge_dict(dct, merge_dct):
     dict_merge recurses down into dicts nested to an arbitrary depth, updating keys. The ``merge_dct`` is merged
     into ``dct``.
 
-    :param dct: dict onto which the merge is executed
-    :param merge_dct: dct merged into dct
-    :return: None
+    Args:
+        dct: Dict onto which the merge is executed.
+        merge_dct: Dict merged into dct.
     """
     dct = copy.deepcopy(dct)
     for k, _v in merge_dct.items():

--- a/ludwig/utils/torch_utils.py
+++ b/ludwig/utils/torch_utils.py
@@ -63,8 +63,11 @@ def place_on_device(x, device):
 def sequence_length_2D(sequence: torch.Tensor) -> torch.Tensor:
     """Returns the number of non-padding elements per sequence in batch.
 
-    :param sequence: (torch.Tensor) A 2D tensor of shape [batch size x max sequence length].  # Return
-    :returns: (torch.Tensor) The count on non-zero elements per sequence.
+    Args:
+        sequence: A 2D tensor of shape [batch size x max sequence length].
+
+    Returns:
+        The count of non-zero elements per sequence.
     """
     used = (sequence != SpecialSymbol.PADDING.value).type(torch.int32)
     length = torch.sum(used, 1)
@@ -75,8 +78,11 @@ def sequence_length_2D(sequence: torch.Tensor) -> torch.Tensor:
 def sequence_length_3D(sequence: torch.Tensor) -> torch.Tensor:
     """Returns the number of non-zero elements per sequence in batch.
 
-    :param sequence: (torch.Tensor) A 3D tensor of shape [batch size x max sequence length x hidden size].  # Return
-    :returns: (torch.Tensor) The count on non-zero elements per sequence.
+    Args:
+        sequence: A 3D tensor of shape [batch size x max sequence length x hidden size].
+
+    Returns:
+        The count of non-zero elements per sequence.
     """
     used = torch.sign(torch.amax(torch.abs(sequence), dim=2))
     length = torch.sum(used, 1)
@@ -89,10 +95,13 @@ def sequence_mask(lengths: torch.Tensor, maxlen: int | None = None, dtype: torch
     """Returns a mask of shape (batch_size x maxlen), where mask[i] is True for each element up to lengths[i],
     otherwise False i.e. if maxlen=5 and lengths[i] = 3, mask[i] = [True, True True, False False].
 
-    :param lengths: (torch.Tensor) A 1d integer tensor of shape [batch size].
-    :param maxlen: (Optional[int]) The maximum sequence length.  If not specified, the max(lengths) is used.
-    :param dtype: (type) The type to output.  # Return
-    :returns: (torch.Tensor) A sequence mask tensor of shape (batch_size x maxlen).
+    Args:
+        lengths: A 1d integer tensor of shape [batch size].
+        maxlen: The maximum sequence length. If not specified, the max(lengths) is used.
+        dtype: The type to output.
+
+    Returns:
+        A sequence mask tensor of shape (batch_size x maxlen).
     """
     if maxlen is None:
         maxlen = lengths.max()

--- a/ludwig/visualize/_utils.py
+++ b/ludwig/visualize/_utils.py
@@ -101,12 +101,11 @@ def _encode_categorical_feature(raw: np.array, str2idx: dict) -> np.array:
     """Encodes raw categorical string value to encoded numeric value.
 
     Args:
-    :param raw: (np.array) string categorical representation
-    :param str2idx: (dict) dictionary that maps string representation to
-        encoded value.
+        raw: String categorical representation.
+        str2idx: Dictionary that maps string representation to encoded value.
 
     Returns:
-        np.array
+        Encoded numeric value.
     """
     return str2idx[raw]
 
@@ -133,16 +132,13 @@ def _extract_ground_truth_values(
     """Helper function to extract ground truth values.
 
     Args:
-    :param ground_truth: (str, DataFrame) path to source data containing ground truth or ground truth dataframe
-    :param output_feature_name: (str) output feature name for ground
-        truth values.
-    :param ground_truth_split: (int) dataset split to use for ground truth,
-        defaults to 2.
-    :param split_file: (Union[str, None]) optional file path to split values.
+        ground_truth: Path to source data containing ground truth or ground truth dataframe.
+        output_feature_name: Output feature name for ground truth values.
+        ground_truth_split: Dataset split to use for ground truth, defaults to 2.
+        split_file: Optional file path to split values.
 
-    # Return
-
-    :return pd.Series: ground truth values from source data set
+    Returns:
+        Ground truth values from source data set.
     """
     ground_truth_df = _get_ground_truth_df(ground_truth) if isinstance(ground_truth, str) else ground_truth
 
@@ -212,9 +208,12 @@ def _get_cols_from_predictions(predictions_paths, cols, metadata):
 def validate_conf_thresholds_and_probabilities_2d_3d(probabilities, threshold_output_feature_names):
     """Ensure probabilities and threshold output_feature_names arrays have two members each.
 
-    :param probabilities: List of probabilities per model
-    :param threshhold_output_feature_names: List of threshhold output_feature_names per model
-    :raise: RuntimeError
+    Args:
+        probabilities: List of probabilities per model.
+        threshold_output_feature_names: List of threshold output_feature_names per model.
+
+    Raises:
+        RuntimeError: If either list does not contain exactly two members.
     """
     validation_mapping = {
         "probabilities": probabilities,
@@ -232,9 +231,12 @@ def validate_conf_thresholds_and_probabilities_2d_3d(probabilities, threshold_ou
 def load_data_for_viz(load_type, model_file_statistics, dtype=int, ground_truth_split=2) -> "dict[str, Any]":
     """Load JSON files (training stats, evaluation stats...) for a list of models.
 
-    :param load_type: type of the data loader to be used.
-    :param model_file_statistics: JSON file or list of json files containing any model experiment stats. :return List of
-        training statistics loaded as json objects.
+    Args:
+        load_type: Type of the data loader to be used.
+        model_file_statistics: JSON file or list of json files containing any model experiment stats.
+
+    Returns:
+        List of training statistics loaded as json objects.
     """
     supported_load_types = {
         "load_json": load_json,
@@ -269,9 +271,12 @@ def _load_training_stats(data: dict) -> TrainingStats:
 def load_training_stats_for_viz(load_type, model_file_statistics, dtype=int, ground_truth_split=2) -> TrainingStats:
     """Load model file data (specifically training stats) for a list of models.
 
-    :param load_type: type of the data loader to be used.
-    :param model_file_statistics: JSON file or list of json files containing any model experiment stats. :return List of
-        model statistics loaded as TrainingStats objects.
+    Args:
+        load_type: Type of the data loader to be used.
+        model_file_statistics: JSON file or list of json files containing any model experiment stats.
+
+    Returns:
+        List of model statistics loaded as TrainingStats objects.
     """
     stats_per_model = load_data_for_viz(
         load_type, model_file_statistics, dtype=dtype, ground_truth_split=ground_truth_split
@@ -288,8 +293,11 @@ def load_training_stats_for_viz(load_type, model_file_statistics, dtype=int, gro
 def convert_to_list(item):
     """If item is not list class instance or None put inside a list.
 
-    :param item: object to be checked and converted
-    :return: original item if it is a list instance or list containing the item.
+    Args:
+        item: Object to be checked and converted.
+
+    Returns:
+        Original item if it is a list instance or list containing the item.
     """
     return item if item is None or isinstance(item, list) else [item]
 
@@ -297,9 +305,12 @@ def convert_to_list(item):
 def _validate_output_feature_name_from_train_stats(output_feature_name, train_stats_per_model):
     """Validate prediction output_feature_name from model train stats and return it as list.
 
-    :param output_feature_name: output_feature_name containing ground truth
-    :param train_stats_per_model: list of per model train stats
-    :return output_feature_names: list of output_feature_name(s) containing ground truth
+    Args:
+        output_feature_name: Output feature name containing ground truth.
+        train_stats_per_model: List of per model train stats.
+
+    Returns:
+        List of output_feature_name(s) containing ground truth.
     """
     output_feature_names_set = set()
     for train_stats in train_stats_per_model:
@@ -318,9 +329,12 @@ def _validate_output_feature_name_from_train_stats(output_feature_name, train_st
 def _validate_output_feature_name_from_test_stats(output_feature_name, test_stats_per_model):
     """Validate prediction output_feature_name from model test stats and return it as list.
 
-    :param output_feature_name: output_feature_name containing ground truth
-    :param test_stats_per_model: list of per model test stats
-    :return output_feature_names: list of output_feature_name(s) containing ground truth
+    Args:
+        output_feature_name: Output feature name containing ground truth.
+        test_stats_per_model: List of per model test stats.
+
+    Returns:
+        List of output_feature_name(s) containing ground truth.
     """
     output_feature_names_set = set()
     for ls in test_stats_per_model:
@@ -340,10 +354,14 @@ def _validate_output_feature_name_from_test_stats(output_feature_name, test_stat
 def generate_filename_template_path(output_dir, filename_template):
     """Ensure path to template file can be constructed given an output dir.
 
-    Create output directory if yet does exist.
-    :param output_dir: Directory that will contain the filename_template file
-    :param filename_template: name of the file template to be appended to the filename template path
-    :return: path to filename template inside the output dir or None if the output dir is None
+    Create output directory if it does not yet exist.
+
+    Args:
+        output_dir: Directory that will contain the filename_template file.
+        filename_template: Name of the file template to be appended to the filename template path.
+
+    Returns:
+        Path to filename template inside the output dir or None if the output dir is None.
     """
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)

--- a/ludwig/visualize/confusion.py
+++ b/ludwig/visualize/confusion.py
@@ -37,12 +37,10 @@ logger = logging.getLogger(__name__)
 def confusion_matrix_cli(test_statistics: "str | list[str]", ground_truth_metadata: str, **kwargs: dict) -> None:
     """Load model data from files to be shown by confusion_matrix.
 
-    # Inputs
-
-    :param test_statistics: (Union[str, List[str]]) path to experiment test statistics file.
-    :param ground_truth_metadata: (str) path to ground truth metadata file.
-    :param kwargs: (dict) parameters for the requested visualizations.  # Return
-    :return None:
+    Args:
+        test_statistics: Path to experiment test statistics file.
+        ground_truth_metadata: Path to ground truth metadata file.
+        **kwargs: Parameters for the requested visualizations.
     """
     test_stats_per_model = load_data_for_viz("load_json", test_statistics)
     metadata = load_json(ground_truth_metadata)
@@ -64,32 +62,24 @@ def confusion_matrix(
     """Show confusion matrix in the models predictions for each `output_feature_name`.
 
     For each model (in the aligned lists of test_statistics and model_names)
-    it  produces a heatmap of the confusion matrix in the predictions for
-    each  output_feature_name that has a confusion matrix in test_statistics.
+    it produces a heatmap of the confusion matrix in the predictions for
+    each output_feature_name that has a confusion matrix in test_statistics.
     The value of `top_n_classes` limits the heatmap to the n most frequent
     classes.
 
-    # Inputs
-
-    :param test_stats_per_model: (List[dict]) dictionary containing evaluation
-      performance statistics.
-    :param metadata: (dict) intermediate preprocess structure created during
-        training containing the mappings of the input dataset.
-    :param output_feature_name: (Union[str, `None`]) name of the output feature
-        to use for the visualization.  If `None`, use all output features.
-    :param top_n_classes: (List[int]) number of top classes or list
-        containing the number of top classes to plot.
-    :param normalize: (bool) flag to normalize rows in confusion matrix.
-    :param model_names: (Union[str, List[str]], default: `None`) model name or
-        list of the model names to use as labels.
-    :param output_directory: (str, default: `None`) directory where to save
-        plots. If not specified, plots will be displayed in a window
-    :param file_format: (str, default: `'pdf'`) file format of output plots -
-        `'pdf'` or `'png'`.
-
-    # Return
-
-    :return: (None)
+    Args:
+        test_stats_per_model: Dictionary containing evaluation performance statistics.
+        metadata: Intermediate preprocess structure created during training containing
+            the mappings of the input dataset.
+        output_feature_name: Name of the output feature to use for the visualization.
+            If None, use all output features.
+        top_n_classes: Number of top classes or list containing the number of top
+            classes to plot.
+        normalize: Flag to normalize rows in confusion matrix.
+        model_names: Model name or list of the model names to use as labels.
+        output_directory: Directory where to save plots. If not specified, plots will
+            be displayed in a window.
+        file_format: File format of output plots — 'pdf' or 'png'.
     """
     test_stats_per_model_list = test_stats_per_model
     model_names_list = convert_to_list(model_names)

--- a/ludwig/visualize/hyperopt.py
+++ b/ludwig/visualize/hyperopt.py
@@ -32,10 +32,10 @@ def hyperopt_report_cli(hyperopt_stats_path, output_directory=None, file_format=
     """Produces a report about hyperparameter optimization creating one graph per hyperparameter to show the
     distribution of results and one additional graph of pairwise hyperparameters interactions.
 
-    :param hyperopt_stats_path: path to the hyperopt results JSON file
-    :param output_directory: path where to save the output plots
-    :param file_format: format of the output plot, pdf or png
-    :return:
+    Args:
+        hyperopt_stats_path: Path to the hyperopt results JSON file.
+        output_directory: Path where to save the output plots.
+        file_format: Format of the output plot, pdf or png.
     """
 
     hyperopt_report(hyperopt_stats_path, output_directory=output_directory, file_format=file_format)
@@ -48,17 +48,10 @@ def hyperopt_report(
     """Produces a report about hyperparameter optimization creating one graph per hyperparameter to show the
     distribution of results and one additional graph of pairwise hyperparameters interactions.
 
-    # Inputs
-
-    :param hyperopt_stats_path: (str) path to the hyperopt results JSON file.
-    :param output_directory: (str, default: `None`) directory where to save
-        plots. If not specified, plots will be displayed in a window.
-    :param file_format: (str, default: `'pdf'`) file format of output plots -
-        `'pdf'` or `'png'`.
-
-    # Return
-
-    :return: (None)
+    Args:
+        hyperopt_stats_path: Path to the hyperopt results JSON file.
+        output_directory: Directory where to save plots. If not specified, plots will be displayed in a window.
+        file_format: File format of output plots — 'pdf' or 'png'.
     """
     filename_template = "hyperopt_{}." + file_format
     filename_template_path = generate_filename_template_path(output_directory, filename_template)
@@ -82,9 +75,9 @@ def hyperopt_hiplot_cli(hyperopt_stats_path, output_directory=None, **kwargs):
     """Produces a parallel coordinate plot about hyperparameter optimization creating one HTML file and optionally
     a CSV file to be read by hiplot.
 
-    :param hyperopt_stats_path: path to the hyperopt results JSON file
-    :param output_directory: path where to save the output plots
-    :return:
+    Args:
+        hyperopt_stats_path: Path to the hyperopt results JSON file.
+        output_directory: Path where to save the output plots.
     """
 
     hyperopt_hiplot(hyperopt_stats_path, output_directory=output_directory)
@@ -95,15 +88,9 @@ def hyperopt_hiplot(hyperopt_stats_path, output_directory=None, **kwargs):
     """Produces a parallel coordinate plot about hyperparameter optimization creating one HTML file and optionally
     a CSV file to be read by hiplot.
 
-    # Inputs
-
-    :param hyperopt_stats_path: (str) path to the hyperopt results JSON file.
-    :param output_directory: (str, default: `None`) directory where to save
-        plots. If not specified, plots will be displayed in a window.
-
-    # Return
-
-    :return: (None)
+    Args:
+        hyperopt_stats_path: Path to the hyperopt results JSON file.
+        output_directory: Directory where to save plots. If not specified, plots will be displayed in a window.
     """
     filename = "hyperopt_hiplot.html"
     filename_path = generate_filename_template_path(output_directory, filename)

--- a/ludwig/visualize/training.py
+++ b/ludwig/visualize/training.py
@@ -34,11 +34,9 @@ logger = logging.getLogger(__name__)
 def learning_curves_cli(training_statistics: "str | list[str]", **kwargs: dict) -> None:
     """Load model data from files to be shown by learning_curves.
 
-    # Inputs
-
-    :param training_statistics: (Union[str, List[str]]) path to experiment training statistics file
-    :param kwargs: (dict) parameters for the requested visualizations.  # Return
-    :return None:
+    Args:
+        training_statistics: Path to experiment training statistics file.
+        **kwargs: Parameters for the requested visualizations.
     """
     train_stats_per_model = load_training_stats_for_viz("load_json", training_statistics)
     learning_curves(train_stats_per_model, **kwargs)
@@ -60,24 +58,16 @@ def learning_curves(
     it produces a line plot showing how that metric changed over the course
     of the epochs of training on the training and validation sets.
 
-    # Inputs
-
-    :param train_stats_per_model: (List[dict]) list containing dictionary of
-        training statistics per model.
-    :param output_feature_name: (Union[str, `None`], default: `None`) name of the output feature
-        to use for the visualization.  If `None`, use all output features.
-    :param model_names: (Union[str, List[str]], default: `None`) model name or
-        list of the model names to use as labels.
-    :param output_directory: (str, default: `None`) directory where to save
-        plots. If not specified, plots will be displayed in a window
-    :param file_format: (str, default: `'pdf'`) file format of output plots -
-        `'pdf'` or `'png'`.
-    :param callbacks: (list, default: `None`) a list of
-        `ludwig.callbacks.Callback` objects that provide hooks into the
-        Ludwig pipeline.
-
-    # Return
-    :return: (None)
+    Args:
+        train_stats_per_model: List containing dictionary of training statistics per model.
+        output_feature_name: Name of the output feature to use for the visualization.
+            If None, use all output features.
+        model_names: Model name or list of the model names to use as labels.
+        output_directory: Directory where to save plots. If not specified, plots will
+            be displayed in a window.
+        file_format: File format of output plots — 'pdf' or 'png'.
+        callbacks: A list of `ludwig.callbacks.Callback` objects that provide hooks
+            into the Ludwig pipeline.
     """
     filename_template = "learning_curves_{}_{}." + file_format
     filename_template_path = generate_filename_template_path(output_directory, filename_template)


### PR DESCRIPTION
## Summary

- `experiment_cli()`: full conversion to Google-style with accurate `Returns:` that documents the 5-tuple `(model, eval_stats, train_stats, preprocessed_data, output_directory)`
- `kfold_cross_validate_cli()`: removes stale `:return: None`, adds proper `Args:` section
- `sequence_encoders.py`: 157 `:param` occurrences across 8 encoder classes converted; also removes stale `# todo: revise docstring` and `# todo: fixup docstring` inline comments that had accumulated but were never acted on

Net: -579 lines

## Test plan

- [ ] `pre-commit run --files` passes (ruff lint + format, blacken-docs)
- [ ] No behavior changes — docstrings and stale comments only