### PR TITLE
refactor: introduce BasePreprocessingModule and BasePostprocessingModule

### DIFF
--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -25,7 +25,7 @@ from packaging import version
 
 from ludwig.constants import AUDIO, AUDIO_FEATURE_KEYS, COLUMN, NAME, PROC_COLUMN, SRC, TYPE
 from ludwig.data.lazy_utils import resolve_lazy_cache_dir
-from ludwig.features.base_feature import BaseFeatureMixin
+from ludwig.features.base_feature import BaseFeatureMixin, BasePreprocessingModule
 from ludwig.features.sequence_feature import SequenceInputFeature
 from ludwig.schema.features.audio_feature import AudioInputFeatureConfig
 from ludwig.types import FeatureMetadataDict, ModelConfigDict, PreprocessingConfigDict, TrainingSetMetadataDict
@@ -166,7 +166,7 @@ def _cache_audio_column_to_disk(
     return paths
 
 
-class _AudioPreprocessing(torch.nn.Module):
+class _AudioPreprocessing(BasePreprocessingModule):
     audio_feature_dict: dict[str, float | int | str]
 
     def __init__(self, metadata: TrainingSetMetadataDict):
@@ -667,7 +667,7 @@ class AudioInputFeature(AudioFeatureMixin, SequenceInputFeature):
         feature_config.encoder.should_embed = False
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return _AudioPreprocessing(metadata)
 
     @staticmethod

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 
 from ludwig.constants import BAG, COLUMN, NAME, PROC_COLUMN
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature
+from ludwig.features.base_feature import BaseFeatureMixin, BasePreprocessingModule, InputFeature
 from ludwig.features.feature_utils import set_str_to_idx
 from ludwig.features.set_feature import _SetPreprocessing
 from ludwig.schema.features.bag_feature import BagInputFeatureConfig
@@ -126,5 +126,5 @@ class BagInputFeature(BagFeatureMixin, InputFeature):
         return BagInputFeatureConfig
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return _SetPreprocessing(metadata, is_bag=True)

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -54,6 +54,33 @@ from ludwig.utils.types import DataFrame, PreprocessingInput
 logger = logging.getLogger(__name__)
 
 
+class BasePreprocessingModule(torch.nn.Module):
+    """Shared base class for all feature preprocessing modules.
+
+    All concrete preprocessing modules (``_CategoryPreprocessing``, ``_NumberPreprocessing``, etc.) must
+    inherit from this class and override ``forward``.  The base class establishes the common interface so
+    that ``create_preproc_module`` can advertise a concrete return type and callers can use
+    ``isinstance(module, BasePreprocessingModule)`` checks.
+
+    Subclasses must be TorchScript-compatible: avoid ABC ``@abstractmethod`` decorators and keep
+    all method signatures fully concrete-typed.
+    """
+
+    def forward(self, v: PreprocessingInput) -> torch.Tensor:
+        raise NotImplementedError("Subclasses must implement forward()")
+
+
+class BasePostprocessingModule(torch.nn.Module):
+    """Shared base class for all feature postprocessing modules.
+
+    All concrete postprocessing modules (``_CategoryPostprocessing``, ``_NumberPostprocessing``, etc.) must
+    inherit from this class and override ``forward``.
+    """
+
+    def forward(self, preds: dict[str, torch.Tensor], feature_name: str) -> dict[str, Any]:
+        raise NotImplementedError("Subclasses must implement forward()")
+
+
 class BaseFeatureMixin(ABC):
     """Parent class for feature mixins.
 
@@ -277,7 +304,7 @@ class InputFeature(BaseFeature, LudwigModule, ABC):
         return "string"
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         raise NotImplementedError("Torchscript tracing not supported for feature")
 
 
@@ -625,7 +652,7 @@ class OutputFeature(BaseFeature, LudwigModule, ABC):
         return feature_hidden
 
 
-class PassthroughPreprocModule(torch.nn.Module):
+class PassthroughPreprocModule(BasePreprocessingModule):
     """Combines preprocessing and encoding into a single module for TorchScript inference.
 
     For encoder outputs that were cached during preprocessing, the encoder is simply the identity function in the ECD
@@ -679,7 +706,7 @@ class PassthroughInputFeature(InputFeature):
     def get_schema_cls(self) -> type:
         return self._wrapped.get_schema_cls()
 
-    def create_preproc_module(self, metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(self, metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return PassthroughPreprocModule(self._wrapped.create_preproc_module(metadata), self._wrapped)
 
     def type(self) -> str:

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -20,7 +20,14 @@ import torch
 
 from ludwig.constants import BINARY, COLUMN, HIDDEN, LOGITS, NAME, PREDICTIONS, PROBABILITIES, PROBABILITY, PROC_COLUMN
 from ludwig.error import InputDataError
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import (
+    BaseFeatureMixin,
+    BasePostprocessingModule,
+    BasePreprocessingModule,
+    InputFeature,
+    OutputFeature,
+    PredictModule,
+)
 from ludwig.schema.features.binary_feature import BinaryInputFeatureConfig, BinaryOutputFeatureConfig
 from ludwig.types import (
     FeatureConfigDict,
@@ -43,7 +50,7 @@ from ludwig.utils.types import DataFrame, PreprocessingInput
 logger = logging.getLogger(__name__)
 
 
-class _BinaryPreprocessing(torch.nn.Module):
+class _BinaryPreprocessing(BasePreprocessingModule):
     def __init__(self, metadata: TrainingSetMetadataDict):
         super().__init__()
         str2bool = metadata.get("str2bool")
@@ -67,7 +74,7 @@ class _BinaryPreprocessing(torch.nn.Module):
         return torch.tensor(indices, dtype=torch.float32)
 
 
-class _BinaryPostprocessing(torch.nn.Module):
+class _BinaryPostprocessing(BasePostprocessingModule):
     def __init__(self, metadata: TrainingSetMetadataDict):
         super().__init__()
         bool2str = metadata.get("bool2str")
@@ -262,7 +269,7 @@ class BinaryInputFeature(BinaryFeatureMixin, InputFeature):
         return "string" if metadata.get("str2bool") else "int32"
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return _BinaryPreprocessing(metadata)
 
 

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -34,7 +34,14 @@ from ludwig.constants import (
     PROJECTION_INPUT,
 )
 from ludwig.error import InputDataError
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import (
+    BaseFeatureMixin,
+    BasePostprocessingModule,
+    BasePreprocessingModule,
+    InputFeature,
+    OutputFeature,
+    PredictModule,
+)
 from ludwig.features.vector_feature import VectorFeatureMixin
 from ludwig.schema.features.category_feature import (
     CategoryDistributionOutputFeatureConfig,
@@ -58,7 +65,7 @@ from ludwig.utils.types import PreprocessingInput
 logger = logging.getLogger(__name__)
 
 
-class _CategoryPreprocessing(torch.nn.Module):
+class _CategoryPreprocessing(BasePreprocessingModule):
     def __init__(self, metadata: TrainingSetMetadataDict):
         super().__init__()
         self.str2idx = metadata["str2idx"]
@@ -77,7 +84,7 @@ class _CategoryPreprocessing(torch.nn.Module):
         return torch.tensor(indices, dtype=torch.int32)
 
 
-class _CategoryPostprocessing(torch.nn.Module):
+class _CategoryPostprocessing(BasePostprocessingModule):
     def __init__(self, metadata: TrainingSetMetadataDict):
         super().__init__()
         self.idx2str = dict(enumerate(metadata["idx2str"]))
@@ -323,7 +330,7 @@ class CategoryInputFeature(CategoryFeatureMixin, InputFeature):
         return CategoryInputFeatureConfig
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return _CategoryPreprocessing(metadata)
 
 

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 
 from ludwig.constants import COLUMN, DATE, DATE_VECTOR_LENGTH, PROC_COLUMN
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature
+from ludwig.features.base_feature import BaseFeatureMixin, BasePreprocessingModule, InputFeature
 from ludwig.schema.features.date_feature import DateInputFeatureConfig
 from ludwig.types import (
     FeatureConfigDict,
@@ -35,7 +35,7 @@ from ludwig.utils.types import DataFrame, PreprocessingInput
 logger = logging.getLogger(__name__)
 
 
-class _DatePreprocessing(torch.nn.Module):
+class _DatePreprocessing(BasePreprocessingModule):
     def __init__(self, metadata: TrainingSetMetadataDict):
         super().__init__()
 
@@ -163,5 +163,5 @@ class DateInputFeature(DateFeatureMixin, InputFeature):
         return DateInputFeatureConfig
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return _DatePreprocessing(metadata)

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -18,7 +18,7 @@ import numpy as np
 import torch
 
 from ludwig.constants import COLUMN, H3, H3_VECTOR_LENGTH, MAX_H3_RESOLUTION, PROC_COLUMN
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature
+from ludwig.features.base_feature import BaseFeatureMixin, BasePreprocessingModule, InputFeature
 from ludwig.schema.features.h3_feature import H3InputFeatureConfig
 from ludwig.types import FeatureMetadataDict, ModelConfigDict, PreprocessingConfigDict, TrainingSetMetadataDict
 from ludwig.utils.h3_util import h3_to_components
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 H3_PADDING_VALUE = 7
 
 
-class _H3Preprocessing(torch.nn.Module):
+class _H3Preprocessing(BasePreprocessingModule):
     def __init__(self, metadata: TrainingSetMetadataDict):
         super().__init__()
         self.max_h3_resolution = MAX_H3_RESOLUTION
@@ -151,7 +151,7 @@ class H3InputFeature(H3FeatureMixin, InputFeature):
         pass
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return _H3Preprocessing(metadata)
 
     @staticmethod

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -54,7 +54,14 @@ from ludwig.constants import (
 from ludwig.data.lazy_utils import resolve_lazy_cache_dir
 from ludwig.encoders.base import Encoder
 from ludwig.encoders.image.torchvision import TVModelVariant
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import (
+    BaseFeatureMixin,
+    BasePostprocessingModule,
+    BasePreprocessingModule,
+    InputFeature,
+    OutputFeature,
+    PredictModule,
+)
 from ludwig.schema.features.augmentation.base import BaseAugmentationConfig
 from ludwig.schema.features.augmentation.image import (
     AutoAugmentationConfig,
@@ -466,7 +473,7 @@ def is_torchvision_encoder(encoder_obj: Encoder) -> bool:
     return isinstance(encoder_obj, TVBaseEncoder)
 
 
-class _ImagePreprocessing(torch.nn.Module):
+class _ImagePreprocessing(BasePreprocessingModule):
     """Torchscript-enabled version of preprocessing done by ImageFeatureMixin.add_feature_data."""
 
     def __init__(
@@ -551,7 +558,7 @@ class _ImagePreprocessing(torch.nn.Module):
         return imgs_stacked
 
 
-class _ImagePostprocessing(torch.nn.Module):
+class _ImagePostprocessing(BasePostprocessingModule):
     def __init__(self):
         super().__init__()
         self.logits_key = LOGITS
@@ -1280,7 +1287,7 @@ class ImageInputFeature(ImageFeatureMixin, InputFeature):
         return ImageInputFeatureConfig
 
     @staticmethod
-    def create_preproc_module(metadata: dict[str, Any]) -> torch.nn.Module:
+    def create_preproc_module(metadata: dict[str, Any]) -> BasePreprocessingModule:
         model_type = metadata["preprocessing"].get("torchvision_model_type")
         model_variant = metadata["preprocessing"].get("torchvision_model_variant")
         if model_variant:

--- a/ludwig/features/number_feature.py
+++ b/ludwig/features/number_feature.py
@@ -24,7 +24,14 @@ import torch
 from torch import nn
 
 from ludwig.constants import COLUMN, HIDDEN, LOGITS, NAME, NUMBER, PREDICTIONS, PROC_COLUMN
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import (
+    BaseFeatureMixin,
+    BasePostprocessingModule,
+    BasePreprocessingModule,
+    InputFeature,
+    OutputFeature,
+    PredictModule,
+)
 from ludwig.schema.features.number_feature import NumberInputFeatureConfig, NumberOutputFeatureConfig
 from ludwig.types import (
     FeatureMetadataDict,
@@ -256,7 +263,7 @@ class _OutlierReplacer(torch.nn.Module):
         return v.to(dtype=torch.float32)
 
 
-class _NumberPreprocessing(torch.nn.Module):
+class _NumberPreprocessing(BasePreprocessingModule):
     def __init__(self, metadata: TrainingSetMetadataDict):
         super().__init__()
         self.computed_fill_value = float(metadata["preprocessing"]["computed_fill_value"])
@@ -281,7 +288,7 @@ class _NumberPreprocessing(torch.nn.Module):
         return self.numeric_transformer.transform_inference(v)
 
 
-class _NumberPostprocessing(torch.nn.Module):
+class _NumberPostprocessing(BasePostprocessingModule):
     def __init__(self, metadata: TrainingSetMetadataDict):
         super().__init__()
         self.numeric_transformer = get_transformer(metadata, metadata["preprocessing"])
@@ -455,7 +462,7 @@ class NumberInputFeature(NumberFeatureMixin, InputFeature):
         return "float32"
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return _NumberPreprocessing(metadata)
 
 

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -31,7 +31,14 @@ from ludwig.constants import (
     PROC_COLUMN,
     SEQUENCE,
 )
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import (
+    BaseFeatureMixin,
+    BasePostprocessingModule,
+    BasePreprocessingModule,
+    InputFeature,
+    OutputFeature,
+    PredictModule,
+)
 from ludwig.features.feature_utils import compute_sequence_probability, compute_token_probabilities
 from ludwig.schema.features.sequence_feature import SequenceInputFeatureConfig, SequenceOutputFeatureConfig
 from ludwig.types import (
@@ -57,7 +64,7 @@ from ludwig.utils.types import PreprocessingInput
 logger = logging.getLogger(__name__)
 
 
-class _SequencePreprocessing(torch.nn.Module):
+class _SequencePreprocessing(BasePreprocessingModule):
     """Torchscript-enabled version of preprocessing done by SequenceFeatureMixin.add_feature_data."""
 
     def __init__(self, metadata: TrainingSetMetadataDict):
@@ -140,7 +147,7 @@ class _SequencePreprocessing(torch.nn.Module):
         return sequence_vector
 
 
-class _SequencePostprocessing(torch.nn.Module):
+class _SequencePostprocessing(BasePostprocessingModule):
     def __init__(self, metadata: TrainingSetMetadataDict):
         super().__init__()
         self.max_sequence_length = int(metadata["max_sequence_length"])
@@ -331,7 +338,7 @@ class SequenceInputFeature(SequenceFeatureMixin, InputFeature):
         return self.encoder_obj.output_shape
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return _SequencePreprocessing(metadata)
 
 

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -20,7 +20,14 @@ import numpy as np
 import torch
 
 from ludwig.constants import COLUMN, HIDDEN, LOGITS, NAME, PREDICTIONS, PROBABILITIES, PROC_COLUMN, SET
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import (
+    BaseFeatureMixin,
+    BasePostprocessingModule,
+    BasePreprocessingModule,
+    InputFeature,
+    OutputFeature,
+    PredictModule,
+)
 from ludwig.features.feature_utils import set_str_to_idx
 from ludwig.schema.features.set_feature import SetInputFeatureConfig, SetOutputFeatureConfig
 from ludwig.types import (
@@ -38,7 +45,7 @@ from ludwig.utils.types import PreprocessingInput
 logger = logging.getLogger(__name__)
 
 
-class _SetPreprocessing(torch.nn.Module):
+class _SetPreprocessing(BasePreprocessingModule):
     """Torchscript-enabled version of preprocessing done by SetFeatureMixin.add_feature_data.
 
     If is_bag is true, forward returns a vector for each sample indicating counts of each token. Else, forward returns a
@@ -92,7 +99,7 @@ class _SetPreprocessing(torch.nn.Module):
         return set_matrix
 
 
-class _SetPostprocessing(torch.nn.Module):
+class _SetPostprocessing(BasePostprocessingModule):
     """Torchscript-enabled version of postprocessing done by SetFeatureMixin.add_feature_data."""
 
     def __init__(self, metadata: TrainingSetMetadataDict):
@@ -245,7 +252,7 @@ class SetInputFeature(SetFeatureMixin, InputFeature):
         return self.encoder_obj.output_shape
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return _SetPreprocessing(metadata)
 
 

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -40,7 +40,7 @@ from ludwig.constants import (
     RESPONSE,
     TEXT,
 )
-from ludwig.features.base_feature import BaseFeatureMixin, OutputFeature
+from ludwig.features.base_feature import BaseFeatureMixin, BasePreprocessingModule, OutputFeature
 from ludwig.features.feature_utils import compute_sequence_probability, compute_token_probabilities
 from ludwig.features.sequence_feature import (
     _SequencePostprocessing,
@@ -300,7 +300,7 @@ class TextInputFeature(TextFeatureMixin, SequenceInputFeature):
         return self.encoder_obj.output_shape
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return _SequencePreprocessing(metadata)
 
 

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 
 from ludwig.constants import COLUMN, HIDDEN, LOGITS, NAME, PREDICTIONS, PROC_COLUMN, TIMESERIES
-from ludwig.features.base_feature import BaseFeatureMixin, OutputFeature, PredictModule
+from ludwig.features.base_feature import BaseFeatureMixin, BasePreprocessingModule, OutputFeature, PredictModule
 from ludwig.features.sequence_feature import SequenceInputFeature
 from ludwig.features.vector_feature import _VectorPostprocessing, _VectorPredict
 from ludwig.schema.features.timeseries_feature import TimeseriesInputFeatureConfig, TimeseriesOutputFeatureConfig
@@ -93,7 +93,7 @@ def create_time_delay_embedding(
     return df.apply(lambda x: np.nan_to_num(np.array(x.tolist()).astype(np.float32), nan=padding_value), axis=1)
 
 
-class _TimeseriesPreprocessing(torch.nn.Module):
+class _TimeseriesPreprocessing(BasePreprocessingModule):
     """Torchscript-enabled version of preprocessing done by TimeseriesFeatureMixin.add_feature_data."""
 
     def __init__(self, metadata: TrainingSetMetadataDict):
@@ -301,7 +301,7 @@ class TimeseriesInputFeature(TimeseriesFeatureMixin, SequenceInputFeature):
         return TimeseriesInputFeatureConfig
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return _TimeseriesPreprocessing(metadata)
 
 

--- a/ludwig/features/vector_feature.py
+++ b/ludwig/features/vector_feature.py
@@ -19,7 +19,13 @@ import numpy as np
 import torch
 
 from ludwig.constants import COLUMN, HIDDEN, LOGITS, NAME, PREDICTIONS, PROC_COLUMN, VECTOR
-from ludwig.features.base_feature import InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import (
+    BasePostprocessingModule,
+    BasePreprocessingModule,
+    InputFeature,
+    OutputFeature,
+    PredictModule,
+)
 from ludwig.schema.features.vector_feature import VectorInputFeatureConfig, VectorOutputFeatureConfig
 from ludwig.types import (
     FeatureMetadataDict,
@@ -34,7 +40,7 @@ from ludwig.utils.types import PreprocessingInput
 logger = logging.getLogger(__name__)
 
 
-class _VectorPreprocessing(torch.nn.Module):
+class _VectorPreprocessing(BasePreprocessingModule):
     def forward(self, v: PreprocessingInput) -> torch.Tensor:
         if torch.jit.isinstance(v, torch.Tensor):
             out = v
@@ -54,7 +60,7 @@ class _VectorPreprocessing(torch.nn.Module):
         return out
 
 
-class _VectorPostprocessing(torch.nn.Module):
+class _VectorPostprocessing(BasePostprocessingModule):
     def __init__(self):
         super().__init__()
         self.predictions_key = PREDICTIONS
@@ -177,7 +183,7 @@ class VectorInputFeature(VectorFeatureMixin, InputFeature):
         feature_config.encoder.input_size = feature_metadata["vector_size"]
 
     @staticmethod
-    def create_preproc_module(metadata: TrainingSetMetadataDict) -> torch.nn.Module:
+    def create_preproc_module(metadata: TrainingSetMetadataDict) -> BasePreprocessingModule:
         return _VectorPreprocessing()
 
     @staticmethod


### PR DESCRIPTION
## Summary

- Adds `BasePreprocessingModule(torch.nn.Module)` and `BasePostprocessingModule(torch.nn.Module)` in `base_feature.py`
- All 11 `_*Preprocessing` classes and 7 `_*Postprocessing` classes now inherit from their respective bases instead of directly from `torch.nn.Module`
- `create_preproc_module()` return type tightened from `torch.nn.Module` → `BasePreprocessingModule`
- `PassthroughPreprocModule` also migrated to `BasePreprocessingModule`
- Enables `isinstance(module, BasePreprocessingModule)` checks and documents the interface contract

## Test plan

- [ ] Existing unit tests pass (all 38)
- [ ] No TorchScript breakage — base classes avoid `@abstractmethod` which TorchScript cannot handle
- [ ] `issubclass(_CategoryPreprocessing, BasePreprocessingModule)` returns `True` (verified locally)

Stacked on: #4174