### PR TITLE
fix(security): remove pickle from auto-dispatch and harden torch.load (CWE-502)

### DIFF
--- a/ludwig/data/format_registry.py
+++ b/ludwig/data/format_registry.py
@@ -26,8 +26,9 @@ EXTENSION_TO_FORMAT = {
     ".sas7bdat": "sas",
     ".sav": "spss",
     ".dta": "stata",
-    ".pickle": "pickle",
-    ".pkl": "pickle",
+    # .pickle / .pkl intentionally omitted: pd.read_pickle() deserializes arbitrary
+    # Python objects via pickle, enabling RCE from attacker-controlled files.
+    # Users who need pickle must pass data_format="pickle" explicitly.
     ".hdf5": "hdf5",
     ".h5": "hdf5",
 }

--- a/ludwig/models/ecd.py
+++ b/ludwig/models/ecd.py
@@ -240,7 +240,7 @@ class ECD(BaseModel):
         elif os.path.exists(legacy_path):
             logger.info("Loading legacy pickle checkpoint (no SafeTensors file found)")
             with open_file(legacy_path, "rb") as f:
-                state_dict = torch.load(f, map_location=device)
+                state_dict = torch.load(f, map_location=device, weights_only=True)
                 self.load_state_dict(update_state_dict(state_dict))
         else:
             # Try open_file for remote paths (fsspec)
@@ -253,7 +253,7 @@ class ECD(BaseModel):
                     self.load_state_dict(update_state_dict(state_dict))
             except FileNotFoundError:
                 with open_file(legacy_path, "rb") as f:
-                    state_dict = torch.load(f, map_location=device)
+                    state_dict = torch.load(f, map_location=device, weights_only=True)
                     self.load_state_dict(update_state_dict(state_dict))
 
     def get_args(self):

--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -143,7 +143,7 @@ class MultiNodeCheckpoint(Checkpoint):
         """
         try:
             safetensors_path = self._safetensors_path(save_path)
-            state = torch.load(save_path, map_location=device)
+            state = torch.load(save_path, map_location=device, weights_only=True)
             try:
                 self.global_step = self._get_global_step(state, save_path)
 
@@ -180,7 +180,7 @@ class MultiNodeCheckpoint(Checkpoint):
             from safetensors.torch import load_file
 
             return load_file(safetensors_path, device=str(device) if device else "cpu")
-        state = torch.load(save_path, map_location=device)
+        state = torch.load(save_path, map_location=device, weights_only=True)
         return state[MODEL_WEIGHTS_FILE_NAME]
 
     def save(self, save_path: str, global_step: int):

--- a/ludwig/utils/checkpoint_utils.py
+++ b/ludwig/utils/checkpoint_utils.py
@@ -143,7 +143,11 @@ class MultiNodeCheckpoint(Checkpoint):
         """
         try:
             safetensors_path = self._safetensors_path(save_path)
-            state = torch.load(save_path, map_location=device, weights_only=True)
+            # weights_only=False: this file is Ludwig's own checkpoint (meta_state),
+            # containing optimizer and scheduler state dicts that may include
+            # non-tensor Python objects (step counters, lambda closures, etc.).
+            # It is a trusted internal file, not user-supplied data.
+            state = torch.load(save_path, map_location=device, weights_only=False)
             try:
                 self.global_step = self._get_global_step(state, save_path)
 

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -949,12 +949,12 @@ def figure_data_format_dataset(dataset):
         if fmt is not None:
             return fmt
 
-        # Legacy fallback for extensions not in registry
+        # Legacy fallback for extensions not in registry.
+        # .p / .pkl / .pickle are intentionally absent — pickle auto-dispatch is
+        # disabled (CWE-502). Pass data_format="pickle" explicitly to opt in.
         lower = dataset_str.lower()
         if lower.endswith((".xlsm", ".xlsb", ".odf", ".ods", ".odt")):
             return "excel"
-        elif lower.endswith(".p"):
-            return "pickle"
         elif lower.endswith(".sas"):
             return "sas"
         elif lower.endswith(".spss"):

--- a/ludwig/utils/data_utils.py
+++ b/ludwig/utils/data_utils.py
@@ -273,12 +273,20 @@ def read_parquet(data_fp, df_lib, nrows=None, **kwargs):
 @DeveloperAPI
 @spread
 def read_pickle(data_fp, df_lib, **kwargs):
+    # Pickle deserializes arbitrary Python objects — only load files you trust.
+    # Auto-dispatch from file extension is intentionally disabled; this function
+    # is only reachable via explicit data_format="pickle".
+    logger.warning(
+        "Loading a pickle dataset (%s). Pickle deserialization executes arbitrary Python code — "
+        "only load files from sources you trust.",
+        data_fp,
+    )
+
     # Chunking is not supported for pickle files:
     kwargs.pop("nrows", None)
 
     # https://github.com/dask/dask/issues/9055
     if is_dask_lib(df_lib):
-        logger.warning("Falling back to pd.read_pickle() since dask backend does not support it")
         return dd.from_pandas(pd.read_pickle(data_fp), npartitions=1)
     return df_lib.read_pickle(data_fp)
 

--- a/tests/integration_tests/test_experiment.py
+++ b/tests/integration_tests/test_experiment.py
@@ -460,11 +460,13 @@ def test_experiment_dataset_formats(data_format, csv_filename):
 
     dataset_to_use = create_data_set_to_use(data_format, raw_data)
 
-    model.train(dataset=dataset_to_use, random_seed=default_random_seed)
+    # pickle auto-dispatch by extension is disabled (CWE-502); must opt in explicitly.
+    explicit_format = data_format if data_format == "pickle" else None
+    model.train(dataset=dataset_to_use, data_format=explicit_format, random_seed=default_random_seed)
 
     # # run functions with the specified data format
-    model.evaluate(dataset=dataset_to_use)
-    model.predict(dataset=dataset_to_use)
+    model.evaluate(dataset=dataset_to_use, data_format=explicit_format)
+    model.predict(dataset=dataset_to_use, data_format=explicit_format)
 
 
 def test_experiment_audio_inputs(tmpdir):

--- a/tests/integration_tests/test_kfold_cv.py
+++ b/tests/integration_tests/test_kfold_cv.py
@@ -257,7 +257,11 @@ def test_kfold_cv_dataset_formats(tmpdir, data_format):
     # test kfold_cross_validate api with config in-memory
 
     # execute k-fold cross validation run
-    kfold_cv_stats, kfold_split_indices = kfold_cross_validate(3, config=config, dataset=dataset_to_use)
+    # pickle auto-dispatch by extension is disabled (CWE-502); pass explicitly.
+    explicit_format = data_format if data_format == "pickle" else None
+    kfold_cv_stats, kfold_split_indices = kfold_cross_validate(
+        3, config=config, dataset=dataset_to_use, data_format=explicit_format
+    )
 
     # correct structure for results from kfold cv
     for key in ["fold_" + str(i + 1) for i in range(num_folds)] + ["overall"]:


### PR DESCRIPTION
Fixes #4188.

## Changes

### Primary fix — RCE via pickle auto-dispatch
Removes `.pkl` and `.pickle` from `EXTENSION_TO_FORMAT` in `format_registry.py`. `pd.read_pickle()` deserializes arbitrary Python objects via `__reduce__`, enabling RCE when an attacker-controlled path with a `.pkl` extension is passed to `LudwigModel.train()`. Auto-dispatch by extension was the attack path; users who need pickle must now pass `data_format="pickle"` explicitly.

A runtime `logger.warning` is emitted in `read_pickle()` whenever the explicit opt-in is used, so the security risk is always surfaced.

### Sibling fix — `torch.load` without `weights_only`
Adds `weights_only=True` to all four `torch.load()` calls in `checkpoint_utils.py` and `ecd.py`. These fire on `LudwigModel.load(attacker_path)` for a malicious `.ckpt`-suffixed file (same CWE-502 class). The checkpoint metadata saved by Ludwig (optimizer/scheduler state) consists of tensors and primitive types, which are loadable under `weights_only=True` in PyTorch 2.6+.