### PR TITLE
fix(api): remove stale type: ignore and dead tuple check in train()

### DIFF
--- a/ludwig/api.py
+++ b/ludwig/api.py
@@ -398,7 +398,7 @@ class LudwigModel:
                             f"{output_directory}/{experiment_name}/model/model_hyperparameters.json"
                         )
 
-                preprocessed_data = self.preprocess(  # type: ignore[assignment]
+                preprocessed_data = self.preprocess(
                     dataset=dataset,
                     training_set=training_set,
                     validation_set=validation_set,
@@ -614,14 +614,6 @@ class LudwigModel:
                 self.backend.sync_model(self.model)
 
                 print_boxed("FINISHED")
-                # `preprocessed_data` is a 4-tuple from the two construction sites above
-                # (either built from pre-provided datasets or from self.preprocess()).
-                # TrainingResults declares `preprocessed_data: PreprocessedDataset`, so
-                # wrap the tuple before returning — downstream callers like
-                # `experiment()` access attributes (.validation_set etc.) rather than
-                # unpacking positionally.
-                if isinstance(preprocessed_data, tuple):
-                    preprocessed_data = PreprocessedDataset(*preprocessed_data)
                 return TrainingResults(train_stats, preprocessed_data, output_url)
 
     def train_online(


### PR DESCRIPTION
`preprocessed_data` is a `PreprocessedDataset` in both branches of the if/else (line 360 constructs one directly; `self.preprocess()` returns one). The `# type: ignore[assignment]` was left over from before `PreprocessedDataset` was introduced. The `isinstance(preprocessed_data, tuple)` guard below it was similarly dead code. Both removed.