### PR TITLE
docs: fix stale BaseFeatureMixin references in adding_a_feature_type guide

### DIFF
--- a/docs/developer_guide/adding_a_feature_type.md
+++ b/docs/developer_guide/adding_a_feature_type.md
@@ -119,10 +119,10 @@ Create `ludwig/features/widget_feature.py`. The required classes are:
 
 ```python
 import torch
-from ludwig.features.base_feature import BaseFeatureMixin, InputFeature, OutputFeature
+from ludwig.features.base_feature import BasePreprocessingModule, FeaturePreprocessingMixin, InputFeature, OutputFeature
 
 
-class _WidgetPreprocessing(torch.nn.Module):
+class _WidgetPreprocessing(BasePreprocessingModule):
     """Runs inside the model graph during inference to preprocess raw input."""
 
     def __init__(self, metadata: dict, preprocessing_config, is_input_feature: bool = True):
@@ -136,10 +136,10 @@ class _WidgetPreprocessing(torch.nn.Module):
 
 ### FeatureMixin (shared preprocessing logic)
 
-`BaseFeatureMixin` (formerly `BaseFeatureMixin`) provides the Python-side preprocessing used during dataset preparation (not inside the model graph). You must implement `add_feature_data` and `get_preprocessing_module`:
+`FeaturePreprocessingMixin` provides the Python-side preprocessing used during dataset preparation (not inside the model graph). You must implement `add_feature_data` and `get_preprocessing_module`:
 
 ```python
-class WidgetFeatureMixin(BaseFeatureMixin):
+class WidgetFeatureMixin(FeaturePreprocessingMixin):
     @staticmethod
     def type():
         return WIDGET


### PR DESCRIPTION
## Summary

- Replaces two `BaseFeatureMixin` references with `FeaturePreprocessingMixin` in `docs/developer_guide/adding_a_feature_type.md`
- Replaces `torch.nn.Module` base class with `BasePreprocessingModule` in the inner preprocessing module example
- These names were renamed in #4186 (refactor: full codebase improvement plan)