### PR TITLE
docs: final cleanup of remaining Sphinx-style docstrings

### DIFF
--- a/ludwig/benchmarking/examples/process_config.py
+++ b/ludwig/benchmarking/examples/process_config.py
@@ -9,10 +9,12 @@ def process_config(ludwig_config: dict, experiment_dict: dict) -> dict:
      attributes of `experiment_dict` (e.g. dataset_name) removing the need to manually apply
      small changes to configs on many datasets.
 
-    :param ludwig_config: a Ludwig config.
-    :param experiment_dict: a benchmarking config experiment dictionary.
+    Args:
+        ludwig_config: A Ludwig config.
+        experiment_dict: A benchmarking config experiment dictionary.
 
-    Returns: a modified Ludwig config.
+    Returns:
+        A modified Ludwig config.
     """
 
     # only keep input_features and output_features

--- a/ludwig/benchmarking/summarize.py
+++ b/ludwig/benchmarking/summarize.py
@@ -21,12 +21,13 @@ def summarize_metrics(
 ) -> tuple[list[str], list[MetricsDiff], list[list[ResourceUsageDiff]]]:
     """Build metric and resource usage diffs from experiment artifacts.
 
-    bench_config_path: bench config file path. Can be the same one that was used to run
-        these experiments.
-    base_experiment: name of the experiment we're comparing against.
-    experimental_experiment: name of the experiment we're comparing.
-    download_base_path: base path under which live the stored artifacts of
-        the benchmarking experiments.
+    Args:
+        bench_config_path: Bench config file path. Can be the same one that was used to run
+            these experiments.
+        base_experiment: Name of the experiment we're comparing against.
+        experimental_experiment: Name of the experiment we're comparing.
+        download_base_path: Base path under which live the stored artifacts of
+            the benchmarking experiments.
     """
     local_dir, dataset_list = download_artifacts(
         bench_config_path, base_experiment, experimental_experiment, download_base_path
@@ -55,9 +56,10 @@ def export_and_print(
 ) -> None:
     """Export to CSV and print a diff of performance and resource usage metrics of two experiments.
 
-    :param dataset_list: list of datasets for which to print the diffs.
-    :param metric_diffs: Diffs for the performance metrics by dataset.
-    :param resource_usage_diffs: Diffs for the resource usage metrics per dataset per LudwigProfiler tag.
+    Args:
+        dataset_list: List of datasets for which to print the diffs.
+        metric_diffs: Diffs for the performance metrics by dataset.
+        resource_usage_diffs: Diffs for the resource usage metrics per dataset per LudwigProfiler tag.
     """
     for dataset_name, experiment_metric_diff in zip(dataset_list, metric_diffs):
         output_path = os.path.join("summarize_output", "performance_metrics", dataset_name)

--- a/ludwig/data/sampler.py
+++ b/ludwig/data/sampler.py
@@ -75,6 +75,7 @@ class DistributedSampler:
         When `shuffle=True`, this ensures all replicas use a different random ordering for each epoch. Otherwise, the
         next iteration of this sampler will yield the same ordering.
 
-        :param epoch: (int) epoch number
+        Args:
+            epoch: Epoch number.
         """
         self.epoch = epoch

--- a/ludwig/datasets/__init__.py
+++ b/ludwig/datasets/__init__.py
@@ -239,11 +239,14 @@ def get_datasets_output_features(
     Because Hugging Face Datasets are loaded dynamically through a shared connector, they don't have fixed output
     features. As such, we exclude Hugging Face datasets here.
 
-    :param dataset: (str) name of the dataset
-    :param include_competitions: (bool) whether to include the output features from kaggle competition datasets
-    :param include_data_modalities: (bool) whether to include the data modalities associated with the prediction task
-    :return: (dict) dictionary with the output features for each dataset or a dictionary with the output features for
-        the specified dataset
+    Args:
+        dataset: Name of the dataset.
+        include_competitions: Whether to include the output features from kaggle competition datasets.
+        include_data_modalities: Whether to include the data modalities associated with the prediction task.
+
+    Returns:
+        Dictionary with the output features for each dataset, or a dictionary with the output features for
+        the specified dataset.
     """
     ordered_configs = OrderedDict(sorted(_get_dataset_configs().items()))
     competition_datasets = []

--- a/ludwig/datasets/loaders/dataset_loader.py
+++ b/ludwig/datasets/loaders/dataset_loader.py
@@ -46,13 +46,12 @@ class TqdmUpTo(tqdm):
     """
 
     def update_to(self, b=1, bsize=1, tsize=None):
-        """
-        b  : int, optional
-            Number of blocks transferred so far [default: 1].
-        bsize  : int, optional
-            Size of each block (in tqdm units) [default: 1].
-        tsize  : int, optional
-            Total size (in tqdm units). If [default: None] remains unchanged.
+        """Update progress bar.
+
+        Args:
+            b: Number of blocks transferred so far.
+            bsize: Size of each block (in tqdm units).
+            tsize: Total size (in tqdm units). If None, remains unchanged.
         """
         if tsize is not None:
             self.total = tsize
@@ -293,10 +292,11 @@ class DatasetLoader:
         Note: This method is also responsible for splitting the data, returning a single dataframe if split=False, and a
         3-tuple of train, val, test if split=True.
 
-        :param kaggle_username: (str) username on Kaggle platform
-        :param kaggle_key: (str) dataset key on Kaggle platform
-        :param split: (bool) splits dataset along 'split' column if present. The split column should always have values
-            0: train, 1: validation, 2: test.
+        Args:
+            kaggle_username: Username on Kaggle platform.
+            kaggle_key: Dataset key on Kaggle platform.
+            split: Splits dataset along 'split' column if present. The split column should always have values
+                0: train, 1: validation, 2: test.
         """
         self._download_and_process(kaggle_username=kaggle_username, kaggle_key=kaggle_key)
         if self.state == DatasetState.TRANSFORMED:

--- a/ludwig/encoders/bag_encoders.py
+++ b/ludwig/encoders/bag_encoders.py
@@ -101,11 +101,13 @@ class BagEmbedWeightedEncoder(Encoder):
         return self.fc_stack.output_shape
 
     def forward(self, inputs: torch.Tensor) -> EncoderOutputDict:
-        """
-        :param inputs: The inputs fed into the encoder.
-               Shape: [batch x vocab size], type torch.int32
+        """Forward pass through the encoder.
 
-        :param return: embeddings of shape [batch x embed size], type torch.float32
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x vocab size].
+
+        Returns:
+            Embeddings of shape [batch x embed size].
         """
         hidden = self.embed_weighted(inputs)
         hidden = self.fc_stack(hidden)

--- a/ludwig/encoders/generic_encoders.py
+++ b/ludwig/encoders/generic_encoders.py
@@ -39,9 +39,10 @@ class PassthroughEncoder(Encoder):
         self.input_size = input_size
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param inputs: The inputs fed into the encoder.
-               Shape: [batch x 1], type tf.float32
+        """Forward pass through the encoder.
+
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x 1].
         """
         return {ENCODER_OUTPUT: inputs}
 
@@ -99,9 +100,10 @@ class DenseEncoder(Encoder):
         )
 
     def forward(self, inputs: torch.Tensor, mask: torch.Tensor | None = None) -> EncoderOutputDict:
-        """
-        :param inputs: The inputs fed into the encoder.
-               Shape: [batch x 1], type tf.float32
+        """Forward pass through the encoder.
+
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x 1].
         """
         return {ENCODER_OUTPUT: self.fc_stack(inputs)}
 

--- a/ludwig/encoders/image/base.py
+++ b/ludwig/encoders/image/base.py
@@ -142,9 +142,10 @@ class Stacked2DCNN(ImageEncoder):
         )
 
     def forward(self, inputs: torch.Tensor) -> EncoderOutputDict:
-        """
-        :param inputs: The inputs fed into the encoder.
-                Shape: [batch x channels x height x width], type torch.uint8
+        """Forward pass through the encoder.
+
+        Args:
+            inputs: The inputs fed into the encoder. Shape: [batch x channels x height x width].
         """
 
         hidden = self.conv_stack_2d(inputs)

--- a/ludwig/explain/captum.py
+++ b/ludwig/explain/captum.py
@@ -156,16 +156,16 @@ class IntegratedGradientsExplainer(Explainer):
     def explain(self) -> ExplanationsResult:
         """Explain the model's predictions using Integrated Gradients.
 
-        # Return
+        Returns:
+            ExplanationsResult containing the explanations.
 
-        :return: ExplanationsResult containing the explanations.
-            `global_explanations`: (Explanation) Aggregate explanation for the entire input data.
+            `global_explanations`: Aggregate explanation for the entire input data.
 
-            `row_explanations`: (List[Explanation]) A list of explanations, one for each row in the input data. Each
+            `row_explanations`: A list of explanations, one for each row in the input data. Each
             explanation contains the integrated gradients for each label in the target feature's vocab with respect to
             each input feature.
 
-            `expected_values`: (List[float]) of length [output feature cardinality] Average convergence delta for each
+            `expected_values`: Of length [output feature cardinality]. Average convergence delta for each
             label in the target feature's vocab.
         """
 
@@ -271,11 +271,12 @@ def get_input_tensors(
 ) -> list[torch.Tensor]:
     """Convert the input data into a list of variables, one for each input feature.
 
-    # Inputs
+    Args:
+        model: The LudwigModel to use for encoding.
+        input_set: The input data to encode of shape [batch size, num input features].
 
-    :param model: The LudwigModel to use for encoding.
-    :param input_set: The input data to encode of shape [batch size, num input features].  # Return
-    :return: A list of variables, one for each input feature. Shape of each variable is [batch size, embedding size].
+    Returns:
+        A list of variables, one for each input feature. Shape of each variable is [batch size, embedding size].
     """
     # Ignore sample_ratio and sample_size from the model config, since we want to explain all the data.
     sample_ratio_bak = model.config_obj.preprocessing.sample_ratio

--- a/ludwig/explain/explainer.py
+++ b/ludwig/explain/explainer.py
@@ -20,12 +20,11 @@ class Explainer(metaclass=ABCMeta):
     ):
         """Constructor for the explainer.
 
-        # Inputs
-
-        :param model: (LudwigModel) The LudwigModel to explain.
-        :param inputs_df: (pd.DataFrame) The input data to explain.
-        :param sample_df: (pd.DataFrame) A sample of the ground truth data.
-        :param target: (str) The name of the target to explain.
+        Args:
+            model: The LudwigModel to explain.
+            inputs_df: The input data to explain.
+            sample_df: A sample of the ground truth data.
+            target: The name of the target to explain.
         """
         self.model = model
         self.inputs_df = inputs_df
@@ -68,7 +67,6 @@ class Explainer(metaclass=ABCMeta):
     def explain(self) -> ExplanationsResult:
         """Explain the model's predictions.
 
-        # Return
-
-        :return: ExplanationsResult containing the explanations.
+        Returns:
+            ExplanationsResult containing the explanations.
         """

--- a/ludwig/modules/optimization_modules.py
+++ b/ludwig/modules/optimization_modules.py
@@ -39,7 +39,8 @@ def get_optimizer_class_and_kwargs(
 ) -> tuple[type[torch.optim.Optimizer], dict]:
     """Returns the optimizer class and kwargs for the optimizer.
 
-    :return: Tuple of optimizer class and kwargs for the optimizer.
+    Returns:
+        Tuple of optimizer class and kwargs for the optimizer.
     """
     from ludwig.schema.optimizers import optimizer_registry
 
@@ -132,10 +133,13 @@ def create_optimizer(
 ) -> torch.optim.Optimizer:
     """Returns a ready-to-use torch optimizer instance based on the given optimizer config.
 
-    :param model: Underlying Ludwig model
-    :param learning_rate: Initial learning rate for the optimizer
-    :param optimizer_config: Instance of `ludwig.modules.optimization_modules.BaseOptimizerConfig`.
-    :return: Initialized instance of a torch optimizer.
+    Args:
+        model: Underlying Ludwig model.
+        learning_rate: Initial learning rate for the optimizer.
+        optimizer_config: Instance of `ludwig.modules.optimization_modules.BaseOptimizerConfig`.
+
+    Returns:
+        Initialized instance of a torch optimizer.
     """
     # Make sure the optimizer is compatible with the available resources:
     if (optimizer_config.is_paged or optimizer_config.is_8bit) and (

--- a/ludwig/schema/hyperopt/scheduler.py
+++ b/ludwig/schema/hyperopt/scheduler.py
@@ -479,9 +479,12 @@ def SchedulerDataclassField(default={"type": "fifo"}, description="Hyperopt sche
     """Custom dataclass field that when used inside of a dataclass will allow any scheduler in
     `ludwig.schema.hyperopt.scheduler.scheduler_registry`. Sets default scheduler to 'fifo'.
 
-    :param default: Dict specifying a scheduler with a `type` field and its associated parameters. Will attempt to use
-           `type` to load scheduler from registry with given params. (default: {"type": "fifo"}).
-    :return: Initialized dataclass field that converts untyped dicts with params to scheduler dataclass instances.
+    Args:
+        default: Dict specifying a scheduler with a `type` field and its associated parameters. Will attempt to
+            use `type` to load scheduler from registry with given params. (default: {"type": "fifo"}).
+
+    Returns:
+        Initialized dataclass field that converts untyped dicts with params to scheduler dataclass instances.
     """
 
     class SchedulerConfigField(schema_utils.SchemaField):

--- a/ludwig/schema/optimizers.py
+++ b/ludwig/schema/optimizers.py
@@ -1189,7 +1189,11 @@ if _SOAPOptimizer is not None:
 @DeveloperAPI
 def get_optimizer_conds():
     """Returns a JSON schema of conditionals to validate against optimizer types defined in
-    `ludwig.modules.optimization_modules.optimizer_registry`."""
+    `ludwig.modules.optimization_modules.optimizer_registry`.
+
+    Returns:
+        List of JSON schema conditionals for all registered optimizer types.
+    """
     conds = []
     for optimizer in optimizer_registry:
         optimizer_cls = optimizer_registry[optimizer][1]
@@ -1210,9 +1214,12 @@ def OptimizerDataclassField(default="adam", description="", parameter_metadata: 
 
     Sets default optimizer to 'adam'.
 
-    :param default: Dict specifying an optimizer with a `type` field and its associated parameters. Will attempt to use
-           `type` to load optimizer from registry with given params. (default: {"type": "adam"}).
-    :return: Initialized dataclass field that converts untyped dicts with params to optimizer dataclass instances.
+    Args:
+        default: Dict specifying an optimizer with a `type` field and its associated parameters. Will attempt
+            to use `type` to load optimizer from registry with given params. (default: {"type": "adam"}).
+
+    Returns:
+        Initialized dataclass field that converts untyped dicts with params to optimizer dataclass instances.
     """
 
     class OptimizerSelection(schema_utils.TypeSelection):
@@ -1284,8 +1291,9 @@ def GradientClippingDataclassField(description: str, default: dict = {}):
     """Returns custom dataclass field for `ludwig.modules.optimization_modules.GradientClippingConfig`. Allows
     `None` by default.
 
-    :param description: Description of the gradient dataclass field
-    :param default: dict that specifies clipping param values that will be loaded by its schema class (default: {}).
+    Args:
+        description: Description of the gradient dataclass field.
+        default: Dict that specifies clipping param values that will be loaded by its schema class (default: {}).
     """
     allow_none = True
 

--- a/ludwig/schema/profiler.py
+++ b/ludwig/schema/profiler.py
@@ -52,8 +52,9 @@ class ProfilerConfig(schema_utils.LudwigBaseConfig):
 def ProfilerDataclassField(description: str, default: dict = {}):
     """Returns custom dataclass field for `ludwig.modules.profiler.ProfilerConfig`. Allows `None` by default.
 
-    :param description: Description of the torch profiler field
-    :param default: dict that specifies clipping param values that will be loaded by its schema class (default: {}).
+    Args:
+        description: Description of the torch profiler field.
+        default: Dict that specifies clipping param values that will be loaded by its schema class (default: {}).
     """
     allow_none = True
 

--- a/ludwig/utils/automl/type_inference.py
+++ b/ludwig/utils/automl/type_inference.py
@@ -18,11 +18,13 @@ TEXT_AVG_WORDS_CUTOFF = 5
 def infer_type(field: FieldInfo, missing_value_percent: float, row_count: int) -> str:
     """Perform type inference on field.
 
-    # Inputs
-    :param field: (FieldInfo) object describing field
-    :param missing_value_percent: (float) percent of missing values in the column
-    :param row_count: (int) total number of entries in original dataset  # Return
-    :return: (str) feature type
+    Args:
+        field: Object describing field.
+        missing_value_percent: Percent of missing values in the column.
+        row_count: Total number of entries in original dataset.
+
+    Returns:
+        Feature type string.
     """
     if field.dtype == DATE or field.dtype.startswith("datetime"):
         return DATE

--- a/ludwig/utils/misc_utils.py
+++ b/ludwig/utils/misc_utils.py
@@ -52,9 +52,9 @@ def merge_dict(dct, merge_dct):
     dict_merge recurses down into dicts nested to an arbitrary depth, updating keys. The ``merge_dct`` is merged
     into ``dct``.
 
-    :param dct: dict onto which the merge is executed
-    :param merge_dct: dct merged into dct
-    :return: None
+    Args:
+        dct: Dict onto which the merge is executed.
+        merge_dct: Dict merged into dct.
     """
     dct = copy.deepcopy(dct)
     for k, _v in merge_dct.items():


### PR DESCRIPTION
## Summary

Eliminates the last 39 `:param`/`:return:` Sphinx-style docstrings across 16 files, bringing the total count to **zero** across the entire codebase.

Files touched (1–4 occurrences each):
`explain/explainer.py`, `explain/captum.py`, `utils/automl/type_inference.py`, `utils/misc_utils.py`, `schema/optimizers.py`, `schema/profiler.py`, `schema/hyperopt/scheduler.py`, `modules/optimization_modules.py`, `datasets/loaders/dataset_loader.py`, `datasets/__init__.py`, `benchmarking/summarize.py`, `benchmarking/examples/process_config.py`, `encoders/generic_encoders.py`, `encoders/bag_encoders.py`, `encoders/image/base.py`, `data/sampler.py`

## Test plan

- [ ] `pre-commit run --files` passes (ruff lint + format, blacken-docs)
- [ ] `grep -r ':param\b' ludwig/ --include='*.py'` returns no matches
- [ ] No behavior changes — docstrings only