### PR TITLE
refactor: rename BaseFeatureMixin and ModuleWrapper to descriptive names

### DIFF
--- a/ludwig/features/anomaly_feature.py
+++ b/ludwig/features/anomaly_feature.py
@@ -56,7 +56,7 @@ from ludwig.constants import (
     PREDICTIONS,
     PROC_COLUMN,
 )
-from ludwig.features.base_feature import BaseFeatureMixin, OutputFeature, PredictModule
+from ludwig.features.base_feature import FeaturePreprocessingMixin, OutputFeature, PredictModule
 from ludwig.schema.features.anomaly_feature import AnomalyOutputFeatureConfig
 from ludwig.types import (
     FeatureConfigDict,
@@ -95,7 +95,7 @@ class _AnomalyPredict(PredictModule):
         }
 
 
-class AnomalyFeatureMixin(BaseFeatureMixin):
+class AnomalyFeatureMixin(FeaturePreprocessingMixin):
     """Mixin providing preprocessing utilities for anomaly output features.
 
     Anomaly detection is typically unsupervised — the target column contains 0 (normal) or 1 (anomaly) labels for

--- a/ludwig/features/audio_feature.py
+++ b/ludwig/features/audio_feature.py
@@ -25,7 +25,7 @@ from packaging import version
 
 from ludwig.constants import AUDIO, AUDIO_FEATURE_KEYS, COLUMN, NAME, PROC_COLUMN, SRC, TYPE
 from ludwig.data.lazy_utils import resolve_lazy_cache_dir
-from ludwig.features.base_feature import BaseFeatureMixin
+from ludwig.features.base_feature import FeaturePreprocessingMixin
 from ludwig.features.sequence_feature import SequenceInputFeature
 from ludwig.schema.features.audio_feature import AudioInputFeatureConfig
 from ludwig.types import FeatureMetadataDict, ModelConfigDict, PreprocessingConfigDict, TrainingSetMetadataDict
@@ -200,7 +200,7 @@ class _AudioPreprocessing(torch.nn.Module):
         return torch.stack(processed_audio_matrix)
 
 
-class AudioFeatureMixin(BaseFeatureMixin):
+class AudioFeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return AUDIO

--- a/ludwig/features/bag_feature.py
+++ b/ludwig/features/bag_feature.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 
 from ludwig.constants import BAG, COLUMN, NAME, PROC_COLUMN
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature
+from ludwig.features.base_feature import FeaturePreprocessingMixin, InputFeature
 from ludwig.features.feature_utils import set_str_to_idx
 from ludwig.features.set_feature import _SetPreprocessing
 from ludwig.schema.features.bag_feature import BagInputFeatureConfig
@@ -30,7 +30,7 @@ from ludwig.utils.strings_utils import create_vocabulary
 logger = logging.getLogger(__name__)
 
 
-class BagFeatureMixin(BaseFeatureMixin):
+class BagFeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return BAG

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -54,7 +54,7 @@ from ludwig.utils.types import DataFrame, PreprocessingInput
 logger = logging.getLogger(__name__)
 
 
-class BaseFeatureMixin(ABC):
+class FeaturePreprocessingMixin(ABC):
     """Parent class for feature mixins.
 
     Feature mixins support preprocessing functionality shared across input and output features.
@@ -122,7 +122,7 @@ class BaseFeatureMixin(ABC):
 
 
 @dataclass
-class ModuleWrapper:
+class NonPropertyModuleWrapper:
     """Used to prevent the PredictModule from showing up as an attribute on the feature module.
 
     This is necessary to avoid inflight errors from some distributed strategies that may believe a param is still in the
@@ -329,7 +329,7 @@ class OutputFeature(BaseFeature, LudwigModule, ABC):
             default_dropout=feature.decoder.fc_dropout,
         )
         self._calibration_module = self.create_calibration_module(feature)
-        self._prediction_module = ModuleWrapper(self.create_predict_module())
+        self._prediction_module = NonPropertyModuleWrapper(self.create_predict_module())
 
         # set up two sequence reducers, one for inputs and other for dependencies
         self.reduce_sequence_input = SequenceReducer(reduce_mode=self.reduce_input)
@@ -379,7 +379,7 @@ class OutputFeature(BaseFeature, LudwigModule, ABC):
 
     def _setup_loss(self) -> None:
         self.train_loss_function = create_loss(self.loss)
-        self._eval_loss_metric = ModuleWrapper(get_metric_cls(self.type(), self.loss.type)(config=self.loss))
+        self._eval_loss_metric = NonPropertyModuleWrapper(get_metric_cls(self.type(), self.loss.type)(config=self.loss))
 
     def _setup_metrics(self) -> None:
         kwargs = {}

--- a/ludwig/features/binary_feature.py
+++ b/ludwig/features/binary_feature.py
@@ -20,7 +20,7 @@ import torch
 
 from ludwig.constants import BINARY, COLUMN, HIDDEN, LOGITS, NAME, PREDICTIONS, PROBABILITIES, PROBABILITY, PROC_COLUMN
 from ludwig.error import InputDataError
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import FeaturePreprocessingMixin, InputFeature, OutputFeature, PredictModule
 from ludwig.schema.features.binary_feature import BinaryInputFeatureConfig, BinaryOutputFeatureConfig
 from ludwig.types import (
     FeatureConfigDict,
@@ -113,7 +113,7 @@ class _BinaryPredict(PredictModule):
         }
 
 
-class BinaryFeatureMixin(BaseFeatureMixin):
+class BinaryFeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return BINARY

--- a/ludwig/features/category_feature.py
+++ b/ludwig/features/category_feature.py
@@ -34,7 +34,7 @@ from ludwig.constants import (
     PROJECTION_INPUT,
 )
 from ludwig.error import InputDataError
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import FeaturePreprocessingMixin, InputFeature, OutputFeature, PredictModule
 from ludwig.features.vector_feature import VectorFeatureMixin
 from ludwig.schema.features.category_feature import (
     CategoryDistributionOutputFeatureConfig,
@@ -135,7 +135,7 @@ class _CategoryPredict(PredictModule):
         return {self.predictions_key: predictions, self.probabilities_key: probabilities, self.logits_key: logits}
 
 
-class CategoryFeatureMixin(BaseFeatureMixin):
+class CategoryFeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return CATEGORY

--- a/ludwig/features/date_feature.py
+++ b/ludwig/features/date_feature.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 
 from ludwig.constants import COLUMN, DATE, DATE_VECTOR_LENGTH, PROC_COLUMN
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature
+from ludwig.features.base_feature import FeaturePreprocessingMixin, InputFeature
 from ludwig.schema.features.date_feature import DateInputFeatureConfig
 from ludwig.types import (
     FeatureConfigDict,
@@ -49,7 +49,7 @@ class _DatePreprocessing(torch.nn.Module):
             raise ValueError(f"Unsupported input: {v}")
 
 
-class DateFeatureMixin(BaseFeatureMixin):
+class DateFeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return DATE

--- a/ludwig/features/h3_feature.py
+++ b/ludwig/features/h3_feature.py
@@ -18,7 +18,7 @@ import numpy as np
 import torch
 
 from ludwig.constants import COLUMN, H3, H3_VECTOR_LENGTH, MAX_H3_RESOLUTION, PROC_COLUMN
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature
+from ludwig.features.base_feature import FeaturePreprocessingMixin, InputFeature
 from ludwig.schema.features.h3_feature import H3InputFeatureConfig
 from ludwig.types import FeatureMetadataDict, ModelConfigDict, PreprocessingConfigDict, TrainingSetMetadataDict
 from ludwig.utils.h3_util import h3_to_components
@@ -62,7 +62,7 @@ class _H3Preprocessing(torch.nn.Module):
         return torch.stack(outputs)
 
 
-class H3FeatureMixin(BaseFeatureMixin):
+class H3FeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return H3

--- a/ludwig/features/image_feature.py
+++ b/ludwig/features/image_feature.py
@@ -54,7 +54,7 @@ from ludwig.constants import (
 from ludwig.data.lazy_utils import resolve_lazy_cache_dir
 from ludwig.encoders.base import Encoder
 from ludwig.encoders.image.torchvision import TVModelVariant
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import FeaturePreprocessingMixin, InputFeature, OutputFeature, PredictModule
 from ludwig.schema.features.augmentation.base import BaseAugmentationConfig
 from ludwig.schema.features.augmentation.image import (
     AutoAugmentationConfig,
@@ -572,7 +572,7 @@ class _ImagePredict(PredictModule):
         return {self.predictions_key: predictions, self.logits_key: logits}
 
 
-class ImageFeatureMixin(BaseFeatureMixin):
+class ImageFeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return IMAGE

--- a/ludwig/features/number_feature.py
+++ b/ludwig/features/number_feature.py
@@ -24,7 +24,7 @@ import torch
 from torch import nn
 
 from ludwig.constants import COLUMN, HIDDEN, LOGITS, NAME, NUMBER, PREDICTIONS, PROC_COLUMN
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import FeaturePreprocessingMixin, InputFeature, OutputFeature, PredictModule
 from ludwig.schema.features.number_feature import NumberInputFeatureConfig, NumberOutputFeatureConfig
 from ludwig.types import (
     FeatureMetadataDict,
@@ -309,7 +309,7 @@ class _NumberPredict(PredictModule):
         return {self.predictions_key: predictions, self.logits_key: logits}
 
 
-class NumberFeatureMixin(BaseFeatureMixin):
+class NumberFeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return NUMBER

--- a/ludwig/features/sequence_feature.py
+++ b/ludwig/features/sequence_feature.py
@@ -31,7 +31,7 @@ from ludwig.constants import (
     PROC_COLUMN,
     SEQUENCE,
 )
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import FeaturePreprocessingMixin, InputFeature, OutputFeature, PredictModule
 from ludwig.features.feature_utils import compute_sequence_probability, compute_token_probabilities
 from ludwig.schema.features.sequence_feature import SequenceInputFeatureConfig, SequenceOutputFeatureConfig
 from ludwig.types import (
@@ -188,7 +188,7 @@ class _SequencePredict(PredictModule):
         return {self.predictions_key: predictions, self.probabilities_key: probabilities, self.logits_key: logits}
 
 
-class SequenceFeatureMixin(BaseFeatureMixin):
+class SequenceFeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return SEQUENCE

--- a/ludwig/features/set_feature.py
+++ b/ludwig/features/set_feature.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 
 from ludwig.constants import COLUMN, HIDDEN, LOGITS, NAME, PREDICTIONS, PROBABILITIES, PROC_COLUMN, SET
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature, PredictModule
+from ludwig.features.base_feature import FeaturePreprocessingMixin, InputFeature, OutputFeature, PredictModule
 from ludwig.features.feature_utils import set_str_to_idx
 from ludwig.schema.features.set_feature import SetInputFeatureConfig, SetOutputFeatureConfig
 from ludwig.types import (
@@ -141,7 +141,7 @@ class _SetPredict(PredictModule):
         return {self.predictions_key: predictions, self.probabilities_key: probabilities, self.logits_key: logits}
 
 
-class SetFeatureMixin(BaseFeatureMixin):
+class SetFeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return SET

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -40,7 +40,7 @@ from ludwig.constants import (
     RESPONSE,
     TEXT,
 )
-from ludwig.features.base_feature import BaseFeatureMixin, OutputFeature
+from ludwig.features.base_feature import FeaturePreprocessingMixin, OutputFeature
 from ludwig.features.feature_utils import compute_sequence_probability, compute_token_probabilities
 from ludwig.features.sequence_feature import (
     _SequencePostprocessing,
@@ -121,7 +121,7 @@ def _get_metadata_reconciled_max_sequence_length(
     return vocabulary.max_sequence_length, vocabulary.sequence_length_99ptile
 
 
-class TextFeatureMixin(BaseFeatureMixin):
+class TextFeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return TEXT

--- a/ludwig/features/timeseries_feature.py
+++ b/ludwig/features/timeseries_feature.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 
 from ludwig.constants import COLUMN, HIDDEN, LOGITS, NAME, PREDICTIONS, PROC_COLUMN, TIMESERIES
-from ludwig.features.base_feature import BaseFeatureMixin, OutputFeature, PredictModule
+from ludwig.features.base_feature import FeaturePreprocessingMixin, OutputFeature, PredictModule
 from ludwig.features.sequence_feature import SequenceInputFeature
 from ludwig.features.vector_feature import _VectorPostprocessing, _VectorPredict
 from ludwig.schema.features.timeseries_feature import TimeseriesInputFeatureConfig, TimeseriesOutputFeatureConfig
@@ -163,7 +163,7 @@ class _TimeseriesPreprocessing(torch.nn.Module):
         raise ValueError(f"Unsupported input: {v}")
 
 
-class TimeseriesFeatureMixin(BaseFeatureMixin):
+class TimeseriesFeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return TIMESERIES

--- a/ludwig/models/base.py
+++ b/ludwig/models/base.py
@@ -11,7 +11,12 @@ import torchmetrics
 from ludwig.combiners.combiners import Combiner
 from ludwig.constants import COMBINED, LOSS, NAME
 from ludwig.encoders.base import Encoder
-from ludwig.features.base_feature import create_passthrough_input_feature, InputFeature, ModuleWrapper, OutputFeature
+from ludwig.features.base_feature import (
+    create_passthrough_input_feature,
+    InputFeature,
+    NonPropertyModuleWrapper,
+    OutputFeature,
+)
 from ludwig.features.feature_registries import get_input_type_registry, get_output_type_registry
 from ludwig.features.feature_utils import LudwigFeatureDict
 from ludwig.modules.metric_modules import LudwigMetric
@@ -52,8 +57,8 @@ class BaseModel(LudwigModule, metaclass=ABCMeta):
         self.output_features = self.create_feature_dict()
 
         # ================ Combined loss metric ================
-        self._eval_loss_metric = ModuleWrapper(torchmetrics.MeanMetric())
-        self._eval_additional_losses_metrics = ModuleWrapper(torchmetrics.MeanMetric())
+        self._eval_loss_metric = NonPropertyModuleWrapper(torchmetrics.MeanMetric())
+        self._eval_additional_losses_metrics = NonPropertyModuleWrapper(torchmetrics.MeanMetric())
 
         # ================ Training Hook Handles ================
         self._forward_hook_handles: list[TrainingHook] = []

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -9,7 +9,7 @@ from transformers import AutoConfig, GenerationConfig
 
 from ludwig.accounting.used_tokens import get_used_tokens_for_llm
 from ludwig.constants import IGNORE_INDEX_TOKEN_ID, LOGITS, MODEL_LLM, PREDICTIONS, TEXT, USED_TOKENS
-from ludwig.features.base_feature import ModuleWrapper, OutputFeature
+from ludwig.features.base_feature import NonPropertyModuleWrapper, OutputFeature
 from ludwig.features.text_feature import TextOutputFeature
 from ludwig.globals import MODEL_WEIGHTS_FILE_NAME
 from ludwig.models.base import BaseModel
@@ -116,7 +116,7 @@ class LLM(BaseModel):
         )
 
         # Extract the decoder object for the forward pass
-        self._output_feature_decoder = ModuleWrapper(next(iter(self.output_features.values())))
+        self._output_feature_decoder = NonPropertyModuleWrapper(next(iter(self.output_features.values())))
 
         self.attention_masks = None
 


### PR DESCRIPTION
## Summary

- `BaseFeatureMixin` → `FeaturePreprocessingMixin`: the old name was vague and didn't describe the mixin's role (preprocessing shared across input/output features)
- `ModuleWrapper` → `NonPropertyModuleWrapper`: the old name said nothing about purpose; the new name describes the intent — wrapping a module as a dataclass field so distributed training frameworks don't treat it as a trainable parameter requiring synchronization

Part of PR-10 from the codebase quality improvement plan. Previous renames already completed on `feat/codebase-quality`: `NoneTrainer→InferenceOnlyTrainer`, `LocalPreprocessingMixin→LocalDataProcessingMixin`, `CacheManager→PreprocessedDataCache`.

## Test plan
- [ ] All existing tests pass (no test files reference the old names)
- [ ] Grep confirms zero remaining references to old names