### PR TITLE
fix(automl): dataset-aware sampling, transformer LR cap, SearchSpace fixes

### DIFF
--- a/ludwig/automl/config_sampler.py
+++ b/ludwig/automl/config_sampler.py
@@ -130,11 +130,17 @@ def _sample_trainer_params(
     max_epochs: int,
     time_limit_s: int | None,
     search_space: SearchSpace | None = None,
+    max_learning_rate: float | None = None,
 ) -> dict:
     """Samples a single set of trainer hyperparameters from the search space grids."""
     ss = search_space or _default_search_space()
+    lr_candidates = ss.trainer.learning_rate_values
+    if max_learning_rate is not None:
+        lr_candidates = [lr for lr in lr_candidates if lr <= max_learning_rate]
+    if not lr_candidates:
+        lr_candidates = ss.trainer.learning_rate_values
     params: dict = {
-        LEARNING_RATE: rng.choice(ss.trainer.learning_rate_values),
+        LEARNING_RATE: rng.choice(lr_candidates),
         BATCH_SIZE: rng.choice(ss.trainer.batch_size_values),
         "epochs": max_epochs,
     }
@@ -243,7 +249,8 @@ def sample_configs(
                     encoder_hyperparams[feat.name] = ss.sample_hyperparams(enc_spec, rng)
 
             decoder = rng.choice(valid_decoders)
-            trainer_params = _sample_trainer_params(rng, max_epochs, time_limit_s, ss)
+            max_lr = combiner_spec.max_learning_rate if combiner_spec is not None else None
+            trainer_params = _sample_trainer_params(rng, max_epochs, time_limit_s, ss, max_learning_rate=max_lr)
 
             # Sample combiner hyperparams via the SearchSpace.
             if combiner_spec is not None:

--- a/ludwig/automl/config_sampler.py
+++ b/ludwig/automl/config_sampler.py
@@ -364,6 +364,7 @@ def configs_from_dataframe(
             trainer=TrainerSpec(
                 learning_rate_values=base.trainer.learning_rate_values,
                 batch_size_values=batch_sizes,
+                default_epochs=max_epochs,
             ),
         )
 

--- a/ludwig/automl/config_sampler.py
+++ b/ludwig/automl/config_sampler.py
@@ -357,7 +357,7 @@ def configs_from_dataframe(
         else:
             max_epochs = 10
             batch_sizes = [128, 256, 512]
-        search_space = SearchSpace(
+        search_space = SearchSpace._from_specs(
             encoders=base.encoders,
             combiners=base.combiners,
             decoders=base.decoders,

--- a/ludwig/automl/config_sampler.py
+++ b/ludwig/automl/config_sampler.py
@@ -131,6 +131,7 @@ def _sample_trainer_params(
     time_limit_s: int | None,
     search_space: SearchSpace | None = None,
     max_learning_rate: float | None = None,
+    max_batch_size: int | None = None,
 ) -> dict:
     """Samples a single set of trainer hyperparameters from the search space grids."""
     ss = search_space or _default_search_space()
@@ -139,9 +140,14 @@ def _sample_trainer_params(
         lr_candidates = [lr for lr in lr_candidates if lr <= max_learning_rate]
     if not lr_candidates:
         lr_candidates = ss.trainer.learning_rate_values
+    bs_candidates = ss.trainer.batch_size_values
+    if max_batch_size is not None:
+        bs_candidates = [bs for bs in bs_candidates if bs <= max_batch_size]
+    if not bs_candidates:
+        bs_candidates = ss.trainer.batch_size_values
     params: dict = {
         LEARNING_RATE: rng.choice(lr_candidates),
-        BATCH_SIZE: rng.choice(ss.trainer.batch_size_values),
+        BATCH_SIZE: rng.choice(bs_candidates),
         "epochs": max_epochs,
     }
     if time_limit_s is not None:
@@ -250,7 +256,10 @@ def sample_configs(
 
             decoder = rng.choice(valid_decoders)
             max_lr = combiner_spec.max_learning_rate if combiner_spec is not None else None
-            trainer_params = _sample_trainer_params(rng, max_epochs, time_limit_s, ss, max_learning_rate=max_lr)
+            max_bs = combiner_spec.max_batch_size if combiner_spec is not None else None
+            trainer_params = _sample_trainer_params(
+                rng, max_epochs, time_limit_s, ss, max_learning_rate=max_lr, max_batch_size=max_bs
+            )
 
             # Sample combiner hyperparams via the SearchSpace.
             if combiner_spec is not None:

--- a/ludwig/automl/config_sampler.py
+++ b/ludwig/automl/config_sampler.py
@@ -342,10 +342,36 @@ def configs_from_dataframe(
         f"output='{output_feature.name}' (type={output_feature.type})."
     )
 
+    # Scale down epochs and cap batch sizes for large datasets to avoid OOM and timeouts.
+    # These thresholds are conservative; they keep wall time and VRAM use manageable on
+    # a single consumer GPU (10–24 GiB) without sacrificing benchmark coverage.
+    n_rows = len(df)
+    max_epochs = 50
+    if search_space is None and n_rows > 100_000:
+        from ludwig.automl.search_space import _DEFAULT_SEARCH_SPACE_DIR, load_search_space, SearchSpace, TrainerSpec
+
+        base = load_search_space(_DEFAULT_SEARCH_SPACE_DIR)
+        if n_rows > 500_000:
+            max_epochs = 5
+            batch_sizes = [256, 512, 1024]
+        else:
+            max_epochs = 10
+            batch_sizes = [128, 256, 512]
+        search_space = SearchSpace(
+            encoders=base.encoders,
+            combiners=base.combiners,
+            decoders=base.decoders,
+            trainer=TrainerSpec(
+                learning_rate_values=base.trainer.learning_rate_values,
+                batch_size_values=batch_sizes,
+            ),
+        )
+
     return sample_configs(
         input_features=input_features,
         output_feature=output_feature,
         n=n,
         seed=seed,
+        max_epochs=max_epochs,
         search_space=search_space,
     )

--- a/ludwig/automl/config_sampler.py
+++ b/ludwig/automl/config_sampler.py
@@ -348,9 +348,9 @@ def configs_from_dataframe(
     n_rows = len(df)
     max_epochs = 50
     if search_space is None and n_rows > 100_000:
-        from ludwig.automl.search_space import _DEFAULT_SEARCH_SPACE_DIR, load_search_space, SearchSpace, TrainerSpec
+        from ludwig.automl.search_space import _build_default_search_space, SearchSpace, TrainerSpec
 
-        base = load_search_space(_DEFAULT_SEARCH_SPACE_DIR)
+        base = _build_default_search_space()
         if n_rows > 500_000:
             max_epochs = 5
             batch_sizes = [256, 512, 1024]

--- a/ludwig/automl/search_space.py
+++ b/ludwig/automl/search_space.py
@@ -50,6 +50,9 @@ class CombinerSpec:
     name: str
     constraints: dict = field(default_factory=dict)
     hyperparameters: dict[str, list] = field(default_factory=dict)
+    # Attention/transformer combiners require lower LRs to stay numerically stable.
+    # When set, the sampler will only draw from trainer LR values <= this threshold.
+    max_learning_rate: float | None = None
 
 
 @dataclass
@@ -199,6 +202,18 @@ _DEFAULT_COMBINER_HYPERPARAMS: dict[str, dict[str, list]] = {
     "transformer": {"num_heads": [2, 4, 8], "num_layers": [1, 2, 3], "dropout": [0.0, 0.1, 0.3]},
 }
 
+# Attention/transformer combiners require lower learning rates to avoid NaN loss.
+# Any combiner listed here will restrict LR sampling to values <= this threshold.
+_TRANSFORMER_COMBINER_MAX_LR: float = 3e-3
+_DEFAULT_COMBINER_MAX_LR: dict[str, float] = {
+    "transformer": _TRANSFORMER_COMBINER_MAX_LR,
+    "tabtransformer": _TRANSFORMER_COMBINER_MAX_LR,
+    "ft_transformer": _TRANSFORMER_COMBINER_MAX_LR,
+    "cross_attention": _TRANSFORMER_COMBINER_MAX_LR,
+    "perceiver": _TRANSFORMER_COMBINER_MAX_LR,
+    "hypernetwork": _TRANSFORMER_COMBINER_MAX_LR,
+}
+
 _DEFAULT_TRAINER_SPEC = TrainerSpec(
     learning_rate_values=[1e-4, 3e-4, 1e-3, 3e-3, 1e-2],
     batch_size_values=[64, 128, 256, 512],
@@ -221,6 +236,7 @@ def _build_default_search_space() -> SearchSpace:
             name=name,
             constraints=_DEFAULT_COMBINER_CONSTRAINTS.get(name, {}),
             hyperparameters=_DEFAULT_COMBINER_HYPERPARAMS.get(name, {}),
+            max_learning_rate=_DEFAULT_COMBINER_MAX_LR.get(name),
         )
         for name in _DEFAULT_ALL_COMBINERS
     }
@@ -284,6 +300,7 @@ def _load_combiners_from_dir(comb_dir: Path) -> dict[str, CombinerSpec]:
             name=data["name"],
             constraints=dict(data.get("constraints", {})),
             hyperparameters=_extract_hyperparameters(data.get("hyperparameters", {})),
+            max_learning_rate=data.get("max_learning_rate"),
         )
         for _, data in _iter_yaml_dir(comb_dir)
     }

--- a/ludwig/automl/search_space.py
+++ b/ludwig/automl/search_space.py
@@ -53,6 +53,9 @@ class CombinerSpec:
     # Attention/transformer combiners require lower LRs to stay numerically stable.
     # When set, the sampler will only draw from trainer LR values <= this threshold.
     max_learning_rate: float | None = None
+    # Attention combiners with many input features can OOM at large batch sizes.
+    # When set, the sampler will only draw from trainer batch_size values <= this threshold.
+    max_batch_size: int | None = None
 
 
 @dataclass
@@ -214,6 +217,15 @@ _DEFAULT_COMBINER_MAX_LR: dict[str, float] = {
     "hypernetwork": _TRANSFORMER_COMBINER_MAX_LR,
 }
 
+# cross_attention and perceiver scale quadratically with n_input_features and OOM at
+# batch_size=512 on consumer GPUs (10-24 GiB) when there are many features.
+# Cap these at 256 to keep VRAM use manageable.
+_ATTENTION_COMBINER_MAX_BATCH_SIZE: int = 256
+_DEFAULT_COMBINER_MAX_BATCH_SIZE: dict[str, int] = {
+    "cross_attention": _ATTENTION_COMBINER_MAX_BATCH_SIZE,
+    "perceiver": _ATTENTION_COMBINER_MAX_BATCH_SIZE,
+}
+
 _DEFAULT_TRAINER_SPEC = TrainerSpec(
     learning_rate_values=[1e-4, 3e-4, 1e-3, 3e-3, 1e-2],
     batch_size_values=[64, 128, 256, 512],
@@ -237,6 +249,7 @@ def _build_default_search_space() -> SearchSpace:
             constraints=_DEFAULT_COMBINER_CONSTRAINTS.get(name, {}),
             hyperparameters=_DEFAULT_COMBINER_HYPERPARAMS.get(name, {}),
             max_learning_rate=_DEFAULT_COMBINER_MAX_LR.get(name),
+            max_batch_size=_DEFAULT_COMBINER_MAX_BATCH_SIZE.get(name),
         )
         for name in _DEFAULT_ALL_COMBINERS
     }
@@ -301,6 +314,7 @@ def _load_combiners_from_dir(comb_dir: Path) -> dict[str, CombinerSpec]:
             constraints=dict(data.get("constraints", {})),
             hyperparameters=_extract_hyperparameters(data.get("hyperparameters", {})),
             max_learning_rate=data.get("max_learning_rate"),
+            max_batch_size=data.get("max_batch_size"),
         )
         for _, data in _iter_yaml_dir(comb_dir)
     }


### PR DESCRIPTION
## Summary

Fixes discovered during AutoML pilot benchmark run (10 datasets × 100 configs):

- **Dataset-size-aware epoch/batch caps** (`configs_from_dataframe`): for datasets >100k rows caps `max_epochs=10` and `batch_size_values=[128,256,512]`; for >500k rows caps `max_epochs=5` and `batch_size_values=[256,512,1024]`. Prevents OOM and timeouts on large datasets (forest_cover 581k rows, otto_group_product 206k rows).

- **Transformer LR cap to prevent NaN loss**: adds `CombinerSpec.max_learning_rate` field. Transformer-based combiners (`transformer`, `tabtransformer`, `ft_transformer`, `cross_attention`, `perceiver`, `hypernetwork`) default to `max_learning_rate=3e-3`, excluding `lr=1e-2` from their sample pool. Observed NaN loss with transformer+lr=0.01 on forest_cover; root cause is attention architecture instability at high LRs. Also wires `max_learning_rate` through `_load_combiners_from_dir` so it can be set per-combiner in YAML.

- **`SearchSpace._from_specs()` and `_build_default_search_space` import fixes**: `configs_from_dataframe` was using non-existent `_DEFAULT_SEARCH_SPACE_DIR`/`load_search_space` names and constructing `SearchSpace` with keyword args instead of `_from_specs()`; also missing `default_epochs` in `TrainerSpec` constructor.

## Test plan

- [ ] `pytest tests/ludwig/automl/` — unit tests for config sampler and search space
- [ ] Verify transformer combiner LR samples stay ≤ 3e-3
- [ ] Verify large dataset configs get capped epochs/batch_sizes
- [ ] Pilot benchmark run completing with 0 NaN-loss failures on transformer configs