### PR TITLE
test(ci): rename integration groups to sequential letters, split distributed tests 6x

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -71,15 +71,15 @@ jobs:
       matrix:
         test-markers:
           - "integration_tests_a"
-          - "integration_tests_a2"
-          - "integration_tests_a3"
-          - "integration_tests_a4"
-          - "integration_tests_a5"
           - "integration_tests_b"
           - "integration_tests_c"
           - "integration_tests_d"
           - "integration_tests_e"
           - "integration_tests_f"
+          - "integration_tests_g"
+          - "integration_tests_h"
+          - "integration_tests_i"
+          - "integration_tests_j"
 
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.LUDWIG_TESTS_AWS_ACCESS_KEY_ID }}
@@ -149,15 +149,27 @@ jobs:
 
   distributed-tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distributed-group:
+          - "distributed_a"
+          - "distributed_b"
+          - "distributed_c"
+          - "distributed_d"
+          - "distributed_e"
+          - "distributed_f"
+
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.LUDWIG_TESTS_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.LUDWIG_TESTS_AWS_SECRET_ACCESS_KEY }}
       KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
       KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
       IS_NOT_FORK: ${{ !(github.event.pull_request.base.repo.full_name == 'ludwig-ai/ludwig' && github.event.pull_request.head.repo.fork) }}
+      DIST_GROUP: ${{ matrix.distributed-group }}
       UV_SYSTEM_PYTHON: "1"
 
-    name: Distributed Tests
+    name: Distributed (${{ matrix.distributed-group }})
     services:
       minio:
         image: fclairamb/minio-github-actions
@@ -167,7 +179,7 @@ jobs:
         ports:
           - 9000:9000
 
-    timeout-minutes: 120
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12
@@ -203,20 +215,16 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - name: Distributed Unit Tests
+      - name: Distributed Tests
         run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "distributed and not slow and not combinatorial and not llm" --junitxml pytest-unit.xml tests/ludwig
-
-      - name: Distributed Integration Tests
-        run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=7200 pytest -v --timeout 300 --durations 100 -m "distributed and not slow and not combinatorial and not llm" --junitxml pytest-integration.xml tests/integration_tests
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "distributed and not slow and not combinatorial and not llm and $DIST_GROUP" --junitxml pytest.xml tests/ludwig tests/integration_tests
 
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Distributed Test Results
-          path: pytest*.xml
+          name: Distributed Test Results (${{ matrix.distributed-group }})
+          path: pytest.xml
 
   test-minimal-install:
     name: Minimal Install

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Distributed Tests
         run: |
-          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "distributed and not slow and not combinatorial and not llm and $DIST_GROUP" --junitxml pytest.xml tests/ludwig tests/integration_tests
+          RUN_PRIVATE=$IS_NOT_FORK LUDWIG_TEST_SUITE_TIMEOUT_S=5400 pytest -v --timeout 300 --durations 100 -m "distributed and not slow and not combinatorial and not llm and $DIST_GROUP" --ignore=tests/integration_tests/test_server.py --junitxml pytest.xml tests/ludwig tests/integration_tests
 
       - name: Upload Test Results
         if: always()

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,15 +7,21 @@ markers =
     combinatorial: mark a test as combinatorial.
     llm: mark a test as an LLM test.
     integration_tests_a: mark a test to be run as part of integration tests, group A.
-    integration_tests_a2: mark a test to be run as part of integration tests, group A2.
-    integration_tests_a3: mark a test to be run as part of integration tests, group A3.
-    integration_tests_a4: mark a test to be run as part of integration tests, group A4.
-    integration_tests_a5: mark a test to be run as part of integration tests, group A5.
     integration_tests_b: mark a test to be run as part of integration tests, group B.
     integration_tests_c: mark a test to be run as part of integration tests, group C.
     integration_tests_d: mark a test to be run as part of integration tests, group D.
     integration_tests_e: mark a test to be run as part of integration tests, group E.
     integration_tests_f: mark a test to be run as part of integration tests, group F.
+    integration_tests_g: mark a test to be run as part of integration tests, group G.
+    integration_tests_h: mark a test to be run as part of integration tests, group H.
+    integration_tests_i: mark a test to be run as part of integration tests, group I.
+    integration_tests_j: mark a test to be run as part of integration tests, group J.
+    distributed_a: mark a distributed test to be run in distributed group A.
+    distributed_b: mark a distributed test to be run in distributed group B.
+    distributed_c: mark a distributed test to be run in distributed group C.
+    distributed_d: mark a distributed test to be run in distributed group D.
+    distributed_e: mark a distributed test to be run in distributed group E.
+    distributed_f: mark a distributed test to be run in distributed group F.
 filterwarnings =
     ignore::marshmallow.warnings.RemovedInMarshmallow4Warning
     ignore::DeprecationWarning:importlib._bootstrap

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,14 +40,14 @@ TEST_SUITE_TIMEOUT_S = int(os.environ.get("LUDWIG_TEST_SUITE_TIMEOUT_S", 3600))
 
 explicit_int_markers = {
     "integration_tests_a",
-    "integration_tests_a2",
-    "integration_tests_a3",
-    "integration_tests_a4",
-    "integration_tests_a5",
     "integration_tests_b",
     "integration_tests_c",
     "integration_tests_d",
     "integration_tests_e",
+    "integration_tests_f",
+    "integration_tests_g",
+    "integration_tests_h",
+    "integration_tests_i",
 }
 
 
@@ -58,7 +58,7 @@ def pytest_sessionstart(session):
 def pytest_collection_modifyitems(config, items):
     for item in items:
         if all(False for x in item.iter_markers() if x.name in explicit_int_markers):
-            item.add_marker("integration_tests_f")
+            item.add_marker("integration_tests_j")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration_tests/test_api.py
+++ b/tests/integration_tests/test_api.py
@@ -757,7 +757,7 @@ def test_constant_metadata(tmpdir):
     assert metadata1 == metadata2
 
 
-@pytest.mark.integration_tests_e
+@pytest.mark.integration_tests_i
 @pytest.mark.parametrize(
     "input_max_sequence_length, global_max_sequence_length, expect_raise",
     [

--- a/tests/integration_tests/test_automl.py
+++ b/tests/integration_tests/test_automl.py
@@ -32,7 +32,7 @@ from ludwig.automl import auto_train, create_auto_config, train_with_config  # n
 from ludwig.automl.automl import OUTPUT_DIR  # noqa E402
 from ludwig.hyperopt.execution import RayTuneExecutor  # noqa E402
 
-pytestmark = [pytest.mark.distributed, pytest.mark.integration_tests_c]
+pytestmark = [pytest.mark.distributed, pytest.mark.distributed_e, pytest.mark.integration_tests_g]
 
 
 def to_name_set(features: list[FeatureConfigDict]) -> set[str]:

--- a/tests/integration_tests/test_cached_preprocessing.py
+++ b/tests/integration_tests/test_cached_preprocessing.py
@@ -35,6 +35,7 @@ def test_onehot_encoding(tmpdir):
 
 @pytest.mark.slow
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_onehot_encoding_ray(tmpdir, ray_cluster_2cpu):
     config, dataset = _onehot_encoding_config(tmpdir)
     run_test_suite(config, dataset, "ray")
@@ -66,6 +67,7 @@ def test_hf_text_embedding(tmpdir):
 
 @pytest.mark.slow
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_hf_text_embedding_ray(tmpdir, ray_cluster_2cpu):
     config, dataset = _hf_text_embedding_config(tmpdir)
     run_test_suite(config, dataset, "ray")

--- a/tests/integration_tests/test_class_imbalance_feature.py
+++ b/tests/integration_tests/test_class_imbalance_feature.py
@@ -127,6 +127,7 @@ def run_test_imbalance_local(
     ["oversample_minority", "undersample_majority"],
 )
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 @pytest.mark.skip(reason="Flaky")
 def test_imbalance_ray(balance):
     config = {

--- a/tests/integration_tests/test_cli.py
+++ b/tests/integration_tests/test_cli.py
@@ -39,7 +39,7 @@ from ludwig.types import FeatureConfigDict
 from ludwig.utils.data_utils import load_yaml
 from tests.integration_tests.utils import category_feature, generate_data, number_feature, sequence_feature
 
-pytestmark = pytest.mark.integration_tests_b
+pytestmark = pytest.mark.integration_tests_f
 
 
 def _run_commands(commands, **ludwig_kwargs):
@@ -200,6 +200,7 @@ def test_evaluate_cli(tmpdir, csv_filename):
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_hyperopt_cli(tmpdir, csv_filename):
     """Test hyperopt cli."""
     config_filename = os.path.join(tmpdir, "config.yaml")
@@ -362,6 +363,7 @@ def test_reproducible_cli_runs(
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_init_config(tmpdir):
     """Test initializing a config from a dataset and a target."""
     input_features = [

--- a/tests/integration_tests/test_contrib_aim.py
+++ b/tests/integration_tests/test_contrib_aim.py
@@ -14,6 +14,7 @@ TEST_SCRIPT = os.path.join(os.path.dirname(__file__), "scripts", "run_train_aim.
 
 @pytest.mark.skip(reason="Aim integration not compatible with Aim 4.0.")
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_contrib_experiment(csv_filename, tmpdir):
     aim_test_path = os.path.join(tmpdir, "results")
     os.makedirs(aim_test_path, exist_ok=True)

--- a/tests/integration_tests/test_date_feature.py
+++ b/tests/integration_tests/test_date_feature.py
@@ -27,6 +27,7 @@ ray = pytest.importorskip("ray")
 
 pytestmark = [
     pytest.mark.distributed,
+    pytest.mark.distributed_f,
 ]
 
 

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -61,7 +61,7 @@ from tests.integration_tests.utils import (
     vector_feature,
 )
 
-pytestmark = pytest.mark.integration_tests_d
+pytestmark = pytest.mark.integration_tests_h
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -574,6 +574,7 @@ def test_sequence_tagger_text(csv_filename):
 
 """
 @pytest.mark.distributed
+@pytest.mark.distributed_d
 def test_sequence_tagger_text_ray(csv_filename, ray_cluster_2cpu):
     # Define input and output features
     input_features = [text_feature(encoder={"max_len": 10, "type": "rnn", "reduce_output": None})]
@@ -780,6 +781,7 @@ def test_experiment_model_resume_missing_file(tmpdir, missing_file):
 
 @pytest.mark.slow
 @pytest.mark.distributed
+@pytest.mark.distributed_d
 def test_experiment_model_resume_before_1st_epoch_distributed(tmpdir, ray_cluster_4cpu):
     # Single sequence input, single category output
     # Tests saving a model file, loading it to rerun training and predict
@@ -830,6 +832,7 @@ def test_experiment_model_resume_before_1st_epoch_distributed(tmpdir, ray_cluste
 
 @pytest.mark.slow
 @pytest.mark.distributed
+@pytest.mark.distributed_d
 def test_tabnet_with_batch_size_1(tmpdir, ray_cluster_4cpu):
     input_features = [number_feature()]
     output_features = [category_feature(output_feature=True)]

--- a/tests/integration_tests/test_explain.py
+++ b/tests/integration_tests/test_explain.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     RayIntegratedGradientsExplainer = None
 
-pytestmark = pytest.mark.integration_tests_d
+pytestmark = pytest.mark.integration_tests_h
 
 
 def test_explanation_dataclass():
@@ -81,6 +81,7 @@ def test_explainer_api(explainer_class, model_type, output_feature, additional_c
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_d
 @pytest.mark.parametrize(
     "output_feature",
     [binary_feature(), number_feature(), category_feature(decoder={"vocab_size": 3})],
@@ -102,6 +103,7 @@ def test_explainer_api_ray(output_feature, tmpdir, ray_cluster_2cpu):
 
 @pytest.mark.slow
 @pytest.mark.distributed
+@pytest.mark.distributed_d
 def test_explainer_api_ray_minimum_batch_size(tmpdir, ray_cluster_2cpu):
     from ludwig.explain.captum_ray import RayIntegratedGradientsExplainer
 

--- a/tests/integration_tests/test_hyperopt.py
+++ b/tests/integration_tests/test_hyperopt.py
@@ -53,7 +53,7 @@ ray = pytest.importorskip("ray")
 
 from ludwig.hyperopt.execution import get_build_hyperopt_executor, RayTuneExecutor  # noqa
 
-pytestmark = [pytest.mark.distributed, pytest.mark.integration_tests_a3]
+pytestmark = [pytest.mark.distributed, pytest.mark.distributed_c, pytest.mark.integration_tests_c]
 
 RANDOM_SEARCH_SIZE = 2
 

--- a/tests/integration_tests/test_hyperopt_ray.py
+++ b/tests/integration_tests/test_hyperopt_ray.py
@@ -44,7 +44,7 @@ except ImportError:
     Trial = None
     TuneCallback = object  # needed to set up HyperoptTestCallback when not distributed
 
-pytestmark = pytest.mark.integration_tests_d
+pytestmark = pytest.mark.integration_tests_h
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -206,6 +206,7 @@ def run_hyperopt_executor(
 
 @pytest.mark.slow
 @pytest.mark.distributed
+@pytest.mark.distributed_c
 @pytest.mark.parametrize("scenario", SCENARIOS)
 def test_hyperopt_executor(scenario, csv_filename, tmpdir, ray_cluster_4cpu):
     search_alg = scenario["search_alg"]
@@ -221,6 +222,7 @@ def test_hyperopt_executor(scenario, csv_filename, tmpdir, ray_cluster_4cpu):
 
 @pytest.mark.slow
 @pytest.mark.distributed
+@pytest.mark.distributed_c
 @pytest.mark.parametrize("use_split", [True, False], ids=["split", "no_split"])
 def test_hyperopt_executor_with_metric(use_split, csv_filename, tmpdir, ray_cluster_4cpu):
     run_hyperopt_executor(
@@ -236,6 +238,7 @@ def test_hyperopt_executor_with_metric(use_split, csv_filename, tmpdir, ray_clus
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_c
 @pytest.mark.parametrize(
     "backend",
     [
@@ -315,6 +318,7 @@ def test_hyperopt_run_hyperopt(csv_filename, backend, tmpdir, ray_cluster_4cpu):
 
 @pytest.mark.slow
 @pytest.mark.distributed
+@pytest.mark.distributed_c
 def test_hyperopt_ray_mlflow(csv_filename, tmpdir, ray_cluster_4cpu):
     mlflow_uri = f"file://{tmpdir}/mlruns"
     mlflow.set_tracking_uri(mlflow_uri)

--- a/tests/integration_tests/test_missing_value_strategy.py
+++ b/tests/integration_tests/test_missing_value_strategy.py
@@ -69,7 +69,7 @@ def test_missing_value_prediction(tmpdir, csv_filename):
     "backend",
     [
         pytest.param("local", id="local"),
-        pytest.param("ray", id="ray", marks=pytest.mark.distributed),
+        pytest.param("ray", id="ray", marks=[pytest.mark.distributed, pytest.mark.distributed_f]),
     ],
 )
 def test_missing_values_fill_with_mean(backend, csv_filename, tmpdir, ray_cluster_2cpu):
@@ -134,7 +134,9 @@ def test_missing_values_drop_rows(csv_filename, tmpdir):
         pytest.param("local", None, 3.0, id="local_none"),
         pytest.param("local", "fill_with_mean", 1.0, id="local_mean_strict"),
         pytest.param("local", "fill_with_const", 3.0, id="local_const_relaxed"),
-        pytest.param("ray", "fill_with_mean", 3.0, id="ray_mean", marks=pytest.mark.distributed),
+        pytest.param(
+            "ray", "fill_with_mean", 3.0, id="ray_mean", marks=[pytest.mark.distributed, pytest.mark.distributed_f]
+        ),
     ],
 )
 def test_outlier_strategy(outlier_strategy, outlier_threshold, backend, tmpdir, ray_cluster_2cpu):

--- a/tests/integration_tests/test_mlflow.py
+++ b/tests/integration_tests/test_mlflow.py
@@ -175,6 +175,7 @@ def test_export_mlflow_local(tmpdir):
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_mlflow_ray(tmpdir, ray_cluster_2cpu):
     epochs = 2
     batch_size = 8

--- a/tests/integration_tests/test_peft.py
+++ b/tests/integration_tests/test_peft.py
@@ -6,12 +6,12 @@ from ludwig.constants import COMBINER, EPOCHS, INPUT_FEATURES, OUTPUT_FEATURES, 
 from tests.integration_tests.utils import binary_feature, generate_data, run_test_suite, text_feature
 
 
-@pytest.mark.integration_tests_e
+@pytest.mark.integration_tests_i
 @pytest.mark.parametrize(
     "backend",
     [
         pytest.param("local", id="local"),
-        pytest.param("ray", id="ray", marks=pytest.mark.distributed),
+        pytest.param("ray", id="ray", marks=[pytest.mark.distributed, pytest.mark.distributed_f]),
     ],
 )
 def test_text_adapter_lora(tmpdir, backend, ray_cluster_2cpu):

--- a/tests/integration_tests/test_postprocessing.py
+++ b/tests/integration_tests/test_postprocessing.py
@@ -114,6 +114,7 @@ def test_binary_predictions(tmpdir, distinct_values, ray_cluster_2cpu):
 
 @pytest.mark.slow
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 @pytest.mark.parametrize("distinct_values", [(False, True), ("No", "Yes")])
 def test_binary_predictions_ray(tmpdir, distinct_values, ray_cluster_2cpu):
     _run_binary_predictions(tmpdir, "ray", distinct_values, ray_cluster_2cpu)
@@ -181,6 +182,7 @@ def test_binary_predictions_with_number_dtype(tmpdir, distinct_values, ray_clust
 
 @pytest.mark.slow
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 @pytest.mark.parametrize("distinct_values", [(0.0, 1.0), (0, 1)])
 def test_binary_predictions_with_number_dtype_ray(tmpdir, distinct_values, ray_cluster_2cpu):
     _run_binary_predictions_with_number_dtype(tmpdir, "ray", distinct_values, ray_cluster_2cpu)

--- a/tests/integration_tests/test_preprocessing.py
+++ b/tests/integration_tests/test_preprocessing.py
@@ -329,6 +329,7 @@ def test_with_split(backend, csv_filename, tmpdir, ray_cluster_2cpu):
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 @pytest.mark.parametrize("feature_fn", [image_feature, audio_feature])
 def test_dask_known_divisions(feature_fn, csv_filename, tmpdir, ray_cluster_2cpu):
     import dask.dataframe as dd
@@ -356,6 +357,7 @@ def test_dask_known_divisions(feature_fn, csv_filename, tmpdir, ray_cluster_2cpu
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_drop_empty_partitions(csv_filename, tmpdir, ray_cluster_2cpu):
     import dask.dataframe as dd
 
@@ -672,6 +674,7 @@ def test_empty_training_set_error(backend, tmpdir, ray_cluster_2cpu):
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 @pytest.mark.parametrize(
     "backend",
     [

--- a/tests/integration_tests/test_ray.py
+++ b/tests/integration_tests/test_ray.py
@@ -377,6 +377,7 @@ def run_test_with_features(
 
 
 @pytest.mark.integration_tests_a
+@pytest.mark.distributed_a
 @pytest.mark.parametrize("df_engine", ["pandas", "dask"])
 @pytest.mark.distributed
 def test_ray_read_binary_files(tmpdir, df_engine, ray_cluster_2cpu):
@@ -424,6 +425,7 @@ def test_ray_read_binary_files(tmpdir, df_engine, ray_cluster_2cpu):
 
 
 @pytest.mark.integration_tests_a
+@pytest.mark.distributed_a
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "trainer_strategy",
@@ -465,6 +467,7 @@ def test_ray_outputs(trainer_strategy, ray_cluster_2cpu):
 
 
 @pytest.mark.integration_tests_a
+@pytest.mark.distributed_a
 @pytest.mark.skip(reason="Occasional metadata mismatch error: https://github.com/ludwig-ai/ludwig/issues/2889")
 @pytest.mark.parametrize("dataset_type", ["csv", "parquet"])
 @pytest.mark.distributed
@@ -498,6 +501,7 @@ def test_ray_set_and_vector_outputs(dataset_type, ray_cluster_2cpu):
 
 
 @pytest.mark.integration_tests_a
+@pytest.mark.distributed_a
 @pytest.mark.distributed
 @pytest.mark.parametrize(
     "df_engine",
@@ -536,6 +540,7 @@ def test_ray_tabular(tmpdir, df_engine, ray_cluster_2cpu):
 
 
 @pytest.mark.integration_tests_a
+@pytest.mark.distributed_a
 @pytest.mark.parametrize("dataset_type", ["csv", "parquet"])
 @pytest.mark.distributed
 def test_ray_tabular_save_inputs(tmpdir, dataset_type, ray_cluster_2cpu):
@@ -565,6 +570,7 @@ def test_ray_tabular_save_inputs(tmpdir, dataset_type, ray_cluster_2cpu):
 
 
 @pytest.mark.integration_tests_a
+@pytest.mark.distributed_a
 @pytest.mark.distributed
 @pytest.mark.parametrize("dataset_type", ["csv", "parquet"])
 def test_ray_text_sequence_timeseries(tmpdir, dataset_type, ray_cluster_2cpu):
@@ -587,6 +593,7 @@ def test_ray_text_sequence_timeseries(tmpdir, dataset_type, ray_cluster_2cpu):
 
 
 @pytest.mark.integration_tests_a
+@pytest.mark.distributed_a
 @pytest.mark.parametrize("dataset_type", ["csv", "parquet"])
 @pytest.mark.distributed
 def test_ray_vector(tmpdir, dataset_type, ray_cluster_2cpu):
@@ -607,6 +614,7 @@ def test_ray_vector(tmpdir, dataset_type, ray_cluster_2cpu):
 
 
 @pytest.mark.integration_tests_a
+@pytest.mark.distributed_a
 @pytest.mark.parametrize("dataset_type", ["csv", "parquet"])
 @pytest.mark.distributed
 def test_ray_audio(tmp_path, dataset_type, ray_cluster_2cpu):
@@ -637,6 +645,7 @@ def test_ray_audio(tmp_path, dataset_type, ray_cluster_2cpu):
 
 
 @pytest.mark.integration_tests_a
+@pytest.mark.distributed_a
 @pytest.mark.parametrize("dataset_type", ["csv", "parquet", "pandas+numpy_images"])
 @pytest.mark.distributed
 def test_ray_image(tmpdir, dataset_type, ray_cluster_2cpu):
@@ -662,6 +671,7 @@ def test_ray_image(tmpdir, dataset_type, ray_cluster_2cpu):
 
 
 @pytest.mark.integration_tests_a
+@pytest.mark.distributed_a
 @pytest.mark.parametrize(
     "settings",
     [(True, False, "ffill"), (False, True, "bfill"), (True, True, "bfill"), (True, True, "ffill")],
@@ -703,7 +713,8 @@ def test_ray_image_with_fill_strategy_edge_cases(tmpdir, settings, ray_cluster_2
 # TODO(geoffrey): Fold modin tests into test_ray_image as @pytest.mark.parametrized once tests are optimized
 
 
-@pytest.mark.integration_tests_a2
+@pytest.mark.integration_tests_b
+@pytest.mark.distributed_b
 @pytest.mark.distributed
 @pytest.mark.skipif(modin is None, reason="modin not installed")
 @pytest.mark.skip(reason="https://github.com/ludwig-ai/ludwig/issues/2643")
@@ -732,7 +743,8 @@ def test_ray_image_modin(tmpdir, ray_cluster_2cpu):
     )
 
 
-@pytest.mark.integration_tests_a5
+@pytest.mark.integration_tests_e
+@pytest.mark.distributed_e
 @pytest.mark.distributed
 def test_ray_image_multiple_features(tmpdir, ray_cluster_2cpu):
     input_features = [
@@ -760,7 +772,8 @@ def test_ray_image_multiple_features(tmpdir, ray_cluster_2cpu):
     )
 
 
-@pytest.mark.integration_tests_a2
+@pytest.mark.integration_tests_b
+@pytest.mark.distributed_b
 @pytest.mark.skip(reason="flaky: ray is running out of resources")
 @pytest.mark.distributed
 def test_ray_split(ray_cluster_2cpu):
@@ -777,7 +790,8 @@ def test_ray_split(ray_cluster_2cpu):
     )
 
 
-@pytest.mark.integration_tests_a2
+@pytest.mark.integration_tests_b
+@pytest.mark.distributed_b
 @pytest.mark.distributed
 def test_ray_audio_basic(tmpdir, ray_cluster_2cpu):
     # in_memory=False lazy loading was removed (everything is in-memory now,
@@ -798,7 +812,8 @@ def _run_no_evaluate(config, dataset, backend_config, **kwargs):
     return train_with_backend(backend_config, config, dataset=dataset, evaluate=False, predict=False, **kwargs)
 
 
-@pytest.mark.integration_tests_a2
+@pytest.mark.integration_tests_b
+@pytest.mark.distributed_b
 @pytest.mark.slow
 @pytest.mark.distributed
 def test_ray_lazy_load_image_works(tmpdir, ray_cluster_2cpu):
@@ -834,7 +849,8 @@ def test_ray_lazy_load_image_works(tmpdir, ray_cluster_2cpu):
 #     run_test_with_features(input_features, output_features, run_fn=_run_train_gpu_load_cpu, num_gpus=1)
 
 
-@pytest.mark.integration_tests_a4
+@pytest.mark.integration_tests_d
+@pytest.mark.distributed_d
 @pytest.mark.distributed
 @pytest.mark.parametrize(
     "method, balance",
@@ -885,7 +901,8 @@ def _run_train_gpu_load_cpu(config, data_parquet):
 # TODO(geoffrey): add a GPU test for batch size tuning
 
 
-@pytest.mark.integration_tests_a4
+@pytest.mark.integration_tests_d
+@pytest.mark.distributed_d
 @pytest.mark.distributed
 @pytest.mark.parametrize(
     ("max_batch_size", "expected_final_learning_rate"),
@@ -958,7 +975,8 @@ def test_tune_batch_size_lr_cpu(tmpdir, ray_cluster_2cpu, max_batch_size, expect
     assert model.config[TRAINER]["learning_rate"] == expected_final_learning_rate
 
 
-@pytest.mark.integration_tests_a4
+@pytest.mark.integration_tests_d
+@pytest.mark.distributed_d
 @pytest.mark.distributed
 def test_tune_batch_size_ray_non_mean_metric_output(tmpdir, ray_cluster_2cpu):
     """Regression: tune_batch_size_fn must call init_dist_strategy("local") before running.
@@ -990,7 +1008,8 @@ def test_tune_batch_size_ray_non_mean_metric_output(tmpdir, ray_cluster_2cpu):
     run_api_experiment(config, dataset=dataset_parquet, backend_config=RAY_BACKEND_CONFIG, evaluate=False)
 
 
-@pytest.mark.integration_tests_a2
+@pytest.mark.integration_tests_b
+@pytest.mark.distributed_b
 @pytest.mark.slow
 @pytest.mark.parametrize("calibration", [True, False])
 @pytest.mark.distributed
@@ -1007,7 +1026,8 @@ def test_ray_calibration(calibration, ray_cluster_2cpu):
     run_test_with_features(input_features, output_features)
 
 
-@pytest.mark.integration_tests_a2
+@pytest.mark.integration_tests_b
+@pytest.mark.distributed_b
 @pytest.mark.slow
 @pytest.mark.distributed
 @pytest.mark.parametrize("use_placement_group", [False, True], ids=["default", "placement_group"])

--- a/tests/integration_tests/test_remote.py
+++ b/tests/integration_tests/test_remote.py
@@ -23,7 +23,7 @@ from tests.integration_tests.utils import (
     sequence_feature,
 )
 
-pytestmark = pytest.mark.integration_tests_b
+pytestmark = pytest.mark.integration_tests_f
 
 
 @pytest.mark.slow
@@ -31,7 +31,7 @@ pytestmark = pytest.mark.integration_tests_b
     "backend",
     [
         pytest.param("local", id="local"),
-        pytest.param("ray", id="ray", marks=pytest.mark.distributed),
+        pytest.param("ray", id="ray", marks=[pytest.mark.distributed, pytest.mark.distributed_f]),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/integration_tests/test_sequence_decoders.py
+++ b/tests/integration_tests/test_sequence_decoders.py
@@ -22,13 +22,14 @@ from tests.integration_tests.utils import (
     train_with_backend,
 )
 
-pytestmark = pytest.mark.integration_tests_c
+pytestmark = pytest.mark.integration_tests_g
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize("feature_type,feature_gen", [(TEXT, text_feature), (SEQUENCE, sequence_feature)])
 @pytest.mark.parametrize("decoder_type", ["generator", "tagger"])
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_sequence_decoder_predictions(tmpdir, csv_filename, ray_cluster_2cpu, feature_type, feature_gen, decoder_type):
     """Test that sequence decoders return the correct successfully predict."""
     input_feature = feature_gen()

--- a/tests/integration_tests/test_visualization.py
+++ b/tests/integration_tests/test_visualization.py
@@ -45,7 +45,7 @@ from tests.integration_tests.utils import (
     text_feature,
 )
 
-pytestmark = pytest.mark.integration_tests_c
+pytestmark = pytest.mark.integration_tests_g
 
 
 def run_experiment_with_visualization(input_features, output_features, dataset):

--- a/tests/integration_tests/test_visualization_api.py
+++ b/tests/integration_tests/test_visualization_api.py
@@ -38,7 +38,7 @@ from tests.integration_tests.utils import (
     text_feature,
 )
 
-pytestmark = pytest.mark.integration_tests_c
+pytestmark = pytest.mark.integration_tests_g
 
 
 def run_api_experiment(input_features, output_features):
@@ -875,6 +875,7 @@ def test_frequency_vs_f1_vis_api(experiment_to_use):
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_hyperopt_report_vis_api(hyperopt_results_multiple_parameters, tmpdir):
     vis_dir = os.path.join(tmpdir, "visualizations")
 
@@ -895,6 +896,7 @@ def test_hyperopt_report_vis_api(hyperopt_results_multiple_parameters, tmpdir):
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_hyperopt_hiplot_vis_api(hyperopt_results_multiple_parameters, tmpdir):
     vis_dir = os.path.join(tmpdir, "visualizations")
 
@@ -915,6 +917,7 @@ def test_hyperopt_hiplot_vis_api(hyperopt_results_multiple_parameters, tmpdir):
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_hyperopt_report_vis_api_no_pairplot(hyperopt_results_single_parameter, tmpdir):
     vis_dir = os.path.join(tmpdir, "visualizations")
 

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -418,6 +418,7 @@ def audio_feature(folder, **kwargs):
             "window_shift_in_s": 0.02,
             "num_filter_bands": 8,
             "audio_file_length_limit_in_s": 0.5,
+            "missing_value_strategy": "bfill",
         },
         ENCODER: {
             "type": "stacked_cnn",

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -419,6 +419,9 @@ def audio_feature(folder, **kwargs):
             "num_filter_bands": 8,
             "audio_file_length_limit_in_s": 0.5,
             "missing_value_strategy": "bfill",
+            "in_memory": True,
+            "padding_value": 0.0,
+            "norm": None,
         },
         ENCODER: {
             "type": "stacked_cnn",

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -422,6 +422,7 @@ def audio_feature(folder, **kwargs):
             "in_memory": True,
             "padding_value": 0.0,
             "norm": None,
+            "lazy": False,
         },
         ENCODER: {
             "type": "stacked_cnn",

--- a/tests/ludwig/augmentation/test_augmentation_pipeline.py
+++ b/tests/ludwig/augmentation/test_augmentation_pipeline.py
@@ -230,6 +230,7 @@ def test_local_model_training_with_augmentation_pipeline(
 # and focus on interaction of Ludwig encoder with image preprocessing and augmentation
 @pytest.mark.slow
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 @pytest.mark.parametrize("augmentation_pipeline_ops", AUGMENTATION_PIPELINE_OPS)
 @pytest.mark.parametrize("preprocessing", IMAGE_PREPROCESSING)
 def test_ray_model_training_with_augmentation_pipeline(

--- a/tests/ludwig/automl/test_base_config.py
+++ b/tests/ludwig/automl/test_base_config.py
@@ -24,7 +24,7 @@ from ludwig.data.dataframe.pandas import PandasEngine  # noqa
 from ludwig.schema.model_types.base import ModelConfig  # noqa
 from ludwig.utils.automl.data_source import DataframeSource, wrap_data_source  # noqa
 
-pytestmark = pytest.mark.distributed
+pytestmark = [pytest.mark.distributed, pytest.mark.distributed_c]
 
 
 @pytest.fixture(scope="module")

--- a/tests/ludwig/automl/test_data_source.py
+++ b/tests/ludwig/automl/test_data_source.py
@@ -30,6 +30,7 @@ def get_test_df():
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_c
 def test_mixed_csv_data_source(ray_cluster_2cpu):
     config = create_auto_config(dataset=get_test_df(), target=[], time_limit_s=3600)
 

--- a/tests/ludwig/automl/test_tune_config.py
+++ b/tests/ludwig/automl/test_tune_config.py
@@ -7,6 +7,7 @@ except ImportError:
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_c
 def test_reduce_text_model_mem_99ptile():
     config = {"input_features": [{"name": "description", "column": "description", "type": "text", "encoder": "bert"}]}
     training_set_metadata = {"description": {"max_sequence_length_99ptile": 117.0}}
@@ -19,6 +20,7 @@ def test_reduce_text_model_mem_99ptile():
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_c
 def test_reduce_text_model_mem_128():
     config = {"input_features": [{"name": "description", "column": "description", "type": "text", "encoder": "bert"}]}
     training_set_metadata = {"description": {"max_sequence_length_99ptile": 512.0}}
@@ -31,6 +33,7 @@ def test_reduce_text_model_mem_128():
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_c
 def test_reduce_text_model_mem_override():
     config = {
         "input_features": [{"name": "description", "column": "description", "type": "text", "encoder": "bert"}],
@@ -46,6 +49,7 @@ def test_reduce_text_model_mem_override():
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_c
 def test_reduce_text_model_mem_respect():
     config = {
         "input_features": [{"name": "description", "column": "description", "type": "text", "encoder": "bert"}],

--- a/tests/ludwig/automl/test_utils.py
+++ b/tests/ludwig/automl/test_utils.py
@@ -4,7 +4,7 @@ ray = pytest.importorskip("ray")
 
 from ludwig.utils.automl.utils import get_model_type  # noqa
 
-pytestmark = pytest.mark.distributed
+pytestmark = [pytest.mark.distributed, pytest.mark.distributed_c]
 
 
 def _features(*in_types, out):

--- a/tests/ludwig/backend/test_ray.py
+++ b/tests/ludwig/backend/test_ray.py
@@ -13,7 +13,7 @@ from ludwig.backend.ray import get_trainer_kwargs  # noqa
 from ludwig.constants import AUTO, EXECUTOR, MAX_CONCURRENT_TRIALS, RAY  # noqa
 
 # Mark the entire module as distributed
-pytestmark = pytest.mark.distributed
+pytestmark = [pytest.mark.distributed, pytest.mark.distributed_d]
 
 
 @pytest.mark.parametrize(

--- a/tests/ludwig/data/dataframe/test_dask.py
+++ b/tests/ludwig/data/dataframe/test_dask.py
@@ -50,6 +50,7 @@ def test_dask_image_bytes_no_unicode_error():
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_from_ray_dataset_empty(tmpdir, ray_cluster_2cpu):
     import dask.dataframe as dd
 

--- a/tests/ludwig/data/test_cache_util.py
+++ b/tests/ludwig/data/test_cache_util.py
@@ -111,6 +111,7 @@ def test_proc_col_checksum_consistency_same_preprocessing_different_types():
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_e
 def test_checksum_determinism(ray_cluster_2cpu):
     """Tests that checksums are deterministic across different processes (no unordered hash maps)."""
     import ray

--- a/tests/ludwig/data/test_dask_preprocessing.py
+++ b/tests/ludwig/data/test_dask_preprocessing.py
@@ -19,7 +19,7 @@ import pytest
 ray = pytest.importorskip("ray")
 dask = pytest.importorskip("dask")
 
-pytestmark = pytest.mark.distributed
+pytestmark = [pytest.mark.distributed, pytest.mark.distributed_e]
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/ludwig/data/test_ray_data.py
+++ b/tests/ludwig/data/test_ray_data.py
@@ -12,7 +12,7 @@ dask = pytest.importorskip("dask")
 from ludwig.data.dataset.ray import RayDatasetBatcher, RayDatasetShardBatcher, read_remote_parquet  # noqa
 
 # Mark the entire module as distributed
-pytestmark = pytest.mark.distributed
+pytestmark = [pytest.mark.distributed, pytest.mark.distributed_d]
 
 
 def test_prefetch_batches_value():

--- a/tests/ludwig/data/test_split.py
+++ b/tests/ludwig/data/test_split.py
@@ -41,7 +41,7 @@ def test_make_divisions_ensure_minimum_rows():
     ("df_engine",),
     [
         pytest.param(PandasEngine(), id="pandas"),
-        pytest.param(DaskEngine(_use_ray=False), id="dask", marks=pytest.mark.distributed),
+        pytest.param(DaskEngine(_use_ray=False), id="dask", marks=[pytest.mark.distributed, pytest.mark.distributed_d]),
     ],
 )
 def test_random_split(df_engine, ray_cluster_2cpu):
@@ -89,7 +89,7 @@ def test_random_split(df_engine, ray_cluster_2cpu):
     ("df_engine",),
     [
         pytest.param(PandasEngine(), id="pandas"),
-        pytest.param(DaskEngine(_use_ray=False), id="dask", marks=pytest.mark.distributed),
+        pytest.param(DaskEngine(_use_ray=False), id="dask", marks=[pytest.mark.distributed, pytest.mark.distributed_d]),
     ],
 )
 def test_random_split_zero_probability_for_test_produces_no_zombie(df_engine, ray_cluster_2cpu):
@@ -118,7 +118,7 @@ def test_random_split_zero_probability_for_test_produces_no_zombie(df_engine, ra
     ("df_engine",),
     [
         pytest.param(PandasEngine(), id="pandas"),
-        pytest.param(DaskEngine(_use_ray=False), id="dask", marks=pytest.mark.distributed),
+        pytest.param(DaskEngine(_use_ray=False), id="dask", marks=[pytest.mark.distributed, pytest.mark.distributed_d]),
     ],
 )
 def test_fixed_split(df_engine, ray_cluster_2cpu):
@@ -167,7 +167,9 @@ def test_fixed_split(df_engine, ray_cluster_2cpu):
     [
         pytest.param(PandasEngine(), 100, 1, id="pandas"),
         # Splitting with a distributed engine becomes more accurate with more rows.
-        pytest.param(DaskEngine(_use_ray=False), 10000, 10, id="dask", marks=pytest.mark.distributed),
+        pytest.param(
+            DaskEngine(_use_ray=False), 10000, 10, id="dask", marks=[pytest.mark.distributed, pytest.mark.distributed_d]
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -237,7 +239,9 @@ def test_stratify_split(df_engine, nrows, atol, class_probs, ray_cluster_2cpu):
     ("df_engine", "atol"),
     [
         pytest.param(PandasEngine(), 1, id="pandas"),
-        pytest.param(DaskEngine(_use_ray=False), 10, id="dask", marks=pytest.mark.distributed),
+        pytest.param(
+            DaskEngine(_use_ray=False), 10, id="dask", marks=[pytest.mark.distributed, pytest.mark.distributed_d]
+        ),
     ],
 )
 def test_single_occurrence_stratified_split(df_engine, atol, ray_cluster_2cpu):
@@ -276,7 +280,7 @@ def test_single_occurrence_stratified_split(df_engine, atol, ray_cluster_2cpu):
     ("df_engine",),
     [
         pytest.param(PandasEngine(), id="pandas"),
-        pytest.param(DaskEngine(_use_ray=False), id="dask", marks=pytest.mark.distributed),
+        pytest.param(DaskEngine(_use_ray=False), id="dask", marks=[pytest.mark.distributed, pytest.mark.distributed_d]),
     ],
 )
 @pytest.mark.parametrize("format", ["str", "datetime"])
@@ -334,7 +338,7 @@ def test_datetime_split(format, df_engine, ray_cluster_2cpu):
     ("df_engine",),
     [
         pytest.param(PandasEngine(), id="pandas"),
-        pytest.param(DaskEngine(_use_ray=False), id="dask", marks=pytest.mark.distributed),
+        pytest.param(DaskEngine(_use_ray=False), id="dask", marks=[pytest.mark.distributed, pytest.mark.distributed_d]),
     ],
 )
 def test_hash_split(df_engine, ray_cluster_2cpu):

--- a/tests/ludwig/models/test_training_determinism.py
+++ b/tests/ludwig/models/test_training_determinism.py
@@ -50,6 +50,7 @@ from tests.integration_tests.utils import (  # noqa: E402
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 @pytest.mark.skip(reason="https://github.com/ludwig-ai/ludwig/issues/2686")
 def test_training_determinism_ray_backend(csv_filename, tmpdir, ray_cluster_4cpu):
     experiment_output_1, experiment_output_2 = train_twice("ray", csv_filename, tmpdir)

--- a/tests/ludwig/schema/test_model_config.py
+++ b/tests/ludwig/schema/test_model_config.py
@@ -972,6 +972,7 @@ class TestTorchaoQuantizationUtil:
     reason="TODO(geoffrey, arnav): re-enable this when we have reconciled the config with the backend kwarg in api.py"
 )
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_llm_quantization_backend_compatibility():
     config = {
         MODEL_TYPE: MODEL_LLM,

--- a/tests/ludwig/utils/test_data_utils.py
+++ b/tests/ludwig/utils/test_data_utils.py
@@ -94,6 +94,7 @@ def test_figure_data_format_dataset_strip(path, expected_format):
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_figure_data_format_dataset():
     assert figure_data_format_dataset({"a": "b"}) == dict
     assert figure_data_format_dataset(pd.DataFrame([1, 2, 3, 4, 5], columns=["x"])) == pd.DataFrame
@@ -207,7 +208,11 @@ def test_chunking(synthetic_1k_files, fmt_idx, nrows):
 
 
 @pytest.mark.parametrize(
-    "df_lib", [pytest.param(pd, id="pandas"), pytest.param(dd, marks=pytest.mark.distributed, id="dask")]
+    "df_lib",
+    [
+        pytest.param(pd, id="pandas"),
+        pytest.param(dd, marks=[pytest.mark.distributed, pytest.mark.distributed_f], id="dask"),
+    ],
 )
 @pytest.mark.parametrize("nrows", [None, 10])
 def test_read_html(df_lib, nrows):

--- a/tests/ludwig/utils/test_dataframe_utils.py
+++ b/tests/ludwig/utils/test_dataframe_utils.py
@@ -12,6 +12,7 @@ except ImportError:
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_to_numpy_dataset_with_dask(ray_cluster_2cpu):
     dd_df = dd.from_pandas(pd.DataFrame([[1, 2, 3]], columns=["col1", "col2", "col3"]), npartitions=1)
     ray_backend = create_backend("ray")
@@ -22,6 +23,7 @@ def test_to_numpy_dataset_with_dask(ray_cluster_2cpu):
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_to_numpy_dataset_with_dask_backend_mismatch():
     dd_df = dd.from_pandas(pd.DataFrame([[1, 2, 3]], columns=["col1", "col2", "col3"]), npartitions=1)
 
@@ -54,6 +56,7 @@ def test_to_numpy_dataset_empty():
 
 
 @pytest.mark.distributed
+@pytest.mark.distributed_f
 def test_to_numpy_dataset_with_pandas_backend_mismatch(ray_cluster_2cpu):
     pd_df = pd.DataFrame([[1, 2, 3]], columns=["col1", "col2", "col3"])
     ray_backend = create_backend("ray")

--- a/tests/ludwig/utils/test_normalization.py
+++ b/tests/ludwig/utils/test_normalization.py
@@ -46,7 +46,7 @@ def get_test_data(backend: str) -> tuple[DataFrame, DataFrame]:
     "backend",
     [
         pytest.param("local", id="local"),
-        pytest.param("ray", id="ray", marks=pytest.mark.distributed),
+        pytest.param("ray", id="ray", marks=[pytest.mark.distributed, pytest.mark.distributed_f]),
     ],
 )
 def test_norm(backend, ray_cluster_2cpu):
@@ -108,7 +108,7 @@ def test_norm(backend, ray_cluster_2cpu):
     "backend",
     [
         pytest.param("local", id="local"),
-        pytest.param("ray", id="ray", marks=pytest.mark.distributed),
+        pytest.param("ray", id="ray", marks=[pytest.mark.distributed, pytest.mark.distributed_f]),
     ],
 )
 def test_numeric_transformation_registry(transformation, backend, ray_cluster_2cpu):


### PR DESCRIPTION
## Summary

- **Integration test group renaming**: The awkward `a/a2/a3/a4/a5/b/c/d/e/f` marker naming is replaced with a clean sequential `a–j` scheme
  - `a`: 10 heavy ray tests
  - `b`: 6 ray tests (audio_basic, image_modin, split, lazy_load, calibration, distributed_predict)
  - `c`: hyperopt tests
  - `d`: ray balance/tune tests + nothing else (fast)
  - `e`: ray image_multiple_features
  - `f`: cli, remote
  - `g`: automl, visualization, sequence_decoders
  - `h`: experiment, hyperopt_ray, explain
  - `i`: peft, api
  - `j`: auto-assigned fallback for any unmarked tests

- **Distributed test parallelization**: The single 120-minute distributed job is split into 6 parallel `distributed_a`–`distributed_f` matrix jobs (60-min timeout each), reducing wallclock time ~6x. A new `distributed_X` marker family (registered in `pytest.ini`) is added to every distributed test to route it to the right group.

## Test plan

- [ ] CI shows 10 integration matrix jobs (a–j) all passing
- [ ] CI shows 6 distributed matrix jobs (distributed_a–f) all passing
- [ ] No tests are skipped or dropped vs. the old scheme