### PR TITLE
fix: improve exception handling across critical paths

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -703,9 +703,8 @@ class LudwigModel:
                             train_stats=train_stats,
                             model_dir=model_dir,
                         )
-                    except Exception as e:
-                        logger.warning(f"Failed to generate model card: {e}")
-                        logger.debug(traceback.format_exc())
+                    except Exception:
+                        logger.warning("Failed to generate model card.", exc_info=True)
 
                 # Save training report (always, alongside the model)
                 if self.backend.is_coordinator() and not skip_save_model:
@@ -720,9 +719,8 @@ class LudwigModel:
                             model_dir=model_dir,
                             random_seed=random_seed,
                         )
-                    except Exception as e:
-                        logger.warning(f"Failed to generate training report: {e}")
-                        logger.debug(traceback.format_exc())
+                    except Exception:
+                        logger.warning("Failed to generate training report.", exc_info=True)
 
                 # Synchronize model weights between workers
                 self.backend.sync_model(self.model)

--- a/ludwig/contribs/mlflow/mlflow3.py
+++ b/ludwig/contribs/mlflow/mlflow3.py
@@ -71,7 +71,7 @@ def log_training_run(model, train_stats=None, config=None, tags=None):
                 mlflow.log_metric("model.size_mb", round(model_size_mb, 2))
                 mlflow.set_tag("model.param_efficiency", f"{trainable_params / max(total_params, 1) * 100:.1f}%")
             except Exception:
-                pass
+                logger.debug("Failed to log model parameter counts to MLflow.", exc_info=True)
 
             # Log base model name for LLMs (useful for cost estimation)
             if config and config.get("model_type") == "llm":
@@ -164,7 +164,7 @@ def _log_config_params(config):
         try:
             mlflow.log_params(batch)
         except Exception:
-            pass  # Skip params that fail (duplicates, etc.)
+            logger.debug("Failed to log config param batch to MLflow (duplicates or value limits).", exc_info=True)
 
 
 def _log_training_metrics(train_stats):
@@ -187,7 +187,9 @@ def _log_training_metrics(train_stats):
                     try:
                         mlflow.log_metric(f"{split_name}.{feat_name}.{metric_name}", best)
                     except Exception:
-                        pass
+                        logger.debug(
+                            f"Failed to log metric {split_name}.{feat_name}.{metric_name} to MLflow.", exc_info=True
+                        )
 
 
 def _create_logged_model(run, model, config):

--- a/ludwig/features/base_feature.py
+++ b/ludwig/features/base_feature.py
@@ -267,8 +267,8 @@ class InputFeature(BaseFeature, LudwigModule, ABC):
 
         except ImportError:
             logger.warning("PEFT not installed. Cannot apply adapter to encoder. pip install peft")
-        except Exception as e:
-            logger.warning(f"Failed to apply adapter to encoder: {e}")
+        except Exception:
+            logger.warning("Failed to apply adapter to encoder.", exc_info=True)
 
         return encoder
 

--- a/ludwig/features/text_feature.py
+++ b/ludwig/features/text_feature.py
@@ -362,8 +362,8 @@ class TextOutputFeature(TextFeatureMixin, SequenceOutputFeature):
                 else:
                     metric_fn = metric_fn.to(predictions[prediction_key].device)
                     metric_fn.update(predictions[prediction_key].detach(), targets)
-            except Exception as e:
-                logger.info(f"Ran into error when calculating metric {metric_name}. Skipping. The error is: {e}")
+            except Exception:
+                logger.warning(f"Ran into error when calculating metric {metric_name}. Skipping.", exc_info=True)
 
     @staticmethod
     def update_config_with_metadata(feature_config, feature_metadata, *args, **kwargs):

--- a/ludwig/utils/audio_utils.py
+++ b/ludwig/utils/audio_utils.py
@@ -70,8 +70,8 @@ def read_audio_from_path(path: str) -> TorchAudioTuple | None:
     """
     try:
         return torchaudio.load(path)
-    except Exception as e:
-        logger.warning(e)
+    except Exception:
+        logger.warning(f"Failed to load audio from path: {path}", exc_info=True)
         return None
 
 
@@ -81,8 +81,8 @@ def read_audio_from_bytes_obj(bytes_obj: bytes) -> TorchAudioTuple | None:
     try:
         f = BytesIO(bytes_obj)
         return torchaudio.load(f)
-    except Exception as e:
-        logger.warning(e)
+    except Exception:
+        logger.warning("Failed to load audio from bytes object.", exc_info=True)
         return None
 
 

--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -387,8 +387,8 @@ class CheckpointManager:
             try:
                 sd = self.checkpoint.get_state_for_inference(path, device)
                 state_dicts.append(sd)
-            except Exception as e:
-                logger.warning(f"Could not load top-K checkpoint from {path}: {e}")
+            except Exception:
+                logger.warning(f"Could not load top-K checkpoint from {path}.", exc_info=True)
         return state_dicts
 
     def close(self):

--- a/ludwig/utils/fs_utils.py
+++ b/ludwig/utils/fs_utils.py
@@ -94,8 +94,8 @@ def get_bytes_obj_from_path(path: str) -> bytes | None:
     if is_http(path):
         try:
             return get_bytes_obj_from_http_path(path)
-        except Exception as e:
-            logger.warning(e)
+        except Exception:
+            logger.warning(f"Failed to fetch bytes from HTTP path: {path}", exc_info=True)
             return None
     else:
         try:

--- a/ludwig/utils/hf_utils.py
+++ b/ludwig/utils/hf_utils.py
@@ -105,10 +105,11 @@ def load_pretrained_hf_model_with_hub_fallback(
                     _load_pretrained_hf_model_from_dir(model_class, pretrained_model_path, **pretrained_kwargs),
                     False,
                 )
-            except Exception as e:
+            except Exception:
                 logger.warning(
-                    f"Failed to download pretrained model from {pretrained_models_dir} with error {e}. "
-                    "Falling back to HuggingFace model hub."
+                    f"Failed to download pretrained model from {pretrained_models_dir}. "
+                    "Falling back to HuggingFace model hub.",
+                    exc_info=True,
                 )
 
     # Fallback to HF hub.

--- a/ludwig/utils/image_utils.py
+++ b/ludwig/utils/image_utils.py
@@ -194,8 +194,8 @@ def read_image_as_png(bytes_obj: bytes, mode: ImageReadMode = ImageReadMode.UNCH
             image = decode_image(torch.frombuffer(buffer_view, dtype=torch.uint8), mode=mode)
             del buffer_view
             return image
-    except Exception as e:
-        warnings.warn(f"Failed to read image from PNG file. Original exception: {e}")
+    except Exception:
+        logger.warning("Failed to read image from PNG file.", exc_info=True)
         return None
 
 
@@ -206,8 +206,8 @@ def read_image_as_numpy(bytes_obj: bytes) -> torch.Tensor | None:
         with BytesIO(bytes_obj) as buffer:
             image = np.load(buffer)
             return torch.from_numpy(image)
-    except Exception as e:
-        warnings.warn(f"Failed to read image from numpy file. Original exception: {e}")
+    except Exception:
+        logger.warning("Failed to read image from numpy file.", exc_info=True)
         return None
 
 
@@ -225,8 +225,8 @@ def read_image_as_tif(bytes_obj: bytes) -> torch.Tensor | None:
             if len(image.shape) == 2:
                 image = torch.unsqueeze(image, dim=0)
             return image
-    except Exception as e:
-        warnings.warn(f"Failed to read image from tif file. Original exception: {e}")
+    except Exception:
+        logger.warning("Failed to read image from tif file.", exc_info=True)
         return None
 
 


### PR DESCRIPTION
## Summary

Improves exception handling across production-critical paths to ensure failures are visible in logs:

- **`image_utils.py`**: `warnings.warn()` → `logger.warning(exc_info=True)` for image read failures (PNG, numpy, tif)
- **`audio_utils.py`**: bare `logger.warning(e)` → `logger.warning(msg, exc_info=True)` for torchaudio load failures
- **`fs_utils.py`**: bare `logger.warning(e)` → `logger.warning(msg, exc_info=True)` for HTTP fetch failures
- **`hf_utils.py`**: add `exc_info=True` to HF model download fallback warning
- **`base_feature.py`**: add `exc_info=True` to adapter application failure
- **`text_feature.py`**: upgrade metric calculation failure from `logger.info` to `logger.warning(exc_info=True)`
- **`checkpoint_utils.py`**: add `exc_info=True` to top-K checkpoint load failure
- **`api.py`**: consolidate model card / training report warnings with `exc_info=True` (was logging warning + redundant `logger.debug(traceback.format_exc())` separately)
- **`mlflow3.py`**: replace silent `pass` handlers with `logger.debug(exc_info=True)` for non-critical metric/param logging failures

Part of PR-7 from the codebase quality improvement plan.

## Test plan
- [ ] Existing tests pass
- [ ] No `warnings.warn` usages remain for recoverable read failures that should be logged